### PR TITLE
Зафиксировать semantic-collision challenge для BundleForm v0.2

### DIFF
--- a/contracts/mts-bundle-challenge-v0.2.json
+++ b/contracts/mts-bundle-challenge-v0.2.json
@@ -1,0 +1,176 @@
+{
+  "schema": "mts-bundle-challenge/v0.2",
+  "status": "candidate-challenge",
+  "dependsOn": "mts-contract/v0.2",
+  "issue": 50,
+  "acceptedConstraintBundle": {
+    "ast": "BundleForm",
+    "interpreter": "interpret_constraints",
+    "semantics": "ordered evaluation of contained constraints in one local interpretation state",
+    "effect": "none",
+    "emptyBundle": {
+      "source": "{}",
+      "meaning": "empty constraint bundle",
+      "expectedSuccess": true
+    },
+    "rootDefinitionsUsingConstraintBundles": [
+      "∞ : {◁ = ∞, ▷ = ∞}",
+      "(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}"
+    ],
+    "identityInvariant": "anonymous [] identity remains AST-occurrence-path inside a bundle"
+  },
+  "candidateValueBundleIntegrationModels": [
+    {
+      "id": "context-sensitive-overload",
+      "accepted": false,
+      "question": "Can the same BundleForm glyph be classified as constraint/value solely from typed context without runtime guessing?"
+    },
+    {
+      "id": "distinct-typed-ast-same-glyph",
+      "accepted": false,
+      "question": "Can parser grammar produce separate ConstraintBundle/ValueBundle nodes unambiguously while preserving current root syntax?"
+    },
+    {
+      "id": "distinct-value-bundle-notation",
+      "accepted": false,
+      "question": "Should accepted constraint {...} remain unchanged and a future value bundle use a different explicit constructor/glyph?"
+    },
+    {
+      "id": "no-separate-value-bundle",
+      "accepted": false,
+      "question": "Can existing LinkForm, Sequence, anonymous patterns and L4 indices express the required queries without a new semantic value?"
+    }
+  ],
+  "valueAlgebraModelsAfterCollisionResolution": [
+    {
+      "id": "extensional-set-like",
+      "commutative": true,
+      "duplicateIdempotent": true,
+      "accepted": false
+    },
+    {
+      "id": "ordered",
+      "commutative": false,
+      "duplicateIdempotent": false,
+      "accepted": false
+    },
+    {
+      "id": "multibundle",
+      "commutative": true,
+      "duplicateIdempotent": false,
+      "accepted": false
+    },
+    {
+      "id": "occurrence-preserving",
+      "commutative": null,
+      "duplicateIdempotent": null,
+      "accepted": false,
+      "note": "syntax occurrences retain identity; any extensional equality would be a separate relation"
+    }
+  ],
+  "syntaxCases": [
+    {
+      "source": "{}",
+      "canonical": "{}",
+      "structuralKey": ["bundle", []],
+      "currentInterpreter": "accepted-empty-constraint-bundle"
+    },
+    {
+      "source": "{x}",
+      "canonical": "{x}",
+      "structuralKey": ["bundle", [["symbol", "x"]]],
+      "currentInterpreter": "unsupported-as-value"
+    },
+    {
+      "source": "{x,x}",
+      "canonical": "{x, x}",
+      "structuralKey": ["bundle", [["symbol", "x"], ["symbol", "x"]]],
+      "currentInterpreter": "unsupported-as-value"
+    },
+    {
+      "source": "{x,y}",
+      "canonical": "{x, y}",
+      "structuralKey": ["bundle", [["symbol", "x"], ["symbol", "y"]]],
+      "currentInterpreter": "unsupported-as-value"
+    },
+    {
+      "source": "{y,x}",
+      "canonical": "{y, x}",
+      "structuralKey": ["bundle", [["symbol", "y"], ["symbol", "x"]]],
+      "currentInterpreter": "unsupported-as-value"
+    },
+    {
+      "source": "a{x,y}",
+      "canonical": "a{x, y}",
+      "structuralKey": ["sequence", [["symbol", "a"], ["bundle", [["symbol", "x"], ["symbol", "y"]]]]],
+      "currentInterpreter": "unsupported-sequence"
+    },
+    {
+      "source": "{x,y}a",
+      "canonical": "{x, y}a",
+      "structuralKey": ["sequence", [["bundle", [["symbol", "x"], ["symbol", "y"]]], ["symbol", "a"]]],
+      "currentInterpreter": "unsupported-sequence"
+    },
+    {
+      "source": "{x,y}{a,b}",
+      "canonical": "{x, y}{a, b}",
+      "structuralKey": ["sequence", [["bundle", [["symbol", "x"], ["symbol", "y"]]], ["bundle", [["symbol", "a"], ["symbol", "b"]]]]],
+      "currentInterpreter": "unsupported-sequence"
+    },
+    {
+      "source": "{[],[]}",
+      "canonical": "{[], []}",
+      "structuralKey": ["bundle", [["square", null], ["square", null]]],
+      "currentInterpreter": "unsupported-as-value"
+    }
+  ],
+  "constraintNonRegressionCases": [
+    {
+      "source": "{}",
+      "context": {"start": 1, "end": 2},
+      "symbols": {},
+      "expected": {"success": true, "substitutions": [], "aliases": []}
+    },
+    {
+      "source": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 1},
+      "symbols": {"∞": 1},
+      "expected": {"success": true, "substitutions": [], "aliases": []}
+    },
+    {
+      "source": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 2},
+      "symbols": {"∞": 1},
+      "expected": {"success": false, "substitutions": [], "aliases": []}
+    },
+    {
+      "source": "{[] = ◁, [] = ▷}",
+      "context": {"start": 10, "end": 12},
+      "symbols": {},
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [0, 0], "link": 10},
+          {"path": [1, 0], "link": 12}
+        ],
+        "aliases": []
+      }
+    }
+  ],
+  "effectVeto": {
+    "ordinaryBundleMayRealize": false,
+    "ordinaryBundleMayDelete": false,
+    "emptyBundleMayDelete": false,
+    "descriptionIsCommand": false,
+    "interpretEqualsRealize": false
+  },
+  "rootProgramMustRemainUnchanged": true,
+  "acceptedContractLinkAllowed": false,
+  "releaseGate": [
+    "resolve constraint/value semantic collision",
+    "choose or reject a value algebra model",
+    "publish an accepted semantic contract and conformance corpus",
+    "extend the single existing parser/interpreter path only after acceptance",
+    "repin downstream consumers only after accepted contract changes"
+  ]
+}

