### PR TITLE
[Experiment] Смоделировать occurrence/PatternSlot semantics для #79

### DIFF
--- a/core/occurrence_model_candidate.py
+++ b/core/occurrence_model_candidate.py
@@ -1,13 +1,12 @@
-"""Experimental occurrence/slot model for issue #79.
+"""Experimental occurrence/slot models for issue #79.
 
-This module is deliberately NOT part of the accepted reference model. It makes
-Candidate C1 executable: the visible empty square form ``[]`` is a schema, while
-individual occurrences inside one definition template may be assigned local
-``PatternSlot`` identities.
+Candidate C1 separates the visible ``[]`` schema from local PatternSlot identity.
+Candidate C1a adds one deterministic elaboration hypothesis: every definition
+scope has an arity ``n`` and anonymous empty-square occurrences consume a cyclic
+positional stream ``1..n, 1..n, ...``.
 
-The missing theoretical decision is the elaboration rule that derives slot IDs
-from unannotated source. Until that rule is accepted, templates below are explicit
-challenge fixtures rather than normative semantics.
+Nothing in this module is part of the accepted reference model. The point is to
+make the hypothesis executable and challengeable before theoretical acceptance.
 """
 
 from dataclasses import dataclass
@@ -18,6 +17,7 @@ from core.mtc_ast import (
     EndProjection,
     Equality,
     Expression,
+    Inequality,
     Inversion,
     LinkForm,
     RoundForm,
@@ -31,16 +31,12 @@ from core.mtc_parser import parse_formula
 
 @dataclass(frozen=True, order=True)
 class PatternSlot:
-    """One locally scoped placeholder identity inside a template."""
-
     scope: str
     index: int
 
 
 @dataclass(frozen=True)
 class BoundOccurrence:
-    """One concrete ``[]`` occurrence bound to a local slot."""
-
     ordinal: int
     span: SourceSpan
     slot: PatternSlot
@@ -48,30 +44,20 @@ class BoundOccurrence:
 
 @dataclass(frozen=True)
 class CandidateTemplate:
-    """Explicit slot annotation for one current root-template challenge case."""
+    """Expected slot annotation for one challenge case."""
 
     name: str
     source: str
     slot_ids: tuple[int, ...]
 
-    def elaborate(self) -> tuple[BoundOccurrence, ...]:
+    def elaborate_expected(self) -> tuple[BoundOccurrence, ...]:
         ast = parse_formula(self.source)
         spans = empty_square_spans(ast)
-        if len(spans) != len(self.slot_ids):
-            raise ValueError(
-                f"{self.name}: source has {len(spans)} empty-square occurrences, "
-                f"annotation has {len(self.slot_ids)}"
-            )
-        if self.slot_ids and set(self.slot_ids) != set(range(1, max(self.slot_ids) + 1)):
-            raise ValueError(f"{self.name}: slot IDs must be contiguous from 1")
-        return tuple(
-            BoundOccurrence(
-                ordinal=ordinal,
-                span=span,
-                slot=PatternSlot(self.name, slot_id),
-            )
-            for ordinal, (span, slot_id) in enumerate(zip(spans, self.slot_ids), 1)
-        )
+        _validate_slot_ids(self.name, spans, self.slot_ids)
+        return _bind(self.name, spans, self.slot_ids)
+
+    def elaborate_automatic(self) -> tuple[BoundOccurrence, ...]:
+        return elaborate_cyclic_positions(self.name, self.source)
 
     @property
     def arity(self) -> int:
@@ -114,9 +100,76 @@ def template(name: str) -> CandidateTemplate:
     raise KeyError(name)
 
 
-def empty_square_spans(expression: Expression) -> tuple[SourceSpan, ...]:
-    """Collect visible ``[]`` AST occurrences in deterministic source order."""
+def elaborate_cyclic_positions(
+    scope: str,
+    source: str,
+) -> tuple[BoundOccurrence, ...]:
+    """Apply experimental Candidate C1a to one definition source.
 
