### PR TITLE
Реализовать конечный cyclic Link carrier принятой части L1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ L5  теория вывода
 
 ```text
 core/reference_model.py     декларативный контракт МТС/Anum v0.1
+core/semantic_carrier.py    конечный cyclic Link carrier принятой части L1
 core/mtc_ast.py             typed AST формального языка L2
 core/mtc_parser.py          tokenizer, Pratt parser и static validation L2
 core/root_library.py        загрузка fixture через typed AST
@@ -68,11 +69,13 @@ converters/anum_to_text.py  quaternary запись → UTF-8 payload
 converters/ascii_unicode.py ASCII ↔ Unicode
 ```
 
+L1 carrier уже умеет конечные циклы, self-closure начала/конца, конкретную Link-инверсию и проверку точной rooted carrier topology. `carrier_isomorphic()` является инженерным сравнением конечного носителя и **не является L2-оператором `=`**; полная equality/substitution semantics остаётся открытой в #79.
+
 L2 имеет один production parsing path: `core/mtc_parser.py`. L3 имеет один protocol path: `core/anum_parser.py` читает только raw carrier, а `core/anum_protocol.py` выполняет context validation/projection.
 
 Старые `mtc_reader.py`, `layers.py`, двухабитный `anum_projector.py` и отдельный symbolic `Quote` удалены после миграции consumers.
 
-`core/reference_model.py` не является interpreter или prover. `core/anum_memory.py` не является реализацией полноценной апамяти.
+`core/reference_model.py` не является prover. `core/semantic_carrier.py` не решает `:`/`=`. `core/anum_memory.py` не является реализацией полноценной апамяти.
 
 ## Проверка
 

