### PR TITLE
Собрать canonical end-to-end контур МТС/Anum v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [Основания МТС](docs/theory/Основания%20МТС.md) | онтологические основания |
 | [Система аксиом МТС](docs/theory/Система%20аксиом%20МТС.md) | нормативное чтение 10 root definitions |
 | [Reference model МТС v0.2](docs/specs/Reference%20model%20МТС%20v0.2.md) | границы L0–L5 и инженерная semantics |
-| [Формальная нотация МТС](docs/specs/Формальная%20нотацияция%20МТС.md) | typed L2 syntax и interpretation |
+| [Формальная нотация МТС](docs/specs/Формальная%20нотация%20МТС.md) | typed L2 syntax и interpretation |
 | [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md) | L3 `*.anum`, raw carrier, denotation и serialization |
 | [Протокол абитов ачисел](docs/specs/Протокол%20абитов%20ачисел.md) | contextual L3 projection и quote semantics |
 | [MTS contract v0.2](contracts/mts-contract-v0.2.json) | language-neutral normative contract |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [Основания МТС](docs/theory/Основания%20МТС.md) | онтологические основания |
 | [Система аксиом МТС](docs/theory/Система%20аксиом%20МТС.md) | нормативное чтение 10 root definitions |
 | [Reference model МТС v0.2](docs/specs/Reference%20model%20МТС%20v0.2.md) | границы L0–L5 и инженерная semantics |
-| [Формальная нотация МТС](docs/specs/Формальная%20нотация%20МТС.md) | typed L2 syntax и interpretation |
+| [Формальная нотация МТС](docs/specs/Формальная%20нотацияция%20МТС.md) | typed L2 syntax и interpretation |
 | [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md) | L3 `*.anum`, raw carrier, denotation и serialization |
 | [Протокол абитов ачисел](docs/specs/Протокол%20абитов%20ачисел.md) | contextual L3 projection и quote semantics |
 | [MTS contract v0.2](contracts/mts-contract-v0.2.json) | language-neutral normative contract |
@@ -203,7 +203,8 @@ core/anum_pair_denotation.py    direct pair subset
 core/anum_raw_carrier.py        structural raw carrier description
 core/anum_recursive_denotation.py
                                recursive root decode + canonical inverse
-core/anum_memory.py             временный L4 test-double до production apamemory #72
+core/anum_memory.py             canonical indexed in-memory L4 store
+core/proof_checker.py           replay-only trusted L5 checker
 
 converters/anum_cli.py
 converters/text_to_anum.py
@@ -230,6 +231,32 @@ normalized resolution trace kinds
 Python reference runtime обязан проходить этот corpus в CI. Другие consumers, включая `aprover`, должны проходить тот же файл, а не копировать правила вручную.
 
 L3 имеет отдельные language-neutral corpora для raw carrier, denotation IR, pair subset и recursive root denotation. Downstream L4/AVM adapters должны потреблять typed результаты этих контрактов и не дублировать quaternary grammar.
+
+## Сквозной vertical slice v0.2
+
+Один integration test связывает production APIs без mock/legacy обходов:
+
+```text
+raw Anum
+→ parse
+→ RawCarrierDescription
+→ accepted recursive AnumDenotation
+→ L4 load/find/realize/find
+→ canonical inverse
+
+materialized LinkRef
+→ L2 structural interpretation
+→ mts-proof/v0.2
+→ independent L5 replay
+```
+
+Запуск:
+
+```bash
+python -m pytest tests/test_mts_v02_end_to_end.py -v
+```
+
+В этом же suite проверяется отрицательный путь: noncanonical `010` остаётся `RAW`, quote остаётся `QUOTED_RAW`, и ни один из них не превращается в скрытую команду materialization.
 
 ## Интеграция с визуальным апрувером
 

