### PR TITLE
Зафиксировать challenge corpus перед recursive Anum denotation

### DIFF
--- a/contracts/anum-recursive-denotation-challenge-v0.2.json
+++ b/contracts/anum-recursive-denotation-challenge-v0.2.json
@@ -1,0 +1,113 @@
+{
+  "schema": "anum-recursive-denotation-challenge/v0.2",
+  "status": "challenged",
+  "dependsOn": [
+    "anum-boundary-projection/v0.2",
+    "anum-denotation/v0.2",
+    "anum-pair-denotation/v0.2"
+  ],
+  "parentIssues": [89, 95],
+  "purpose": "freeze ambiguities and non-regression constraints before any recursive production decoder is accepted",
+  "acceptedBaseline": {
+    "rootStructural": ["0", "1", "00", "01", "10", "11"],
+    "rootAliases": {
+      "][": "0",
+      "[]": "1"
+    },
+    "canonicalAliasInverse": {
+      "][": "0",
+      "[]": "1"
+    }
+  },
+  "directSequenceChallenges": [
+    {
+      "raw": "000",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(0,0),0)", "Link(0,Link(0,0))"]
+    },
+    {
+      "raw": "001",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(0,0),1)", "Link(0,Link(0,1))"]
+    },
+    {
+      "raw": "010",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(0,1),0)", "Link(0,Link(1,0))"]
+    },
+    {
+      "raw": "011",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(0,1),1)", "Link(0,Link(1,1))"]
+    },
+    {
+      "raw": "100",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(1,0),0)", "Link(1,Link(0,0))"]
+    },
+    {
+      "raw": "101",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(1,0),1)", "Link(1,Link(0,1))"]
+    },
+    {
+      "raw": "110",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(1,1),0)", "Link(1,Link(1,0))"]
+    },
+    {
+      "raw": "111",
+      "requiredCurrentKind": "raw",
+      "competingAssociationShapes": ["Link(Link(1,1),1)", "Link(1,Link(1,1))"]
+    }
+  ],
+  "bracketChallenges": [
+    {
+      "raw": "[01]",
+      "rootRequiredCurrentKind": "raw",
+      "reason": "ordinary-looking brackets are not a recursive denotation rule by themselves"
+    },
+    {
+      "raw": "[01]0",
+      "rootRequiredCurrentKind": "raw",
+      "reason": "left nested candidate has no accepted root grammar"
+    },
+    {
+      "raw": "0[10]",
+      "rootRequiredCurrentKind": "raw",
+      "reason": "right nested candidate has no accepted root grammar"
+    },
+    {
+      "raw": "[01][10]",
+      "rootRequiredCurrentKind": "raw",
+      "reason": "two bracketed candidates have no accepted composition rule"
+    },
+    {
+      "raw": "[[01]]",
+      "rootRequiredCurrentKind": "raw",
+      "reason": "root recursive meaning must not be inferred from quote-envelope syntax"
+    }
+  ],
+  "contextSeparation": {
+    "root": "recursive structural semantics not accepted beyond baseline",
+    "quote": "existing one-envelope quote semantics remains separate",
+    "relative": "remains raw until separately accepted"
+  },
+  "identityConstraints": {
+    "displayLabelIsIdentity": false,
+    "rawSpellingIsRuntimeIdentity": false,
+    "persistentLinkIdAllowed": false,
+    "structuralNodeIdentity": "description-local"
+  },
+  "futureAcceptanceGates": [
+    "unique parse for every newly accepted raw carrier",
+    "no change to accepted 0/1 direct-pair denotations",
+    "explicit root/quote/relative context separation",
+    "storage-neutral DenotationIR only",
+    "deterministic canonical inverse",
+    "decode(canonical_encode(D)) = D on accepted recursive subset",
+    "canonical_encode(decode(raw)) = canonical(raw) on accepted recursive subset",
+    "negative corpus remains explicit for unsupported carriers",
+    "production decoder extends the existing single path instead of creating a compatibility decoder"
+  ]
+}