--- a/core/semantic_carrier.py
+++ b/core/semantic_carrier.py
@@ -1,0 +1,177 @@
+"""Finite cyclic carrier primitives for the accepted part of L1 v0.1.
+
+This module deliberately does NOT implement the L2 operator ``=``. In
+particular, ``carrier_isomorphic`` is an engineering check for exact rooted
+finite carrier topology and must not be used as MTS equality while issue #79 is
+open.
+"""
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LinkNode:
+    """One carrier node with ordered start/end references by node index."""
+
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class CarrierGraph:
+    """Finite rooted graph of Link nodes; cycles and sharing are allowed."""
+
+    nodes: tuple[LinkNode, ...]
+    root: int
+
+    def __post_init__(self) -> None:
+        if not self.nodes:
+            raise ValueError("CarrierGraph должен содержать хотя бы один LinkNode")
+        if self.root < 0 or self.root >= len(self.nodes):
+            raise ValueError(f"Некорректный root index: {self.root}")
+
+        for index, node in enumerate(self.nodes):
+            for role, target in (("start", node.start), ("end", node.end)):
+                if target < 0 or target >= len(self.nodes):
+                    raise ValueError(
+                        f"Node {index}: {role} index {target} вне carrier"
+                    )
+
+    @property
+    def root_node(self) -> LinkNode:
+        return self.nodes[self.root]
+
+
+def associative_root_carrier() -> CarrierGraph:
+    """Return the minimal finite carrier ``root.start=root; root.end=root``."""
+
+    return CarrierGraph(nodes=(LinkNode(start=0, end=0),), root=0)
+
+
+def link_carrier(left: CarrierGraph, right: CarrierGraph) -> CarrierGraph:
+    """Create a new Link whose ordered endpoints are two existing carriers.
+
+    Inputs are copied into disjoint index spaces. Sharing inside each input is
+    preserved; no semantic interning/equality is attempted here.
+    """
+
+    left_nodes = left.nodes
+    right_offset = len(left_nodes)
+    right_nodes = _shift_nodes(right.nodes, right_offset)
+
+    root_index = len(left_nodes) + len(right_nodes)
+    root = LinkNode(
+        start=left.root,
+        end=right.root + right_offset,
+    )
+    return CarrierGraph(
+        nodes=left_nodes + right_nodes + (root,),
+        root=root_index,
+    )
+
+
+def start_carrier(form: CarrierGraph) -> CarrierGraph:
+    """Build a finite carrier with a self-closed start pole.
+
+    ``start(F).start = start(F)`` and ``start(F).end = F``.
+    """
+
+    root_index = len(form.nodes)
+    node = LinkNode(start=root_index, end=form.root)
+    return CarrierGraph(nodes=form.nodes + (node,), root=root_index)
+
+
+def end_carrier(form: CarrierGraph) -> CarrierGraph:
+    """Build a finite carrier with a self-closed end pole.
+
+    ``end(F).start = F`` and ``end(F).end = end(F)``.
+    """
+
+    root_index = len(form.nodes)
+    node = LinkNode(start=form.root, end=root_index)
+    return CarrierGraph(nodes=form.nodes + (node,), root=root_index)
+
+
+def invert_root_carrier(form: CarrierGraph) -> CarrierGraph:
+    """Create ``Link(original.end, original.start)`` without mutating input.
+
+    The original carrier remains present as the endpoint substrate. This models
+    inversion of one already distinguished concrete Link, not recursive
+    inversion of all reachable links.
+    """
+
+    original = form.root_node
+    root_index = len(form.nodes)
+    inverse = LinkNode(start=original.end, end=original.start)
+    return CarrierGraph(nodes=form.nodes + (inverse,), root=root_index)
+
+
+def reachable_indices(graph: CarrierGraph) -> tuple[int, ...]:
+    """Return deterministic BFS order of nodes reachable from the root."""
+
+    seen: set[int] = set()
+    order: list[int] = []
+    queue = deque([graph.root])
+
+    while queue:
+        current = queue.popleft()
+        if current in seen:
+            continue
+        seen.add(current)
+        order.append(current)
+
+        node = graph.nodes[current]
+        queue.append(node.start)
+        queue.append(node.end)
+
+    return tuple(order)
+
+
+def carrier_isomorphic(left: CarrierGraph, right: CarrierGraph) -> bool:
+    """Check exact rooted finite carrier topology with ordered edges.
+
+    This is intentionally stronger/different from generic coalgebraic
+    bisimulation and is NOT the semantics of the L2 equality operator.
+    The root mapping forces all subsequent mappings because ``start``/``end``
+    edges are ordered. Sharing and cycle topology must match bijectively.
+    """
+
+    mapping: dict[int, int] = {left.root: right.root}
+    reverse: dict[int, int] = {right.root: left.root}
+    queue = deque([(left.root, right.root)])
+
+    while queue:
+        left_index, right_index = queue.popleft()
+        left_node = left.nodes[left_index]
+        right_node = right.nodes[right_index]
+
+        for left_child, right_child in (
+            (left_node.start, right_node.start),
+            (left_node.end, right_node.end),
+        ):
+            mapped = mapping.get(left_child)
+            if mapped is not None:
+                if mapped != right_child:
+                    return False
+                continue
+
+            reverse_mapped = reverse.get(right_child)
+            if reverse_mapped is not None and reverse_mapped != left_child:
+                return False
+
+            mapping[left_child] = right_child
+            reverse[right_child] = left_child
+            queue.append((left_child, right_child))
+
+    return (
+        len(mapping) == len(reachable_indices(left))
+        and len(reverse) == len(reachable_indices(right))
+    )
+
+
+def _shift_nodes(nodes: tuple[LinkNode, ...], offset: int) -> tuple[LinkNode, ...]:
+    return tuple(
+        LinkNode(start=node.start + offset, end=node.end + offset)
+        for node in nodes
+    )

--- a/docs/specs/Reference model МТС v0.1.md
+++ b/docs/specs/Reference model МТС v0.1.md
@@ -52,16 +52,24 @@ Link(start, end)
 
 Важно: `Link(start, end)` является **reference carrier для уже различённой связи**, а не автоматически полной семантикой всех L2-шаблонов и не правилом подстановки по `=`.
 
+Машинная реализация принятой части carrier находится в:
+
+```text
+core/semantic_carrier.py
+```
+
+Она хранит конечный rooted graph из `LinkNode(start,end)` и не содержит evaluator-а `:`/`=`.
+
 ### Акорень
 
-Для carrier полного самозамыкания допустимо:
+Для carrier полного самозамыкания:
 
 ```text
 root.start = root
 root.end = root
 ```
 
-Это конечное представление рекурсивной формы акорня. Из него само по себе не следует разрешение глобально заменять каждый `∞` или каждый `[]` любым равным выражением внутри произвольного L2-контекста.
+Это минимальный конечный self-cycle из одного LinkNode.
 
 ### Начало формы
 
