### PR TITLE
L3: define structural raw Anum carrier contract

### DIFF
--- a/contracts/anum-raw-carrier-conformance-v0.2.json
+++ b/contracts/anum-raw-carrier-conformance-v0.2.json
@@ -1,0 +1,61 @@
+{
+  "schema": "anum-raw-carrier-conformance/v0.2",
+  "contract": "anum-raw-carrier/v0.2",
+  "status": "accepted",
+  "cases": [
+    {
+      "name": "empty",
+      "raw": "",
+      "expected": {"kind":"raw-carrier","raw":"","nodes":[],"root":{"role":"root"}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[],\"raw\":\"\",\"root\":{\"role\":\"root\"}}"
+    },
+    {
+      "name": "zero",
+      "raw": "0",
+      "expected": {"kind":"raw-carrier","raw":"0","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:0"}}],"root":{"node":0}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:0\"},\"id\":0,\"start\":{\"role\":\"root\"}}],\"raw\":\"0\",\"root\":{\"node\":0}}"
+    },
+    {
+      "name": "one",
+      "raw": "1",
+      "expected": {"kind":"raw-carrier","raw":"1","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:1"}}],"root":{"node":0}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:1\"},\"id\":0,\"start\":{\"role\":\"root\"}}],\"raw\":\"1\",\"root\":{\"node\":0}}"
+    },
+    {
+      "name": "pair-01",
+      "raw": "01",
+      "expected": {"kind":"raw-carrier","raw":"01","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:0"}},{"id":1,"start":{"node":0},"end":{"role":"abit:1"}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:0\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:1\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"01\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "pair-10",
+      "raw": "10",
+      "expected": {"kind":"raw-carrier","raw":"10","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:1"}},{"id":1,"start":{"node":0},"end":{"role":"abit:0"}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:1\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:0\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"10\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "boundary-link-spelling",
+      "raw": "[]",
+      "expected": {"kind":"raw-carrier","raw":"[]","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:["}},{"id":1,"start":{"node":0},"end":{"role":"abit:]"}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:[\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:]\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"[]\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "boundary-unlink-spelling",
+      "raw": "][",
+      "expected": {"kind":"raw-carrier","raw":"][","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:]"}},{"id":1,"start":{"node":0},"end":{"role":"abit:["}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:]\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:[\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"][\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "quoted-looking-raw",
+      "raw": "[01]",
+      "expected": {"kind":"raw-carrier","raw":"[01]","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:["}},{"id":1,"start":{"node":0},"end":{"role":"abit:0"}},{"id":2,"start":{"node":1},"end":{"role":"abit:1"}},{"id":3,"start":{"node":2},"end":{"role":"abit:]"}}],"root":{"node":3}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:[\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:0\"},\"id\":1,\"start\":{\"node\":0}},{\"end\":{\"role\":\"abit:1\"},\"id\":2,\"start\":{\"node\":1}},{\"end\":{\"role\":\"abit:]\"},\"id\":3,\"start\":{\"node\":2}}],\"raw\":\"[01]\",\"root\":{\"node\":3}}"
+    },
+    {
+      "name": "long-repeated-sequence",
+      "raw": "00110",
+      "expected": {"kind":"raw-carrier","raw":"00110","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:0"}},{"id":1,"start":{"node":0},"end":{"role":"abit:0"}},{"id":2,"start":{"node":1},"end":{"role":"abit:1"}},{"id":3,"start":{"node":2},"end":{"role":"abit:1"}},{"id":4,"start":{"node":3},"end":{"role":"abit:0"}}],"root":{"node":4}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:0\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:0\"},\"id\":1,\"start\":{\"node\":0}},{\"end\":{\"role\":\"abit:1\"},\"id\":2,\"start\":{\"node\":1}},{\"end\":{\"role\":\"abit:1\"},\"id\":3,\"start\":{\"node\":2}},{\"end\":{\"role\":\"abit:0\"},\"id\":4,\"start\":{\"node\":3}}],\"raw\":\"00110\",\"root\":{\"node\":4}}"
+    }
+  ]
+}

