### PR TITLE
L3: align Anum root boundary projection with accepted MTS v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md) | L3 `*.anum`, raw parser и serialization |
 | [Протокол абитов ачисел](docs/specs/Протокол%20абитов%20ачисел.md) | contextual L3 projection и quote semantics |
 | [MTS contract v0.2](contracts/mts-contract-v0.2.json) | language-neutral normative contract |
+| [Anum boundary projection v0.2](contracts/anum-boundary-projection-v0.2.json) | принятый root-context boundary subset L3 |
 | [MTS conformance v0.2](contracts/mts-conformance-v0.2.json) | cross-language executable compatibility corpus |
 | [Корневая программа](tests/mtc_formulas.mtc) | единственный машинный root definitions source |
 
@@ -135,7 +136,16 @@ interpret ≠ realize
 
 В L2 квадратные скобки являются формальной нотацией. Их видимое совпадение с L3-абитами не создаёт автоматического тождества.
 
-Рабочая проекция issue #61 остаётся experimental.
+Принятый root-context boundary subset L3 выводится из root definitions МТС v0.2:
+
+```text
+[  → ♀∞
+]  → ∞♂
+[] → 1
+][ → 0
+```
+
+`[[` и `]]` остаются boundary forms без protocol value. Общая structural denotation произвольного raw carrier и relative denotation остаются открытыми в #89.
 
 ## Рабочие инструменты
 
@@ -150,6 +160,8 @@ core/validate_root.py     structural root validation
 
 contracts/mts-contract-v0.2.json
                          versioned language-neutral contract
+contracts/anum-boundary-projection-v0.2.json
+                         accepted root-context Anum boundary vectors
 contracts/mts-conformance-v0.2.json
                          versioned cross-language conformance vectors
 

--- a/contracts/anum-boundary-projection-v0.2.json
+++ b/contracts/anum-boundary-projection-v0.2.json
@@ -1,0 +1,50 @@
+{
+  "schema": "anum-boundary-projection/v0.2",
+  "status": "accepted-subset",
+  "dependsOn": "mts-contract/v0.2",
+  "context": "root",
+  "orientation": {
+    "open": "♀∞",
+    "close": "∞♂"
+  },
+  "projection": [
+    {
+      "raw": "[[",
+      "form": "♀∞ ⟼ ♀∞",
+      "kind": "boundary-form",
+      "protocolValue": null
+    },
+    {
+      "raw": "[]",
+      "form": "♀∞ ⟼ ∞♂",
+      "kind": "protocol-value",
+      "protocolValue": "1"
+    },
+    {
+      "raw": "][",
+      "form": "∞♂ ⟼ ♀∞",
+      "kind": "protocol-value",
+      "protocolValue": "0"
+    },
+    {
+      "raw": "]]",
+      "form": "∞♂ ⟼ ∞♂",
+      "kind": "boundary-form",
+      "protocolValue": null
+    }
+  ],
+  "scope": {
+    "absoluteRule": false,
+    "quoteContextApplies": false,
+    "relativeContextApplies": false,
+    "generalRawDenotationDefined": false
+  },
+  "derivation": [
+    "([) : (♀∞)",
+    "(]) : (∞♂)",
+    "(⟼) : (♀∞ ⟼ ∞♂)",
+    "(↛) : (∞♂ ⟼ ♀∞)",
+    "[1] : (⟼)",
+    "[0] : (↛)"
+  ]
+}

