### PR TITLE
Опубликовать cross-language conformance corpus МТС v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 | [Формальная нотация МТС](docs/specs/Формальная%20нотация%20МТС.md) | typed L2 syntax и interpretation |
 | [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md) | L3 `*.anum`, raw parser и serialization |
 | [Протокол абитов ачисел](docs/specs/Протокол%20абитов%20ачисел.md) | contextual L3 projection и quote semantics |
-| [MTS contract v0.2](contracts/mts-contract-v0.2.json) | machine-readable contract для внешних consumers |
+| [MTS contract v0.2](contracts/mts-contract-v0.2.json) | language-neutral normative contract |
+| [MTS conformance v0.2](contracts/mts-conformance-v0.2.json) | cross-language executable compatibility corpus |
 | [Корневая программа](tests/mtc_formulas.mtc) | единственный машинный root definitions source |
 
 `docs/research/` содержит ненормативные исходные заметки и не определяет активную систему.
@@ -149,6 +150,8 @@ core/validate_root.py     structural root validation
 
 contracts/mts-contract-v0.2.json
                          versioned language-neutral contract
+contracts/mts-conformance-v0.2.json
+                         versioned cross-language conformance vectors
 
 core/anum_model.py        typed L3 contexts/results
 core/anum_parser.py       raw parse + incremental decoder + serialization
@@ -165,11 +168,25 @@ converters/ascii_unicode.py
 
 `core/mtc_interpreter.py` — единственный active formal interpreter. Candidate/legacy copies после promotion не сохраняются.
 
+## Cross-language conformance
+
+`contracts/mts-conformance-v0.2.json` содержит одинаковые входы и ожидаемые результаты для любой реализации МТС v0.2:
+
+```text
+lexing cases
+canonicalization cases
+ContextFrame + memory fixtures
+expected local substitutions / aliases
+normalized resolution trace kinds
+```
+
+Python reference runtime обязан проходить этот corpus в CI. Другие consumers, включая `aprover`, должны проходить тот же файл, а не копировать правила вручную.
+
 ## Интеграция с визуальным апрувером
 
-`anum_docs` должен оставаться единственным normative source МТС.
+`anum_docs` остаётся единственным normative source МТС.
 
-Будущий `aprover` потребляет versioned machine contract и conformance vectors отсюда. Display labels не являются runtime identity: визуально одинаковые occurrences могут иметь разные `HoleId`/`LinkRef`.
+`aprover` потребляет versioned contract и conformance corpus отсюда. Display labels не являются runtime identity: визуально одинаковые occurrences могут иметь разные `HoleId`/`LinkRef`.
 
 ## Проверка
 

