### PR TITLE
L3: accept minimal 0/1 pair denotation subset

### DIFF
--- a/contracts/anum-pair-denotation-conformance-v0.2.json
+++ b/contracts/anum-pair-denotation-conformance-v0.2.json
@@ -5,9 +5,18 @@
   "cases": [
     {"name":"zero","raw":"0","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[],"root":{"anchor":"protocol:0"}},"canonicalRaw":"0"},
     {"name":"one","raw":"1","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[],"root":{"anchor":"protocol:1"}},"canonicalRaw":"1"},
+    {"name":"root-link-alias","raw":"[]","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[],"root":{"anchor":"protocol:1"}},"canonicalRaw":"1"},
+    {"name":"root-unlink-alias","raw":"][","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[],"root":{"anchor":"protocol:0"}},"canonicalRaw":"0"},
     {"name":"pair-00","raw":"00","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:0"}}],"root":{"node":0}},"canonicalRaw":"00"},
     {"name":"pair-01","raw":"01","context":"root","expected":{"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"01"},
     {"name":"pair-10","raw":"10","context":"root","expected":{"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:0"}}],"root":{"node":0}},"canonicalRaw":"10"},
-    {"name":"pair-11","raw":"11","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"11"}
+    {"name":"pair-11","raw":"11","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"11"},
+    {"name":"open-open-raw","raw":"[[","context":"root","expected":{"kind":"raw","raw":"[["},"canonicalRaw":null},
+    {"name":"close-close-raw","raw":"]]","context":"root","expected":{"kind":"raw","raw":"]]"},"canonicalRaw":null},
+    {"name":"long-sequence-raw","raw":"010","context":"root","expected":{"kind":"raw","raw":"010"},"canonicalRaw":null},
+    {"name":"bracket-composition-raw","raw":"[0]","context":"root","expected":{"kind":"raw","raw":"[0]"},"canonicalRaw":null},
+    {"name":"quote-envelope","raw":"[01]","context":"quote","expected":{"kind":"quoted-raw","raw":"01"},"canonicalRaw":null},
+    {"name":"quote-unwrapped","raw":"01","context":"quote","expected":{"kind":"quoted-raw","raw":"01"},"canonicalRaw":null},
+    {"name":"relative-pair","raw":"01","context":"relative","expected":{"kind":"raw","raw":"01"},"canonicalRaw":null}
   ]
 }

--- a/contracts/anum-pair-denotation-conformance-v0.2.json
+++ b/contracts/anum-pair-denotation-conformance-v0.2.json
@@ -1,0 +1,13 @@
+{
+  "schema": "anum-pair-denotation-conformance/v0.2",
+  "contract": "anum-pair-denotation/v0.2",
+  "status": "accepted",
+  "cases": [
+    {"name":"zero","raw":"0","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[],"root":{"anchor":"protocol:0"}},"canonicalRaw":"0"},
+    {"name":"one","raw":"1","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[],"root":{"anchor":"protocol:1"}},"canonicalRaw":"1"},
+    {"name":"pair-00","raw":"00","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:0"}}],"root":{"node":0}},"canonicalRaw":"00"},
+    {"name":"pair-01","raw":"01","context":"root","expected":{"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"01"},
+    {"name":"pair-10","raw":"10","context":"root","expected":{"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:0"}}],"root":{"node":0}},"canonicalRaw":"10"},
+    {"name":"pair-11","raw":"11","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"11"}
+  ]
+}