--- a/contracts/mts-contract-v0.2.json
+++ b/contracts/mts-contract-v0.2.json
@@ -59,7 +59,9 @@
   },
   "anum": {
     "operations": ["serialize", "deserialize"],
-    "alphabet": ["[", "]", "1", "0"]
+    "alphabet": ["[", "]", "1", "0"],
+    "rootBoundaryProjection": "contracts/anum-boundary-projection-v0.2.json",
+    "generalDenotationIssue": 89
   },
   "memory": {
     "readOperations": [

--- a/core/anum_model.py
+++ b/core/anum_model.py
@@ -1,4 +1,4 @@
-"""Typed data model for the L3 Anum protocol v0.1."""
+"""Typed data model for the contextual L3 Anum protocol v0.2."""
 
 from dataclasses import dataclass
 from enum import Enum

--- a/core/anum_protocol.py
+++ b/core/anum_protocol.py
@@ -1,9 +1,16 @@
-"""Contextual L3 Anum protocol v0.1.
+"""Contextual L3 Anum protocol v0.2 boundary subset.
 
-The protocol keeps raw syntax, validation and projection separate. The current
-``[] -> 0`` / ``][ -> 1`` root projection remains the experimental issue #61
-projection; this module makes the context and unresolved boundary forms explicit
-rather than silently normalizing them.
+Raw syntax, validation and projection remain separate.  The root projection for
+the four two-boundary carriers is derived from the accepted MTS v0.2 root
+program instead of the superseded issue #61 orientation:
+
+``[`` -> ``♀∞``
+``]`` -> ``∞♂``
+``[]`` -> ``♀∞ ⟼ ∞♂`` -> protocol value ``1``
+``][`` -> ``∞♂ ⟼ ♀∞`` -> protocol value ``0``
+
+This is a root-context projection only.  Quote and relative contexts keep their
+own behavior, and general raw denotation is deliberately not invented here.
 """
 
 from core.anum_model import (
@@ -18,29 +25,29 @@ from core.anum_model import (
 from core.anum_parser import FORMAT_STRING, normalize_raw_form, parse_raw_quaternary
 
 
-ALPHA = "α"
-BETA = "β"
+OPEN_FORM = "♀∞"
+CLOSE_FORM = "∞♂"
 
 _BOUNDARY_PROJECTIONS = {
     (Abit.OPEN, Abit.OPEN): (
-        f"{ALPHA} ⟼ {ALPHA}",
+        f"{OPEN_FORM} ⟼ {OPEN_FORM}",
         None,
-        "open-open boundary form; no root protocol value is assigned in v0.1",
+        "open-open boundary form; no root protocol value is assigned in v0.2",
     ),
     (Abit.OPEN, Abit.CLOSE): (
-        f"{ALPHA} ⟼ {BETA}",
-        "0",
-        "experimental root container / non-materializing projection",
+        f"{OPEN_FORM} ⟼ {CLOSE_FORM}",
+        "1",
+        "root-context link projection derived from accepted MTS v0.2",
     ),
     (Abit.CLOSE, Abit.OPEN): (
-        f"{BETA} ⟼ {ALPHA}",
-        "1",
-        "experimental root bridge / materializing-transition projection",
+        f"{CLOSE_FORM} ⟼ {OPEN_FORM}",
+        "0",
+        "root-context unlink projection derived from accepted MTS v0.2",
     ),
     (Abit.CLOSE, Abit.CLOSE): (
-        f"{BETA} ⟼ {BETA}",
+        f"{CLOSE_FORM} ⟼ {CLOSE_FORM}",
         None,
-        "close-close boundary form; no root protocol value is assigned in v0.1",
+        "close-close boundary form; no root protocol value is assigned in v0.2",
     ),
 }
 
@@ -83,10 +90,10 @@ def validate_anum(
 ) -> AnumValidation:
     """Validate a parsed raw carrier for one explicit context.
 
-    V0.1 intentionally adds no hidden root-start or bracket-balance restrictions:
+    V0.2 intentionally adds no hidden root-start or bracket-balance restrictions:
     every sequence already accepted by the raw quaternary parser is a valid raw
-    carrier. Context-specific semantic restrictions can be added only after they
-    are accepted by the protocol specification.
+    carrier. Context-specific semantic restrictions require an accepted protocol
+    rule rather than a parser heuristic.
     """
 
     if not isinstance(context, ProjectionContext):
@@ -134,7 +141,7 @@ def project_anum(
             source=normalize_raw_form(form),
             kind=ProjectionKind.RAW,
             projected=form,
-            note="relative semantics are intentionally preserved as raw in v0.1",
+            note="relative semantics are intentionally preserved as raw in v0.2",
         )
 
     return _project_root(form)
@@ -200,5 +207,5 @@ def _project_root(form: AnumForm) -> AnumProjection:
         source=source,
         kind=ProjectionKind.RAW,
         projected=form,
-        note="no general root denotation is assigned to this raw carrier in v0.1",
+        note="no general root denotation is assigned beyond the v0.2 boundary subset",
     )

--- a/core/reference_model.py
+++ b/core/reference_model.py
@@ -194,10 +194,10 @@ CONCEPTS = (
         "Базовый четверичный алфавит использует [ ] 1 0.",
     ),
     ConceptSpec(
-        "issue-61-projection",
+        "anum-root-boundary-projection",
         Layer.SERIALIZATION,
-        StatementStatus.EXPERIMENTAL,
-        "Проекция []→0 и ][→1 остаётся рабочей L3-гипотезой issue #61.",
+        StatementStatus.DEFINITION,
+        "В root context принятый v0.2 boundary subset задаёт [→♀∞, ]→∞♂, []→1 и ][→0; общая raw denotation остаётся открытой в #89.",
     ),
     ConceptSpec(
         "formal-interpretation",
@@ -478,8 +478,11 @@ def validate_reference_model() -> tuple[str, ...]:
     if not operator("{...}").variadic:
         errors.append("bundle container must accept a variadic expression list")
 
-    if concept("issue-61-projection").status is not StatementStatus.EXPERIMENTAL:
-        errors.append("issue #61 protocol projection must remain experimental")
+    boundary = concept("anum-root-boundary-projection")
+    if boundary.status is not StatementStatus.DEFINITION:
+        errors.append("MTS v0.2 root Anum boundary projection must be accepted")
+    if "[]→1" not in boundary.description or "][→0" not in boundary.description:
+        errors.append("root Anum boundary projection must follow accepted link/unlink orientation")
     if concept("equality-meaning").status is not StatementStatus.DEFINITION:
         errors.append("contextual equality must be accepted in v0.2")
     if any(item.issue == 79 for item in OPEN_QUESTIONS):

--- a/docs/specs/Reference model МТС v0.2.md
+++ b/docs/specs/Reference model МТС v0.2.md
@@ -6,6 +6,8 @@
 
 Language-neutral контракт для внешних реализаций: [`contracts/mts-contract-v0.2.json`](../../contracts/mts-contract-v0.2.json).
 
+Принятый L3 boundary subset: [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json).
+
 Этот документ фиксирует инженерную reference model, относительно которой работают parser, interpreter, протокол ачисел, будущая апамять и апрувер. Он не подменяет [Основания МТС](../theory/Основания%20МТС.md) и не объявляет Python-представление окончательной «природой связи».
 
 ## 1. Архитектурные уровни
@@ -238,7 +240,7 @@ Round grouping сохраняется в AST и canonical printer, но проз
 
 Каноническая root-программа: [`tests/mtc_formulas.mtc`](../../tests/mtc_formulas.mtc).
 
-Она содержит только 10 именованных определений. Parser/conformance-примеры последовательностей и пучков не являются корневыми аксиомами.
+Она содержит только 10 именованных definitions. Parser/conformance-примеры последовательностей и пучков не являются корневыми аксиомами.
 
 Ключевые определения:
 
@@ -266,14 +268,29 @@ parse_raw_quaternary
 → deterministic serialize
 ```
 
-Рабочая проекция issue #61:
+Принятые root definitions v0.2 фиксируют boundary orientation:
 
 ```text
-[] → 0
-][ → 1
+([) : (♀∞)
+(]) : (∞♂)
+(⟼) : (♀∞ ⟼ ∞♂)
+(↛) : (∞♂ ⟼ ♀∞)
+[1] : (⟼)
+[0] : (↛)
 ```
 
-остаётся **experimental**. Принятие L2 v0.2 не повышает её статус.
+Поэтому в **root context** принят boundary subset:
+
+```text
+[  → ♀∞
+]  → ∞♂
+[] → 1
+][ → 0
+```
+
+`[[` и `]]` остаются `boundary-form` без protocol value. Это contextual root projection, а не абсолютное переписывание raw carrier: quote и relative contexts его не применяют.
+
+Общая structural denotation произвольного raw carrier, recursive decode и inverse denotation serialization остаются открытым dependency gate #89.
 
 ## 6. L4 — исполнение
 
@@ -308,7 +325,7 @@ ContextFrame(
 
 ```text
 load
- decode
+decode
 project
 find
 realize
@@ -328,7 +345,7 @@ realize(...) — единственная явная materializing operation
 
 ## 7. L5 — теория вывода
 
-L5 ещё не содержит принятого полного trusted proof kernel.
+L5 имеет replay-only candidate trusted proof kernel, который доверяет только повторному исполнению принятой read-only `interpret` semantics. Полный набор правил вывода и proof search остаются отдельной задачей.
 
 Будущий апрувер обязан разделять:
 
@@ -361,14 +378,16 @@ context ascent ↑;
 occurrence-local anonymous [];
 локальная interpretation semantics;
 structural LinkForm matching;
-contextual equality.
+contextual equality;
+root Anum boundary orientation [] → 1, ][ → 0.
 ```
 
-Явно experimental остаются как минимум:
+Явно не завершены как минимум:
 
 ```text
-issue #61 L3 projection;
-trusted L5 proof rules.
+general L3 raw denotation и inverse denotation serialization (#89);
+relative L3 denotation;
+полный trusted L5 inference kernel.
 ```
 
 ## 9. Жизненный цикл фундаментального решения
@@ -391,7 +410,7 @@ Deferred
 Superseded
 ```
 
-Формальная нотация v0.2 прошла Candidate → Challenged → Modeled в PR #84; нормативный contract фиксируется отдельной promotion-миграцией.
+Формальная нотация v0.2 прошла Candidate → Challenged → Modeled в PR #84 и затем была принята в единственный active contract.
 
 ## 10. Единственные активные реализации
 
@@ -403,6 +422,7 @@ L2 tokenizer/parser                    core/mtc_parser.py
 L2 interpreter                         core/mtc_interpreter.py
 L2 root library                        core/root_library.py
 L3 Anum protocol                       core/anum_protocol.py
+L3 boundary contract                   contracts/anum-boundary-projection-v0.2.json
 versioned external contract            contracts/mts-contract-v0.2.json
 ```
 

--- a/docs/specs/Ачисла и сериализация.md
+++ b/docs/specs/Ачисла и сериализация.md
@@ -1,10 +1,12 @@
 # Ачисла и сериализация
 
-Статус: актуальное, нормативное для контейнера и raw-слоя `*.anum`; root-проекция issue #61 остаётся experimental.
+Статус: актуальное, нормативное для контейнера и raw-слоя `*.anum`; root boundary subset согласован с принятой МТС v0.2. Общая structural denotation остаётся задачей #89.
 
 Уровень: **L3 — сериализация**.
 
 Граница L2/L3/L4 задаётся [Reference model МТС v0.2](Reference%20model%20МТС%20v0.2.md).
+
+Boundary contract: [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json).
 
 ## 1. Ачисло и raw carrier
 
@@ -137,7 +139,7 @@ batch parse == incremental parse
 
 включая абсолютные offsets токенов.
 
-## 6. Deterministic serialization
+## 6. Deterministic raw serialization
 
 `serialize_quaternary_anum` выдаёт канонический compact body:
 
@@ -154,13 +156,15 @@ batch parse == incremental parse
 
 Комментарии и пробелы не входят в каноническое представление.
 
-Для поддерживаемого quaternary-слоя:
+Для raw-слоя:
 
 ```text
 parse(serialize(parse(A)))
 ```
 
 сохраняет последовательность абитов.
+
+Это transport round-trip. Он не является ещё inverse serialization structural denotation из #89.
 
 ## 7. Цитирование
 
@@ -187,13 +191,13 @@ project(quote(A), quote)  = A
 
 Если quote-context получает raw payload без внешней оболочки, payload сохраняется без root-проекции.
 
-Поскольку контекст указан явно, одинаковая последовательность абитов может иметь разные projection semantics без скрытой неоднозначности parser-а.
+Поскольку context указан явно, одинаковая последовательность абитов может иметь разные projection semantics без скрытой неоднозначности parser-а.
 
-## 8. Граница L2/L3
+## 8. Граница L2/L3 и root boundary projection
 
 Совпадение glyph `[` и `]` с квадратной формой L2 не означает автоматического тождества.
 
-L2 v0.2 дополнительно гарантирует, что context pronouns **вообще не используют квадратные скобки**:
+L2 v0.2 гарантирует, что context pronouns не используют квадратные скобки:
 
 ```text
 ◁  start context role
@@ -201,29 +205,31 @@ L2 v0.2 дополнительно гарантирует, что context pronou
 ↑  context ascent
 ```
 
-Это позволяет L3 scanner-у анализировать `[ ]` независимо от L2 context syntax.
-
 Корневая L2-система содержит:
 
 ```text
 ([) : (♀∞)
 (]) : (∞♂)
+(⟼) : (♀∞ ⟼ ∞♂)
+(↛) : (∞♂ ⟼ ♀∞)
 [1] : (⟼)
 [0] : (↛)
 ```
 
-L3 содержит физические абиты `[ ] 1 0`. Переход между уровнями задаётся только protocol rules.
-
-Рабочая root-проекция issue #61:
+Поэтому принятый L3 v0.2 boundary subset в **root context**:
 
 ```text
-[] -> 0
-][ -> 1
+[  -> ♀∞
+]  -> ∞♂
+[] -> 1
+][ -> 0
 ```
 
-остаётся `experimental` и не переносится в `tests/mtc_formulas.mtc`.
+`[] -> 1` и `][ -> 0` не являются абсолютным rewriting rule. Quote context работает с оболочкой как с raw-данными, а relative context пока не имеет принятой denotation.
 
-`[[` и `]]` не являются raw parse errors и не получают protocol value автоматически.
+Старая experimental ориентация issue #61 `[] -> 0`, `][ -> 1` относилась к прежней полюсной записи и больше не является активной L3-семантикой.
+
+`[[` и `]]` остаются валидными raw carriers и root `boundary-form` без `protocol_value`.
 
 ## 9. Граница L3/L4
 
@@ -243,7 +249,7 @@ realize(A) может явно материализовать den(A)
 interpret(F) не выполняет realize(F)
 ```
 
-`core/anum_memory.py` пока остаётся test-double L4-инвариантов до issue #72.
+`core/anum_memory.py` остаётся test-double L4-инвариантов.
 
 ## 10. Актуальные модули
 
@@ -251,11 +257,12 @@ interpret(F) не выполняет realize(F)
 core/anum_model.py       Abit, ProjectionContext, typed protocol results
 core/anum_parser.py      raw parser, incremental decoder, deterministic serializer
 core/anum_protocol.py    validate/project/quote/unquote/AnumDictionary
-core/anum_memory.py      временный L4 test-double
+core/anum_memory.py      L4 test-double
+contracts/anum-boundary-projection-v0.2.json
 converters/anum_cli.py   parse/validate/project/normalize/quote/unquote
 ```
 
-Старый `core/anum_projector.py` удалён после перевода consumers на `core/anum_protocol.py`.
+Один canonical projection path находится в `core/anum_protocol.py`.
 
 ## 11. CLI
 

--- a/docs/specs/Протокол абитов ачисел.md
+++ b/docs/specs/Протокол абитов ачисел.md
@@ -1,6 +1,8 @@
 # Протокол абитов ачисел
 
-Статус: актуальная L3-спецификация. Root-проекция `[] -> 0`, `][ -> 1` реализована как **experimental** кандидат issue #61 и не входит автоматически в корневую L2-систему.
+Статус: **актуальная L3-спецификация v0.2 для принятого boundary subset**. Общая денотация произвольного raw carrier остаётся задачей #89.
+
+Machine-readable boundary contract: [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json).
 
 ## 1. Цель
 
@@ -21,11 +23,40 @@ L3 отвечает за raw carrier и context projection. Materialization `den
 [ ] 1 0
 ```
 
-Это единственный базовый quaternary alphabet v0.1.
+Это единственный базовый quaternary alphabet.
 
 `][`, `[[`, `]]`, `[]` являются допустимыми raw carriers. Raw parser не применяет обычную скобочную валидность языка программирования.
 
-## 3. Явный контекст K
+## 3. Граница с принятой МТС v0.2
+
+L3 не выводит смысл абитов из их glyph. Boundary projection фиксируется только через принятые root definitions МТС v0.2:
+
+```text
+([) : (♀∞)
+(]) : (∞♂)
+(⟼) : (♀∞ ⟼ ∞♂)
+(↛) : (∞♂ ⟼ ♀∞)
+[1] : (⟼)
+[0] : (↛)
+```
+
+Отсюда для **root context** следует:
+
+```text
+[  -> ♀∞
+]  -> ∞♂
+
+[[ -> ♀∞ ⟼ ♀∞ -> boundary-form, no protocol value
+[] -> ♀∞ ⟼ ∞♂ -> 1
+][ -> ∞♂ ⟼ ♀∞ -> 0
+]] -> ∞♂ ⟼ ∞♂ -> boundary-form, no protocol value
+```
+
+Это заменяет старую experimental ориентацию issue #61 `[] -> 0`, `][ -> 1`, которая была сформулирована для прежней полюсной записи и противоречит принятому root program v0.2.
+
+Важно: `[] -> 1` и `][ -> 0` являются **contextual root projection rules**, а не абсолютным переписыванием raw-текста. В quote/relative contexts эти пары не получают root semantics.
+
+## 4. Явный контекст K
 
 Каждая projection operation получает typed context:
 
@@ -47,18 +78,7 @@ project_anum(A, K)
 
 ### root
 
-Root context применяет текущую experimental projection двух boundary-абитов:
-
-```text
-[[ -> α ⟼ α -> no protocol value
-[] -> α ⟼ β -> 0
-][ -> β ⟼ α -> 1
-]] -> β ⟼ β -> no protocol value
-```
-
-`[[` и `]]` **не нормализуются** в `[` и `]`. В v0.1 они остаются отдельными `boundary-form` без protocol value.
-
-Для общего raw carrier, которому ещё не определена root denotation, projection возвращает typed `RAW`, а не придумывает семантику.
+Root context применяет только принятый boundary subset выше. Для общего raw carrier, которому ещё не определена structural denotation, projection возвращает typed `RAW`, а не придумывает семантику.
 
 ### quote
 
@@ -76,11 +96,11 @@ Quote context подавляет root projection и работает с raw carr
 
 ### relative
 
-Relative context в v0.1 сохраняет raw carrier без нормализации. Это явно фиксирует отсутствие принятой relative semantics вместо неявной эвристики.
+Relative context в v0.2 сохраняет raw carrier без нормализации. Это явное отсутствие принятой relative denotation, а не эвристика parser-а.
 
-## 4. Цитирование реальными абитами
+## 5. Цитирование реальными абитами
 
-Отдельного Python-типа `Quote` больше нет.
+Отдельного Python-типа `Quote` нет.
 
 ```text
 quote(A) := [ A ]
@@ -104,38 +124,9 @@ project(A, quote)         = A
 
 Последняя строка означает: quote-context не материализует и не применяет root projection к уже полученному payload.
 
-## 5. Root projection issue #61
+## 6. Boundary forms `[[` и `]]`
 
-Рабочая гипотеза использует две условные boundary-формы:
-
-```text
-α
-β
-```
-
-и проекцию:
-
-```text
-[[ -> α ⟼ α
-[] -> α ⟼ β
-][ -> β ⟼ α
-]] -> β ⟼ β
-```
-
-В текущем API:
-
-```text
-project([], root).protocol_value = 0
-project(][, root).protocol_value = 1
-```
-
-Это **protocol projection**, а не формула root fixture.
-
-Историческое описание issue #61 связывало `α/β` с ориентацией `∞♀ / ♂∞`. Активная L1/L2 нотация теперь использует `♀F / F♂`, поэтому v0.1 **не объявляет** эти исторические записи нормативным L1-равенством. Root projection хранит `α/β` как протокольные boundary labels до отдельного теоретического принятия их точной L1-денотации.
-
-## 6. `[[` и `]]`
-
-Статус v0.1:
+Статус v0.2:
 
 ```text
 root:     существующие boundary forms, protocol_value=None
@@ -152,7 +143,7 @@ relative: raw data
 
 нет.
 
-Если такая нормализация будет нужна, она должна появиться отдельным принятым context rule и challenge tests.
+Если такая нормализация понадобится, она должна появиться отдельным принятым context rule и challenge vectors. До этого `[[` и `]]` не получают L4 denotation.
 
 ## 7. String/dictionary layer
 
@@ -197,9 +188,9 @@ recognized tokens
 
 Batch и streaming decode обязаны давать одинаковую последовательность абитов и offsets.
 
-Protocol decoder не объявляет «конец ачисла» на основании балансировки `[ ]`: raw-уровень не имеет такого правила.
+Protocol decoder не объявляет «конец ачисла» по балансу `[ ]`: raw-уровень не имеет такого правила.
 
-## 9. Canonical serialization
+## 9. Canonical raw serialization
 
 Для quaternary mode:
 
@@ -221,13 +212,15 @@ serialize(parse(A))
 # anum-format: quaternary
 ```
 
-Round-trip детерминирован на поддерживаемом raw-слое.
+Round-trip детерминирован на raw-слое.
+
+Это не следует путать с будущим inverse serialization `den(A) -> A` для general denotation contract #89.
 
 ## 10. Разделение L3/L4
 
 L3 не имеет команд `load/find/realize/delete` над настоящей памятью.
 
-Эти инварианты определены reference model:
+Инварианты:
 
 ```text
 load(A) не создаёт den(A)
@@ -235,7 +228,18 @@ find(A) не создаёт den(A)
 realize(A) — отдельная materializing operation
 ```
 
-`core/anum_memory.py` остаётся временным test-double до #72 и не определяет protocol context.
+Историческая рабочая процедура issue #61 также разделяла:
+
+```text
+load(A)
+decode(A)
+project_K(A)
+realize(A)
+```
+
+Это разделение сохраняется. Изменение boundary orientation не превращает projection в materialization.
+
+`core/anum_memory.py` остаётся test-double L4-инвариантов и не определяет protocol context.
 
 CLI L3 сознательно не содержит `realize`.
 
@@ -245,19 +249,21 @@ CLI L3 сознательно не содержит `realize`.
 core/anum_model.py
 core/anum_parser.py
 core/anum_protocol.py
+contracts/anum-boundary-projection-v0.2.json
 converters/anum_cli.py
 ```
 
-Старый `core/anum_projector.py` удалён: один canonical projection path находится в `core/anum_protocol.py`.
+Один canonical projection path находится в `core/anum_protocol.py`.
 
-## 12. Открытые теоретические вопросы
+## 12. Оставшийся dependency gate #89
 
-До переноса experimental root projection в нормативную систему остаётся решить:
+После фиксации boundary subset остаются вопросы **general denotation**, а не ориентации `0/1`:
 
-1. точную L1-денотацию boundary labels `α` и `β` в актуальной ориентации `♀F / F♂`;
-2. является ли `[] -> 0` абсолютным протокольным правилом или только root-context projection;
-3. является ли `][ -> 1` абсолютным протокольным правилом или только root-context projection;
-4. нужна ли отдельная принятая relative semantics;
-5. какие context rules, если вообще нужны, должны преобразовывать `[[` и `]]`.
+1. structural denotation произвольного поддерживаемого raw carrier;
+2. recursive decode rule для вложенных описаний связей;
+3. первая поддерживаемая relative semantics либо явное исключение relative из denoting subset;
+4. правила identity/context anchors для L4;
+5. deterministic inverse serialization для denoting subset;
+6. executable round-trip/challenge vectors.
 
-До такого решения текущая реализация служит изолированной executable model протокольного кандидата и не меняет `tests/mtc_formulas.mtc`.
+До принятия этих правил общий raw carrier продолжает возвращаться как typed `RAW`. Downstream AVM не должен восполнять этот пробел собственными эвристиками.

--- a/docs/specs/Формальная нотация МТС.md
+++ b/docs/specs/Формальная нотация МТС.md
@@ -317,7 +317,27 @@ Raw L3:
 
 может быть валидной последовательностью абитов, но strict L2 parser не обязан принимать её как L2 expression.
 
-Рабочая L3-проекция issue #61 остаётся experimental.
+Принятые root definitions v0.2 связывают значения boundary forms только через явный protocol rule:
+
+```text
+([) : (♀∞)
+(]) : (∞♂)
+(⟼) : (♀∞ ⟼ ∞♂)
+(↛) : (∞♂ ⟼ ♀∞)
+[1] : (⟼)
+[0] : (↛)
+```
+
+Отсюда в **root context L3** принят boundary subset:
+
+```text
+[  → ♀∞
+]  → ∞♂
+[] → 1
+][ → 0
+```
+
+Это не превращает L2 `[]` в L3 `[]` и не является абсолютным rewriting raw carrier. Quote/relative contexts остаются отдельными. `[[`/`]]` и общая structural denotation произвольного raw carrier остаются вне принятого subset до #89.
 
 ## 11. Операторы и приоритеты
 

--- a/tests/test_anum_boundary_contract.py
+++ b/tests/test_anum_boundary_contract.py
@@ -1,0 +1,65 @@
+"""Cross-check the L3 root-boundary projection against accepted MTS v0.2."""
+
+import json
+from pathlib import Path
+
+from core.anum_model import ProjectionContext, ProjectionKind
+from core.anum_parser import parse_raw_quaternary
+from core.anum_protocol import project_anum
+
+
+CONTRACT = Path(__file__).parents[1] / "contracts" / "anum-boundary-projection-v0.2.json"
+ROOT_PROGRAM = Path(__file__).with_name("mtc_formulas.mtc")
+
+
+def _contract():
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def test_boundary_contract_is_root_scoped_and_does_not_claim_general_denotation():
+    contract = _contract()
+
+    assert contract["schema"] == "anum-boundary-projection/v0.2"
+    assert contract["status"] == "accepted-subset"
+    assert contract["dependsOn"] == "mts-contract/v0.2"
+    assert contract["context"] == "root"
+    assert contract["scope"] == {
+        "absoluteRule": False,
+        "quoteContextApplies": False,
+        "relativeContextApplies": False,
+        "generalRawDenotationDefined": False,
+    }
+
+
+def test_boundary_orientation_is_derived_from_the_accepted_root_program():
+    root = ROOT_PROGRAM.read_text(encoding="utf-8")
+    contract = _contract()
+
+    for formula in contract["derivation"]:
+        assert formula in root
+
+    assert contract["orientation"] == {"open": "♀∞", "close": "∞♂"}
+
+
+def test_executable_projection_matches_every_contract_vector():
+    for vector in _contract()["projection"]:
+        projection = project_anum(
+            parse_raw_quaternary(vector["raw"]), ProjectionContext.ROOT
+        )
+
+        expected_kind = (
+            ProjectionKind.PROTOCOL_VALUE
+            if vector["kind"] == "protocol-value"
+            else ProjectionKind.BOUNDARY_FORM
+        )
+        assert projection.kind is expected_kind
+        assert projection.arrow_form == vector["form"]
+        assert projection.protocol_value == vector["protocolValue"]
+
+
+def test_root_boundary_values_follow_current_mts_link_and_unlink_orientation():
+    link = project_anum(parse_raw_quaternary("[]"), ProjectionContext.ROOT)
+    unlink = project_anum(parse_raw_quaternary("]["), ProjectionContext.ROOT)
+
+    assert link.protocol_value == "1"
+    assert unlink.protocol_value == "0"

--- a/tests/test_anum_cli.py
+++ b/tests/test_anum_cli.py
@@ -43,8 +43,8 @@ def test_cli_project_outputs_contextual_root_projection(tmp_path):
     assert "context: root" in result.stdout
     assert "input: []" in result.stdout
     assert "kind: protocol-value" in result.stdout
-    assert "protocol_value: 0" in result.stdout
-    assert "arrow_form: α ⟼ β" in result.stdout
+    assert "protocol_value: 1" in result.stdout
+    assert "arrow_form: ♀∞ ⟼ ∞♂" in result.stdout
 
 
 def test_cli_quote_and_unquote_use_real_quaternary_envelope(tmp_path):

--- a/tests/test_anum_protocol_projection.py
+++ b/tests/test_anum_protocol_projection.py
@@ -1,4 +1,4 @@
-"""Conformance tests for contextual L3 Anum protocol v0.1."""
+"""Conformance tests for contextual L3 Anum protocol v0.2."""
 
 import pytest
 
@@ -13,23 +13,24 @@ from core.anum_protocol import (
 )
 
 
-def test_root_context_projects_container_to_experimental_zero():
+def test_root_context_projects_open_close_to_canonical_link_value():
     projection = project_anum(parse_raw_quaternary("[]"), ProjectionContext.ROOT)
 
     assert projection.kind is ProjectionKind.PROTOCOL_VALUE
     assert projection.source == "[]"
-    assert projection.arrow_form == "α ⟼ β"
-    assert projection.protocol_value == "0"
-    assert "experimental" in projection.note
+    assert projection.arrow_form == "♀∞ ⟼ ∞♂"
+    assert projection.protocol_value == "1"
+    assert "accepted MTS v0.2" in projection.note
 
 
-def test_root_context_projects_bridge_to_experimental_one():
+def test_root_context_projects_close_open_to_canonical_unlink_value():
     projection = project_anum(parse_raw_quaternary("]["), ProjectionContext.ROOT)
 
     assert projection.kind is ProjectionKind.PROTOCOL_VALUE
     assert projection.source == "]["
-    assert projection.arrow_form == "β ⟼ α"
-    assert projection.protocol_value == "1"
+    assert projection.arrow_form == "∞♂ ⟼ ♀∞"
+    assert projection.protocol_value == "0"
+    assert "accepted MTS v0.2" in projection.note
 
 
 def test_open_open_and_close_close_remain_boundary_forms_without_value():
@@ -37,11 +38,11 @@ def test_open_open_and_close_close_remain_boundary_forms_without_value():
     close_close = project_anum(parse_raw_quaternary("]]"), ProjectionContext.ROOT)
 
     assert open_open.kind is ProjectionKind.BOUNDARY_FORM
-    assert open_open.arrow_form == "α ⟼ α"
+    assert open_open.arrow_form == "♀∞ ⟼ ♀∞"
     assert open_open.protocol_value is None
 
     assert close_close.kind is ProjectionKind.BOUNDARY_FORM
-    assert close_close.arrow_form == "β ⟼ β"
+    assert close_close.arrow_form == "∞♂ ⟼ ∞♂"
     assert close_close.protocol_value is None
 
 

--- a/tests/test_mts_contract_v02.py
+++ b/tests/test_mts_contract_v02.py
@@ -10,6 +10,7 @@ from core.mtc_parser import parse_formula
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "contracts/mts-contract-v0.2.json"
 CONFORMANCE = ROOT / "contracts/mts-conformance-v0.2.json"
+ANUM_BOUNDARY = ROOT / "contracts/anum-boundary-projection-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests/mtc_formulas.mtc"
 
 
@@ -32,11 +33,20 @@ def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     assert contract["status"] == "accepted"
     assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
     assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
+    assert contract["anum"]["rootBoundaryProjection"] == (
+        "contracts/anum-boundary-projection-v0.2.json"
+    )
+    assert contract["anum"]["generalDenotationIssue"] == 89
     assert CONFORMANCE.is_file()
+    assert ANUM_BOUNDARY.is_file()
 
     corpus = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
     assert corpus["contract"] == contract["schema"]
     assert corpus["status"] == "accepted"
+
+    boundary = json.loads(ANUM_BOUNDARY.read_text(encoding="utf-8"))
+    assert boundary["dependsOn"] == contract["schema"]
+    assert boundary["scope"]["generalRawDenotationDefined"] is False
 
 
 def test_contract_exposes_exactly_two_atomic_non_bracket_context_pronouns():

--- a/tests/test_reference_model.py
+++ b/tests/test_reference_model.py
@@ -77,10 +77,13 @@ def test_l2_square_form_does_not_claim_identity_with_l3_abits_or_context_pronoun
     assert "не перегруж" in square
 
 
-def test_issue_61_projection_remains_experimental():
-    projection = concept("issue-61-projection")
+def test_anum_root_boundary_projection_is_accepted_without_claiming_general_denotation():
+    projection = concept("anum-root-boundary-projection")
     assert projection.layer is Layer.SERIALIZATION
-    assert projection.status is StatementStatus.EXPERIMENTAL
+    assert projection.status is StatementStatus.DEFINITION
+    assert "[]→1" in projection.description
+    assert "][→0" in projection.description
+    assert "#89" in projection.description
 
 
 def test_interpret_is_read_only_and_non_materializing():


### PR DESCRIPTION
Closes #90. Refs #89. Downstream prerequisite for netkeep80/avm#79.

## Problem
The accepted MTS v0.2 root program and the active Anum L3 implementation disagreed about the two mixed boundary carriers. The old issue #61 experimental orientation used `[] -> 0`, `][ -> 1`, while current accepted root definitions are:

```text
([) : (♀∞)
(]) : (∞♂)
(⟼) : (♀∞ ⟼ ∞♂)
(↛) : (∞♂ ⟼ ♀∞)
[1] : (⟼)
[0] : (↛)
```

Therefore the only root-context boundary mapping consistent with the accepted v0.2 root is:

```text
[  -> ♀∞
]  -> ∞♂
[] -> 1
][ -> 0
```

## Changes
- adds `contracts/anum-boundary-projection-v0.2.json` with all four two-boundary vectors and provenance formulas;
- updates `core/anum_protocol.py` to the accepted v0.2 orientation;
- promotes the boundary subset in the declarative `core/reference_model.py` while keeping general raw denotation open in #89;
- exposes the boundary contract from `mts-contract-v0.2.json`;
- updates CLI/protocol/reference-model contract tests;
- updates active normative docs and README to remove the superseded orientation.

## Deliberate limits
This PR does **not** define general structural denotation, recursive arbitrary-raw decode, relative denotation, or L4 materialization. `[[` and `]]` remain non-denoting boundary forms, quote/relative contexts do not inherit root projection, and arbitrary raw remains typed `RAW`.

## Veto checks
- machine contract vectors must match `tests/mtc_formulas.mtc` provenance;
- executable `project_anum` must match every vector;
- raw parser remains unchanged;
- `load/find/project/interpret` materialization invariants remain unchanged;
- full ruff + pytest + repository-structure CI must be green before merge.