### PR TITLE
Add CI protection for Исходные мысли МТС.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,25 @@ jobs:
           done
           echo "Documentation check complete."
 
+  protect-readonly-files:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check protected files are not modified
+        run: |
+          PROTECTED_FILE="docs/research/Исходные мысли МТС.md"
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -Fxq "$PROTECTED_FILE"; then
+            echo "::error::The file '$PROTECTED_FILE' is protected and may not be modified in a pull request. Only the repository owner may edit this file directly."
+            exit 1
+          fi
+          echo "Protected file check passed."
+
   validate-structure:
     runs-on: ubuntu-latest
     steps:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T17:10:28.315Z for PR creation at branch issue-59-30703ba6ccd8 for issue https://github.com/netkeep80/anum_docs/issues/59

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T17:10:28.315Z for PR creation at branch issue-59-30703ba6ccd8 for issue https://github.com/netkeep80/anum_docs/issues/59


### PR DESCRIPTION
## Summary

- Adds a new `protect-readonly-files` CI job that runs on every pull request
- The job compares changed files between the PR's base and head commits
- If `docs/research/Исходные мысли МТС.md` appears in the diff, the job fails with a clear error message
- The check is skipped on direct pushes (e.g. by the repository owner), so the file can still be edited directly

## How to reproduce the issue

1. Create a branch that modifies `docs/research/Исходные мысли МТС.md`
2. Open a pull request — the `protect-readonly-files` CI job will fail with:
   > The file 'docs/research/Исходные мысли МТС.md' is protected and may not be modified in a pull request.

## Test plan

- [x] Verify the new `protect-readonly-files` job is present in `.github/workflows/ci.yml`
- [x] Verify the job only runs on `pull_request` events (not on direct pushes)
- [x] Confirm CI passes on this PR (which does not touch the protected file)
- [ ] Manually confirm: open a test PR that edits the file and verify the job fails


Fixes netkeep80/anum_docs#59