### PR TITLE
Проверить read-only bundle expansion через L4 indices

### DIFF
--- a/contracts/mts-bundle-expansion-challenge-v0.2.json
+++ b/contracts/mts-bundle-expansion-challenge-v0.2.json
@@ -1,0 +1,174 @@
+{
+  "schema": "mts-bundle-expansion-challenge/v0.2",
+  "status": "candidate-challenge",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "mts-bundle-decision/v0.2",
+    "mts-bundle-elaboration-challenge/v0.2",
+    "mts-bundle-algebra-challenge/v0.2"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionSemanticsChanged": false,
+  "scope": "Read-only expansion/query when at least one juxtaposed endpoint operand is a statically elaborated ValueBundle.",
+  "historicalIntent": {
+    "explicitExpansion": [
+      "a{b,c}",
+      "{a,b}c",
+      "{a,b}{c,d}"
+    ],
+    "openQuestionRecovered": [
+      "a{} means all existing outgoing links from a",
+      "{}b means all existing incoming links to b",
+      "{}{} means all existing links in the selected memory view"
+    ],
+    "source": "issue-50 discussion",
+    "operationalDeleteExcluded": true
+  },
+  "models": [
+    {
+      "id": "pure-cartesian-empty-set",
+      "verdict": "reject-for-issue-50",
+      "reason": "Ordinary set product makes a{} and {}b empty, so it cannot express the explicitly preserved all-outgoing/all-incoming query intent."
+    },
+    {
+      "id": "read-only-empty-endpoint-wildcard",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "reason": "In expansion position only, an empty ValueBundle means an unconstrained endpoint domain. Non-empty bundles remain extensional sets of resolved endpoint identities. The result is the set of already existing Link identities satisfying the endpoint constraints."
+    },
+    {
+      "id": "materializing-cartesian-product",
+      "verdict": "reject",
+      "reason": "Creating missing links during interpretation violates interpret != realize and would turn a query notation into an implicit mutation."
+    },
+    {
+      "id": "synthetic-unmaterialized-linkforms",
+      "verdict": "defer",
+      "reason": "Returning hypothetical LinkForm values rather than existing L1 Link identities changes the result domain and is not required for the historical query/expansion intent."
+    }
+  ],
+  "preferredCandidate": {
+    "id": "read-only-empty-endpoint-wildcard",
+    "input": {
+      "left": "resolved Form identity or flat resolved ValueBundle",
+      "right": "resolved Form identity or flat resolved ValueBundle",
+      "precondition": "at least one side is a statically elaborated ValueBundle"
+    },
+    "endpointDomains": {
+      "singleForm": "singleton resolved identity set",
+      "nonEmptyValueBundle": "its extensional set of resolved identities",
+      "emptyValueBundleInExpansionPosition": "wildcard / unconstrained endpoint"
+    },
+    "result": "flat extensional ValueBundle of existing Link identities",
+    "query": {
+      "leftConstrainedRightWildcard": "L4 outgoing(start)",
+      "leftWildcardRightConstrained": "L4 incoming(end)",
+      "bothConstrained": "intersection/filter by exact ordered endpoint pairs",
+      "bothWildcard": "all links in the selected immutable/read-only memory view"
+    },
+    "missingPair": "omit; never materialize",
+    "ordering": "semantic result order-insensitive; deterministic sorted LinkRef order may be used only for presentation/conformance",
+    "provenance": "query constraints and source occurrence paths remain observable separately from the extensional result set",
+    "emptyBundleContextualNote": "{} is the empty ValueBundle under value algebra. The expansion operator gives that empty endpoint operand a wildcard query role only because its parent operation is statically known to be bundle expansion; this is not runtime role guessing."
+  },
+  "memoryFixture": {
+    "links": {
+      "0": [0, 0],
+      "1": [0, 1],
+      "2": [1, 0],
+      "3": [1, 1]
+    },
+    "symbols": {
+      "a": 0,
+      "b": 1,
+      "c": 0,
+      "d": 1,
+      "e": 2
+    },
+    "note": "The four links 0..3 form a closed finite graph. Symbol e resolves to existing LinkRef 2, but pair (0,2) is absent, enabling a missing-pair no-realize veto."
+  },
+  "cases": [
+    {
+      "id": "single-to-explicit-bundle",
+      "source": "a{c, d}",
+      "left": {"kind": "single", "symbol": "a"},
+      "right": {"kind": "bundle", "symbols": ["c", "d"]},
+      "expectedLinks": [0, 1]
+    },
+    {
+      "id": "explicit-bundle-to-single",
+      "source": "{a, b}d",
+      "left": {"kind": "bundle", "symbols": ["a", "b"]},
+      "right": {"kind": "single", "symbol": "d"},
+      "expectedLinks": [1, 3]
+    },
+    {
+      "id": "explicit-cartesian-existing-links",
+      "source": "{a, b}{c, d}",
+      "left": {"kind": "bundle", "symbols": ["a", "b"]},
+      "right": {"kind": "bundle", "symbols": ["c", "d"]},
+      "expectedLinks": [0, 1, 2, 3]
+    },
+    {
+      "id": "all-outgoing-empty-right",
+      "source": "a{}",
+      "left": {"kind": "single", "symbol": "a"},
+      "right": {"kind": "bundle", "symbols": []},
+      "expectedLinks": [0, 1]
+    },
+    {
+      "id": "all-incoming-empty-left",
+      "source": "{}d",
+      "left": {"kind": "bundle", "symbols": []},
+      "right": {"kind": "single", "symbol": "d"},
+      "expectedLinks": [1, 3]
+    },
+    {
+      "id": "all-links-both-empty",
+      "source": "{}{}",
+      "left": {"kind": "bundle", "symbols": []},
+      "right": {"kind": "bundle", "symbols": []},
+      "expectedLinks": [0, 1, 2, 3]
+    },
+    {
+      "id": "singleton-bundles-exact-existing",
+      "source": "{a}{d}",
+      "left": {"kind": "bundle", "symbols": ["a"]},
+      "right": {"kind": "bundle", "symbols": ["d"]},
+      "expectedLinks": [1]
+    },
+    {
+      "id": "missing-pair-is-omitted",
+      "source": "a{e}",
+      "left": {"kind": "single", "symbol": "a"},
+      "right": {"kind": "bundle", "symbols": ["e"]},
+      "expectedLinks": []
+    },
+    {
+      "id": "wildcard-with-no-existing-outgoing",
+      "source": "e{}",
+      "left": {"kind": "single", "symbol": "e"},
+      "right": {"kind": "bundle", "symbols": []},
+      "expectedLinks": []
+    }
+  ],
+  "vetoes": {
+    "requiresAtLeastOneBundleOperand": true,
+    "plainFormJuxtapositionSemanticsUnchanged": true,
+    "readsOnlyExistingL4Links": true,
+    "missingPairsAreNeverCreated": true,
+    "realize": false,
+    "delete": false,
+    "cascade": false,
+    "globalRewrite": false,
+    "memorySnapshotUnchanged": true,
+    "nestedValueBundle": "out-of-scope"
+  },
+  "deferred": {
+    "nestedValueBundleExpansion": "unresolved",
+    "queryProvenanceObject": "future-contract-detail",
+    "productionSyntaxElaboration": "after semantic acceptance only",
+    "persistentStorage": "out-of-scope"
+  },
+  "passMeaning": "The historical bundle expansion/all-outgoing/all-incoming intent can be modeled as a statically selected read-only L4 query over existing links, without implicit materialization. Passing does not accept this semantics or modify mts-contract/v0.2."
+}