@@ -87,7 +95,40 @@ end(F).end = end(F)
 invert(Link(a, b)) = Link(b, a)
 ```
 
-Инверсия меняет направление уже различённой Link-структуры; отсутствие связи из этого не следует.
+Реализация создаёт новый root с переставленными endpoint references и не мутирует исходный carrier. Она не выполняет рекурсивную инверсию всех достижимых связей.
+
+### Техническое сравнение carrier topology
+
+`core/semantic_carrier.py` предоставляет:
+
+```text
+carrier_isomorphic(A, B)
+```
+
+Это **не оператор МТС `=`**.
+
+Функция проверяет точный изоморфизм конечного rooted carrier с сохранением:
+
+```text
+root;
+start/end edge roles;
+cycle topology;
+sharing topology.
+```
+
+Она намеренно может различать:
+
+```text
+один self-cyclic root
+```
+
+и:
+
+```text
+явный Link двух отдельных копий root-carrier.
+```
+
+Наличие этой инженерной операции не решает вопрос #79 и не даёт права использовать её как semantic equality в prover/interpreter.
 
 ### Равенство: принятая часть и открытая часть
 
@@ -126,7 +167,7 @@ substitution;
 congruence `⟼`.
 ```
 
-Экспериментальный comparator конкретных уже материализованных cyclic Link-carriers допустим как инструмент #70, но его результат нельзя выдавать за полную семантику L2 `=` до принятия #79.
+Экспериментальный comparator concrete carriers допустим как технический инструмент #70, но его результат нельзя выдавать за полную семантику L2 `=` до принятия #79.
 
 ### Пучок
 
@@ -228,6 +269,25 @@ raw carrier
 
 Имена типа `window`, `position`, `int` не являются пятым видом абита.
 
+Канонический L3 pipeline уже реализован:
+
+```text
+parse_raw_quaternary
+→ validate_anum(context)
+→ project_anum(context)
+→ deterministic serialize
+```
+
+Контексты:
+
+```text
+root
+quote
+relative
+```
+
+Также реализованы incremental raw decoder, explicit `AnumDictionary` и quote envelope реальными абитами.
+
 Рабочая проекция issue #61:
 
 ```text
@@ -235,7 +295,7 @@ raw carrier
 ][ → 1
 ```
 
-остаётся **experimental**. Её наличие в prototype-коде не переносит гипотезу в корневую систему.
+остаётся **experimental**. Её наличие в коде не переносит гипотезу в корневую систему.
 
 ## 6. L4 — исполнение
 
@@ -323,9 +383,11 @@ Superseded
 
 ```text
 L0–L5 declarative contract                 core/reference_model.py
+accepted finite L1 carrier subset          core/semantic_carrier.py
 L2 typed AST                               core/mtc_ast.py
 L2 tokenizer/parser/static validation      core/mtc_parser.py
 L2 root-library loading                    core/root_library.py
+L3 contextual/incremental *.anum protocol core/anum_protocol.py + core/anum_parser.py
 ```
 
 Открытый gate:
@@ -337,8 +399,7 @@ L2 root-library loading                    core/root_library.py
 Ещё не реализованы как production layers:
 
 ```text
-полный L1 semantic evaluator (#70, заблокирован #79 в части `:`/`=`);
-полная L3 context model *.anum (#71);
+полный L1 evaluator `:`/`=` (#70, заблокирован #79);
 настоящая L4 апамять (#72);
 L5 proof kernel/search (#73, зависит от #79).
 ```