--- a/contracts/anum-raw-carrier-v0.2.json
+++ b/contracts/anum-raw-carrier-v0.2.json
@@ -1,0 +1,54 @@
+{
+  "schema": "anum-raw-carrier/v0.2",
+  "status": "accepted",
+  "dependsOn": [
+    "mts-contract/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-raw-carrier-conformance-v0.2.json",
+  "purpose": "storage-neutral structural description of raw Anum transport carrier",
+  "roles": [
+    "root",
+    "abit:[",
+    "abit:]",
+    "abit:1",
+    "abit:0"
+  ],
+  "construction": {
+    "initial": "current = role:root",
+    "step": "for each raw abit x in order: node[i] = Link(current, role:abit:x); current = node[i]",
+    "root": "current after the final step, or role:root for the empty carrier"
+  },
+  "identity": {
+    "rolesAreProtocolPositionsNotGlobalObjects": true,
+    "displayLabelsAreIdentity": false,
+    "nodeIdentity": "description-local sequential position",
+    "persistentLinkIdAllowed": false,
+    "classicalGraphNodeIdentityClaimed": false
+  },
+  "separation": {
+    "rawAbitRoles": ["abit:[", "abit:]", "abit:1", "abit:0"],
+    "denotationProtocolAnchors": ["protocol:1", "protocol:0"],
+    "rawCarrierIsDenotation": false
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false
+  },
+  "canonicalJson": {
+    "utf8": true,
+    "sortObjectKeys": true,
+    "compactSeparators": true,
+    "nodesInSequenceOrder": true
+  },
+  "explicitlyOutOfScope": [
+    "context projection",
+    "denotation",
+    "quote interpretation",
+    "recursive bracket interpretation",
+    "persistent identity",
+    "find",
+    "realize",
+    "delete"
+  ]
+}

--- a/contracts/mts-contract-v0.2.json
+++ b/contracts/mts-contract-v0.2.json
@@ -60,9 +60,11 @@
   "anum": {
     "operations": ["serialize", "deserialize"],
     "alphabet": ["[", "]", "1", "0"],
+    "rawCarrierDescription": "contracts/anum-raw-carrier-v0.2.json",
     "rootBoundaryProjection": "contracts/anum-boundary-projection-v0.2.json",
     "denotationHandoff": "contracts/anum-denotation-v0.2.json",
     "acceptedPairDenotationSubset": "contracts/anum-pair-denotation-v0.2.json",
+    "rawCarrierIssue": 99,
     "recursiveDenotationIssue": 95,
     "generalDenotationIssue": 89
   },

--- a/core/anum_raw_carrier.py
+++ b/core/anum_raw_carrier.py
@@ -1,0 +1,216 @@
+"""Storage-neutral structural description of a raw Anum carrier.
+
+A raw carrier is deliberately distinct from its denotation. The description is
+an ordered chain rooted at a protocol role. Local node positions exist only
+inside one serialized description and are not persistent or ontological IDs.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+import json
+
+from core.anum_model import Abit, AnumForm
+from core.anum_parser import normalize_raw_form
+
+
+class RawCarrierRole(str, Enum):
+    ROOT = "root"
+    OPEN = "abit:["
+    CLOSE = "abit:]"
+    LINK = "abit:1"
+    UNLINK = "abit:0"
+
+
+class RawCarrierRefKind(str, Enum):
+    ROLE = "role"
+    NODE = "node"
+
+
+@dataclass(frozen=True)
+class RawCarrierRef:
+    kind: RawCarrierRefKind
+    role: RawCarrierRole | None = None
+    node: int | None = None
+
+    @staticmethod
+    def role_ref(role: RawCarrierRole) -> "RawCarrierRef":
+        return RawCarrierRef(kind=RawCarrierRefKind.ROLE, role=role)
+
+    @staticmethod
+    def node_ref(node_id: int) -> "RawCarrierRef":
+        return RawCarrierRef(kind=RawCarrierRefKind.NODE, node=node_id)
+
+
+@dataclass(frozen=True)
+class RawCarrierNode:
+    id: int
+    start: RawCarrierRef
+    end: RawCarrierRef
+
+
+@dataclass(frozen=True)
+class RawCarrierDescription:
+    raw: str
+    nodes: tuple[RawCarrierNode, ...]
+    root: RawCarrierRef
+
+    def __post_init__(self) -> None:
+        validate_raw_carrier(self)
+
+
+def describe_raw_carrier(form: AnumForm) -> RawCarrierDescription:
+    """Build the deterministic raw sequence carrier without projecting meaning."""
+
+    current = RawCarrierRef.role_ref(RawCarrierRole.ROOT)
+    nodes: list[RawCarrierNode] = []
+
+    for node_id, token in enumerate(form.tokens):
+        node = RawCarrierNode(
+            id=node_id,
+            start=current,
+            end=RawCarrierRef.role_ref(_role_for_abit(token.abit)),
+        )
+        nodes.append(node)
+        current = RawCarrierRef.node_ref(node_id)
+
+    return RawCarrierDescription(
+        raw=normalize_raw_form(form),
+        nodes=tuple(nodes),
+        root=current,
+    )
+
+
+def validate_raw_carrier(value: RawCarrierDescription) -> None:
+    """Validate the exact root-then-abits chain shape of one raw carrier."""
+
+    expected_start = RawCarrierRef.role_ref(RawCarrierRole.ROOT)
+    reconstructed: list[str] = []
+
+    for expected_id, node in enumerate(value.nodes):
+        if node.id != expected_id:
+            raise ValueError("raw carrier node ids must be contiguous sequence positions")
+        _validate_ref(node.start, available_nodes=expected_id)
+        _validate_ref(node.end, available_nodes=expected_id)
+        if node.start != expected_start:
+            raise ValueError("raw carrier nodes must form one ordered sequence chain")
+        if node.end.kind is not RawCarrierRefKind.ROLE or node.end.role not in _ABIT_FOR_ROLE:
+            raise ValueError("raw carrier node end must be one raw abit role")
+
+        reconstructed.append(_ABIT_FOR_ROLE[node.end.role])
+        expected_start = RawCarrierRef.node_ref(expected_id)
+
+    expected_root = (
+        RawCarrierRef.node_ref(len(value.nodes) - 1)
+        if value.nodes
+        else RawCarrierRef.role_ref(RawCarrierRole.ROOT)
+    )
+    if value.root != expected_root:
+        raise ValueError("raw carrier root must be the final sequence node or root role")
+    _validate_ref(value.root, available_nodes=len(value.nodes))
+
+    if value.raw != "".join(reconstructed):
+        raise ValueError("raw carrier text must match the structural abit sequence")
+
+
+def canonical_raw_carrier_json(value: RawCarrierDescription) -> str:
+    """Serialize one validated raw carrier description deterministically."""
+
+    validate_raw_carrier(value)
+    payload = {
+        "kind": "raw-carrier",
+        "raw": value.raw,
+        "nodes": [
+            {
+                "id": node.id,
+                "start": _ref_to_data(node.start),
+                "end": _ref_to_data(node.end),
+            }
+            for node in value.nodes
+        ],
+        "root": _ref_to_data(value.root),
+    }
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def raw_carrier_from_data(data: dict) -> RawCarrierDescription:
+    """Parse canonical raw-carrier-shaped data without invoking the raw parser."""
+
+    if not isinstance(data, dict) or set(data) != {"kind", "raw", "nodes", "root"}:
+        raise ValueError("raw carrier data must contain exactly kind, raw, nodes and root")
+    if data["kind"] != "raw-carrier" or not isinstance(data["raw"], str):
+        raise ValueError("raw carrier data has invalid kind or raw payload")
+    if not isinstance(data["nodes"], list):
+        raise ValueError("raw carrier nodes must be a list")
+
+    nodes: list[RawCarrierNode] = []
+    for node_data in data["nodes"]:
+        if not isinstance(node_data, dict) or set(node_data) != {"id", "start", "end"}:
+            raise ValueError("raw carrier node must contain exactly id, start and end")
+        if not isinstance(node_data["id"], int) or isinstance(node_data["id"], bool):
+            raise ValueError("raw carrier node id must be an integer")
+        nodes.append(
+            RawCarrierNode(
+                id=node_data["id"],
+                start=_ref_from_data(node_data["start"]),
+                end=_ref_from_data(node_data["end"]),
+            )
+        )
+
+    return RawCarrierDescription(
+        raw=data["raw"],
+        nodes=tuple(nodes),
+        root=_ref_from_data(data["root"]),
+    )
+
+
+def _validate_ref(ref: RawCarrierRef, available_nodes: int) -> None:
+    if ref.kind is RawCarrierRefKind.ROLE:
+        if ref.role is None or ref.node is not None:
+            raise ValueError("raw carrier role reference must contain only a role")
+        return
+
+    if ref.node is None or ref.role is not None:
+        raise ValueError("raw carrier node reference must contain only a node position")
+    if ref.node < 0 or ref.node >= available_nodes:
+        raise ValueError("raw carrier node reference must target an earlier node")
+
+
+def _ref_from_data(data: object) -> RawCarrierRef:
+    if not isinstance(data, dict):
+        raise ValueError("raw carrier reference must be an object")
+    if set(data) == {"role"} and isinstance(data["role"], str):
+        try:
+            return RawCarrierRef.role_ref(RawCarrierRole(data["role"]))
+        except ValueError as exc:
+            raise ValueError("unknown raw carrier role") from exc
+    if (
+        set(data) == {"node"}
+        and isinstance(data["node"], int)
+        and not isinstance(data["node"], bool)
+    ):
+        return RawCarrierRef.node_ref(data["node"])
+    raise ValueError("raw carrier reference must contain exactly one role or node")
+
+
+def _ref_to_data(ref: RawCarrierRef) -> dict:
+    if ref.kind is RawCarrierRefKind.ROLE:
+        return {"role": ref.role.value if ref.role is not None else None}
+    return {"node": ref.node}
+
+
+def _role_for_abit(abit: Abit) -> RawCarrierRole:
+    return _ROLE_FOR_ABIT[abit]
+
+
+_ROLE_FOR_ABIT = {
+    Abit.OPEN: RawCarrierRole.OPEN,
+    Abit.CLOSE: RawCarrierRole.CLOSE,
+    Abit.LINK: RawCarrierRole.LINK,
+    Abit.UNLINK: RawCarrierRole.UNLINK,
+}
+_ABIT_FOR_ROLE = {role: abit.value for abit, role in _ROLE_FOR_ABIT.items()}

--- a/docs/specs/Ачисла и сериализация.md
+++ b/docs/specs/Ачисла и сериализация.md
@@ -8,6 +8,7 @@
 
 Machine contracts:
 
+- [`contracts/anum-raw-carrier-v0.2.json`](../../contracts/anum-raw-carrier-v0.2.json);
 - [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json);
 - [`contracts/anum-denotation-v0.2.json`](../../contracts/anum-denotation-v0.2.json);
 - [`contracts/anum-pair-denotation-v0.2.json`](../../contracts/anum-pair-denotation-v0.2.json).
@@ -37,10 +38,61 @@ Raw parser отвечает только за чтение четырёх аби
 []
 ```
 
+### 1.1. Structural raw carrier
+
+Помимо текста raw carrier имеет storage-neutral структурное описание, которое сохраняет последовательностную форму и **не является denotation**.
+
+Для raw-последовательности:
+
+```text
+x0 x1 ... xn
+```
+
+принята reference-конструкция:
+
+```text
+c0 = RootRole
+c1 = Link(c0, AbitRole(x0))
+c2 = Link(c1, AbitRole(x1))
+...
+rawRoot = cn
+```
+
+Например:
+
+```text
+raw(01)
+=
+Link(Link(RootRole, AbitRole(0)), AbitRole(1))
+```
+
+При этом принятый minimal denotation subset отдельно даёт:
+
+```text
+den(01) = Link(protocol:0, protocol:1)
+```
+
+Это разные типы и разные контракты. Raw-роли:
+
+```text
+root
+abit:[
+abit:]
+abit:1
+abit:0
+```
+
+не являются `protocol:0/1` denotation anchors.
+
+Локальный номер carrier-node — только позиция внутри переносимого structural description. Он не является глобальным идентификатором узла МТС, persistent `LinkId` или утверждением, что онтология МТС является классическим графом с внешними ID.
+
+`core/anum_raw_carrier.py` строит carrier только из уже разобранного `AnumForm`; он не знает `ProjectionContext`, quote, root projection или L4 memory.
+
 ## 2. Канонический pipeline L3
 
 ```text
 parse_raw_quaternary
+→ raw carrier description
 → validate_anum(context)
 → project_anum(context)
 → denotation subset
@@ -48,7 +100,7 @@ parse_raw_quaternary
 
 Это разные операции.
 
-`parse_raw_quaternary` не знает семантики. `validate_anum` не меняет raw carrier. `project_anum` всегда получает явный `ProjectionContext`. Denotation layer выдаёт storage-neutral `AnumDenotation` и не обращается к L4-памяти.
+`parse_raw_quaternary` не знает семантики. Structural raw carrier сохраняет только последовательность. `validate_anum` не меняет raw carrier. `project_anum` всегда получает явный `ProjectionContext`. Denotation layer выдаёт storage-neutral `AnumDenotation` и не обращается к L4-памяти.
 
 Контексты протокола:
 
@@ -198,6 +250,8 @@ project(quote(A), quote)  = A
 
 Поскольку context указан явно, одинаковая последовательность абитов может иметь разные projection semantics без скрытой неоднозначности parser-а.
 
+Structural raw carrier при этом **не снимает** оболочку: `[A]` для него всегда последовательность raw-абитов `[`, carrier(A), `]`. Снятие уровня относится только к явному quote context.
+
 ## 8. Граница L2/L3 и root boundary projection
 
 Совпадение glyph `[` и `]` с квадратной формой L2 не означает автоматического тождества.
@@ -304,18 +358,21 @@ interpret(F) не выполняет realize(F)
 
 `core/anum_memory.py` остаётся test-double L4-инвариантов.
 
-`core/anum_pair_denotation.py` не читает и не мутирует память: он только строит storage-neutral `AnumDenotation`.
+`core/anum_raw_carrier.py` и `core/anum_pair_denotation.py` не читают и не мутируют память. Первый описывает raw(A), второй — только принятый минимальный den(A) subset.
 
 ## 11. Актуальные модули
 
 ```text
 core/anum_model.py              Abit, ProjectionContext, typed protocol results
 core/anum_parser.py             raw parser, incremental decoder, deterministic serializer
+core/anum_raw_carrier.py        storage-neutral structural raw(A) chain
 core/anum_protocol.py           validate/project/quote/unquote/AnumDictionary
-core/anum_denotation.py         storage-neutral L3→L4 structural handoff
+core/anum_denotation.py         storage-neutral L3→L4 structural denotation handoff
 core/anum_pair_denotation.py    accepted minimal 0/1 pair denotation + canonical inverse
 core/anum_memory.py             L4 test-double
 
+contracts/anum-raw-carrier-v0.2.json
+contracts/anum-raw-carrier-conformance-v0.2.json
 contracts/anum-boundary-projection-v0.2.json
 contracts/anum-denotation-v0.2.json
 contracts/anum-denotation-conformance-v0.2.json
@@ -325,7 +382,7 @@ contracts/anum-pair-denotation-conformance-v0.2.json
 converters/anum_cli.py          parse/validate/project/normalize/quote/unquote
 ```
 
-`core/anum_protocol.py` остаётся единственным contextual projection path. Pair denotation вызывается после него и не создаёт второй raw parser.
+`core/anum_protocol.py` остаётся единственным contextual projection path. Raw carrier builder не делает projection, а pair denotation вызывается после него и не создаёт второй raw parser.
 
 ## 12. CLI
 

--- a/tests/test_anum_raw_carrier.py
+++ b/tests/test_anum_raw_carrier.py
@@ -1,0 +1,269 @@
+"""Conformance tests for the storage-neutral raw Anum carrier description."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_pair_denotation import denotate_anum_pair_subset
+from core.anum_model import ProjectionContext
+from core.anum_parser import parse_raw_quaternary
+from core.anum_raw_carrier import (
+    RawCarrierDescription,
+    RawCarrierNode,
+    RawCarrierRef,
+    RawCarrierRole,
+    canonical_raw_carrier_json,
+    describe_raw_carrier,
+    raw_carrier_from_data,
+)
+from core.anum_denotation import canonical_denotation_json
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts/anum-raw-carrier-v0.2.json"
+CORPUS = ROOT / "contracts/anum-raw-carrier-conformance-v0.2.json"
+SOURCE = ROOT / "core/anum_raw_carrier.py"
+
+
+def test_contract_is_accepted_storage_neutral_and_not_denotation():
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    assert contract["schema"] == "anum-raw-carrier/v0.2"
+    assert contract["status"] == "accepted"
+    assert contract["conformanceCorpus"] == (
+        "contracts/anum-raw-carrier-conformance-v0.2.json"
+    )
+    assert contract["separation"]["rawCarrierIsDenotation"] is False
+    assert set(contract["separation"]["rawAbitRoles"]).isdisjoint(
+        contract["separation"]["denotationProtocolAnchors"]
+    )
+    assert contract["effects"] == {
+        "mayReadMemory": False,
+        "mayMutateMemory": False,
+        "mayRealize": False,
+    }
+    assert contract["identity"]["rolesAreProtocolPositionsNotGlobalObjects"] is True
+    assert contract["identity"]["classicalGraphNodeIdentityClaimed"] is False
+
+
+def test_reference_module_has_no_storage_projection_or_denotation_dependency():
+    source = SOURCE.read_text(encoding="utf-8")
+
+    for forbidden in (
+        "LinkStore",
+        "PersistentLinkStore",
+        "database",
+        "sqlite",
+        "realize(",
+        "find(",
+        "project_anum",
+        "ProjectionContext",
+        "AnumDenotation",
+        "protocol:0",
+        "protocol:1",
+    ):
+        assert forbidden not in source
+
+
+def test_all_language_neutral_vectors_match_reference_builder_and_json():
+    corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
+
+    assert corpus["schema"] == "anum-raw-carrier-conformance/v0.2"
+    assert corpus["contract"] == "anum-raw-carrier/v0.2"
+    assert corpus["status"] == "accepted"
+
+    for case in corpus["cases"]:
+        description = describe_raw_carrier(parse_raw_quaternary(case["raw"]))
+        expected = raw_carrier_from_data(case["expected"])
+
+        assert description == expected
+        assert canonical_raw_carrier_json(description) == case["canonicalJson"]
+        assert canonical_raw_carrier_json(expected) == case["canonicalJson"]
+
+
+def test_empty_raw_carrier_is_root_role_only_without_denotation_claim():
+    description = describe_raw_carrier(parse_raw_quaternary(""))
+
+    assert description.raw == ""
+    assert description.nodes == ()
+    assert description.root == RawCarrierRef.role_ref(RawCarrierRole.ROOT)
+
+
+def test_each_raw_abit_has_a_distinct_role():
+    expected = {
+        "[": RawCarrierRole.OPEN,
+        "]": RawCarrierRole.CLOSE,
+        "1": RawCarrierRole.LINK,
+        "0": RawCarrierRole.UNLINK,
+    }
+
+    assert len(set(expected.values())) == 4
+    for raw, role in expected.items():
+        description = describe_raw_carrier(parse_raw_quaternary(raw))
+        assert len(description.nodes) == 1
+        assert description.nodes[0].start == RawCarrierRef.role_ref(RawCarrierRole.ROOT)
+        assert description.nodes[0].end == RawCarrierRef.role_ref(role)
+
+
+def test_pair_raw_carrier_is_chain_and_not_pair_denotation():
+    form = parse_raw_quaternary("01")
+    carrier = describe_raw_carrier(form)
+    denotation = denotate_anum_pair_subset(form, ProjectionContext.ROOT)
+
+    assert isinstance(carrier, RawCarrierDescription)
+    assert carrier.raw == "01"
+    assert carrier.nodes == (
+        RawCarrierNode(
+            id=0,
+            start=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+            end=RawCarrierRef.role_ref(RawCarrierRole.UNLINK),
+        ),
+        RawCarrierNode(
+            id=1,
+            start=RawCarrierRef.node_ref(0),
+            end=RawCarrierRef.role_ref(RawCarrierRole.LINK),
+        ),
+    )
+    assert carrier.root == RawCarrierRef.node_ref(1)
+
+    assert denotation.structural is not None
+    assert len(denotation.structural.nodes) == 1
+    assert canonical_raw_carrier_json(carrier) != canonical_denotation_json(denotation)
+    assert "abit:0" in canonical_raw_carrier_json(carrier)
+    assert "protocol:0" in canonical_denotation_json(denotation)
+
+
+def test_brackets_remain_plain_raw_roles_without_quote_or_root_projection():
+    description = describe_raw_carrier(parse_raw_quaternary("[01]"))
+
+    assert [node.end.role for node in description.nodes] == [
+        RawCarrierRole.OPEN,
+        RawCarrierRole.UNLINK,
+        RawCarrierRole.LINK,
+        RawCarrierRole.CLOSE,
+    ]
+    assert description.raw == "[01]"
+
+
+def test_repeated_and_long_sequences_are_preserved_exactly():
+    raw = "00110][[10"
+    description = describe_raw_carrier(parse_raw_quaternary(raw))
+
+    assert description.raw == raw
+    assert len(description.nodes) == len(raw)
+    assert description.root == RawCarrierRef.node_ref(len(raw) - 1)
+
+    for index, node in enumerate(description.nodes):
+        expected_start = (
+            RawCarrierRef.role_ref(RawCarrierRole.ROOT)
+            if index == 0
+            else RawCarrierRef.node_ref(index - 1)
+        )
+        assert node.id == index
+        assert node.start == expected_start
+
+
+def test_validator_rejects_non_contiguous_node_positions():
+    with pytest.raises(ValueError, match="contiguous"):
+        RawCarrierDescription(
+            raw="0",
+            nodes=(
+                RawCarrierNode(
+                    id=1,
+                    start=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+                    end=RawCarrierRef.role_ref(RawCarrierRole.UNLINK),
+                ),
+            ),
+            root=RawCarrierRef.node_ref(0),
+        )
+
+
+def test_validator_rejects_branching_or_skipped_sequence_chain():
+    with pytest.raises(ValueError, match="ordered sequence chain"):
+        RawCarrierDescription(
+            raw="01",
+            nodes=(
+                RawCarrierNode(
+                    id=0,
+                    start=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+                    end=RawCarrierRef.role_ref(RawCarrierRole.UNLINK),
+                ),
+                RawCarrierNode(
+                    id=1,
+                    start=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+                    end=RawCarrierRef.role_ref(RawCarrierRole.LINK),
+                ),
+            ),
+            root=RawCarrierRef.node_ref(1),
+        )
+
+
+def test_validator_rejects_non_abit_end_role():
+    with pytest.raises(ValueError, match="raw abit role"):
+        RawCarrierDescription(
+            raw="0",
+            nodes=(
+                RawCarrierNode(
+                    id=0,
+                    start=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+                    end=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+                ),
+            ),
+            root=RawCarrierRef.node_ref(0),
+        )
+
+
+def test_validator_rejects_wrong_root_and_raw_text_mismatch():
+    valid_node = RawCarrierNode(
+        id=0,
+        start=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+        end=RawCarrierRef.role_ref(RawCarrierRole.UNLINK),
+    )
+
+    with pytest.raises(ValueError, match="raw carrier root"):
+        RawCarrierDescription(
+            raw="0",
+            nodes=(valid_node,),
+            root=RawCarrierRef.role_ref(RawCarrierRole.ROOT),
+        )
+
+    with pytest.raises(ValueError, match="raw carrier text"):
+        RawCarrierDescription(
+            raw="1",
+            nodes=(valid_node,),
+            root=RawCarrierRef.node_ref(0),
+        )
+
+
+def test_data_parser_rejects_mixed_refs_unknown_roles_and_extra_fields():
+    with pytest.raises(ValueError, match="exactly one role or node"):
+        raw_carrier_from_data(
+            {
+                "kind": "raw-carrier",
+                "raw": "",
+                "nodes": [],
+                "root": {"role": "root", "node": 0},
+            }
+        )
+
+    with pytest.raises(ValueError, match="unknown raw carrier role"):
+        raw_carrier_from_data(
+            {
+                "kind": "raw-carrier",
+                "raw": "",
+                "nodes": [],
+                "root": {"role": "protocol:0"},
+            }
+        )
+
+    with pytest.raises(ValueError, match="exactly kind, raw, nodes and root"):
+        raw_carrier_from_data(
+            {
+                "kind": "raw-carrier",
+                "raw": "",
+                "nodes": [],
+                "root": {"role": "root"},
+                "linkId": 42,
+            }
+        )

--- a/tests/test_mts_contract_v02.py
+++ b/tests/test_mts_contract_v02.py
@@ -10,6 +10,7 @@ from core.mtc_parser import parse_formula
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "contracts/mts-contract-v0.2.json"
 CONFORMANCE = ROOT / "contracts/mts-conformance-v0.2.json"
+ANUM_RAW_CARRIER = ROOT / "contracts/anum-raw-carrier-v0.2.json"
 ANUM_BOUNDARY = ROOT / "contracts/anum-boundary-projection-v0.2.json"
 ANUM_DENOTATION = ROOT / "contracts/anum-denotation-v0.2.json"
 ANUM_PAIR_DENOTATION = ROOT / "contracts/anum-pair-denotation-v0.2.json"
@@ -35,6 +36,9 @@ def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     assert contract["status"] == "accepted"
     assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
     assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
+    assert contract["anum"]["rawCarrierDescription"] == (
+        "contracts/anum-raw-carrier-v0.2.json"
+    )
     assert contract["anum"]["rootBoundaryProjection"] == (
         "contracts/anum-boundary-projection-v0.2.json"
     )
@@ -44,9 +48,11 @@ def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     assert contract["anum"]["acceptedPairDenotationSubset"] == (
         "contracts/anum-pair-denotation-v0.2.json"
     )
+    assert contract["anum"]["rawCarrierIssue"] == 99
     assert contract["anum"]["recursiveDenotationIssue"] == 95
     assert contract["anum"]["generalDenotationIssue"] == 89
     assert CONFORMANCE.is_file()
+    assert ANUM_RAW_CARRIER.is_file()
     assert ANUM_BOUNDARY.is_file()
     assert ANUM_DENOTATION.is_file()
     assert ANUM_PAIR_DENOTATION.is_file()
@@ -54,6 +60,12 @@ def test_contract_is_accepted_v02_and_points_to_canonical_artifacts():
     corpus = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
     assert corpus["contract"] == contract["schema"]
     assert corpus["status"] == "accepted"
+
+    raw_carrier = json.loads(ANUM_RAW_CARRIER.read_text(encoding="utf-8"))
+    assert raw_carrier["status"] == "accepted"
+    assert contract["schema"] in raw_carrier["dependsOn"]
+    assert raw_carrier["separation"]["rawCarrierIsDenotation"] is False
+    assert raw_carrier["effects"]["mayRealize"] is False
 
     boundary = json.loads(ANUM_BOUNDARY.read_text(encoding="utf-8"))
     assert boundary["dependsOn"] == contract["schema"]


### PR DESCRIPTION
Closes #99. Parent #95/#89. Downstream prerequisite for recursive bracket denotation and netkeep80/avm#79.

## Why
The accepted pair subset already distinguishes loaded raw sequence `(∞⟼a)⟼b` from its denotation `a⟼b`. Recursive quote/bracket semantics can refer to description level, so L3 needs an explicit structural representation of `raw(A)` before extending `den(A)`.

## Contract
Adds accepted `anum-raw-carrier/v0.2` as a separate type/contract from `AnumDenotation`.

For raw abits `x0...xn`:
```text
current = RootRole
for x in raw order:
    node[i] = Link(current, AbitRole(x))
    current = node[i]
rawRoot = current
```

The empty transport carrier is the root role only. `[` and `]` are plain raw roles here; no quote/root/relative context is interpreted.

## Identity discipline
In line with #98, `RootRole`, `AbitRole` and local node positions are protocol/transport roles inside one description, not named ontological graph nodes or persistent identities. No `LinkId` enters L3.

Raw roles `abit:0/1` are explicitly disjoint from denotation anchors `protocol:0/1`.

## Conformance
Adds language-neutral exact vectors for empty, `0`, `1`, `01`, `10`, `[]`, `][`, `[01]`, and a longer repeated sequence, including deterministic canonical JSON.

Tests prove:
- the carrier is a single ordered chain;
- all four abits have distinct raw roles;
- `raw(01)` is type/structure-distinct from accepted `den(01)=Link(protocol:0,protocol:1)`;
- bracket-looking carriers are not interpreted by the raw builder;
- malformed chain/root/text/ref shapes are rejected;
- implementation has no storage, projection, denotation or realization dependency.

## Integration
`mts-contract/v0.2` and the existing active serialization spec now expose the raw-carrier contract. No new normative spec file is added.

Full ruff + pytest + repository structure/protected-file CI must be green before merge.