### PR TITLE
Добавить replay-only trusted proof kernel МТС v0.2

### DIFF
--- a/contracts/mts-proof-v0.2.json
+++ b/contracts/mts-proof-v0.2.json
@@ -1,0 +1,48 @@
+{
+  "schema": "mts-proof/v0.2",
+  "status": "candidate",
+  "dependsOn": "mts-contract/v0.2",
+  "purpose": "trusted replay of accepted contextual interpretation; no additional inference rules",
+  "proofObject": {
+    "contractVersion": "mts-contract/v0.2",
+    "steps": "ordered InterpretStep[]"
+  },
+  "interpretStep": {
+    "rule": "interpret",
+    "expression": "canonical MTS v0.2 source",
+    "context": {
+      "start": "LinkRef",
+      "end": "LinkRef",
+      "parent": "optional recursive ContextFrame"
+    },
+    "symbols": "name -> LinkRef",
+    "distinguishedMemory": "array of {id,start,end}",
+    "expected": {
+      "success": "boolean",
+      "substitutions": "array of {path:int[],link:LinkRef}",
+      "aliases": "array of {path:int[],targetPath:int[]}"
+    }
+  },
+  "checker": {
+    "trustedRuleSet": ["interpret"],
+    "replaysCanonicalInterpreter": true,
+    "usesDisplayLabelsAsIdentity": false,
+    "mayMaterialize": false,
+    "checks": [
+      "contractVersion",
+      "rule",
+      "success",
+      "substitutions",
+      "aliases"
+    ]
+  },
+  "explicitlyNotTrusted": [
+    "lowercase-metavariables",
+    "global-textual-substitution",
+    "global-equality-rewrite",
+    "symmetry",
+    "transitivity",
+    "congruence",
+    "modus-ponens"
+  ]
+}

