### PR TITLE
Зафиксировать typed decision для bundle value semantics

### DIFF
--- a/contracts/mts-bundle-decision-v0.2.json
+++ b/contracts/mts-bundle-decision-v0.2.json
@@ -1,0 +1,201 @@
+{
+  "schema": "mts-bundle-decision/v0.2",
+  "status": "candidate-decision",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "mts-bundle-challenge/v0.2"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "purpose": "Choose the next typed integration model for value-bundle semantics without changing accepted MTS v0.2 semantics.",
+  "nonNormativeUntil": "A separate versioned semantic contract and conformance corpus are accepted and linked from mts-contract.",
+  "preservedAcceptedFacts": {
+    "rootDefinitionsUnchanged": [
+      "∞ : {◁ = ∞, ▷ = ∞}",
+      "() : ♀() ⟼ ()♂",
+      "([) : (♀∞)",
+      "(]) : (∞♂)",
+      "(⟼) : (♀∞ ⟼ ∞♂)",
+      "(↛) : (∞♂ ⟼ ♀∞)",
+      "[1] : (⟼)",
+      "[0] : (↛)",
+      "(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}",
+      "(!=) : ¬(=)"
+    ],
+    "constraintBundle": {
+      "glyph": "{...}",
+      "meaning": "shared-state conjunction of constraints",
+      "empty": "success-with-no-effects"
+    },
+    "anonymousSquareForm": {
+      "source": "[]",
+      "identity": "ast-occurrence-path",
+      "globalIdentity": false
+    },
+    "effects": {
+      "interpretMayRealize": false,
+      "interpretMayDelete": false,
+      "bundleDescriptionIsCommand": false
+    }
+  },
+  "originalIntentEvidence": {
+    "source": "issue-50-discussion",
+    "requiredIdea": "{...} remains the visual notation for a bundle/aset of links rather than abandoning bundle values entirely",
+    "historicalExamplesAreNotAcceptedSemantics": true,
+    "examples": [
+      "{[], []} = {[]}",
+      "{[], [][]} = {[][], []}",
+      "[]{[], [][]}",
+      "{[], [][]}[]",
+      "{[], [][]}{[], [][]}"
+    ]
+  },
+  "models": [
+    {
+      "id": "A",
+      "name": "runtime-overload-one-semantic-BundleForm",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "The same semantic AST node would be interpreted as constraint or value by runtime inspection. Empty {} has no item evidence, so the model requires guessing or hidden defaults inside interpretation.",
+      "vetoes": [
+        "runtime-role-guessing",
+        "empty-bundle-ambiguity",
+        "constraint-and-value-semantics-share-one-runtime-type"
+      ]
+    },
+    {
+      "id": "B",
+      "name": "single-glyph-static-elaboration-distinct-semantic-types",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "reason": "Preserves the intended {...} notation while separating constraint and value semantics before interpretation. Requires an executable elaboration challenge before any contract acceptance.",
+      "syntaxStage": {
+        "node": "CurlySyntax",
+        "semanticType": false,
+        "preserves": [
+          "source-order",
+          "multiplicity",
+          "item-occurrence-paths",
+          "empty-vs-nonempty"
+        ]
+      },
+      "elaborationStage": {
+        "outputs": [
+          "ConstraintBundle",
+          "ValueBundle"
+        ],
+        "runtimeGuessing": false,
+        "rules": [
+          {
+            "when": "all non-empty items elaborate as Judgment",
+            "result": "ConstraintBundle"
+          },
+          {
+            "when": "all non-empty items elaborate as Form",
+            "result": "ValueBundle"
+          },
+          {
+            "when": "items mix Judgment and Form roles",
+            "result": "static-error"
+          },
+          {
+            "when": "{} occurs where parent syntax requires Form",
+            "result": "ValueBundle"
+          },
+          {
+            "when": "{} occurs at the constraint interpretation entry point",
+            "result": "ConstraintBundle"
+          },
+          {
+            "when": "{} is a definition RHS with no stronger expected Form role",
+            "result": "ConstraintBundle",
+            "reason": "Preserve current accepted empty-constraint behavior; a direct empty value definition must use a context that statically requires Form rather than an implicit role switch."
+          }
+        ],
+        "examples": [
+          {
+            "source": "{x = y, y = z}",
+            "result": "ConstraintBundle"
+          },
+          {
+            "source": "{x, y}",
+            "result": "ValueBundle"
+          },
+          {
+            "source": "{} = {}",
+            "result": "Equality(ValueBundle(), ValueBundle())"
+          },
+          {
+            "source": "{}",
+            "entryPoint": "interpret-constraints",
+            "result": "ConstraintBundle()"
+          },
+          {
+            "source": "x : {}",
+            "result": "Definition(x, ConstraintBundle())"
+          },
+          {
+            "source": "{x, y = z}",
+            "result": "static-error"
+          }
+        ]
+      },
+      "requiredBeforeAcceptance": [
+        "typed-elaboration-challenge-corpus",
+        "proof-that-current-ten-root-definitions-elaborate-identically",
+        "proof-that-value-bundle-never-enters-interpret_constraints-as-constraint",
+        "proof-that-constraint-bundle-never-resolves-as-L1-form",
+        "explicit-empty-bundle-vectors",
+        "no-new-memory-effects"
+      ]
+    },
+    {
+      "id": "C",
+      "name": "distinct-value-bundle-notation",
+      "verdict": "defer-fallback",
+      "accepted": false,
+      "reason": "Statically simplest if model B cannot be made unambiguous, but it abandons the established intention that {...} itself is the bundle notation and introduces a new L2 distinction.",
+      "trigger": "Use only if the B elaboration challenge demonstrates an unavoidable ambiguity or breaks accepted root syntax."
+    },
+    {
+      "id": "D",
+      "name": "no-value-bundle",
+      "verdict": "reject-for-issue-50",
+      "accepted": false,
+      "reason": "It can keep the current runtime minimal but does not satisfy the explicitly preserved goal of issue #50: {...} as a bundle/aset value notation and future bundle expansion semantics."
+    }
+  ],
+  "currentTypedAstDefect": {
+    "fact": "BundleForm currently inherits Form although the accepted interpreter supports it only as a constraint expression container.",
+    "risk": "The parser therefore admits value-looking bundle positions that have no accepted semantic type.",
+    "decision": "Do not fix this by adding value runtime behavior. The next challenge must prove a static split/elaboration first."
+  },
+  "algebra": {
+    "accepted": false,
+    "leadingIntent": "extensional-set-like",
+    "evidence": [
+      "historical issue #50 examples propose duplicate idempotence",
+      "historical issue #50 examples propose order-insensitive equality"
+    ],
+    "veto": "Syntax occurrence identity, source order and multiplicity must remain observable for provenance even if a future value algebra is extensional.",
+    "decisionAfter": "model-B-elaboration-challenge"
+  },
+  "nextGate": {
+    "artifact": "mts-bundle-elaboration-challenge/v0.2",
+    "status": "candidate-challenge",
+    "mustNotChangeProductionSemantics": true,
+    "requiredVectors": [
+      "accepted root definitions",
+      "empty constraint bundle",
+      "empty value bundle in Form-required position",
+      "nonempty all-Judgment constraint bundle",
+      "nonempty all-Form value bundle",
+      "mixed-role static rejection",
+      "value bundle as equality operand",
+      "value bundle as LinkForm operand",
+      "value bundle in Sequence",
+      "definition RHS defaults",
+      "occurrence-local [] inside both bundle roles",
+      "no realize/delete effects"
+    ]
+  }
+}