+    Arity inference:
+
+    1. If the definition target contains ``[]`` occurrences, each target
+       position establishes one slot from left to right.
+    2. Otherwise a single equality establishes arity from the placeholders on
+       its left side (recursive-equation case such as the associative root).
+    3. Otherwise a bundle of binary judgments establishes arity from all
+       placeholder occurrences of its first judgment (relation case such as
+       ``(=)``).
+
+    Once arity is known, RHS/value occurrences consume a cyclic slot stream.
+    Grouping does not reset the stream.
+    """
+
+    ast = parse_formula(source)
+    if not isinstance(ast, Definition):
+        raise ValueError(f"{scope}: cyclic slot elaboration requires Definition")
+
+    target_spans = empty_square_spans(ast.target)
+    value_spans = empty_square_spans(ast.value)
+
+    if target_spans:
+        arity = len(target_spans)
+        target_ids = tuple(range(1, arity + 1))
+    else:
+        arity = infer_definition_arity(ast.value)
+        target_ids = ()
+
+    if not value_spans and not target_spans:
+        return ()
+    if arity <= 0:
+        raise ValueError(f"{scope}: cannot infer positional arity")
+
+    value_ids = tuple((index % arity) + 1 for index in range(len(value_spans)))
+    pairs = list(zip(target_spans, target_ids)) + list(zip(value_spans, value_ids))
+    pairs.sort(key=lambda item: (item[0].start, item[0].end))
+
+    return tuple(
+        BoundOccurrence(
+            ordinal=ordinal,
+            span=span,
+            slot=PatternSlot(scope, slot_id),
+        )
+        for ordinal, (span, slot_id) in enumerate(pairs, 1)
+    )
+
+
+def infer_definition_arity(value: Expression) -> int:
+    """Infer local arity for target-less Candidate C1a definitions."""
+
+    if isinstance(value, (Equality, Inequality)):
+        return len(empty_square_spans(value.left))
+
+    if isinstance(value, BundleForm) and value.items:
+        first = value.items[0]
+        if isinstance(first, (Equality, Inequality)):
+            return len(empty_square_spans(first.left)) + len(
+                empty_square_spans(first.right)
+            )
+
+    return 0
+
+
+def empty_square_spans(expression: Expression) -> tuple[SourceSpan, ...]:
     spans: list[SourceSpan] = []
     _collect_empty_squares(expression, spans)
     spans.sort(key=lambda span: (span.start, span.end))
@@ -124,14 +177,22 @@ def empty_square_spans(expression: Expression) -> tuple[SourceSpan, ...]:
 
 
 def validate_candidate() -> tuple[str, ...]:
-    """Check only internal consistency of Candidate C1 annotations."""
-
     errors: list[str] = []
+
     for item in CANDIDATE_TEMPLATES:
         try:
-            item.elaborate()
+            expected = item.elaborate_expected()
+            automatic = item.elaborate_automatic()
         except ValueError as exc:
             errors.append(str(exc))
+            continue
+
+        expected_ids = tuple(occurrence.slot.index for occurrence in expected)
+        automatic_ids = tuple(occurrence.slot.index for occurrence in automatic)
+        if automatic_ids != expected_ids:
+            errors.append(
+                f"{item.name}: automatic slots {automatic_ids} != expected {expected_ids}"
+            )
 
     root = template("associative-root")
     pair = template("pair-sequence")
@@ -147,12 +208,41 @@ def validate_candidate() -> tuple[str, ...]:
     if equality.slot_ids != (1, 2, 1, 2):
         errors.append("equality-meaning must preserve two operand columns")
 
-    root_slot = root.elaborate()[0].slot
-    pair_slot = pair.elaborate()[0].slot
+    root_slot = root.elaborate_expected()[0].slot
+    pair_slot = pair.elaborate_expected()[0].slot
     if root_slot == pair_slot:
         errors.append("slots from different templates must never bind globally")
 
     return tuple(errors)
+
+
+def _validate_slot_ids(
+    name: str,
+    spans: tuple[SourceSpan, ...],
+    slot_ids: tuple[int, ...],
+) -> None:
+    if len(spans) != len(slot_ids):
+        raise ValueError(
+            f"{name}: source has {len(spans)} empty-square occurrences, "
+            f"annotation has {len(slot_ids)}"
+        )
+    if slot_ids and set(slot_ids) != set(range(1, max(slot_ids) + 1)):
+        raise ValueError(f"{name}: slot IDs must be contiguous from 1")
+
+
+def _bind(
+    scope: str,
+    spans: tuple[SourceSpan, ...],
+    slot_ids: tuple[int, ...],
+) -> tuple[BoundOccurrence, ...]:
+    return tuple(
+        BoundOccurrence(
+            ordinal=ordinal,
+            span=span,
+            slot=PatternSlot(scope, slot_id),
+        )
+        for ordinal, (span, slot_id) in enumerate(zip(spans, slot_ids), 1)
+    )
 
 
 def _collect_empty_squares(expression: Expression, spans: list[SourceSpan]) -> None:
@@ -182,7 +272,7 @@ def _collect_empty_squares(expression: Expression, spans: list[SourceSpan]) -> N
         _collect_empty_squares(expression.value, spans)
         return
 
-    if isinstance(expression, (LinkForm, Equality)):
+    if isinstance(expression, (LinkForm, Equality, Inequality)):
         _collect_empty_squares(expression.left, spans)
         _collect_empty_squares(expression.right, spans)
         return

--- a/core/occurrence_model_candidate.py
+++ b/core/occurrence_model_candidate.py
@@ -1,0 +1,192 @@
+"""Experimental occurrence/slot model for issue #79.
+
+This module is deliberately NOT part of the accepted reference model. It makes
+Candidate C1 executable: the visible empty square form ``[]`` is a schema, while
+individual occurrences inside one definition template may be assigned local
+``PatternSlot`` identities.
+
+The missing theoretical decision is the elaboration rule that derives slot IDs
+from unannotated source. Until that rule is accepted, templates below are explicit
+challenge fixtures rather than normative semantics.
+"""
+
+from dataclasses import dataclass
+
+from core.mtc_ast import (
+    BundleForm,
+    Definition,
+    EndProjection,
+    Equality,
+    Expression,
+    Inversion,
+    LinkForm,
+    RoundForm,
+    Sequence,
+    SourceSpan,
+    SquareForm,
+    StartProjection,
+)
+from core.mtc_parser import parse_formula
+
+
+@dataclass(frozen=True, order=True)
+class PatternSlot:
+    """One locally scoped placeholder identity inside a template."""
+
+    scope: str
+    index: int
+
+
+@dataclass(frozen=True)
+class BoundOccurrence:
+    """One concrete ``[]`` occurrence bound to a local slot."""
+
+    ordinal: int
+    span: SourceSpan
+    slot: PatternSlot
+
+
+@dataclass(frozen=True)
+class CandidateTemplate:
+    """Explicit slot annotation for one current root-template challenge case."""
+
+    name: str
+    source: str
+    slot_ids: tuple[int, ...]
+
+    def elaborate(self) -> tuple[BoundOccurrence, ...]:
+        ast = parse_formula(self.source)
+        spans = empty_square_spans(ast)
+        if len(spans) != len(self.slot_ids):
+            raise ValueError(
+                f"{self.name}: source has {len(spans)} empty-square occurrences, "
+                f"annotation has {len(self.slot_ids)}"
+            )
+        if self.slot_ids and set(self.slot_ids) != set(range(1, max(self.slot_ids) + 1)):
+            raise ValueError(f"{self.name}: slot IDs must be contiguous from 1")
+        return tuple(
+            BoundOccurrence(
+                ordinal=ordinal,
+                span=span,
+                slot=PatternSlot(self.name, slot_id),
+            )
+            for ordinal, (span, slot_id) in enumerate(zip(spans, self.slot_ids), 1)
+        )
+
+    @property
+    def arity(self) -> int:
+        return max(self.slot_ids, default=0)
+
+
+CANDIDATE_TEMPLATES = (
+    CandidateTemplate(
+        name="associative-root",
+        source="∞ : [] = [] ⟼ []",
+        slot_ids=(1, 1, 1),
+    ),
+    CandidateTemplate(
+        name="pair-sequence",
+        source="[][] : [] ⟼ []",
+        slot_ids=(1, 2, 1, 2),
+    ),
+    CandidateTemplate(
+        name="triple-sequence",
+        source="[][][] : ([][]) ⟼ []",
+        slot_ids=(1, 2, 3, 1, 2, 3),
+    ),
+    CandidateTemplate(
+        name="grouped-triple",
+        source="[]([][]) : [] ⟼ ([][])",
+        slot_ids=(1, 2, 3, 1, 2, 3),
+    ),
+    CandidateTemplate(
+        name="equality-meaning",
+        source="(=) : {♀[] = ♀[], []♂ = []♂}",
+        slot_ids=(1, 2, 1, 2),
+    ),
+)
+
+
+def template(name: str) -> CandidateTemplate:
+    for item in CANDIDATE_TEMPLATES:
+        if item.name == name:
+            return item
+    raise KeyError(name)
+
+
+def empty_square_spans(expression: Expression) -> tuple[SourceSpan, ...]:
+    """Collect visible ``[]`` AST occurrences in deterministic source order."""
+
+    spans: list[SourceSpan] = []
+    _collect_empty_squares(expression, spans)
+    spans.sort(key=lambda span: (span.start, span.end))
+    return tuple(spans)
+
+
+def validate_candidate() -> tuple[str, ...]:
+    """Check only internal consistency of Candidate C1 annotations."""
+
+    errors: list[str] = []
+    for item in CANDIDATE_TEMPLATES:
+        try:
+            item.elaborate()
+        except ValueError as exc:
+            errors.append(str(exc))
+
+    root = template("associative-root")
+    pair = template("pair-sequence")
+    triple = template("triple-sequence")
+    equality = template("equality-meaning")
+
+    if root.arity != 1:
+        errors.append("associative-root must model one repeated local pattern slot")
+    if pair.arity != 2:
+        errors.append("pair-sequence must model two positional slots")
+    if triple.arity != 3:
+        errors.append("triple-sequence must model three positional slots")
+    if equality.slot_ids != (1, 2, 1, 2):
+        errors.append("equality-meaning must preserve two operand columns")
+
+    root_slot = root.elaborate()[0].slot
+    pair_slot = pair.elaborate()[0].slot
+    if root_slot == pair_slot:
+        errors.append("slots from different templates must never bind globally")
+
+    return tuple(errors)
+
+
+def _collect_empty_squares(expression: Expression, spans: list[SourceSpan]) -> None:
+    if isinstance(expression, SquareForm):
+        if expression.content is None:
+            spans.append(expression.span)
+        else:
+            _collect_empty_squares(expression.content, spans)
+        return
+
+    if isinstance(expression, RoundForm):
+        if expression.content is not None:
+            _collect_empty_squares(expression.content, spans)
+        return
+
+    if isinstance(expression, BundleForm):
+        for item in expression.items:
+            _collect_empty_squares(item, spans)
+        return
+
+    if isinstance(expression, Sequence):
+        for item in expression.items:
+            _collect_empty_squares(item, spans)
+        return
+
+    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
+        _collect_empty_squares(expression.value, spans)
+        return
+
+    if isinstance(expression, (LinkForm, Equality)):
+        _collect_empty_squares(expression.left, spans)
+        _collect_empty_squares(expression.right, spans)
+        return
+
+    if isinstance(expression, Definition):
+        _collect_empty_squares(expression.target, spans)
+        _collect_empty_squares(expression.value, spans)

--- a/tests/test_occurrence_model_candidate.py
+++ b/tests/test_occurrence_model_candidate.py
@@ -1,0 +1,58 @@
+"""Challenge tests for experimental issue #79 Candidate C1."""
+
+from core.occurrence_model_candidate import (
+    PatternSlot,
+    template,
+    validate_candidate,
+)
+
+
+def slot_ids(name: str) -> tuple[int, ...]:
+    return tuple(item.slot.index for item in template(name).elaborate())
+
+
+def test_candidate_annotations_are_internally_consistent():
+    assert validate_candidate() == ()
+
+
+def test_root_self_closure_reuses_one_local_slot():
+    assert slot_ids("associative-root") == (1, 1, 1)
+    assert template("associative-root").arity == 1
+
+
+def test_pair_sequence_has_two_positions_and_reuses_them_on_rhs():
+    assert slot_ids("pair-sequence") == (1, 2, 1, 2)
+    assert template("pair-sequence").arity == 2
+
+
+def test_triple_sequence_preserves_left_associative_three_positions():
+    assert slot_ids("triple-sequence") == (1, 2, 3, 1, 2, 3)
+    assert template("triple-sequence").arity == 3
+
+
+def test_grouped_triple_preserves_three_positions_across_grouping():
+    assert slot_ids("grouped-triple") == (1, 2, 3, 1, 2, 3)
+
+
+def test_equality_meaning_has_two_operand_columns():
+    assert slot_ids("equality-meaning") == (1, 2, 1, 2)
+    assert template("equality-meaning").arity == 2
+
+
+def test_same_slot_index_in_different_templates_is_not_global_binding():
+    root_slot = template("associative-root").elaborate()[0].slot
+    pair_slot = template("pair-sequence").elaborate()[0].slot
+
+    assert root_slot == PatternSlot("associative-root", 1)
+    assert pair_slot == PatternSlot("pair-sequence", 1)
+    assert root_slot != pair_slot
+
+
+def test_each_bound_occurrence_keeps_real_source_span():
+    candidate = template("equality-meaning")
+    occurrences = candidate.elaborate()
+
+    for occurrence in occurrences:
+        assert candidate.source[
+            occurrence.span.start : occurrence.span.end
+        ] == "[]"