--- a/contracts/mts-bundle-challenge-v0.2.json
+++ b/contracts/mts-bundle-challenge-v0.2.json
@@ -6,7 +6,8 @@
   "acceptedConstraintBundle": {
     "ast": "BundleForm",
     "interpreter": "interpret_constraints",
-    "semantics": "ordered evaluation of contained constraints in one local interpretation state",
+    "semantics": "shared-state conjunction of contained constraints",
+    "referenceTraversal": "current reference interpreter visits items in source order; no algebraic significance of order is claimed here",
     "effect": "none",
     "emptyBundle": {
       "source": "{}",

--- a/contracts/mts-bundle-challenge-v0.2.json
+++ b/contracts/mts-bundle-challenge-v0.2.json
@@ -100,6 +100,24 @@
       "currentInterpreter": "unsupported-as-value"
     },
     {
+      "source": "{x,y} = {x,y}",
+      "canonical": "{x, y} = {x, y}",
+      "structuralKey": ["equality", ["bundle", [["symbol", "x"], ["symbol", "y"]]], ["bundle", [["symbol", "x"], ["symbol", "y"]]]],
+      "currentInterpreter": "unsupported-bundle-form-operand"
+    },
+    {
+      "source": "{x,y} ⟼ a",
+      "canonical": "{x, y} ⟼ a",
+      "structuralKey": ["link", ["bundle", [["symbol", "x"], ["symbol", "y"]]], ["symbol", "a"]],
+      "currentInterpreter": "unsupported-top-level-form"
+    },
+    {
+      "source": "a ⟼ {x,y}",
+      "canonical": "a ⟼ {x, y}",
+      "structuralKey": ["link", ["symbol", "a"], ["bundle", [["symbol", "x"], ["symbol", "y"]]]],
+      "currentInterpreter": "unsupported-top-level-form"
+    },
+    {
       "source": "a{x,y}",
       "canonical": "a{x, y}",
       "structuralKey": ["sequence", [["symbol", "a"], ["bundle", [["symbol", "x"], ["symbol", "y"]]]]],

--- a/tests/test_mts_bundle_challenge.py
+++ b/tests/test_mts_bundle_challenge.py
@@ -1,0 +1,172 @@
+"""Executable challenge gate for post-foundation BundleForm value semantics.
+
+This suite deliberately does not implement a value bundle. It freezes the
+already accepted constraint-bundle behavior and records the current typed
+syntax of value-looking forms so a future proposal cannot silently overload it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mtc_ast import BundleForm, Definition, format_expression, structural_key
+from core.mtc_interpreter import (
+    ContextFrame,
+    InterpretationError,
+    MemoryView,
+    interpret_constraints,
+)
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-bundle-challenge-v0.2.json"
+MTS_CONTRACT = ROOT / "contracts" / "mts-contract-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+class NoReadMemory(MemoryView):
+    """Memory view that proves challenge constraint cases need no L4 access."""
+
+    def poles(self, link: int) -> tuple[int, int]:
+        raise AssertionError("bundle challenge case unexpectedly read L4 poles")
+
+    def find_link(self, start: int, end: int) -> int | None:
+        raise AssertionError("bundle challenge case unexpectedly searched L4 links")
+
+    def find_start_projection(self, form: int) -> int | None:
+        raise AssertionError("bundle challenge case unexpectedly read start projection")
+
+    def find_end_projection(self, form: int) -> int | None:
+        raise AssertionError("bundle challenge case unexpectedly read end projection")
+
+
+def challenge() -> dict:
+    return json.loads(CHALLENGE.read_text(encoding="utf-8"))
+
+
+def json_key(value):
+    if isinstance(value, tuple):
+        return [json_key(item) for item in value]
+    return value
+
+
+def result_payload(result) -> dict:
+    return {
+        "success": result.success,
+        "substitutions": [
+            {"path": list(hole.path), "link": link} for hole, link in result.holes
+        ],
+        "aliases": [
+            {"path": list(hole.path), "targetPath": list(target.path)}
+            for hole, target in result.aliases
+        ],
+    }
+
+
+def test_challenge_is_not_an_accepted_mts_contract_extension():
+    data = challenge()
+    mts_contract_text = MTS_CONTRACT.read_text(encoding="utf-8")
+
+    assert data["schema"] == "mts-bundle-challenge/v0.2"
+    assert data["status"] == "candidate-challenge"
+    assert data["dependsOn"] == "mts-contract/v0.2"
+    assert data["acceptedContractLinkAllowed"] is False
+    assert "mts-bundle-challenge" not in mts_contract_text
+
+
+def test_existing_root_constraint_bundles_remain_exactly_in_root_program():
+    data = challenge()
+    sources = {
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    for source in data["acceptedConstraintBundle"]["rootDefinitionsUsingConstraintBundles"]:
+        assert source in sources
+        ast = parse_formula(source)
+        assert isinstance(ast, Definition)
+        assert isinstance(ast.value, BundleForm)
+
+
+def test_current_bundle_parser_shape_matches_challenge_vectors_without_semantic_canonicalization():
+    for case in challenge()["syntaxCases"]:
+        ast = parse_formula(case["source"])
+        assert format_expression(ast) == case["canonical"]
+        assert json_key(structural_key(ast)) == case["structuralKey"]
+
+
+def test_parser_preserves_order_multiplicity_and_anonymous_occurrences_syntactically():
+    xy = structural_key(parse_formula("{x,y}"))
+    yx = structural_key(parse_formula("{y,x}"))
+    xx = structural_key(parse_formula("{x,x}"))
+    anonymous = structural_key(parse_formula("{[],[]}"))
+
+    assert xy != yx
+    assert xx == ("bundle", (("symbol", "x"), ("symbol", "x")))
+    assert anonymous == ("bundle", (("square", None), ("square", None)))
+
+    # These are syntax facts only. They deliberately do not decide semantic
+    # commutativity, idempotence, multiplicity, or bundle identity.
+
+
+def test_accepted_constraint_bundle_vectors_replay_with_shared_occurrence_local_state():
+    data = challenge()
+    memory = NoReadMemory()
+
+    for case in data["constraintNonRegressionCases"]:
+        result = interpret_constraints(
+            parse_formula(case["source"]),
+            ContextFrame(**case["context"]),
+            memory,
+            symbols=case["symbols"],
+        )
+        assert result_payload(result) == case["expected"]
+
+
+def test_value_looking_bundle_forms_have_no_accepted_interpreter_semantics_yet():
+    data = challenge()
+    memory = NoReadMemory()
+
+    unsupported = [
+        case
+        for case in data["syntaxCases"]
+        if case["currentInterpreter"] != "accepted-empty-constraint-bundle"
+    ]
+    for case in unsupported:
+        with pytest.raises(InterpretationError):
+            interpret_constraints(
+                parse_formula(case["source"]),
+                ContextFrame(start=1, end=2),
+                memory,
+                symbols={"a": 1, "b": 2, "x": 1, "y": 2},
+            )
+
+
+def test_all_value_integration_and_algebra_models_remain_unaccepted():
+    data = challenge()
+
+    assert len(data["candidateValueBundleIntegrationModels"]) == 4
+    assert all(
+        model["accepted"] is False
+        for model in data["candidateValueBundleIntegrationModels"]
+    )
+    assert len(data["valueAlgebraModelsAfterCollisionResolution"]) == 4
+    assert all(
+        model["accepted"] is False
+        for model in data["valueAlgebraModelsAfterCollisionResolution"]
+    )
+
+
+def test_bundle_challenge_forbids_implicit_effects():
+    veto = challenge()["effectVeto"]
+
+    assert veto == {
+        "ordinaryBundleMayRealize": False,
+        "ordinaryBundleMayDelete": False,
+        "emptyBundleMayDelete": False,
+        "descriptionIsCommand": False,
+        "interpretEqualsRealize": False,
+    }


### PR DESCRIPTION
Refs #50.

Этот PR **не принимает value-bundle semantics** и не меняет production parser/interpreter.

Он фиксирует executable challenge после обнаружения ключевого конфликта: `{...}` уже является canonical constraint `BundleForm` и используется root definitions.

### Accepted non-regression
- `{}` = successful empty constraint bundle, effect none;
- `∞ : {◁ = ∞, ▷ = ∞}` и `(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}` остаются exact root forms;
- `{[] = ◁, [] = ▷}` подтверждает два independent occurrence-local `[]` в shared constraint state.

### Syntax-only value-looking vectors
Corpus фиксирует текущие AST/canonical strings для:

```text
{x}
{x,x}
{x,y}
{y,x}
a{x,y}
{x,y}a
{x,y}{a,b}
{[],[]}
```

Parser сохраняет order/multiplicity occurrences, но это **не объявляется semantic equality/algebra**.

### Competing models
Зафиксированы, но `accepted=false`:
- context-sensitive overload;
- distinct typed AST with same glyph;
- separate value-bundle notation;
- no separate value-bundle;
- extensional / ordered / multibundle / occurrence-preserving algebra models.

### Effects veto

```text
ordinary bundle mayRealize = false
ordinary bundle mayDelete  = false
empty bundle mayDelete     = false
description != command
interpret != realize
```

Artifact `mts-bundle-challenge/v0.2` намеренно **не подключён** к accepted `mts-contract/v0.2`.

Merge только после зелёного CI и `behind_by=0`.