### PR TITLE
[superseded by #96] Минимальная structural denotation 0/1

### DIFF
--- a/contracts/anum-pair-denotation-conformance-v0.2.json
+++ b/contracts/anum-pair-denotation-conformance-v0.2.json
@@ -1,0 +1,187 @@
+{
+  "schema": "anum-pair-denotation-conformance/v0.2",
+  "contract": "anum-pair-denotation/v0.2",
+  "status": "accepted-subset",
+  "cases": [
+    {
+      "name": "protocol-zero",
+      "context": "root",
+      "raw": "0",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0"],
+        "nodes": [],
+        "root": {"anchor": "protocol:0"}
+      },
+      "canonicalRaw": "0"
+    },
+    {
+      "name": "protocol-one",
+      "context": "root",
+      "raw": "1",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:1"],
+        "nodes": [],
+        "root": {"anchor": "protocol:1"}
+      },
+      "canonicalRaw": "1"
+    },
+    {
+      "name": "boundary-zero-alias",
+      "context": "root",
+      "raw": "][",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0"],
+        "nodes": [],
+        "root": {"anchor": "protocol:0"}
+      },
+      "canonicalRaw": "0"
+    },
+    {
+      "name": "boundary-one-alias",
+      "context": "root",
+      "raw": "[]",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:1"],
+        "nodes": [],
+        "root": {"anchor": "protocol:1"}
+      },
+      "canonicalRaw": "1"
+    },
+    {
+      "name": "pair-00",
+      "context": "root",
+      "raw": "00",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0"],
+        "nodes": [
+          {"id": 0, "start": {"anchor": "protocol:0"}, "end": {"anchor": "protocol:0"}}
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "00"
+    },
+    {
+      "name": "pair-01",
+      "context": "root",
+      "raw": "01",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0", "protocol:1"],
+        "nodes": [
+          {"id": 0, "start": {"anchor": "protocol:0"}, "end": {"anchor": "protocol:1"}}
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "01"
+    },
+    {
+      "name": "pair-10",
+      "context": "root",
+      "raw": "10",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0", "protocol:1"],
+        "nodes": [
+          {"id": 0, "start": {"anchor": "protocol:1"}, "end": {"anchor": "protocol:0"}}
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "10"
+    },
+    {
+      "name": "pair-11",
+      "context": "root",
+      "raw": "11",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:1"],
+        "nodes": [
+          {"id": 0, "start": {"anchor": "protocol:1"}, "end": {"anchor": "protocol:1"}}
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "11"
+    },
+    {
+      "name": "open-open-remains-raw",
+      "context": "root",
+      "raw": "[[",
+      "denotation": {"kind": "raw", "raw": "[["},
+      "canonicalRaw": null
+    },
+    {
+      "name": "close-close-remains-raw",
+      "context": "root",
+      "raw": "]]",
+      "denotation": {"kind": "raw", "raw": "]]"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "longer-root-remains-raw",
+      "context": "root",
+      "raw": "010",
+      "denotation": {"kind": "raw", "raw": "010"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "mixed-root-remains-raw",
+      "context": "root",
+      "raw": "[01]",
+      "denotation": {"kind": "raw", "raw": "[01]"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "quote-one-level",
+      "context": "quote",
+      "raw": "[01]",
+      "denotation": {"kind": "quoted-raw", "raw": "01"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "quote-two-levels",
+      "context": "quote",
+      "raw": "[[01]]",
+      "denotation": {"kind": "quoted-raw", "raw": "[01]"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "relative-pair-remains-raw",
+      "context": "relative",
+      "raw": "01",
+      "denotation": {"kind": "raw", "raw": "01"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "relative-boundary-alias-remains-raw",
+      "context": "relative",
+      "raw": "[]",
+      "denotation": {"kind": "raw", "raw": "[]"},
+      "canonicalRaw": null
+    }
+  ],
+  "challenge": [
+    {
+      "name": "one-alias-is-many-to-one",
+      "sources": ["1", "[]"],
+      "sameDenotation": true,
+      "canonicalRaw": "1"
+    },
+    {
+      "name": "zero-alias-is-many-to-one",
+      "sources": ["0", "]["],
+      "sameDenotation": true,
+      "canonicalRaw": "0"
+    },
+    {
+      "name": "recursive-grammar-not-guessed",
+      "raw": "[01]01",
+      "requiredKind": "raw",
+      "deferredToIssue": 95
+    }
+  ]
+}

--- a/contracts/anum-pair-denotation-v0.2.json
+++ b/contracts/anum-pair-denotation-v0.2.json
@@ -1,0 +1,55 @@
+{
+  "schema": "anum-pair-denotation/v0.2",
+  "status": "accepted-subset",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "anum-boundary-projection/v0.2",
+    "anum-denotation/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-pair-denotation-conformance-v0.2.json",
+  "scope": {
+    "context": "root",
+    "recursiveBracketGrammar": false,
+    "relativeDenotation": false,
+    "boundaryOpenOpenDenotation": false,
+    "boundaryCloseCloseDenotation": false
+  },
+  "protocolAnchors": {
+    "0": "protocol:0",
+    "1": "protocol:1"
+  },
+  "rootGrammar": {
+    "atom": ["0", "1"],
+    "pair": "exactly two direct protocol atoms",
+    "boundaryAliases": {
+      "][": "0",
+      "[]": "1"
+    },
+    "unsupportedResult": "raw"
+  },
+  "denotation": {
+    "atom": "structural anchor root",
+    "pair": "one structural Link node from first protocol anchor to second protocol anchor",
+    "boundaryAlias": "same structural anchor denotation as projected canonical atom"
+  },
+  "canonicalInverse": {
+    "anchor:protocol:0": "0",
+    "anchor:protocol:1": "1",
+    "oneNodePair": "concatenate canonical start/end protocol atoms",
+    "sourcePreservingAliases": false
+  },
+  "otherContexts": {
+    "quote": "quoted-raw after canonical one-envelope quote projection",
+    "relative": "raw"
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false,
+    "persistentLinkIdAllowed": false
+  },
+  "deferredToIssue": {
+    "recursiveBracketDenotation": 95,
+    "generalDenotation": 89
+  }
+}

--- a/core/anum_denotation_codec.py
+++ b/core/anum_denotation_codec.py
@@ -1,0 +1,155 @@
+"""Canonical L3 Anum -> storage-neutral denotation subset for MTS v0.2.
+
+This is the single active denotation codec. The accepted subset is deliberately
+small:
+
+* root ``0`` / ``1`` denote protocol anchors;
+* root boundary aliases ``][`` / ``[]`` denote the same anchors;
+* exactly two direct protocol atoms ``00`` / ``01`` / ``10`` / ``11`` denote
+  one structural Link node;
+* quote context yields ``quoted-raw`` after the already accepted one-envelope
+  quote projection;
+* relative and every unsupported root carrier remain typed ``raw``.
+
+No memory backend, persistent LinkId, ``find`` or ``realize`` operation is used
+here. Recursive bracket denotation is intentionally left to issue #95.
+"""
+
+from core.anum_denotation import (
+    AnumDenotation,
+    DenotationKind,
+    DenotationNode,
+    DenotationRef,
+    DenotationRefKind,
+    StructuralDenotation,
+)
+from core.anum_model import AnumForm, ProjectionContext, ProjectionKind
+from core.anum_parser import normalize_raw_form
+from core.anum_protocol import project_anum
+
+
+PROTOCOL_ZERO_ANCHOR = "protocol:0"
+PROTOCOL_ONE_ANCHOR = "protocol:1"
+_PROTOCOL_ANCHOR_BY_ATOM = {
+    "0": PROTOCOL_ZERO_ANCHOR,
+    "1": PROTOCOL_ONE_ANCHOR,
+}
+_ATOM_BY_PROTOCOL_ANCHOR = {
+    PROTOCOL_ZERO_ANCHOR: "0",
+    PROTOCOL_ONE_ANCHOR: "1",
+}
+
+
+def decode_anum_denotation(
+    form: AnumForm,
+    context: ProjectionContext,
+) -> AnumDenotation:
+    """Decode the accepted v0.2 subset without reading or mutating L4 memory."""
+
+    source = normalize_raw_form(form)
+
+    if context is ProjectionContext.QUOTE:
+        projection = project_anum(form, ProjectionContext.QUOTE)
+        if projection.kind is not ProjectionKind.QUOTED_RAW or projection.projected is None:
+            raise ValueError("quote projection must return quoted raw payload")
+        return AnumDenotation.quoted_raw_result(normalize_raw_form(projection.projected))
+
+    if context is ProjectionContext.RELATIVE:
+        return AnumDenotation.raw_result(source)
+
+    if context is not ProjectionContext.ROOT:
+        raise TypeError("context должен быть ProjectionContext")
+
+    if source in _PROTOCOL_ANCHOR_BY_ATOM:
+        return _anchor_denotation(source)
+
+    if source in ("[]", "]["):
+        projection = project_anum(form, ProjectionContext.ROOT)
+        if projection.kind is not ProjectionKind.PROTOCOL_VALUE:
+            raise ValueError("accepted boundary alias must project to a protocol value")
+        if projection.protocol_value not in _PROTOCOL_ANCHOR_BY_ATOM:
+            raise ValueError("boundary alias projected outside the accepted 0/1 subset")
+        return _anchor_denotation(projection.protocol_value)
+
+    if len(source) == 2 and all(atom in _PROTOCOL_ANCHOR_BY_ATOM for atom in source):
+        return _pair_denotation(source[0], source[1])
+
+    return AnumDenotation.raw_result(source)
+
+
+def canonical_anum_from_denotation(value: AnumDenotation) -> str:
+    """Return the deterministic raw inverse for structural values in this subset.
+
+    The inverse is canonical, not source-preserving: contextual boundary aliases
+    ``[]`` and ``][`` decode to the same anchor values as ``1`` and ``0`` and
+    therefore serialize canonically as the direct protocol atoms.
+    """
+
+    if value.kind is not DenotationKind.STRUCTURAL or value.structural is None:
+        raise ValueError("canonical inverse is defined only for structural denotations")
+
+    structural = value.structural
+    if not structural.nodes:
+        return _serialize_anchor_only(structural)
+
+    if len(structural.nodes) != 1:
+        raise ValueError("denotation is outside the accepted direct-pair subset")
+
+    node = structural.nodes[0]
+    if node.id != 0 or structural.root != DenotationRef.node_ref(0):
+        raise ValueError("direct-pair denotation must have node 0 as structural root")
+
+    start = _atom_from_anchor_ref(node.start)
+    end = _atom_from_anchor_ref(node.end)
+    expected_anchors = tuple(sorted({_PROTOCOL_ANCHOR_BY_ATOM[start], _PROTOCOL_ANCHOR_BY_ATOM[end]}))
+    if structural.anchors != expected_anchors:
+        raise ValueError("direct-pair denotation contains anchors outside the accepted subset")
+    return start + end
+
+
+def _anchor_denotation(atom: str) -> AnumDenotation:
+    anchor = _PROTOCOL_ANCHOR_BY_ATOM[atom]
+    return AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=(anchor,),
+            nodes=(),
+            root=DenotationRef.anchor_ref(anchor),
+        )
+    )
+
+
+def _pair_denotation(start_atom: str, end_atom: str) -> AnumDenotation:
+    start_anchor = _PROTOCOL_ANCHOR_BY_ATOM[start_atom]
+    end_anchor = _PROTOCOL_ANCHOR_BY_ATOM[end_atom]
+    return AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=tuple(sorted({start_anchor, end_anchor})),
+            nodes=(
+                DenotationNode(
+                    id=0,
+                    start=DenotationRef.anchor_ref(start_anchor),
+                    end=DenotationRef.anchor_ref(end_anchor),
+                ),
+            ),
+            root=DenotationRef.node_ref(0),
+        )
+    )
+
+
+def _serialize_anchor_only(structural: StructuralDenotation) -> str:
+    root = structural.root
+    if root.kind is not DenotationRefKind.ANCHOR or root.anchor is None:
+        raise ValueError("zero-node structural denotation must be rooted at a protocol anchor")
+    atom = _ATOM_BY_PROTOCOL_ANCHOR.get(root.anchor)
+    if atom is None or structural.anchors != (root.anchor,):
+        raise ValueError("anchor-only denotation is outside the accepted protocol subset")
+    return atom
+
+
+def _atom_from_anchor_ref(ref: DenotationRef) -> str:
+    if ref.kind is not DenotationRefKind.ANCHOR or ref.anchor is None:
+        raise ValueError("direct-pair node poles must reference protocol anchors")
+    try:
+        return _ATOM_BY_PROTOCOL_ANCHOR[ref.anchor]
+    except KeyError as exc:
+        raise ValueError("direct-pair node uses an unsupported anchor") from exc

--- a/core/anum_denotation_codec.py
+++ b/core/anum_denotation_codec.py
@@ -11,8 +11,8 @@ small:
   quote projection;
 * relative and every unsupported root carrier remain typed ``raw``.
 
-No memory backend, persistent LinkId, ``find`` or ``realize`` operation is used
-here. Recursive bracket denotation is intentionally left to issue #95.
+No memory backend, storage-assigned LinkId, ``find`` or ``realize`` operation is
+used here. Recursive bracket denotation is intentionally left to issue #95.
 """
 
 from core.anum_denotation import (
@@ -101,7 +101,9 @@ def canonical_anum_from_denotation(value: AnumDenotation) -> str:
 
     start = _atom_from_anchor_ref(node.start)
     end = _atom_from_anchor_ref(node.end)
-    expected_anchors = tuple(sorted({_PROTOCOL_ANCHOR_BY_ATOM[start], _PROTOCOL_ANCHOR_BY_ATOM[end]}))
+    expected_anchors = tuple(
+        sorted({_PROTOCOL_ANCHOR_BY_ATOM[start], _PROTOCOL_ANCHOR_BY_ATOM[end]})
+    )
     if structural.anchors != expected_anchors:
         raise ValueError("direct-pair denotation contains anchors outside the accepted subset")
     return start + end

--- a/docs/specs/Денотация ачисел v0.2.md
+++ b/docs/specs/Денотация ачисел v0.2.md
@@ -1,0 +1,182 @@
+# Денотация ачисел v0.2
+
+Статус: **принятый минимальный structural subset** внутри общего blocker #89.
+
+Машинные контракты:
+
+- [`anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json) — contextual boundary projection;
+- [`anum-denotation-v0.2.json`](../../contracts/anum-denotation-v0.2.json) — storage-neutral IR;
+- [`anum-pair-denotation-v0.2.json`](../../contracts/anum-pair-denotation-v0.2.json) — первый denoting subset;
+- [`anum-pair-denotation-conformance-v0.2.json`](../../contracts/anum-pair-denotation-conformance-v0.2.json) — executable vectors.
+
+## 1. Граница задачи
+
+Этот слой отвечает только на вопрос:
+
+```text
+какой storage-neutral DenotationIR соответствует уже принятому
+минимальному raw subset в конкретном ProjectionContext?
+```
+
+Он не определяет L4 storage identity, не выполняет `find`/`realize` и не вводит recursive bracket grammar.
+
+## 2. Protocol anchors
+
+Два уже существующих protocol atoms получают opaque structural anchors:
+
+```text
+0 → protocol:0
+1 → protocol:1
+```
+
+Это **не display labels** и не persistent LinkId. Это ключи semantic values внутри `anum-denotation/v0.2`.
+
+IR:
+
+```text
+0 → {
+  anchors: [protocol:0],
+  nodes: [],
+  root: anchor(protocol:0)
+}
+
+1 → {
+  anchors: [protocol:1],
+  nodes: [],
+  root: anchor(protocol:1)
+}
+```
+
+## 3. Contextual boundary aliases
+
+Принятый root-boundary contract уже устанавливает:
+
+```text
+][ → 0
+[] → 1
+```
+
+Поэтому только в `root` context:
+
+```text
+den(][) = den(0)
+den([]) = den(1)
+```
+
+Это many-to-one decode. Raw spelling не становится runtime identity.
+
+Canonical inverse выбирает прямые protocol atoms:
+
+```text
+serialize(den(][)) = 0
+serialize(den([])) = 1
+```
+
+Исходное alias spelling намеренно не восстанавливается.
+
+## 4. Первый structural Link subset
+
+Ровно два **прямых** protocol atoms образуют один Link node:
+
+```text
+00 → Link(protocol:0, protocol:0)
+01 → Link(protocol:0, protocol:1)
+10 → Link(protocol:1, protocol:0)
+11 → Link(protocol:1, protocol:1)
+```
+
+Storage-neutral representation использует один local node:
+
+```text
+nodes = [
+  node 0(start = anchor(first), end = anchor(second))
+]
+root = node 0
+```
+
+Persistent IDs здесь отсутствуют.
+
+## 5. Deterministic inverse
+
+Для принятого structural subset inverse однозначен:
+
+```text
+anchor(protocol:0) → 0
+anchor(protocol:1) → 1
+Link(protocol:0, protocol:0) → 00
+Link(protocol:0, protocol:1) → 01
+Link(protocol:1, protocol:0) → 10
+Link(protocol:1, protocol:1) → 11
+```
+
+Structural IR иной формы данным contract не сериализуется. Это явная ошибка subset boundary, а не попытка угадать raw grammar.
+
+## 6. Что остаётся non-denoting
+
+В `root` context typed `RAW` остаются:
+
+```text
+[[
+]]
+любая более длинная последовательность, например 010
+mixed/recursive bracket carriers, например [01]
+```
+
+Даже если такая строка синтаксически валидна на raw L3, данный subset не приписывает ей structural semantics.
+
+Recursive bracket denotation вынесена в #95.
+
+## 7. Quote и relative
+
+`quote` не наследует root denotation. Сначала действует уже принятая quote semantics — снимается не более одной явной `[A]` envelope — после чего результат возвращается как `QUOTED_RAW`.
+
+Примеры:
+
+```text
+[01]   --quote→ quoted-raw(01)
+[[01]] --quote→ quoted-raw([01])
+```
+
+`relative` не получает structural denotation и возвращает typed `RAW`.
+
+## 8. Effects
+
+Decoder является чистым L3→IR преобразованием:
+
+```text
+mayReadMemory   = false
+mayMutateMemory = false
+mayRealize      = false
+```
+
+`core/anum_denotation_codec.py` не импортирует L4 memory backend и не получает persistent LinkId.
+
+## 9. Challenge ambiguity
+
+Принятые aliases образуют две many-to-one пары:
+
+```text
+1  ≡ []   по denotation в root context
+0  ≡ ][   по denotation в root context
+```
+
+Ambiguity устраняется canonical inverse rule:
+
+```text
+direct protocol atom wins
+```
+
+То есть canonical serialization structural value никогда не выбирает `[]` или `][`.
+
+## 10. Следующий blocker
+
+Этот subset сознательно не отвечает на вопрос, как кодировать:
+
+```text
+Link(Link(a,b), c)
+Link(a, Link(b,c))
+shared substructure
+recursive bracket forms
+```
+
+Это #95. До отдельного принятого recursive rule такие carriers остаются typed `RAW` и не могут быть самостоятельно истолкованы downstream AVM или `aprover`.

--- a/tests/test_anum_pair_denotation_v02.py
+++ b/tests/test_anum_pair_denotation_v02.py
@@ -1,0 +1,196 @@
+"""Executable conformance for the accepted minimal Anum denotation subset v0.2."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_denotation import (
+    AnumDenotation,
+    DenotationNode,
+    DenotationRef,
+    StructuralDenotation,
+    denotation_from_data,
+)
+from core.anum_denotation_codec import (
+    PROTOCOL_ONE_ANCHOR,
+    PROTOCOL_ZERO_ANCHOR,
+    canonical_anum_from_denotation,
+    decode_anum_denotation,
+)
+from core.anum_model import ProjectionContext
+from core.anum_parser import parse_raw_quaternary
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / "contracts" / "anum-pair-denotation-v0.2.json"
+CORPUS_PATH = ROOT / "contracts" / "anum-pair-denotation-conformance-v0.2.json"
+CODEC_PATH = ROOT / "core" / "anum_denotation_codec.py"
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def _corpus() -> dict:
+    return json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+def _context(name: str) -> ProjectionContext:
+    return ProjectionContext(name)
+
+
+def test_pair_denotation_contract_is_narrow_and_storage_neutral():
+    contract = _contract()
+
+    assert contract["schema"] == "anum-pair-denotation/v0.2"
+    assert contract["status"] == "accepted-subset"
+    assert contract["dependsOn"] == [
+        "mts-contract/v0.2",
+        "anum-boundary-projection/v0.2",
+        "anum-denotation/v0.2",
+    ]
+    assert contract["protocolAnchors"] == {
+        "0": PROTOCOL_ZERO_ANCHOR,
+        "1": PROTOCOL_ONE_ANCHOR,
+    }
+    assert contract["scope"]["recursiveBracketGrammar"] is False
+    assert contract["scope"]["relativeDenotation"] is False
+    assert contract["effects"] == {
+        "mayReadMemory": False,
+        "mayMutateMemory": False,
+        "mayRealize": False,
+        "persistentLinkIdAllowed": False,
+    }
+
+
+def test_every_conformance_vector_executes_through_the_single_codec_path():
+    corpus = _corpus()
+    assert corpus["schema"] == "anum-pair-denotation-conformance/v0.2"
+    assert corpus["contract"] == "anum-pair-denotation/v0.2"
+
+    for case in corpus["cases"]:
+        actual = decode_anum_denotation(
+            parse_raw_quaternary(case["raw"]),
+            _context(case["context"]),
+        )
+        expected = denotation_from_data(case["denotation"])
+        assert actual == expected, case["name"]
+
+        canonical_raw = case["canonicalRaw"]
+        if canonical_raw is not None:
+            assert canonical_anum_from_denotation(actual) == canonical_raw, case["name"]
+
+
+def test_protocol_atoms_are_opaque_anchor_values_not_display_labels():
+    zero = decode_anum_denotation(parse_raw_quaternary("0"), ProjectionContext.ROOT)
+    one = decode_anum_denotation(parse_raw_quaternary("1"), ProjectionContext.ROOT)
+
+    assert zero.structural == StructuralDenotation(
+        anchors=(PROTOCOL_ZERO_ANCHOR,),
+        nodes=(),
+        root=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+    )
+    assert one.structural == StructuralDenotation(
+        anchors=(PROTOCOL_ONE_ANCHOR,),
+        nodes=(),
+        root=DenotationRef.anchor_ref(PROTOCOL_ONE_ANCHOR),
+    )
+    assert PROTOCOL_ZERO_ANCHOR not in {"0", "∞♂", "♀∞"}
+    assert PROTOCOL_ONE_ANCHOR not in {"1", "∞♂", "♀∞"}
+
+
+def test_all_four_direct_pairs_denote_exactly_one_link_node():
+    expected = {
+        "00": (PROTOCOL_ZERO_ANCHOR, PROTOCOL_ZERO_ANCHOR),
+        "01": (PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR),
+        "10": (PROTOCOL_ONE_ANCHOR, PROTOCOL_ZERO_ANCHOR),
+        "11": (PROTOCOL_ONE_ANCHOR, PROTOCOL_ONE_ANCHOR),
+    }
+
+    for raw, (start, end) in expected.items():
+        result = decode_anum_denotation(parse_raw_quaternary(raw), ProjectionContext.ROOT)
+        assert result.structural is not None
+        assert result.structural.nodes == (
+            DenotationNode(
+                id=0,
+                start=DenotationRef.anchor_ref(start),
+                end=DenotationRef.anchor_ref(end),
+            ),
+        )
+        assert result.structural.root == DenotationRef.node_ref(0)
+        assert canonical_anum_from_denotation(result) == raw
+
+
+def test_boundary_aliases_are_many_to_one_but_inverse_is_canonical():
+    zero = decode_anum_denotation(parse_raw_quaternary("0"), ProjectionContext.ROOT)
+    zero_alias = decode_anum_denotation(parse_raw_quaternary("]["), ProjectionContext.ROOT)
+    one = decode_anum_denotation(parse_raw_quaternary("1"), ProjectionContext.ROOT)
+    one_alias = decode_anum_denotation(parse_raw_quaternary("[]"), ProjectionContext.ROOT)
+
+    assert zero_alias == zero
+    assert one_alias == one
+    assert canonical_anum_from_denotation(zero_alias) == "0"
+    assert canonical_anum_from_denotation(one_alias) == "1"
+
+
+def test_unsupported_root_forms_remain_typed_raw_instead_of_guessing_denotation():
+    for raw in ("[[", "]]", "010", "[01]", "[01]01", "10[]"):
+        result = decode_anum_denotation(parse_raw_quaternary(raw), ProjectionContext.ROOT)
+        assert result == AnumDenotation.raw_result(raw)
+
+
+def test_quote_context_lowers_one_description_envelope_without_structural_decode():
+    first = decode_anum_denotation(parse_raw_quaternary("[01]"), ProjectionContext.QUOTE)
+    second = decode_anum_denotation(parse_raw_quaternary("[[01]]"), ProjectionContext.QUOTE)
+
+    assert first == AnumDenotation.quoted_raw_result("01")
+    assert second == AnumDenotation.quoted_raw_result("[01]")
+
+
+def test_relative_context_never_inherits_root_pair_semantics():
+    for raw in ("0", "1", "00", "01", "10", "11", "[]", "]["):
+        assert decode_anum_denotation(
+            parse_raw_quaternary(raw), ProjectionContext.RELATIVE
+        ) == AnumDenotation.raw_result(raw)
+
+
+def test_inverse_rejects_structural_shapes_outside_the_accepted_subset():
+    nested = AnumDenotation.structural_result(
+        StructuralDenotation(
+            anchors=(PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR),
+            nodes=(
+                DenotationNode(
+                    id=0,
+                    start=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+                    end=DenotationRef.anchor_ref(PROTOCOL_ONE_ANCHOR),
+                ),
+                DenotationNode(
+                    id=1,
+                    start=DenotationRef.node_ref(0),
+                    end=DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR),
+                ),
+            ),
+            root=DenotationRef.node_ref(1),
+        )
+    )
+
+    with pytest.raises(ValueError, match="outside the accepted direct-pair subset"):
+        canonical_anum_from_denotation(nested)
+    with pytest.raises(ValueError, match="only for structural denotations"):
+        canonical_anum_from_denotation(AnumDenotation.raw_result("010"))
+
+
+def test_codec_has_no_l4_or_storage_dependency():
+    source = CODEC_PATH.read_text(encoding="utf-8")
+
+    forbidden = (
+        "anum_memory",
+        "PersistMemoryManager",
+        "persistent",
+        "find(",
+        "realize(",
+        "delete(",
+    )
+    for marker in forbidden:
+        assert marker not in source, marker


### PR DESCRIPTION
Superseded by merged #96 (`9921ce2c6c5ccf5cc62ec27daca571752e116fe9`), which implements the same #94 scope with the canonical `core/anum_pair_denotation.py` path and repository contract linkage.

This duplicate branch is intentionally not merged. No parallel denotation codec should remain active; Git history is sufficient.