--- a/contracts/anum-pair-denotation-v0.2.json
+++ b/contracts/anum-pair-denotation-v0.2.json
@@ -1,0 +1,49 @@
+{
+  "schema": "anum-pair-denotation/v0.2",
+  "status": "accepted",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "anum-boundary-projection/v0.2",
+    "anum-denotation/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-pair-denotation-conformance-v0.2.json",
+  "context": "root",
+  "protocolAnchors": {
+    "0": "protocol:0",
+    "1": "protocol:1"
+  },
+  "rules": [
+    "root protocol value 0 denotes anchor protocol:0",
+    "root protocol value 1 denotes anchor protocol:1",
+    "exactly two direct protocol atoms ab denote one ordered Link(a,b)",
+    "root boundary aliases use their accepted projected protocol value",
+    "all other root carriers remain raw in this subset"
+  ],
+  "canonicalInverse": {
+    "protocol:0": "0",
+    "protocol:1": "1",
+    "singlePair": "concatenate canonical start and end protocol atoms",
+    "sourcePreserving": false,
+    "aliases": {
+      "][": "0",
+      "[]": "1"
+    }
+  },
+  "unsupported": {
+    "recursiveBrackets": "issue #95",
+    "relativeDenotation": true,
+    "openOpenBoundaryDenotation": true,
+    "closeCloseBoundaryDenotation": true,
+    "longerDirectSequences": true
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false
+  },
+  "evidence": {
+    "readOnlyResearch": "docs/research/Исходные мысли МТС.md",
+    "sequenceRule": "an achislo implicitly starts at ∞; deserializing ∞ab produces a⟼b while the loaded sequence itself does not contain a⟼b",
+    "scopeDecision": "apply that rule only where both a and b are already accepted direct protocol atoms 0/1"
+  }
+}

--- a/contracts/mts-contract-v0.2.json
+++ b/contracts/mts-contract-v0.2.json
@@ -62,6 +62,8 @@
     "alphabet": ["[", "]", "1", "0"],
     "rootBoundaryProjection": "contracts/anum-boundary-projection-v0.2.json",
     "denotationHandoff": "contracts/anum-denotation-v0.2.json",
+    "acceptedPairDenotationSubset": "contracts/anum-pair-denotation-v0.2.json",
+    "recursiveDenotationIssue": 95,
     "generalDenotationIssue": 89
   },
   "memory": {

--- a/core/anum_pair_denotation.py
+++ b/core/anum_pair_denotation.py
@@ -1,0 +1,132 @@
+"""Minimal storage-neutral structural denotation subset for Anum L3 v0.2.
+
+This module deliberately recognizes only semantics already justified by the
+accepted protocol plus the original sequence rule ``∞ab -> denotation a⟼b``:
+protocol atoms 0/1, their accepted root boundary aliases, and exactly two
+direct protocol atoms. Recursive bracket denotation is outside this module.
+"""
+
+from core.anum_denotation import (
+    AnumDenotation,
+    DenotationNode,
+    DenotationRef,
+    DenotationRefKind,
+    StructuralDenotation,
+)
+from core.anum_model import Abit, AnumForm, ProjectionContext, ProjectionKind
+from core.anum_parser import normalize_raw_form
+from core.anum_protocol import project_anum
+
+
+PROTOCOL_ZERO_ANCHOR = "protocol:0"
+PROTOCOL_ONE_ANCHOR = "protocol:1"
+_PROTOCOL_ANCHORS = {
+    "0": PROTOCOL_ZERO_ANCHOR,
+    "1": PROTOCOL_ONE_ANCHOR,
+}
+_ANCHOR_ATOMS = {value: key for key, value in _PROTOCOL_ANCHORS.items()}
+
+
+def denotate_anum_pair_subset(
+    form: AnumForm,
+    context: ProjectionContext,
+) -> AnumDenotation:
+    """Return the accepted v0.2 pair-subset denotation without L4 effects."""
+
+    source = normalize_raw_form(form)
+    projection = project_anum(form, context)
+
+    if context is ProjectionContext.QUOTE:
+        projected = projection.projected
+        if projected is None:
+            raise ValueError("quote projection must preserve a raw payload")
+        return AnumDenotation.quoted_raw_result(normalize_raw_form(projected))
+
+    if context is ProjectionContext.RELATIVE:
+        return AnumDenotation.raw_result(source)
+
+    if projection.kind is ProjectionKind.PROTOCOL_VALUE:
+        protocol_value = projection.protocol_value
+        if protocol_value not in _PROTOCOL_ANCHORS:
+            raise ValueError("unsupported protocol value in pair denotation subset")
+        return _anchor_denotation(_PROTOCOL_ANCHORS[protocol_value])
+
+    direct_atoms = _direct_protocol_atoms(form)
+    if direct_atoms is not None:
+        start, end = direct_atoms
+        return _pair_denotation(_PROTOCOL_ANCHORS[start], _PROTOCOL_ANCHORS[end])
+
+    return AnumDenotation.raw_result(source)
+
+
+def canonical_pair_anum(value: AnumDenotation) -> str:
+    """Serialize one structural value from the accepted pair subset canonically."""
+
+    structural = value.structural
+    if structural is None:
+        raise ValueError("only structural pair-subset denotations have a canonical inverse")
+
+    if not structural.nodes:
+        atom = _protocol_atom(structural.root)
+        if tuple(sorted({structural.root.anchor})) != structural.anchors:
+            raise ValueError("anchor-only denotation is outside the canonical pair subset")
+        return atom
+
+    if len(structural.nodes) != 1:
+        raise ValueError("nested structural denotation is outside the pair subset")
+
+    node = structural.nodes[0]
+    if node.id != 0 or structural.root != DenotationRef.node_ref(0):
+        raise ValueError("pair-subset structural root must be node 0")
+
+    start = _protocol_atom(node.start)
+    end = _protocol_atom(node.end)
+    expected_anchors = tuple(sorted({node.start.anchor, node.end.anchor}))
+    if structural.anchors != expected_anchors:
+        raise ValueError("pair-subset denotation contains unused or missing anchors")
+    return start + end
+
+
+def _direct_protocol_atoms(form: AnumForm) -> tuple[str, str] | None:
+    if len(form.tokens) != 2:
+        return None
+
+    values = tuple(token.abit for token in form.tokens)
+    if any(abit not in (Abit.LINK, Abit.UNLINK) for abit in values):
+        return None
+    return values[0].value, values[1].value
+
+
+def _anchor_denotation(anchor: str) -> AnumDenotation:
+    return AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=(anchor,),
+            nodes=(),
+            root=DenotationRef.anchor_ref(anchor),
+        )
+    )
+
+
+def _pair_denotation(start: str, end: str) -> AnumDenotation:
+    anchors = tuple(sorted({start, end}))
+    return AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=anchors,
+            nodes=(
+                DenotationNode(
+                    id=0,
+                    start=DenotationRef.anchor_ref(start),
+                    end=DenotationRef.anchor_ref(end),
+                ),
+            ),
+            root=DenotationRef.node_ref(0),
+        )
+    )
+
+
+def _protocol_atom(ref: DenotationRef) -> str:
+    if ref.kind is not DenotationRefKind.ANCHOR or ref.anchor not in _ANCHOR_ATOMS:
+        raise ValueError("pair-subset endpoint must be a protocol anchor")
+    if ref.node is not None:
+        raise ValueError("protocol anchor reference cannot contain a node id")
+    return _ANCHOR_ATOMS[ref.anchor]