--- a/tests/test_occurrence_model_candidate.py
+++ b/tests/test_occurrence_model_candidate.py
@@ -1,47 +1,67 @@
-"""Challenge tests for experimental issue #79 Candidate C1."""
+"""Challenge tests for experimental issue #79 Candidates C1/C1a."""
 
 from core.occurrence_model_candidate import (
     PatternSlot,
+    elaborate_cyclic_positions,
     template,
     validate_candidate,
 )
 
 
-def slot_ids(name: str) -> tuple[int, ...]:
-    return tuple(item.slot.index for item in template(name).elaborate())
+def expected_slot_ids(name: str) -> tuple[int, ...]:
+    return tuple(
+        item.slot.index for item in template(name).elaborate_expected()
+    )
+
+
+def automatic_slot_ids(name: str) -> tuple[int, ...]:
+    return tuple(
+        item.slot.index for item in template(name).elaborate_automatic()
+    )
 
 
 def test_candidate_annotations_are_internally_consistent():
     assert validate_candidate() == ()
 
 
+def test_automatic_elaborator_matches_all_five_manual_challenge_templates():
+    for name in (
+        "associative-root",
+        "pair-sequence",
+        "triple-sequence",
+        "grouped-triple",
+        "equality-meaning",
+    ):
+        assert automatic_slot_ids(name) == expected_slot_ids(name)
+
+
 def test_root_self_closure_reuses_one_local_slot():