--- a/tests/test_semantic_carrier.py
+++ b/tests/test_semantic_carrier.py
@@ -1,0 +1,107 @@
+"""Tests for the accepted finite cyclic carrier subset of L1 v0.1."""
+
+import pytest
+
+from core.semantic_carrier import (
+    CarrierGraph,
+    LinkNode,
+    associative_root_carrier,
+    carrier_isomorphic,
+    end_carrier,
+    invert_root_carrier,
+    link_carrier,
+    reachable_indices,
+    start_carrier,
+)
+
+
+def test_associative_root_is_one_finite_self_closed_link():
+    root = associative_root_carrier()
+
+    assert len(root.nodes) == 1
+    assert root.root == 0
+    assert root.root_node == LinkNode(start=0, end=0)
+    assert reachable_indices(root) == (0,)
+
+
+def test_start_carrier_is_finite_self_closed_at_start():
+    form = associative_root_carrier()
+    started = start_carrier(form)
+
+    assert len(started.nodes) == 2
+    assert started.root_node.start == started.root
+    assert started.root_node.end == form.root
+    assert reachable_indices(started) == (1, 0)
+
+
+def test_end_carrier_is_finite_self_closed_at_end():
+    form = associative_root_carrier()
+    ended = end_carrier(form)
+
+    assert len(ended.nodes) == 2
+    assert ended.root_node.start == form.root
+    assert ended.root_node.end == ended.root
+    assert reachable_indices(ended) == (1, 0)
+
+
+def test_link_carrier_preserves_ordered_start_and_end_subcarriers():
+    left = start_carrier(associative_root_carrier())
+    right = end_carrier(associative_root_carrier())
+    linked = link_carrier(left, right)
+
+    assert linked.root_node.start == left.root
+    assert linked.root_node.end == len(left.nodes) + right.root
+
+    swapped = link_carrier(right, left)
+    assert not carrier_isomorphic(linked, swapped)
+
+
+def test_inversion_creates_new_root_with_swapped_endpoints_without_mutation():
+    original = link_carrier(
+        start_carrier(associative_root_carrier()),
+        end_carrier(associative_root_carrier()),
+    )
+    before = original
+    inverted = invert_root_carrier(original)
+
+    assert original == before
+    assert inverted.root != original.root
+    assert inverted.root_node.start == original.root_node.end
+    assert inverted.root_node.end == original.root_node.start
+
+
+def test_exact_rooted_carrier_isomorphism_preserves_cycle_and_sharing_topology():
+    first = start_carrier(associative_root_carrier())
+    second = start_carrier(associative_root_carrier())
+    different = end_carrier(associative_root_carrier())
+
+    assert carrier_isomorphic(first, second)
+    assert not carrier_isomorphic(first, different)
+
+
+def test_root_self_cycle_does_not_collapse_to_explicit_link_of_two_root_copies():
+    root = associative_root_carrier()
+    expanded = link_carrier(root, root)
+
+    assert len(reachable_indices(root)) == 1
+    assert len(reachable_indices(expanded)) == 3
+    assert not carrier_isomorphic(root, expanded)
+
+
+def test_carrier_isomorphic_is_not_presented_as_l2_equality():
+    """The utility must distinguish topologies even where future MTS `=` may not.
+
+    This protects #79 from being accidentally decided by implementation detail.
+    """
+
+    root = associative_root_carrier()
+    expanded = link_carrier(root, root)
+    assert carrier_isomorphic(root, expanded) is False
+
+
+def test_invalid_carrier_references_are_rejected():
+    with pytest.raises(ValueError, match="вне carrier"):
+        CarrierGraph(nodes=(LinkNode(start=0, end=1),), root=0)
+
+    with pytest.raises(ValueError, match="root index"):
+        CarrierGraph(nodes=(LinkNode(start=0, end=0),), root=2)


### PR DESCRIPTION
Refs #70. Не закрывает #70 и не решает #79.

## Scope

Этот PR реализует только ту часть L1 reference model, которая уже принята после challenge #80 и не зависит от полной семантики `:`/`=`:

```text
finite cyclic Link carrier
associative-root self-cycle
start self-closure
end self-closure
concrete Link inversion
exact rooted carrier topology check
```

## Реализация

Добавлен `core/semantic_carrier.py`:

```text
LinkNode(start, end)
CarrierGraph(nodes, root)
associative_root_carrier()
link_carrier(left, right)
start_carrier(form)
end_carrier(form)
invert_root_carrier(form)
reachable_indices(graph)
carrier_isomorphic(left, right)
```

Carrier конечен, но допускает cycles и sharing.

## Критическая граница #79

`carrier_isomorphic()` **не является оператором МТС `=`**.

Это инженерная проверка точного rooted finite topology, сохраняющая:

```text
root
ordered start/end edges
cycle topology
sharing topology
```

Например она намеренно различает:

```text
один self-cyclic root
```

и:

```text
явный Link двух отдельных root carriers
```

Полная equality/substitution/congruence semantics остаётся experimental до #79.

## Почему не bisimulation

PR сознательно не возвращает старую гипотезу «MTS equality = generic cyclic bisimulation». Для чистого unlabeled total Link-coalgebra обычная бисимуляция слишком легко схлопывает различия; именно поэтому #79 отделён от carrier storage.

## Тесты

Проверяются:

- one-node associative self-cycle;
- finite start/end self-closure;
- ordered link endpoints;
- inversion без mutation исходного carrier;
- rooted topology isomorphism;
- различие start/end carriers;
- self-root != explicit link of two root copies по topology utility;
- invalid indices rejected;
- отдельный regression test фиксирует, что `carrier_isomorphic` не выдаётся за L2 `=`.

## Документация

README и Reference model обновлены только в части фактически реализованного carrier subset. #70 остаётся открытым для полного evaluator после #79.