--- a/docs/specs/Ачисла и сериализация.md
+++ b/docs/specs/Ачисла и сериализация.md
@@ -1,12 +1,16 @@
 # Ачисла и сериализация
 
-Статус: актуальное, нормативное для контейнера и raw-слоя `*.anum`; root boundary subset согласован с принятой МТС v0.2. Общая structural denotation остаётся задачей #89.
+Статус: актуальное, нормативное для контейнера и raw-слоя `*.anum`; root boundary subset согласован с принятой МТС v0.2. Принят минимальный structural-denoting subset для `0/1` и двух direct protocol atoms; recursive denotation остаётся задачей #95, общий gate — #89.
 
 Уровень: **L3 — сериализация**.
 
 Граница L2/L3/L4 задаётся [Reference model МТС v0.2](Reference%20model%20МТС%20v0.2.md).
 
-Boundary contract: [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json).
+Machine contracts:
+
+- [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json);
+- [`contracts/anum-denotation-v0.2.json`](../../contracts/anum-denotation-v0.2.json);
+- [`contracts/anum-pair-denotation-v0.2.json`](../../contracts/anum-pair-denotation-v0.2.json).
 
 ## 1. Ачисло и raw carrier
 
@@ -39,11 +43,12 @@ Raw parser отвечает только за чтение четырёх аби
 parse_raw_quaternary
 → validate_anum(context)
 → project_anum(context)