-    assert slot_ids("associative-root") == (1, 1, 1)
+    assert automatic_slot_ids("associative-root") == (1, 1, 1)
     assert template("associative-root").arity == 1
 
 
 def test_pair_sequence_has_two_positions_and_reuses_them_on_rhs():
-    assert slot_ids("pair-sequence") == (1, 2, 1, 2)
+    assert automatic_slot_ids("pair-sequence") == (1, 2, 1, 2)
     assert template("pair-sequence").arity == 2
 
 
 def test_triple_sequence_preserves_left_associative_three_positions():
-    assert slot_ids("triple-sequence") == (1, 2, 3, 1, 2, 3)
+    assert automatic_slot_ids("triple-sequence") == (1, 2, 3, 1, 2, 3)
     assert template("triple-sequence").arity == 3
 
 
 def test_grouped_triple_preserves_three_positions_across_grouping():
-    assert slot_ids("grouped-triple") == (1, 2, 3, 1, 2, 3)
+    assert automatic_slot_ids("grouped-triple") == (1, 2, 3, 1, 2, 3)
 
 
 def test_equality_meaning_has_two_operand_columns():
-    assert slot_ids("equality-meaning") == (1, 2, 1, 2)
+    assert automatic_slot_ids("equality-meaning") == (1, 2, 1, 2)
     assert template("equality-meaning").arity == 2
 
 
 def test_same_slot_index_in_different_templates_is_not_global_binding():