--- a/tests/test_mts_bundle_expansion_challenge.py
+++ b/tests/test_mts_bundle_expansion_challenge.py
@@ -1,0 +1,194 @@
+"""Executable, non-production challenge for bundle expansion/query semantics.
+
+The evaluator is deliberately test-local. It uses only the existing read-only
+L4 indexes and never calls ``intern_link`` or ``realize_denotation``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_memory import AnumMemory
+from core.mtc_ast import BundleForm, Sequence, Symbol, format_expression
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CORPUS = ROOT / "contracts" / "mts-bundle-expansion-challenge-v0.2.json"
+MTS_CONTRACT = ROOT / "contracts" / "mts-contract-v0.2.json"
+ALGEBRA = ROOT / "contracts" / "mts-bundle-algebra-challenge-v0.2.json"
+
+
+class ExpansionError(ValueError):
+    pass
+
+
+def corpus() -> dict:
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def memory_and_symbols() -> tuple[AnumMemory, dict[str, int]]:
+    fixture = corpus()["memoryFixture"]
+    initial = {int(ref): tuple(pair) for ref, pair in fixture["links"].items()}
+    return AnumMemory(initial_links=initial), fixture["symbols"]
+
+
+def _domain(expression, symbols: dict[str, int]) -> set[int] | None:
+    """Return endpoint identities; None means expansion-position wildcard."""
+
+    if isinstance(expression, Symbol):
+        if expression.name not in symbols:
+            raise ExpansionError(f"Unbound symbol: {expression.name}")
+        return {symbols[expression.name]}
+
+    if isinstance(expression, BundleForm):
+        if not expression.items:
+            return None
+        result: set[int] = set()
+        for item in expression.items:
+            if not isinstance(item, Symbol):
+                raise ExpansionError("Expansion challenge supports flat symbol bundles only")
+            if item.name not in symbols:
+                raise ExpansionError(f"Unbound symbol: {item.name}")
+            result.add(symbols[item.name])
+        return result
+
+    raise ExpansionError("Expansion endpoint must be a Form identity or ValueBundle")
+
+
+def _query(source: str, memory: AnumMemory, symbols: dict[str, int]) -> list[int]:
+    ast = parse_formula(source)
+    if not isinstance(ast, Sequence) or len(ast.items) != 2:
+        raise ExpansionError("Expansion source must parse as a two-endpoint Sequence")
+
+    left_expr, right_expr = ast.items
+    if not isinstance(left_expr, BundleForm) and not isinstance(right_expr, BundleForm):
+        raise ExpansionError("Expansion requires at least one ValueBundle operand")
+
+    left = _domain(left_expr, symbols)
+    right = _domain(right_expr, symbols)
+
+    if left is None and right is None:
+        return sorted(ref for ref, _record in memory.snapshot().links)
+
+    if left is None:
+        assert right is not None
+        return sorted({ref for end in right for ref in memory.incoming(end)})
+
+    if right is None:
+        return sorted({ref for start in left for ref in memory.outgoing(start)})
+
+    found: set[int] = set()
+    for start in left:
+        for end in right:
+            ref = memory.find_link(start, end)
+            if ref is not None:
+                found.add(ref)
+    return sorted(found)
+
+
+def test_challenge_is_non_normative_and_follows_flat_algebra_gate():
+    data = corpus()
+    algebra = json.loads(ALGEBRA.read_text(encoding="utf-8"))
+    mts_contract_text = MTS_CONTRACT.read_text(encoding="utf-8")
+
+    assert data["schema"] == "mts-bundle-expansion-challenge/v0.2"
+    assert data["status"] == "candidate-challenge"
+    assert data["acceptedContractLinkAllowed"] is False
+    assert data["productionSemanticsChanged"] is False
+    assert algebra["deferred"]["expansion"]["status"] == "separate-challenge-required"
+    assert "mts-bundle-expansion-challenge" not in mts_contract_text
+
+
+def test_model_verdicts_reject_materialization_and_select_read_only_wildcard_candidate():
+    models = {model["id"]: model for model in corpus()["models"]}
+
+    assert models["pure-cartesian-empty-set"]["verdict"] == "reject-for-issue-50"
+    assert models["read-only-empty-endpoint-wildcard"]["verdict"] == "preferred-candidate"
+    assert models["read-only-empty-endpoint-wildcard"]["accepted"] is False
+    assert models["materializing-cartesian-product"]["verdict"] == "reject"
+    assert models["synthetic-unmaterialized-linkforms"]["verdict"] == "defer"
+
+
+def test_every_query_vector_uses_existing_links_only_and_matches_expected_result():
+    memory, symbols = memory_and_symbols()
+    before = memory.snapshot()
+
+    for case in corpus()["cases"]:
+        ast = parse_formula(case["source"])
+        assert format_expression(ast) == case["source"], case["id"]
+        assert _query(case["source"], memory, symbols) == case["expectedLinks"], case["id"]
+        assert memory.snapshot() == before, case["id"]
+
+
+def test_nonempty_bundle_expansion_is_cartesian_filter_over_existing_exact_pairs():
+    memory, symbols = memory_and_symbols()
+
+    assert _query("a{c, d}", memory, symbols) == [0, 1]
+    assert _query("{a, b}d", memory, symbols) == [1, 3]
+    assert _query("{a, b}{c, d}", memory, symbols) == [0, 1, 2, 3]
+    assert _query("{a}{d}", memory, symbols) == [1]
+
+
+def test_empty_bundle_is_wildcard_only_under_statically_known_expansion_parent():
+    memory, symbols = memory_and_symbols()
+
+    assert _query("a{}", memory, symbols) == list(memory.outgoing(symbols["a"]))
+    assert _query("{}d", memory, symbols) == list(memory.incoming(symbols["d"]))
+    assert _query("{}{}", memory, symbols) == [0, 1, 2, 3]
+
+    preferred = corpus()["preferredCandidate"]
+    assert preferred["endpointDomains"]["emptyValueBundleInExpansionPosition"] == (
+        "wildcard / unconstrained endpoint"
+    )
+    assert "parent operation is statically known" in preferred["emptyBundleContextualNote"]
+
+
+def test_missing_exact_pair_is_omitted_without_realization():
+    memory, symbols = memory_and_symbols()
+    before = memory.snapshot()
+    before_count = memory.link_count
+
+    # e is an existing LinkRef, so (a,e) is a valid query pair; it is simply absent.
+    assert symbols["e"] == 2
+    assert memory.find_link(symbols["a"], symbols["e"]) is None
+    assert _query("a{e}", memory, symbols) == []
+    assert memory.link_count == before_count
+    assert memory.snapshot() == before
+
+
+def test_wildcard_query_with_no_matching_links_returns_empty_set_without_side_effects():
+    memory, symbols = memory_and_symbols()
+    before = memory.snapshot()
+
+    assert memory.outgoing(symbols["e"]) == ()
+    assert _query("e{}", memory, symbols) == []
+    assert memory.snapshot() == before
+
+
+def test_plain_form_juxtaposition_is_outside_expansion_challenge():
+    memory, symbols = memory_and_symbols()
+
+    with pytest.raises(ExpansionError, match="requires at least one ValueBundle"):
+        _query("a d", memory, symbols)
+
+
+def test_nested_value_bundles_are_not_silently_flattened_by_query_challenge():
+    memory, symbols = memory_and_symbols()
+
+    with pytest.raises(ExpansionError, match="flat symbol bundles only"):
+        _query("a{{c, d}}", memory, symbols)
+    assert corpus()["vetoes"]["nestedValueBundle"] == "out-of-scope"
+
+
+def test_effect_veto_matches_read_only_l4_query_boundary():
+    vetoes = corpus()["vetoes"]
+
+    assert vetoes["readsOnlyExistingL4Links"] is True
+    assert vetoes["missingPairsAreNeverCreated"] is True
+    assert vetoes["realize"] is False
+    assert vetoes["delete"] is False
+    assert vetoes["cascade"] is False
+    assert vetoes["globalRewrite"] is False
+    assert vetoes["memorySnapshotUnchanged"] is True


### PR DESCRIPTION
Refs #50.

Executable non-production expansion/query challenge после #112.

Сравниваются модели раскрытия bundle operands. Preferred candidate — **read-only empty-endpoint wildcard**:

- `a{b,c}` / `{a,b}c` / `{a,b}{c,d}` фильтруют только уже существующие Link identities;
- `a{}` → все существующие outgoing links из `a`;
- `{}b` → все существующие incoming links в `b`;
- `{}{}` → все links выбранного read-only memory view;
- empty `{}` получает wildcard-роль только потому, что parent operation статически известен как expansion; сам ValueBundle `{}` в value algebra остаётся пустым set;
- missing exact pair опускается и никогда не materialize-ится;
- materializing Cartesian model отвергнут;
- synthetic hypothetical LinkForm output deferred;
- nested ValueBundle expansion deferred.

Test-local evaluator использует существующий `AnumMemory` и только `find_link/outgoing/incoming/snapshot`; snapshot сравнивается до/после каждого query. Production AST/parser/interpreter/L4 не меняются, `mts-contract/v0.2` не получает ссылку на challenge.

Passing challenge ещё не принимает bundle semantics.