--- a/tests/test_mts_v02_end_to_end.py
+++ b/tests/test_mts_v02_end_to_end.py
@@ -1,0 +1,122 @@
+"""Canonical MTS/Anum v0.2 vertical slice through accepted production APIs."""
+
+import pytest
+
+from core.anum_denotation import DenotationKind
+from core.anum_memory import AnumMemory, NonStructuralDenotationError
+from core.anum_model import ProjectionContext
+from core.anum_pair_denotation import denotate_anum_pair_subset
+from core.anum_parser import parse_raw_quaternary
+from core.anum_raw_carrier import describe_raw_carrier
+from core.anum_recursive_denotation import (
+    canonical_recursive_anum,
+    denotate_recursive_anum,
+)
+from core.proof_checker import (
+    DistinguishedLink,
+    ExpectedSubstitution,
+    InterpretProofStep,
+    ProofContext,
+    ProofObject,
+    check_proof,
+)
+
+
+INITIAL_GRAPH = {
+    0: (0, 0),
+    1: (1, 0),
+    2: (0, 2),
+}
+ANCHORS = {
+    "protocol:0": 1,
+    "protocol:1": 2,
+}
+
+
+def test_recursive_anum_load_find_realize_round_trip_uses_one_l3_l4_path():
+    raw = "[01]1"
+    form = parse_raw_quaternary(raw)
+    carrier = describe_raw_carrier(form)
+    denotation = denotate_recursive_anum(form, ProjectionContext.ROOT)
+    store = AnumMemory(initial_links=INITIAL_GRAPH)
+
+    assert denotation.kind is DenotationKind.STRUCTURAL
+    assert canonical_recursive_anum(denotation) == raw
+
+    store.load_raw(carrier)
+    after_load = store.snapshot()
+    assert store.has_raw(carrier)
+    assert store.find_denotation(denotation, ANCHORS) is None
+    assert store.snapshot() == after_load
+
+    root = store.realize_denotation(denotation, ANCHORS)
+    inner = store.find_link(1, 2)
+
+    assert inner == 3
+    assert root == 4
+    assert store.poles(inner) == (1, 2)
+    assert store.poles(root) == (inner, 2)
+    assert store.find_denotation(denotation, ANCHORS) == root
+
+    after_realize = store.snapshot()
+    assert store.realize_denotation(denotation, ANCHORS) == root
+    assert store.snapshot() == after_realize
+
+
+def test_noncanonical_and_quote_context_never_become_hidden_l4_commands():
+    store = AnumMemory(initial_links=INITIAL_GRAPH)
+
+    noncanonical_form = parse_raw_quaternary("010")
+    noncanonical_carrier = describe_raw_carrier(noncanonical_form)
+    noncanonical = denotate_recursive_anum(
+        noncanonical_form,
+        ProjectionContext.ROOT,
+    )
+    store.load_raw(noncanonical_carrier)
+    before = store.snapshot()
+
+    assert noncanonical.kind is DenotationKind.RAW
+    with pytest.raises(NonStructuralDenotationError):
+        store.realize_denotation(noncanonical, ANCHORS)
+    assert store.snapshot() == before
+
+    quoted = denotate_recursive_anum(
+        parse_raw_quaternary("[01]"),
+        ProjectionContext.QUOTE,
+    )
+    assert quoted.kind is DenotationKind.QUOTED_RAW
+    assert quoted.raw == "01"
+    with pytest.raises(NonStructuralDenotationError):
+        store.realize_denotation(quoted, ANCHORS)
+    assert store.snapshot() == before
+
+
+def test_materialized_l3_link_is_checked_by_independent_l2_l5_replay():
+    store = AnumMemory(initial_links=INITIAL_GRAPH)
+    pair = denotate_anum_pair_subset(
+        parse_raw_quaternary("01"),
+        ProjectionContext.ROOT,
+    )
+
+    materialized = store.realize_denotation(pair, ANCHORS)
+    start, end = store.poles(materialized)
+    assert (materialized, start, end) == (3, 1, 2)
+
+    proof = ProofObject(
+        steps=(
+            InterpretProofStep(
+                expression=f"{materialized} = [] ⟼ []",
+                context=ProofContext(start=0, end=0),
+                symbols=((str(materialized), materialized),),
+                distinguished_memory=(
+                    DistinguishedLink(materialized, start, end),
+                ),
+                expected_substitutions=(
+                    ExpectedSubstitution((1, 0), start),
+                    ExpectedSubstitution((1, 1), end),
+                ),
+            ),
+        )
+    )
+
+    assert check_proof(proof)


### PR DESCRIPTION
Closes #74.

Один executable vertical slice через уже принятые production APIs, без новых semantics.

### L3 → L4
- raw `[01]1` → `parse_raw_quaternary` → `RawCarrierDescription` → accepted `denotate_recursive_anum`;
- `load_raw` не materializes denotation;
- `find_denotation` read-only и до realize возвращает not-found;
- `realize_denotation` создаёт canonical inner/root links, repeated realize idempotent;
- `canonical_recursive_anum` восстанавливает исходный canonical raw.

### Negative/context isolation
- noncanonical `010` остаётся `RAW` и L4 rejects implicit materialization;
- quote `[01]` остаётся `QUOTED_RAW` (`01`) и также не materializes.

### L3/L4 → L2/L5
- accepted pair `01` materializes конкретный L4 `LinkRef`;
- его реальные poles превращаются только в immutable distinguished proof-memory snapshot;
- `mts-proof/v0.2` step `LinkRef = [] ⟼ []` independently replayed existing canonical interpreter through `check_proof`.

То есть proof replay проверяет структуру того же materialized link, а не отдельную ручную semantic fixture.

### Reproducible public path
README содержит одну команду:

```bash
python -m pytest tests/test_mts_v02_end_to_end.py -v
```

Новый CLI/runtime path не создаётся.

Merge после полного зелёного CI и `behind_by=0`.