--- a/tests/test_anum_recursive_denotation_challenge_v02.py
+++ b/tests/test_anum_recursive_denotation_challenge_v02.py
@@ -1,0 +1,113 @@
+"""Challenge gate for recursive Anum denotation before a production grammar exists."""
+
+import json
+from pathlib import Path
+
+from core.anum_parser import normalize_raw_form, parse_raw_quaternary
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHALLENGE_PATH = ROOT / "contracts" / "anum-recursive-denotation-challenge-v0.2.json"
+PAIR_PATH = ROOT / "contracts" / "anum-pair-denotation-v0.2.json"
+DENOTATION_PATH = ROOT / "contracts" / "anum-denotation-v0.2.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_challenge_is_non_normative_and_depends_on_accepted_subset():
+    challenge = _load(CHALLENGE_PATH)
+
+    assert challenge["schema"] == "anum-recursive-denotation-challenge/v0.2"
+    assert challenge["status"] == "challenged"
+    assert challenge["dependsOn"] == [
+        "anum-boundary-projection/v0.2",
+        "anum-denotation/v0.2",
+        "anum-pair-denotation/v0.2",
+    ]
+    assert challenge["parentIssues"] == [89, 95]
+
+
+def test_baseline_is_exactly_the_already_accepted_pair_contract():
+    challenge = _load(CHALLENGE_PATH)
+    pair = _load(PAIR_PATH)
+
+    assert challenge["acceptedBaseline"]["rootStructural"] == pair["acceptedStructuralRaw"]
+    assert challenge["acceptedBaseline"]["rootAliases"] == pair["acceptedRootAliases"]
+    assert challenge["acceptedBaseline"]["canonicalAliasInverse"] == {
+        "][": "0",
+        "[]": "1",
+    }
+
+
+def test_all_three_atom_direct_sequences_remain_explicitly_ambiguous():
+    challenge = _load(CHALLENGE_PATH)
+    cases = challenge["directSequenceChallenges"]
+
+    assert [case["raw"] for case in cases] == [
+        "000",
+        "001",
+        "010",
+        "011",
+        "100",
+        "101",
+        "110",
+        "111",
+    ]
+
+    for case in cases:
+        assert case["requiredCurrentKind"] == "raw"
+        assert len(case["competingAssociationShapes"]) == 2
+        assert len(set(case["competingAssociationShapes"])) == 2
+        parsed = parse_raw_quaternary(case["raw"])
+        assert normalize_raw_form(parsed) == case["raw"]
+
+
+def test_bracket_candidates_are_raw_syntax_not_an_assumed_recursive_grammar():
+    challenge = _load(CHALLENGE_PATH)
+    pair = _load(PAIR_PATH)
+    accepted = set(pair["acceptedStructuralRaw"]) | set(pair["acceptedRootAliases"])
+
+    for case in challenge["bracketChallenges"]:
+        assert case["raw"] not in accepted
+        assert case["rootRequiredCurrentKind"] == "raw"
+        assert case["reason"]
+        parsed = parse_raw_quaternary(case["raw"])
+        assert normalize_raw_form(parsed) == case["raw"]
+
+
+def test_contexts_cannot_inherit_recursive_semantics_implicitly():
+    contexts = _load(CHALLENGE_PATH)["contextSeparation"]
+
+    assert "not accepted" in contexts["root"]
+    assert "quote" in contexts["quote"]
+    assert "raw" in contexts["relative"]
+
+
+def test_identity_constraints_match_storage_neutral_denotation_contract():
+    challenge = _load(CHALLENGE_PATH)
+    denotation = _load(DENOTATION_PATH)
+    identity = challenge["identityConstraints"]
+
+    assert identity["displayLabelIsIdentity"] is False
+    assert identity["rawSpellingIsRuntimeIdentity"] is False
+    assert identity["persistentLinkIdAllowed"] is False
+    assert identity["structuralNodeIdentity"] == "description-local"
+
+    assert denotation["identity"]["displayLabelIsIdentity"] is False
+    assert denotation["identity"]["rawSpellingIsRuntimeIdentity"] is False
+    assert denotation["identity"]["persistentLinkIdAllowed"] is False
+    assert denotation["identity"]["nodeIdentity"] == "description-local node id"
+
+
+def test_future_acceptance_requires_round_trip_and_one_decoder_path():
+    gates = _load(CHALLENGE_PATH)["futureAcceptanceGates"]
+    joined = "\n".join(gates)
+
+    assert "unique parse" in joined
+    assert "deterministic canonical inverse" in joined
+    assert "decode(canonical_encode(D)) = D" in joined
+    assert "canonical_encode(decode(raw)) = canonical(raw)" in joined
+    assert "single path" in joined
+    assert "compatibility decoder" in joined


### PR DESCRIPTION
Superseded by merged #102 / completed #95.

Изначально этот PR был veto-gate **до** принятия recursive grammar. Пока он готовился, #102 уже принял более сильный executable contract `anum-recursive-denotation/v0.2` и закрыл требуемые challenge cases: nested left/right/both, `010`→RAW, quote/relative isolation, root-opening-collapse canonicality veto, deterministic inverse и exhaustive collision/round-trip challenge.

Не мержим запоздалый параллельный challenge surface после принятой grammar. Историю сохраняет Git; canonical path остаётся #102.