-    root_slot = template("associative-root").elaborate()[0].slot
-    pair_slot = template("pair-sequence").elaborate()[0].slot
+    root_slot = template("associative-root").elaborate_automatic()[0].slot
+    pair_slot = template("pair-sequence").elaborate_automatic()[0].slot
 
     assert root_slot == PatternSlot("associative-root", 1)
     assert pair_slot == PatternSlot("pair-sequence", 1)
@@ -50,9 +70,34 @@ def test_same_slot_index_in_different_templates_is_not_global_binding():
 
 def test_each_bound_occurrence_keeps_real_source_span():
     candidate = template("equality-meaning")
-    occurrences = candidate.elaborate()
+    occurrences = candidate.elaborate_automatic()
 
     for occurrence in occurrences:
         assert candidate.source[
             occurrence.span.start : occurrence.span.end
         ] == "[]"
+
+
+def test_grouping_does_not_reset_cyclic_position_stream():
+    occurrences = elaborate_cyclic_positions(
+        "synthetic-grouping",
+        "[][][] : [] ⟼ ([][])",
+    )
+
+    assert tuple(item.slot.index for item in occurrences) == (1, 2, 3, 1, 2, 3)
+
+
+def test_candidate_exposes_expressivity_limit_of_implicit_cyclic_slots():
+    """With arity 2, three RHS placeholders necessarily read 1,2,1.
+
+    This is not declared correct MTS semantics. The test documents a challenge:
+    if theory ever needs the order 1,1,2, the current unindexed notation needs
+    an additional binding mechanism because C1a cannot express it.
+    """
+
+    occurrences = elaborate_cyclic_positions(
+        "synthetic-limit",
+        "[][] : [] ⟼ [] ⟼ []",
+    )
+
+    assert tuple(item.slot.index for item in occurrences) == (1, 2, 1, 2, 1)