--- a/tests/test_mts_bundle_decision.py
+++ b/tests/test_mts_bundle_decision.py
@@ -1,0 +1,122 @@
+"""Machine-check the non-normative bundle integration decision.
+
+The decision chooses the next challenge model but must not extend accepted MTS
+semantics. Production AST/interpreter changes are deliberately out of scope.
+"""
+
+import json
+from pathlib import Path
+
+from core.mtc_ast import BundleForm, Form
+
+
+ROOT = Path(__file__).parents[1]
+DECISION = ROOT / "contracts" / "mts-bundle-decision-v0.2.json"
+CHALLENGE = ROOT / "contracts" / "mts-bundle-challenge-v0.2.json"
+MTS_CONTRACT = ROOT / "contracts" / "mts-contract-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def decision() -> dict:
+    return json.loads(DECISION.read_text(encoding="utf-8"))
+
+
+def test_decision_remains_non_normative_and_depends_on_executable_challenge():
+    data = decision()
+    challenge = json.loads(CHALLENGE.read_text(encoding="utf-8"))
+    mts_contract_text = MTS_CONTRACT.read_text(encoding="utf-8")
+
+    assert data["schema"] == "mts-bundle-decision/v0.2"
+    assert data["status"] == "candidate-decision"
+    assert data["dependsOn"] == ["mts-contract/v0.2", challenge["schema"]]
+    assert data["acceptedContractLinkAllowed"] is False
+    assert "mts-bundle-decision" not in mts_contract_text
+
+
+def test_decision_preserves_the_exact_current_root_program():
+    data = decision()
+    root_sources = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert data["preservedAcceptedFacts"]["rootDefinitionsUnchanged"] == root_sources
+
+
+def test_model_verdicts_are_explicit_and_only_b_is_the_preferred_next_challenge():
+    models = {model["id"]: model for model in decision()["models"]}
+
+    assert set(models) == {"A", "B", "C", "D"}
+    assert models["A"]["verdict"] == "reject"
+    assert models["B"]["verdict"] == "preferred-candidate"
+    assert models["C"]["verdict"] == "defer-fallback"
+    assert models["D"]["verdict"] == "reject-for-issue-50"
+    assert all(model["accepted"] is False for model in models.values())
+
+
+def test_preferred_model_is_static_elaboration_not_runtime_guessing():
+    model = next(model for model in decision()["models"] if model["id"] == "B")
+    stage = model["elaborationStage"]
+
+    assert model["syntaxStage"]["node"] == "CurlySyntax"
+    assert model["syntaxStage"]["semanticType"] is False
+    assert stage["outputs"] == ["ConstraintBundle", "ValueBundle"]
+    assert stage["runtimeGuessing"] is False
+
+    by_when = {rule["when"]: rule["result"] for rule in stage["rules"]}
+    assert by_when["all non-empty items elaborate as Judgment"] == "ConstraintBundle"
+    assert by_when["all non-empty items elaborate as Form"] == "ValueBundle"
+    assert by_when["items mix Judgment and Form roles"] == "static-error"
+    assert by_when["{} occurs where parent syntax requires Form"] == "ValueBundle"
+    assert by_when["{} occurs at the constraint interpretation entry point"] == "ConstraintBundle"
+    assert by_when["{} is a definition RHS with no stronger expected Form role"] == "ConstraintBundle"
+
+
+def test_decision_records_current_typed_ast_mismatch_without_fixing_it_here():
+    data = decision()
+
+    # This is the exact current fact exposed by the challenge: syntactically the
+    # node is a Form even though accepted runtime meaning is constraint-only.
+    assert issubclass(BundleForm, Form)
+    assert data["currentTypedAstDefect"]["fact"].startswith("BundleForm currently inherits Form")
+    assert data["currentTypedAstDefect"]["decision"].startswith("Do not fix this by adding value runtime behavior")
+
+
+def test_effect_veto_and_occurrence_identity_survive_the_decision():
+    preserved = decision()["preservedAcceptedFacts"]
+
+    assert preserved["anonymousSquareForm"] == {
+        "source": "[]",
+        "identity": "ast-occurrence-path",
+        "globalIdentity": False,
+    }
+    assert preserved["effects"] == {
+        "interpretMayRealize": False,
+        "interpretMayDelete": False,
+        "bundleDescriptionIsCommand": False,
+    }
+
+
+def test_value_algebra_stays_unaccepted_until_elaboration_is_proven():
+    algebra = decision()["algebra"]
+
+    assert algebra["accepted"] is False
+    assert algebra["leadingIntent"] == "extensional-set-like"
+    assert algebra["decisionAfter"] == "model-B-elaboration-challenge"
+    assert "occurrence" in algebra["veto"].lower()
+
+
+def test_next_gate_is_an_executable_non_production_elaboration_challenge():
+    gate = decision()["nextGate"]
+
+    assert gate["artifact"] == "mts-bundle-elaboration-challenge/v0.2"
+    assert gate["status"] == "candidate-challenge"
+    assert gate["mustNotChangeProductionSemantics"] is True
+    assert {
+        "empty constraint bundle",
+        "empty value bundle in Form-required position",
+        "mixed-role static rejection",
+        "occurrence-local [] inside both bundle roles",
+        "no realize/delete effects",
+    }.issubset(set(gate["requiredVectors"]))


### PR DESCRIPTION
Refs #50.

Non-normative decision artifact после executable `mts-bundle-challenge/v0.2`.

- A runtime-overload — reject;
- B same glyph + static elaboration into distinct `ConstraintBundle|ValueBundle` — preferred candidate, **не accepted**;
- C separate notation — deferred fallback;
- D no value-bundle — reject for #50 because it drops the explicitly preserved bundle/aset goal;
- empty `{}` gets explicit static context rules;
- current `BundleForm <: Form` mismatch recorded as defect, but production AST/interpreter are not changed;
- extensional set-like algebra is only leading historical intent, still unaccepted;
- next gate is `mts-bundle-elaboration-challenge/v0.2`, non-production.

Tests prove exact current root program is preserved, `mts-contract/v0.2` does not link the decision, all A–D remain `accepted=false`, and effect/occurrence vetoes stay intact.

Draft до полного CI; merge этого PR не принимает value-bundle semantics.