--- a/core/proof_checker.py
+++ b/core/proof_checker.py
@@ -1,0 +1,148 @@
+"""Minimal trusted proof replay kernel for MTS v0.2.
+
+The kernel deliberately trusts only one rule: replay of the already accepted
+read-only contextual ``interpret`` semantics.  It does not implement proof
+search and does not promote legacy equality/congruence/Modus-Ponens rules to
+trusted MTS semantics.
+"""
+
+from dataclasses import dataclass
+
+from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
+from core.mtc_parser import parse_formula
+
+CONTRACT_VERSION = "mts-contract/v0.2"
+PROOF_SCHEMA = "mts-proof/v0.2"
+
+
+@dataclass(frozen=True)
+class ProofContext:
+    start: int
+    end: int
+    parent: "ProofContext | None" = None
+
+    def to_runtime(self) -> ContextFrame:
+        return ContextFrame(
+            start=self.start,
+            end=self.end,
+            parent=self.parent.to_runtime() if self.parent is not None else None,
+        )
+
+
+@dataclass(frozen=True)
+class DistinguishedLink:
+    id: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True, order=True)
+class ExpectedSubstitution:
+    path: tuple[int, ...]
+    link: int
+
+
+@dataclass(frozen=True, order=True)
+class ExpectedAlias:
+    path: tuple[int, ...]
+    target_path: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class InterpretProofStep:
+    expression: str
+    context: ProofContext
+    distinguished_memory: tuple[DistinguishedLink, ...] = ()
+    symbols: tuple[tuple[str, int], ...] = ()
+    expected_success: bool = True
+    expected_substitutions: tuple[ExpectedSubstitution, ...] = ()
+    expected_aliases: tuple[ExpectedAlias, ...] = ()
+    rule: str = "interpret"
+
+
+@dataclass(frozen=True)
+class ProofObject:
+    steps: tuple[InterpretProofStep, ...]
+    contract_version: str = CONTRACT_VERSION
+    schema: str = PROOF_SCHEMA
+
+
+class ProofMemory(MemoryView):
+    """Immutable memory snapshot reconstructed from a proof object."""
+
+    def __init__(self, links: tuple[DistinguishedLink, ...]):
+        by_id: dict[int, tuple[int, int]] = {}
+        by_poles: dict[tuple[int, int], int] = {}
+        for item in links:
+            poles = (item.start, item.end)
+            if item.id in by_id:
+                raise ValueError(f"Duplicate LinkRef in proof memory: {item.id}")
+            previous = by_poles.get(poles)
+            if previous is not None and previous != item.id:
+                raise ValueError(
+                    "Ambiguous distinguished Link identity for poles "
+                    f"{poles}: {previous} and {item.id}"
+                )
+            by_id[item.id] = poles
+            by_poles[poles] = item.id
+        self._by_id = by_id
+        self._by_poles = by_poles
+
+    def poles(self, link: int) -> tuple[int, int]:
+        return self._by_id[link]
+
+    def find_link(self, start: int, end: int) -> int | None:
+        return self._by_poles.get((start, end))
+
+    def find_start_projection(self, form: int) -> int | None:
+        for link, poles in self._by_id.items():
+            if poles == (link, form):
+                return link
+        return None
+
+    def find_end_projection(self, form: int) -> int | None:
+        for link, poles in self._by_id.items():
+            if poles == (form, link):
+                return link
+        return None
+
+
+def check_interpret_step(step: InterpretProofStep) -> bool:
+    """Replay one claimed interpretation step against an immutable snapshot."""
+
+    if step.rule != "interpret":
+        return False
+
+    try:
+        expression = parse_formula(step.expression)
+        memory = ProofMemory(step.distinguished_memory)
+        result = interpret_constraints(
+            expression,
+            step.context.to_runtime(),
+            memory,
+            symbols=dict(step.symbols),
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+
+    substitutions = tuple(
+        ExpectedSubstitution(path=hole.path, link=link) for hole, link in result.holes
+    )
+    aliases = tuple(
+        ExpectedAlias(path=hole.path, target_path=target.path)
+        for hole, target in result.aliases
+    )
+
+    return (
+        result.success == step.expected_success
+        and substitutions == tuple(sorted(step.expected_substitutions))
+        and aliases == tuple(sorted(step.expected_aliases))
+    )
+
+
+def check_proof(proof: ProofObject) -> bool:
+    """Independently replay every trusted step in a proof object."""
+
+    if proof.schema != PROOF_SCHEMA or proof.contract_version != CONTRACT_VERSION:
+        return False
+    return all(check_interpret_step(step) for step in proof.steps)

--- a/tests/test_proof_checker.py
+++ b/tests/test_proof_checker.py
@@ -1,0 +1,109 @@
+"""Negative-heavy tests for the replay-only trusted MTS v0.2 proof kernel."""
+
+import json
+from pathlib import Path
+
+from core.proof_checker import (
+    DistinguishedLink,
+    ExpectedSubstitution,
+    InterpretProofStep,
+    ProofContext,
+    ProofObject,
+    check_proof,
+)
+
+CONTRACT = Path(__file__).parents[1] / "contracts" / "mts-proof-v0.2.json"
+
+
+def test_proof_contract_is_candidate_and_trusts_only_interpret_replay():
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    assert contract["schema"] == "mts-proof/v0.2"
+    assert contract["status"] == "candidate"
+    assert contract["checker"]["trustedRuleSet"] == ["interpret"]
+    assert contract["checker"]["mayMaterialize"] is False
+    assert "transitivity" in contract["explicitlyNotTrusted"]
+    assert "modus-ponens" in contract["explicitlyNotTrusted"]
+
+
+def test_checker_replays_occurrence_local_substitution():
+    proof = ProofObject(
+        steps=(
+            InterpretProofStep(
+                expression="[] = ◁",
+                context=ProofContext(start=10, end=12),
+                expected_substitutions=(ExpectedSubstitution((0,), 10),),
+            ),
+        )
+    )
+
+    assert check_proof(proof)
+
+
+def test_checker_rejects_forged_substitution():
+    proof = ProofObject(
+        steps=(
+            InterpretProofStep(
+                expression="[] = ◁",
+                context=ProofContext(start=10, end=12),
+                expected_substitutions=(ExpectedSubstitution((0,), 12),),
+            ),
+        )
+    )
+
+    assert not check_proof(proof)
+
+
+def test_checker_replays_structural_link_decomposition():
+    proof = ProofObject(
+        steps=(
+            InterpretProofStep(
+                expression="30 = [] ⟼ []",
+                context=ProofContext(start=10, end=10),
+                symbols=(("30", 30),),
+                distinguished_memory=(DistinguishedLink(30, 2, 3),),
+                expected_substitutions=(
+                    ExpectedSubstitution((1, 0), 2),
+                    ExpectedSubstitution((1, 1), 3),
+                ),
+            ),
+        )
+    )
+
+    assert check_proof(proof)
+
+
+def test_checker_rejects_unknown_rule_instead_of_extending_trust():
+    proof = ProofObject(
+        steps=(
+            InterpretProofStep(
+                expression="[] = ◁",
+                context=ProofContext(start=10, end=12),
+                expected_substitutions=(ExpectedSubstitution((0,), 10),),
+                rule="transitivity",
+            ),
+        )
+    )
+
+    assert not check_proof(proof)
+
+
+def test_checker_rejects_wrong_contract_provenance():
+    proof = ProofObject(steps=(), contract_version="mts-contract/v0.1")
+
+    assert not check_proof(proof)
+
+
+def test_checker_does_not_realize_missing_distinguished_link():
+    proof = ProofObject(
+        steps=(
+            InterpretProofStep(
+                expression="30 = 2 ⟼ 3",
+                context=ProofContext(start=10, end=10),
+                symbols=(("30", 30), ("2", 2), ("3", 3)),
+                distinguished_memory=(),
+            ),
+        )
+    )
+
+    assert not check_proof(proof)


### PR DESCRIPTION
Refs #73.

Первый безопасный L5 vertical slice поверх уже принятой contextual interpretation semantics.

Что добавлено:
- candidate versioned contract `contracts/mts-proof-v0.2.json`;
- минимальный `core/proof_checker.py`, который доверяет только правилу `interpret` и независимо replay-ит canonical interpreter;
- proof object фиксирует `mts-contract/v0.2` provenance, context, symbols, immutable distinguished memory и ожидаемые substitutions/aliases/success;
- checker не имеет proof search и не материализует связи;
- lowercase metavariables, global rewrite, symmetry/transitivity/congruence и Modus Ponens явно не входят в trusted rule set;
- negative tests отвергают forged substitutions, неизвестное rule, неверную provenance и попытку опереться на отсутствующую distinguished link.

PR намеренно имеет status `candidate`: он не принимает новые inference rules и не меняет теоретическое изложение МТС. Его задача — создать trusted replay/check boundary, на который сможет мигрировать `aprover` без второго semantic fork.