### PR DESCRIPTION
Refs #79. **Experimental Candidate C1 — не закрывает #79 и не меняет нормативную теорию.**

## Зачем этот PR

Challenge при реализации #70 показал, что одинаковый текст `[]` нельзя автоматически считать одной глобальной объектной константой: обычная global substitution схлопывает различие левой/правой ассоциации, прямо запрещённое root fixture.

Candidate C1 вводит только экспериментальный внутренний IR:

```text
EmptySquareForm schema
→ concrete Occurrence
→ locally scoped PatternSlot
```

## Явные challenge annotations

Модель проверяет предполагаемые скрытые slots:

```text
∞ : []₁ = []₁ ⟼ []₁

[][] : []₁ ⟼ []₂

[][][] : ([]₁ ⟼ []₂) ⟼ []₃

[]([][]) : []₁ ⟼ ([]₂ ⟼ []₃)

(=) : {♀[]₁ = ♀[]₂, []₁♂ = []₂♂}
```

Индексы **не предлагается добавлять в пользовательскую нотацию**. Они делают предполагаемую occurrence semantics явной только внутри экспериментальной модели.

## Что проверяется

- self-closure использует один повторный local slot;
- pair sequence имеет две позиции;
- triple sequence имеет три позиции;
- grouping не уничтожает positional identity;
- `(=)` имеет два operand columns, повторённых в start/end constraints;
- `slot 1` разных templates не является global binding;
- каждый BoundOccurrence сохраняет реальный `SourceSpan` typed AST.

## Чего PR сознательно НЕ делает

Он **не выбирает elaboration algorithm**:

```text
исходный fixture без индексов
→ автоматически восстановленные PatternSlot IDs
```

Это и есть оставшаяся теоретическая часть #79.

Нельзя просто:

- объединять одинаковый text — ломается `(=)`;
- выдавать новый slot каждому occurrence — ломается `∞ : [] = [] ⟼ []`.

Следующий challenge должен сравнить минимум:

1. target-driven elaboration;
2. constraint-driven elaboration.

До явного принятия одного правила владельцем теории этот PR остаётся экспериментальным `Modeled`, а не `Accepted/Released`.