### PR TITLE
Зафиксировать версию Ruff в CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          # Pin the lint ruleset. Ruff 0.16 changed default diagnostics and
+          # made unchanged legacy files fail without any repository change.
+          pip install ruff==0.15.22
 
       - name: Run Ruff linter
         run: |


### PR DESCRIPTION
## Причина

CI использовал непинованный `pip install ruff`. Зелёный run #148 устанавливал `ruff 0.15.22`, а run #161 автоматически получил `ruff 0.16.2` и начал проверять новые default rules, из-за чего 67 ошибок появились в давно существующих неизменённых файлах.

Это dependency drift, а не регрессия текущего PR.

## Изменение

```text
pip install ruff==0.15.22
```

Версия выбрана ровно по последнему зелёному CI run #148.

Это стабилизирует lint ruleset. Отдельный переход на Ruff 0.16+ должен выполняться осознанно отдельной задачей с исправлением/настройкой новых diagnostics.