+→ denotation subset
 ```
 
-Это три разные операции.
+Это разные операции.
 
-`parse_raw_quaternary` не знает семантики. `validate_anum` не меняет raw carrier. `project_anum` всегда получает явный `ProjectionContext`.
+`parse_raw_quaternary` не знает семантики. `validate_anum` не меняет raw carrier. `project_anum` всегда получает явный `ProjectionContext`. Denotation layer выдаёт storage-neutral `AnumDenotation` и не обращается к L4-памяти.
 
 Контексты протокола:
 
@@ -164,7 +169,7 @@ parse(serialize(parse(A)))
 
 сохраняет последовательность абитов.
 
-Это transport round-trip. Он не является ещё inverse serialization structural denotation из #89.
+Это transport round-trip. Structural inverse serialization описывается отдельно и существует только для принятых denoting subsets.
 
 ## 7. Цитирование
 
@@ -231,7 +236,55 @@ L2 v0.2 гарантирует, что context pronouns не использую�
 
 `[[` и `]]` остаются валидными raw carriers и root `boundary-form` без `protocol_value`.
 
-## 9. Граница L3/L4
+## 9. Принятый минимальный structural-denoting subset
+
+Исходные read-only заметки фиксируют два свойства:
+
+1. ачисло — последовательность абитов, неявно начинающаяся от `∞`;
+2. последовательность `∞ab` / `(∞ ⟼ a) ⟼ b` сама не содержит `a ⟼ b`, но при десериализации описывает связь `a ⟼ b`.
+
+В v0.2 это правило принимается только для минимального случая, где оба `a` и `b` уже являются однозначно определёнными direct protocol atoms `0` или `1`:
+
+```text
+0  -> Anchor(protocol:0)
+1  -> Anchor(protocol:1)
+
+00 -> 0 ⟼ 0
+01 -> 0 ⟼ 1
+10 -> 1 ⟼ 0
+11 -> 1 ⟼ 1
+```
+
+Structural result использует [`anum-denotation/v0.2`](../../contracts/anum-denotation-v0.2.json): физические `LinkId` отсутствуют, node identity локальна описанию, materialization не выполняется.
+
+Accepted root boundary aliases дают те же anchor denotations:
+
+```text
+][ -> den(0)
+[] -> den(1)
+```
+
+Но inverse serialization канонична, а не source-preserving:
+
+```text
+den(][) -> 0
+den([]) -> 1
+```
+
+Для single-pair denotation inverse равна конкатенации двух canonical protocol atoms.
+
+Не входят в этот subset и остаются неструктурными:
+
+```text
+010 и любые более длинные direct sequences
+[0], [01], [][] и другие recursive bracket compositions в root context
+[[ и ]]
+relative denotation
+```
+
+Recursive bracket grammar — отдельный dependency gate #95. Неразрешённый carrier должен оставаться typed `RAW`, а не получать эвристическую денотацию.
+
+## 10. Граница L3/L4
 
 L3 не реализует память.
 
@@ -251,20 +304,30 @@ interpret(F) не выполняет realize(F)
 
 `core/anum_memory.py` остаётся test-double L4-инвариантов.
 
-## 10. Актуальные модули
+`core/anum_pair_denotation.py` не читает и не мутирует память: он только строит storage-neutral `AnumDenotation`.
+
+## 11. Актуальные модули
 
 ```text
-core/anum_model.py       Abit, ProjectionContext, typed protocol results
-core/anum_parser.py      raw parser, incremental decoder, deterministic serializer
-core/anum_protocol.py    validate/project/quote/unquote/AnumDictionary
-core/anum_memory.py      L4 test-double
+core/anum_model.py              Abit, ProjectionContext, typed protocol results
+core/anum_parser.py             raw parser, incremental decoder, deterministic serializer
+core/anum_protocol.py           validate/project/quote/unquote/AnumDictionary
+core/anum_denotation.py         storage-neutral L3→L4 structural handoff
+core/anum_pair_denotation.py    accepted minimal 0/1 pair denotation + canonical inverse
+core/anum_memory.py             L4 test-double
+
 contracts/anum-boundary-projection-v0.2.json
-converters/anum_cli.py   parse/validate/project/normalize/quote/unquote
+contracts/anum-denotation-v0.2.json
+contracts/anum-denotation-conformance-v0.2.json
+contracts/anum-pair-denotation-v0.2.json
+contracts/anum-pair-denotation-conformance-v0.2.json
+
+converters/anum_cli.py          parse/validate/project/normalize/quote/unquote
 ```
 
-Один canonical projection path находится в `core/anum_protocol.py`.
+`core/anum_protocol.py` остаётся единственным contextual projection path. Pair denotation вызывается после него и не создаёт второй raw parser.
 
-## 11. CLI
+## 12. CLI
 
 ```bash
 python -m converters.anum_cli parse file.anum

--- a/tests/test_anum_pair_denotation.py
+++ b/tests/test_anum_pair_denotation.py
@@ -1,0 +1,204 @@
+"""Conformance tests for the accepted minimal Anum pair denotation subset."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_denotation import (
+    AnumDenotation,
+    DenotationNode,
+    DenotationRef,
+    StructuralDenotation,
+    canonical_denotation_json,
+    denotation_from_data,
+)
+from core.anum_model import ProjectionContext
+from core.anum_pair_denotation import (
+    PROTOCOL_ONE_ANCHOR,
+    PROTOCOL_ZERO_ANCHOR,
+    canonical_pair_anum,
+    denotate_anum_pair_subset,
+)
+from core.anum_parser import parse_raw_quaternary
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts/anum-pair-denotation-v0.2.json"
+CORPUS = ROOT / "contracts/anum-pair-denotation-conformance-v0.2.json"
+SOURCE = ROOT / "core/anum_pair_denotation.py"
+
+
+def _context(name: str) -> ProjectionContext:
+    return ProjectionContext(name)
+
+
+def test_pair_contract_is_accepted_bounded_and_non_materializing():
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    assert contract["schema"] == "anum-pair-denotation/v0.2"
+    assert contract["status"] == "accepted"
+    assert contract["protocolAnchors"] == {
+        "0": PROTOCOL_ZERO_ANCHOR,
+        "1": PROTOCOL_ONE_ANCHOR,
+    }
+    assert contract["unsupported"]["recursiveBrackets"] == "issue #95"
+    assert contract["unsupported"]["relativeDenotation"] is True
+    assert contract["effects"] == {
+        "mayReadMemory": False,
+        "mayMutateMemory": False,
+        "mayRealize": False,
+    }
+
+
+def test_pair_decoder_source_has_no_storage_or_realization_dependency():
+    source = SOURCE.read_text(encoding="utf-8")
+
+    for forbidden in (
+        "LinkStore",
+        "PersistentLinkStore",
+        "database",
+        "sqlite",
+        "realize(",
+        "find(",
+    ):
+        assert forbidden not in source
+
+
+def test_every_language_neutral_pair_vector_matches_reference_decoder():
+    corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
+
+    assert corpus["schema"] == "anum-pair-denotation-conformance/v0.2"
+    assert corpus["contract"] == "anum-pair-denotation/v0.2"
+    assert corpus["status"] == "accepted"
+
+    for case in corpus["cases"]:
+        result = denotate_anum_pair_subset(
+            parse_raw_quaternary(case["raw"]),
+            _context(case["context"]),
+        )
+        expected = denotation_from_data(case["expected"])
+        assert canonical_denotation_json(result) == canonical_denotation_json(expected)
+
+        canonical_raw = case["canonicalRaw"]
+        if canonical_raw is None:
+            with pytest.raises(ValueError, match="structural"):
+                canonical_pair_anum(result)
+        else:
+            assert canonical_pair_anum(result) == canonical_raw
+            round_trip = denotate_anum_pair_subset(
+                parse_raw_quaternary(canonical_raw),
+                ProjectionContext.ROOT,
+            )
+            assert canonical_denotation_json(round_trip) == canonical_denotation_json(result)
+
+
+def test_all_four_direct_protocol_pairs_create_exactly_one_ordered_link():
+    expected = {
+        "00": (PROTOCOL_ZERO_ANCHOR, PROTOCOL_ZERO_ANCHOR),
+        "01": (PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR),
+        "10": (PROTOCOL_ONE_ANCHOR, PROTOCOL_ZERO_ANCHOR),
+        "11": (PROTOCOL_ONE_ANCHOR, PROTOCOL_ONE_ANCHOR),
+    }
+
+    for raw, endpoints in expected.items():
+        result = denotate_anum_pair_subset(
+            parse_raw_quaternary(raw), ProjectionContext.ROOT
+        )
+        assert result.structural is not None
+        assert len(result.structural.nodes) == 1
+        node = result.structural.nodes[0]
+        assert node.start == DenotationRef.anchor_ref(endpoints[0])
+        assert node.end == DenotationRef.anchor_ref(endpoints[1])
+        assert result.structural.root == DenotationRef.node_ref(0)
+
+
+def test_root_boundary_aliases_have_atomic_canonical_inverse():
+    link_alias = denotate_anum_pair_subset(
+        parse_raw_quaternary("[]"), ProjectionContext.ROOT
+    )
+    direct_link = denotate_anum_pair_subset(
+        parse_raw_quaternary("1"), ProjectionContext.ROOT
+    )
+    unlink_alias = denotate_anum_pair_subset(
+        parse_raw_quaternary("]["), ProjectionContext.ROOT
+    )
+    direct_unlink = denotate_anum_pair_subset(
+        parse_raw_quaternary("0"), ProjectionContext.ROOT
+    )
+
+    assert canonical_denotation_json(link_alias) == canonical_denotation_json(direct_link)
+    assert canonical_denotation_json(unlink_alias) == canonical_denotation_json(direct_unlink)
+    assert canonical_pair_anum(link_alias) == "1"
+    assert canonical_pair_anum(unlink_alias) == "0"
+
+
+def test_longer_and_bracket_structures_are_not_guessed():
+    for raw in ("010", "1011", "[0]", "[01]", "[][]", "[[", "]]"):
+        result = denotate_anum_pair_subset(
+            parse_raw_quaternary(raw), ProjectionContext.ROOT
+        )
+        assert result.structural is None
+        assert result.raw == raw
+
+
+def test_quote_and_relative_contexts_never_inherit_root_pair_semantics():
+    quoted = denotate_anum_pair_subset(
+        parse_raw_quaternary("[01]"), ProjectionContext.QUOTE
+    )
+    quoted_plain = denotate_anum_pair_subset(
+        parse_raw_quaternary("01"), ProjectionContext.QUOTE
+    )
+    relative = denotate_anum_pair_subset(
+        parse_raw_quaternary("01"), ProjectionContext.RELATIVE
+    )
+
+    assert quoted.structural is None and quoted.raw == "01"
+    assert quoted_plain.structural is None and quoted_plain.raw == "01"
+    assert relative.structural is None and relative.raw == "01"
+
+
+def test_inverse_rejects_nested_or_non_protocol_structural_values():
+    nested = AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=(PROTOCOL_ZERO_ANCHOR,),
+            nodes=(
+                DenotationNode(
+                    id=0,
+                    start=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+                    end=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+                ),
+                DenotationNode(
+                    id=1,
+                    start=DenotationRef.node_ref(0),
+                    end=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+                ),
+            ),
+            root=DenotationRef.node_ref(1),
+        )
+    )
+    external_anchor = AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=("external:a",),
+            nodes=(),
+            root=DenotationRef.anchor_ref("external:a"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="nested"):
+        canonical_pair_anum(nested)
+    with pytest.raises(ValueError, match="protocol anchor"):
+        canonical_pair_anum(external_anchor)
+
+
+def test_inverse_rejects_extra_unused_anchors():
+    malformed_subset = AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=(PROTOCOL_ONE_ANCHOR, PROTOCOL_ZERO_ANCHOR),
+            nodes=(),
+            root=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+        )
+    )
+
+    with pytest.raises(ValueError, match="outside the canonical pair subset"):
+        canonical_pair_anum(malformed_subset)

--- a/tests/test_anum_pair_denotation.py
+++ b/tests/test_anum_pair_denotation.py
@@ -194,7 +194,7 @@ def test_inverse_rejects_nested_or_non_protocol_structural_values():
 def test_inverse_rejects_extra_unused_anchors():
     malformed_subset = AnumDenotation.structural_result(
         StructuralDenotation(
-            anchors=(PROTOCOL_ONE_ANCHOR, PROTOCOL_ZERO_ANCHOR),
+            anchors=(PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR),
             nodes=(),
             root=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
         )

--- a/tests/test_mts_contract_v02.py
+++ b/tests/test_mts_contract_v02.py
@@ -12,6 +12,7 @@ CONTRACT = ROOT / "contracts/mts-contract-v0.2.json"
 CONFORMANCE = ROOT / "contracts/mts-conformance-v0.2.json"
 ANUM_BOUNDARY = ROOT / "contracts/anum-boundary-projection-v0.2.json"
 ANUM_DENOTATION = ROOT / "contracts/anum-denotation-v0.2.json"
+ANUM_PAIR_DENOTATION = ROOT / "contracts/anum-pair-denotation-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests/mtc_formulas.mtc"
 
 
@@ -40,10 +41,15 @@ def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     assert contract["anum"]["denotationHandoff"] == (
         "contracts/anum-denotation-v0.2.json"
     )
+    assert contract["anum"]["acceptedPairDenotationSubset"] == (
+        "contracts/anum-pair-denotation-v0.2.json"
+    )
+    assert contract["anum"]["recursiveDenotationIssue"] == 95
     assert contract["anum"]["generalDenotationIssue"] == 89
     assert CONFORMANCE.is_file()
     assert ANUM_BOUNDARY.is_file()
     assert ANUM_DENOTATION.is_file()
+    assert ANUM_PAIR_DENOTATION.is_file()
 
     corpus = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
     assert corpus["contract"] == contract["schema"]
@@ -57,6 +63,12 @@ def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     assert denotation["status"] == "accepted"
     assert contract["schema"] in denotation["dependsOn"]
     assert denotation["effects"]["mayRealize"] is False
+
+    pair = json.loads(ANUM_PAIR_DENOTATION.read_text(encoding="utf-8"))
+    assert pair["status"] == "accepted"
+    assert contract["schema"] in pair["dependsOn"]
+    assert pair["unsupported"]["recursiveBrackets"] == "issue #95"
+    assert pair["effects"]["mayRealize"] is False
 
 
 def test_contract_exposes_exactly_two_atomic_non_bracket_context_pronouns():


### PR DESCRIPTION
Closes #94. Refs #89. Recursive structural denotation continues in #95. Downstream: netkeep80/avm#79.

## Evidence-backed scope
The read-only original MTS notes state that an achislo is a sequence implicitly starting at `∞`, and specifically distinguish loaded sequence `(∞⟼a)⟼b` from its deserialized denotation `a⟼b`. This PR applies that rule only where both `a` and `b` are already accepted direct protocol atoms `0/1`.

Accepted root subset:
```text
0  -> Anchor(protocol:0)
1  -> Anchor(protocol:1)
00 -> 0 ⟼ 0
01 -> 0 ⟼ 1
10 -> 1 ⟼ 0
11 -> 1 ⟼ 1
```

Accepted root boundary aliases remain contextual:
```text
][ -> den(0)
[] -> den(1)
```
Their canonical inverse is the atomic form (`0`/`1`), not source-preserving alias text.

## Deliberate non-semantics
Longer direct sequences, recursive bracket compositions, `[[`/`]]`, and relative context remain non-structural. Quote context uses the already accepted one-envelope projection and returns `quoted-raw`. No recursive grammar is guessed here; that dependency is #95.

## Implementation
- `contracts/anum-pair-denotation-v0.2.json` — accepted bounded contract;
- `contracts/anum-pair-denotation-conformance-v0.2.json` — exact cross-language vectors for atoms, all four pairs, aliases, unsupported structures, quote and relative contexts;
- `core/anum_pair_denotation.py` — storage-neutral `AnumForm + ProjectionContext -> AnumDenotation` plus canonical inverse for this subset;
- `mts-contract/v0.2` now exposes the accepted pair subset and points recursive work to #95;
- active serialization spec documents the exact supported/non-supported boundary.

## Veto gates
- no LinkStore/database/find/realize dependency;
- no second raw parser;
- no superseded #61 mixed-boundary orientation;
- no hidden relative or recursive bracket semantics;
- every structural positive vector must inverse-round-trip by denotation;
- full ruff + pytest + repository structure/protected-file CI green before merge.