--- a/contracts/mts-conformance-v0.2.json
+++ b/contracts/mts-conformance-v0.2.json
@@ -1,0 +1,135 @@
+{
+  "schema": "mts-conformance/v0.2",
+  "contract": "mts-contract/v0.2",
+  "status": "accepted",
+  "lexing": [
+    {
+      "id": "atomic-pronouns-do-not-overload-brackets",
+      "source": "◁[]▷",
+      "tokens": ["context-start", "lbracket", "rbracket", "context-end"]
+    },
+    {
+      "id": "context-ascent-is-separate",
+      "source": "↑↑◁",
+      "tokens": ["context-up", "context-up", "context-start"]
+    }
+  ],
+  "canonicalization": [
+    {
+      "id": "context-ascent-whitespace",
+      "source": "↑ ↑  ◁",
+      "canonical": "↑↑◁"
+    },
+    {
+      "id": "canonical-equality-definition",
+      "source": "(=):{♀◁=♀▷,◁♂=▷♂}",
+      "canonical": "(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}"
+    },
+    {
+      "id": "canonical-aroot-definition",
+      "source": "∞:{◁=∞,▷=∞}",
+      "canonical": "∞ : {◁ = ∞, ▷ = ∞}"
+    }
+  ],
+  "interpretation": [
+    {
+      "id": "bind-anonymous-occurrences-to-context-roles",
+      "source": "{[] = ◁, [] = ▷}",
+      "context": {"start": 10, "end": 12},
+      "symbols": {},
+      "memory": {"links": []},
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [0, 0], "link": 10},
+          {"path": [1, 0], "link": 12}
+        ],
+        "aliases": [],
+        "traceKinds": ["bundle", "equality", "context", "bind", "equality", "context", "bind"]
+      }
+    },
+    {
+      "id": "aroot-full-self-cycle",
+      "source": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 1},
+      "symbols": {"∞": 1},
+      "memory": {"links": []},
+      "expected": {
+        "success": true,
+        "substitutions": [],
+        "aliases": [],
+        "traceKinds": ["bundle", "equality", "context", "equality", "context"]
+      }
+    },
+    {
+      "id": "aroot-rejects-non-self-end",
+      "source": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 2},
+      "symbols": {"∞": 1},
+      "memory": {"links": []},
+      "expected": {
+        "success": false,
+        "substitutions": [],
+        "aliases": [],
+        "traceKinds": ["bundle", "equality", "context", "equality", "context"]
+      }
+    },
+    {
+      "id": "decompose-existing-link-into-two-holes",
+      "source": "10 = [] ⟼ []",
+      "context": {"start": 2, "end": 3},
+      "symbols": {"10": 10},
+      "memory": {
+        "links": [
+          {"id": 10, "start": 2, "end": 3}
+        ]
+      },
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [1, 0], "link": 2},
+          {"path": [1, 1], "link": 3}
+        ],
+        "aliases": [],
+        "traceKinds": ["equality", "decompose", "bind", "bind"]
+      }
+    },
+    {
+      "id": "recursive-link-pattern-decomposition",
+      "source": "20 = ([] ⟼ []) ⟼ []",
+      "context": {"start": 2, "end": 3},
+      "symbols": {"20": 20},
+      "memory": {
+        "links": [
+          {"id": 10, "start": 2, "end": 3},
+          {"id": 20, "start": 10, "end": 1}
+        ]
+      },
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [1, 0, 0, 0], "link": 2},
+          {"path": [1, 0, 0, 1], "link": 3},
+          {"path": [1, 1], "link": 1}
+        ],
+        "aliases": [],
+        "traceKinds": ["equality", "decompose", "decompose", "bind", "bind", "bind"]
+      }
+    },
+    {
+      "id": "two-anonymous-occurrences-alias-locally",
+      "source": "[] = []",
+      "context": {"start": 1, "end": 1},
+      "symbols": {},
+      "memory": {"links": []},
+      "expected": {
+        "success": true,
+        "substitutions": [],
+        "aliases": [
+          {"path": [1], "targetPath": [0]}
+        ],
+        "traceKinds": ["equality", "alias"]
+      }
+    }
+  ]
+}

--- a/contracts/mts-contract-v0.2.json
+++ b/contracts/mts-contract-v0.2.json
@@ -1,6 +1,7 @@
 {
   "schema": "mts-contract/v0.2",
   "status": "accepted",
+  "conformanceCorpus": "contracts/mts-conformance-v0.2.json",
   "layers": {
     "formalNotation": "L2",
     "anumSerialization": "L3",

--- a/tests/test_mts_conformance_v02.py
+++ b/tests/test_mts_conformance_v02.py
@@ -1,0 +1,136 @@
+"""Execute the versioned language-neutral MTS v0.2 conformance corpus."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from core.mtc_ast import format_expression
+from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
+from core.mtc_parser import TokenKind, parse_formula, tokenize
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "contracts/mts-conformance-v0.2.json"
+
+TOKEN_NAMES = {
+    TokenKind.CONTEXT_START: "context-start",
+    TokenKind.CONTEXT_END: "context-end",
+    TokenKind.CONTEXT_UP: "context-up",
+    TokenKind.LBRACKET: "lbracket",
+    TokenKind.RBRACKET: "rbracket",
+}
+
+
+@dataclass
+class CorpusMemory(MemoryView):
+    links: dict[int, tuple[int, int]]
+
+    def poles(self, link: int) -> tuple[int, int]:
+        return self.links[link]
+
+    def find_link(self, start: int, end: int) -> int | None:
+        for link, poles in self.links.items():
+            if poles == (start, end):
+                return link
+        return None
+
+    def find_start_projection(self, form: int) -> int | None:
+        for link, poles in self.links.items():
+            if poles == (link, form):
+                return link
+        return None
+
+    def find_end_projection(self, form: int) -> int | None:
+        for link, poles in self.links.items():
+            if poles == (form, link):
+                return link
+        return None
+
+
+def load_corpus() -> dict:
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def _case_ids(section: str) -> list[str]:
+    return [case["id"] for case in load_corpus()[section]]
+
+
+def _case(section: str, case_id: str) -> dict:
+    return next(case for case in load_corpus()[section] if case["id"] == case_id)
+
+
+def _trace_kind(event: str) -> str:
+    return event.split(":", 1)[0]
+
+
+def _memory(case: dict) -> CorpusMemory:
+    return CorpusMemory(
+        {
+            item["id"]: (item["start"], item["end"])
+            for item in case["memory"]["links"]
+        }
+    )
+
+
+def _context(spec: dict) -> ContextFrame:
+    parent_spec = spec.get("parent")
+    parent = _context(parent_spec) if parent_spec is not None else None
+    return ContextFrame(start=spec["start"], end=spec["end"], parent=parent)
+
+
+def _substitutions(result) -> list[dict]:
+    return [
+        {"path": list(hole.path), "link": link}
+        for hole, link in result.holes
+    ]
+
+
+def _aliases(result) -> list[dict]:
+    return [
+        {"path": list(hole.path), "targetPath": list(target.path)}
+        for hole, target in result.aliases
+    ]
+
+
+def test_corpus_identifies_exact_contract_version():
+    corpus = load_corpus()
+    assert corpus["schema"] == "mts-conformance/v0.2"
+    assert corpus["contract"] == "mts-contract/v0.2"
+    assert corpus["status"] == "accepted"
+
+
+@pytest.mark.parametrize("case_id", _case_ids("lexing"))
+def test_lexing_conformance(case_id: str):
+    case = _case("lexing", case_id)
+    tokens = tokenize(case["source"])
+    actual = [TOKEN_NAMES[token.kind] for token in tokens[:-1]]
+    assert actual == case["tokens"]
+
+
+@pytest.mark.parametrize("case_id", _case_ids("canonicalization"))
+def test_canonicalization_conformance(case_id: str):
+    case = _case("canonicalization", case_id)
+    assert format_expression(parse_formula(case["source"])) == case["canonical"]
+
+
+@pytest.mark.parametrize("case_id", _case_ids("interpretation"))
+def test_interpretation_conformance(case_id: str):
+    case = _case("interpretation", case_id)
+    memory = _memory(case)
+    before = dict(memory.links)
+
+    result = interpret_constraints(
+        parse_formula(case["source"]),
+        _context(case["context"]),
+        memory,
+        symbols={name: value for name, value in case["symbols"].items()},
+    )
+
+    expected = case["expected"]
+    assert result.success is expected["success"]
+    assert _substitutions(result) == expected["substitutions"]
+    assert _aliases(result) == expected["aliases"]
+    assert [_trace_kind(event) for event in result.trace] == expected["traceKinds"]
+    assert memory.links == before, "interpret must not mutate the conformance memory fixture"

--- a/tests/test_mts_contract_v02.py
+++ b/tests/test_mts_contract_v02.py
@@ -9,6 +9,7 @@ from core.mtc_parser import parse_formula
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "contracts/mts-contract-v0.2.json"
+CONFORMANCE = ROOT / "contracts/mts-conformance-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests/mtc_formulas.mtc"
 
 
@@ -24,12 +25,18 @@ def root_sources() -> list[str]:
     ]
 
 
-def test_contract_is_accepted_v02_and_points_to_canonical_root():
+def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     contract = load_contract()
 
     assert contract["schema"] == "mts-contract/v0.2"
     assert contract["status"] == "accepted"
     assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
+    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
+    assert CONFORMANCE.is_file()
+
+    corpus = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
+    assert corpus["contract"] == contract["schema"]
+    assert corpus["status"] == "accepted"
 
 
 def test_contract_exposes_exactly_two_atomic_non_bracket_context_pronouns():

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -12,6 +12,7 @@ from core.validate_root import validate_root_library
 ROOT = Path(__file__).resolve().parents[1]
 ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
 MTS_CONTRACT = ROOT / "contracts/mts-contract-v0.2.json"
+MTS_CONFORMANCE = ROOT / "contracts/mts-conformance-v0.2.json"
 ACTIVE_THEORY = {"Основания МТС.md", "Система аксиом МТС.md"}
 ACTIVE_SPECS = {
     "Reference model МТС v0.2.md",
@@ -89,17 +90,28 @@ def test_root_fixture_is_exact_and_excludes_protocol_hypotheses():
     assert len([line for line in formula_text.splitlines() if line]) == 10
 
 
-def test_v02_machine_contract_is_single_active_formal_contract():
+def test_v02_machine_contract_and_conformance_are_single_active_pair():
     assert MTS_CONTRACT.is_file()
+    assert MTS_CONFORMANCE.is_file()
+
     contract = json.loads(MTS_CONTRACT.read_text(encoding="utf-8"))
+    corpus = json.loads(MTS_CONFORMANCE.read_text(encoding="utf-8"))
+
     assert contract["schema"] == "mts-contract/v0.2"
     assert contract["status"] == "accepted"
     assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
+    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
     assert contract["formalNotation"]["context"]["atomicPronouns"] is True
     assert contract["formalNotation"]["context"]["bracketOverloading"] is False
 
+    assert corpus["schema"] == "mts-conformance/v0.2"
+    assert corpus["contract"] == contract["schema"]
+    assert corpus["status"] == "accepted"
+
     contract_files = sorted((ROOT / "contracts").glob("mts-contract-*.json"))
+    conformance_files = sorted((ROOT / "contracts").glob("mts-conformance-*.json"))
     assert contract_files == [MTS_CONTRACT]
+    assert conformance_files == [MTS_CONFORMANCE]
 
 
 def test_candidate_runtime_fixture_and_reference_paths_are_removed_after_promotion():


### PR DESCRIPTION
Refs #73, #74, #75. Подготавливает прямую интеграцию `aprover` с канонической semantics `anum_docs`.

## Проблема

`mts-contract-v0.2.json` фиксирует правила, но один декларативный contract не гарантирует, что Python, TypeScript и будущие runtimes одинаково их исполняют.

Нужен единый executable compatibility corpus:

```text
одни входы
→ разные реализации
→ одинаковые наблюдаемые результаты
```

## Новый артефакт

```text
contracts/mts-conformance-v0.2.json
```

Schema:

```text
mts-conformance/v0.2
```

Corpus содержит три класса cases.

### Lexing

Проверяет, в частности, пользовательский invariant:

```text
◁[]▷
→ context-start, [, ], context-end
```

и отдельность `↑` от pronoun identity.

### Canonicalization

Проверяет canonical printer для context ascent, equality и aroot definitions.

### Interpretation

Каждый case задаёт:

```text
source
ContextFrame
symbol bindings
read-only memory fixture
expected success
expected HoleId-path substitutions
expected aliases
normalized resolution trace kinds
```

Включены:

- binding двух anonymous occurrences к `◁/▷`;
- aroot self-cycle success/failure;
- decomposition `10 = [] ⟼ []`;
- recursive decomposition `20 = ([] ⟼ []) ⟼ []`;
- local alias `[] = []`.

## Reference runtime

`tests/test_mts_conformance_v02.py` исполняет этот JSON через canonical:

```text
mtc_parser
mtc_interpreter
```

и дополнительно проверяет, что interpret не меняет memory fixture.

Таким образом corpus нельзя обновить «на глаз»: изменение observable semantics обязано пройти Python reference implementation.

## Contract linkage

`mts-contract-v0.2.json` теперь явно содержит:

```json
"conformanceCorpus": "contracts/mts-conformance-v0.2.json"
```

Repository contract требует ровно одну активную пару contract+conformance для v0.2.

## Для aprover

Следующий шаг в `netkeep80/aprover#107`: pin-ить этот versioned pair и заставить TypeScript consumer проходить те же vectors. Это устраняет ручное дублирование semantics между репозиториями.