### PR TITLE
Собрать flat ValueBundle v0.2 candidate contract

### DIFF
--- a/contracts/mts-value-bundle-conformance-v0.2.json
+++ b/contracts/mts-value-bundle-conformance-v0.2.json
@@ -1,0 +1,194 @@
+{
+  "schema": "mts-value-bundle-conformance/v0.2",
+  "status": "candidate-conformance",
+  "contract": "mts-value-bundle/v0.2",
+  "accepted": false,
+  "elaboration": [
+    {
+      "id": "constraint-nonempty",
+      "source": "{x = y, y != z}",
+      "expectedRole": "ConstraintBundle"
+    },
+    {
+      "id": "value-nonempty",
+      "source": "{x, y}",
+      "expectedRole": "ValueBundle"
+    },
+    {
+      "id": "empty-constraint-entry",
+      "source": "{}",
+      "context": "constraint-entry",
+      "expectedRole": "ConstraintBundle"
+    },
+    {
+      "id": "empty-value-form-position",
+      "source": "{} = x",
+      "bundlePath": [0],
+      "expectedRole": "ValueBundle"
+    },
+    {
+      "id": "empty-definition-default",
+      "source": "x : {}",
+      "bundlePath": [1],
+      "expectedRole": "ConstraintBundle"
+    }
+  ],
+  "staticRejections": [
+    {
+      "id": "mixed-role",
+      "source": "{x, y = z}",
+      "error": "mixed-bundle-role-evidence"
+    },
+    {
+      "id": "ambiguous-empty",
+      "source": "{{}}",
+      "error": "ambiguous-empty-bundle-role"
+    },
+    {
+      "id": "nested-value",
+      "source": "{{x, y}} = z",
+      "error": "nested-value-bundle-not-supported"
+    },
+    {
+      "id": "value-at-constraint-entry",
+      "source": "{x, y}",
+      "context": "constraint-entry",
+      "error": "bundle-role-mismatch"
+    }
+  ],
+  "valueEquality": [
+    {
+      "id": "order-insensitive",
+      "left": "{a, b}",
+      "right": "{b, a}",
+      "symbols": {"a": 10, "b": 20},
+      "leftHoles": {},
+      "rightHoles": {},
+      "leftSet": [10, 20],
+      "rightSet": [10, 20],
+      "equal": true
+    },
+    {
+      "id": "resolved-duplicate-idempotence",
+      "left": "{a, a}",
+      "right": "{a}",
+      "symbols": {"a": 10},
+      "leftHoles": {},
+      "rightHoles": {},
+      "leftSet": [10],
+      "rightSet": [10],
+      "equal": true
+    },
+    {
+      "id": "anonymous-different-bindings",
+      "left": "{[], []}",
+      "right": "{[]}",
+      "symbols": {},
+      "leftHoles": {"0": 10, "1": 20},
+      "rightHoles": {"0": 10},
+      "leftSet": [10, 20],
+      "rightSet": [10],
+      "equal": false
+    },
+    {
+      "id": "anonymous-same-bindings",
+      "left": "{[], []}",
+      "right": "{[]}",
+      "symbols": {},
+      "leftHoles": {"0": 10, "1": 10},
+      "rightHoles": {"0": 10},
+      "leftSet": [10],
+      "rightSet": [10],
+      "equal": true
+    },
+    {
+      "id": "different-sets",
+      "left": "{a, b}",
+      "right": "{a}",
+      "symbols": {"a": 10, "b": 20},
+      "leftHoles": {},
+      "rightHoles": {},
+      "leftSet": [10, 20],
+      "rightSet": [10],
+      "equal": false
+    }
+  ],
+  "crossKindComparison": [
+    {
+      "id": "singleton-bundle-vs-scalar",
+      "bundle": "{a}",
+      "scalar": "a",
+      "symbols": {"a": 10},
+      "bundleSet": [10],
+      "scalarIdentity": 10,
+      "equal": false,
+      "notEqual": true
+    },
+    {
+      "id": "empty-bundle-vs-scalar",
+      "bundle": "{}",
+      "scalar": "a",
+      "symbols": {"a": 10},
+      "bundleSet": [],
+      "scalarIdentity": 10,
+      "equal": false,
+      "notEqual": true,
+      "context": "form-required"
+    }
+  ],
+  "expansionMemory": {
+    "links": {
+      "0": [0, 0],
+      "1": [0, 1],
+      "2": [1, 0],
+      "3": [1, 1]
+    },
+    "symbols": {"a": 0, "b": 1, "c": 0, "d": 1, "e": 2}
+  },
+  "expansion": [
+    {
+      "id": "single-to-bundle",
+      "source": "a{c, d}",
+      "expectedLinks": [0, 1]
+    },
+    {
+      "id": "bundle-to-single",
+      "source": "{a, b}d",
+      "expectedLinks": [1, 3]
+    },
+    {
+      "id": "cartesian-existing",
+      "source": "{a, b}{c, d}",
+      "expectedLinks": [0, 1, 2, 3]
+    },
+    {
+      "id": "outgoing-wildcard",
+      "source": "a{}",
+      "expectedLinks": [0, 1]
+    },
+    {
+      "id": "incoming-wildcard",
+      "source": "{}d",
+      "expectedLinks": [1, 3]
+    },
+    {
+      "id": "all-links-wildcard",
+      "source": "{}{}",
+      "expectedLinks": [0, 1, 2, 3]
+    },
+    {
+      "id": "missing-pair-no-realize",
+      "source": "a{e}",
+      "expectedLinks": []
+    }
+  ],
+  "veto": {
+    "rootDefinitionsChanged": false,
+    "constraintBundleBehaviorChanged": false,
+    "deduplicateSourceOccurrences": false,
+    "nestedValueBundleAccepted": false,
+    "interpretMayRealize": false,
+    "interpretMayDelete": false,
+    "globalRewrite": false
+  }
+}

--- a/contracts/mts-value-bundle-v0.2.json
+++ b/contracts/mts-value-bundle-v0.2.json
@@ -1,0 +1,155 @@
+{
+  "schema": "mts-value-bundle/v0.2",
+  "status": "candidate-contract",
+  "accepted": false,
+  "acceptedContractLinkAllowed": false,
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "mts-bundle-decision/v0.2",
+    "mts-bundle-elaboration-challenge/v0.2",
+    "mts-bundle-algebra-challenge/v0.2",
+    "mts-bundle-expansion-challenge/v0.2"
+  ],
+  "scope": {
+    "valueBundle": "flat only",
+    "constraintBundle": "existing accepted behavior unchanged",
+    "nestedValueBundle": "rejected/deferred",
+    "materialization": "out-of-scope",
+    "persistentStorage": "out-of-scope"
+  },
+  "syntax": {
+    "glyph": "{...}",
+    "surfaceNode": "CurlySyntax",
+    "surfaceNodeIsSemanticType": false,
+    "sourceOrderPreserved": true,
+    "sourceMultiplicityPreserved": true,
+    "sourceOccurrencePathsPreserved": true
+  },
+  "elaboration": {
+    "phase": "static-before-interpretation",
+    "runtimeRoleGuessing": false,
+    "outputs": [
+      "ConstraintBundle",
+      "ValueBundle"
+    ],
+    "rules": [
+      {
+        "when": "all non-empty direct items are Judgments",
+        "result": "ConstraintBundle"
+      },
+      {
+        "when": "all non-empty direct items are non-bundle Forms",
+        "result": "ValueBundle"
+      },
+      {
+        "when": "direct items mix Judgment and Form evidence",
+        "result": "static-error:mixed-bundle-role-evidence"
+      },
+      {
+        "when": "empty {} occurs in statically Form-required position",
+        "result": "ValueBundle"
+      },
+      {
+        "when": "empty {} is the constraint interpretation entry expression",
+        "result": "ConstraintBundle"
+      },
+      {
+        "when": "empty {} is a definition RHS with no stronger Form evidence",
+        "result": "ConstraintBundle"
+      },
+      {
+        "when": "empty {} has no static role context",
+        "result": "static-error:ambiguous-empty-bundle-role"
+      },
+      {
+        "when": "a ValueBundle directly contains another ValueBundle/CurlySyntax item",
+        "result": "static-error:nested-value-bundle-not-supported"
+      }
+    ],
+    "rootRegression": {
+      "currentTenDefinitionsMustElaborateIdentically": true,
+      "valueBundleMayAppearInCurrentRoot": false
+    }
+  },
+  "runtimeValueModel": {
+    "scalar": {
+      "kind": "link",
+      "identity": "resolved L1 LinkRef"
+    },
+    "bundle": {
+      "kind": "bundle",
+      "identity": "extensional set of unique resolved L1 LinkRefs",
+      "occurrenceProvenanceSeparate": true
+    },
+    "crossKindEquality": false,
+    "crossKindInequality": true,
+    "globalRewrite": false,
+    "equality": "local contextual value comparison"
+  },
+  "elementResolution": {
+    "eachOccurrenceResolvedIndependently": true,
+    "deduplicateBeforeResolution": false,
+    "anonymousSquareIdentity": "ast-occurrence-path",
+    "unresolvedAnonymousOccurrence": "evaluation-unresolved/failure; never choose an arbitrary LinkRef",
+    "resolvedOccurrenceTraceRequired": true,
+    "semanticSetBuiltAfterResolution": true,
+    "semanticOrderRelevant": false,
+    "semanticDuplicateCountRelevant": false
+  },
+  "flatValueAlgebra": {
+    "idempotentAfterResolution": true,
+    "commutativeAfterResolution": true,
+    "sourceOrderStillObservableAsProvenance": true,
+    "sourceDuplicateOccurrencesStillObservableAsProvenance": true,
+    "historicalAnonymousClaim": {
+      "source": "{[], []} = {[]}",
+      "unconditional": false,
+      "conditional": "true only when independently resolved identity sets are equal"
+    }
+  },
+  "expansionQuery": {
+    "trigger": "Sequence/juxtaposition with at least one statically elaborated ValueBundle operand",
+    "result": "flat ValueBundle of existing Link identities",
+    "readOnly": true,
+    "endpointDomains": {
+      "scalar": "singleton resolved identity",
+      "nonEmptyBundle": "resolved extensional identity set",
+      "emptyBundle": "wildcard only in expansion endpoint position"
+    },
+    "operations": {
+      "scalarToEmpty": "all existing outgoing links",
+      "emptyToScalar": "all existing incoming links",
+      "emptyToEmpty": "all existing links in selected memory view",
+      "constrainedToConstrained": "existing exact links whose ordered poles belong to the two endpoint domains"
+    },
+    "missingPair": "omit",
+    "implicitRealize": false,
+    "implicitDelete": false
+  },
+  "effects": {
+    "interpretMayReadMemory": true,
+    "interpretMayRealize": false,
+    "interpretMayDelete": false,
+    "bundleLiteralIsCommand": false,
+    "expansionIsCommand": false
+  },
+  "deferred": {
+    "nestedValueBundleSemantics": [
+      "first-class nested collection",
+      "flatten/union",
+      "other construction"
+    ],
+    "syntheticMissingLinkForms": "not part of current candidate",
+    "explicitBundleMaterialization": "separate L4 operation if ever needed"
+  },
+  "acceptanceGate": {
+    "requires": [
+      "candidate conformance corpus",
+      "single reference elaborator/value evaluator in core",
+      "all current root/conformance tests green",
+      "explicit proof that no current ConstraintBundle behavior changes",
+      "downstream aprover repin and conformance after upstream acceptance"
+    ],
+    "mustVersionIfAccepted": true
+  }
+}

--- a/tests/test_mts_value_bundle_candidate_contract.py
+++ b/tests/test_mts_value_bundle_candidate_contract.py
@@ -1,0 +1,194 @@
+"""Consistency gates for the non-normative flat ValueBundle candidate contract."""
+
+import json
+from pathlib import Path
+
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-value-bundle-v0.2.json"
+CONFORMANCE = ROOT / "contracts" / "mts-value-bundle-conformance-v0.2.json"
+MTS_CONTRACT = ROOT / "contracts" / "mts-contract-v0.2.json"
+ELABORATION = ROOT / "contracts" / "mts-bundle-elaboration-challenge-v0.2.json"
+ALGEBRA = ROOT / "contracts" / "mts-bundle-algebra-challenge-v0.2.json"
+EXPANSION = ROOT / "contracts" / "mts-bundle-expansion-challenge-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_candidate_is_versioned_but_not_accepted_or_linked_from_mts_contract():
+    contract = load(CONTRACT)
+    conformance = load(CONFORMANCE)
+    accepted_text = MTS_CONTRACT.read_text(encoding="utf-8")
+
+    assert contract["schema"] == "mts-value-bundle/v0.2"
+    assert contract["status"] == "candidate-contract"
+    assert contract["accepted"] is False
+    assert contract["acceptedContractLinkAllowed"] is False
+    assert conformance["schema"] == "mts-value-bundle-conformance/v0.2"
+    assert conformance["status"] == "candidate-conformance"
+    assert conformance["contract"] == contract["schema"]
+    assert conformance["accepted"] is False
+    assert "mts-value-bundle" not in accepted_text
+
+
+def test_candidate_depends_on_all_three_passed_semantic_challenges():
+    contract = load(CONTRACT)
+    elaboration = load(ELABORATION)
+    algebra = load(ALGEBRA)
+    expansion = load(EXPANSION)
+
+    assert contract["dependsOn"] == [
+        "mts-contract/v0.2",
+        "mts-bundle-decision/v0.2",
+        elaboration["schema"],
+        algebra["schema"],
+        expansion["schema"],
+    ]
+    assert elaboration["status"] == "candidate-challenge"
+    assert algebra["status"] == "candidate-challenge"
+    assert expansion["status"] == "candidate-challenge"
+
+
+def test_candidate_is_flat_only_and_does_not_smuggle_nested_semantics():
+    contract = load(CONTRACT)
+    conformance = load(CONFORMANCE)
+
+    assert contract["scope"]["valueBundle"] == "flat only"
+    assert contract["scope"]["nestedValueBundle"] == "rejected/deferred"
+    assert conformance["veto"]["nestedValueBundleAccepted"] is False
+    assert any(
+        case["error"] == "nested-value-bundle-not-supported"
+        for case in conformance["staticRejections"]
+    )
+    assert "nestedValueBundleSemantics" in contract["deferred"]
+
+
+def test_static_elaboration_vectors_are_supported_by_the_passed_model_b_challenge():
+    conformance = load(CONFORMANCE)
+    challenge = load(ELABORATION)
+    challenge_by_source = {}
+    for case in challenge["cases"]:
+        challenge_by_source.setdefault(case["source"], []).append(case)
+
+    for case in conformance["elaboration"]:
+        parse_formula(case["source"])
+        source_cases = challenge_by_source[case["source"]]
+        assert any(
+            any(role["role"] == case["expectedRole"] for role in source_case.get("roles", []))
+            for source_case in source_cases
+        )
+
+    mixed = next(item for item in conformance["staticRejections"] if item["id"] == "mixed-role")
+    assert any(
+        item.get("error") == mixed["error"] for item in challenge_by_source[mixed["source"]]
+    )
+
+
+def test_flat_equality_vectors_match_resolved_identity_algebra_challenge():
+    conformance = load(CONFORMANCE)
+    challenge = load(ALGEBRA)
+
+    def key(case: dict) -> tuple:
+        return (
+            case["left"],
+            case["right"],
+            json.dumps(case["symbols"], sort_keys=True),
+            json.dumps(case["leftHoles"], sort_keys=True),
+            json.dumps(case["rightHoles"], sort_keys=True),
+        )
+
+    challenge_cases = {key(case): case for case in challenge["cases"]}
+    for case in conformance["valueEquality"]:
+        upstream = challenge_cases[key(case)]
+        assert upstream["leftSet"] == case["leftSet"]
+        assert upstream["rightSet"] == case["rightSet"]
+        assert upstream["equal"] is case["equal"]
+
+
+def test_cross_kind_comparison_is_tagged_and_has_no_singleton_coercion():
+    contract = load(CONTRACT)
+    conformance = load(CONFORMANCE)
+
+    model = contract["runtimeValueModel"]
+    assert model["scalar"]["kind"] == "link"
+    assert model["bundle"]["kind"] == "bundle"
+    assert model["crossKindEquality"] is False
+    assert model["crossKindInequality"] is True
+
+    for case in conformance["crossKindComparison"]:
+        assert case["equal"] is False
+        assert case["notEqual"] is True
+        assert case["bundleSet"] != case["scalarIdentity"]
+
+
+def test_expansion_vectors_match_read_only_l4_query_challenge():
+    conformance = load(CONFORMANCE)
+    challenge = load(EXPANSION)
+    challenge_by_source = {case["source"]: case for case in challenge["cases"]}
+
+    assert conformance["expansionMemory"] == {
+        "links": challenge["memoryFixture"]["links"],
+        "symbols": challenge["memoryFixture"]["symbols"],
+    }
+    for case in conformance["expansion"]:
+        assert challenge_by_source[case["source"]]["expectedLinks"] == case["expectedLinks"]
+
+
+def test_anonymous_occurrences_remain_independent_until_resolution():
+    contract = load(CONTRACT)
+    anonymous = contract["elementResolution"]
+
+    assert anonymous["eachOccurrenceResolvedIndependently"] is True
+    assert anonymous["deduplicateBeforeResolution"] is False
+    assert anonymous["anonymousSquareIdentity"] == "ast-occurrence-path"
+    assert anonymous["semanticSetBuiltAfterResolution"] is True
+
+    cases = {case["id"]: case for case in load(CONFORMANCE)["valueEquality"]}
+    assert cases["anonymous-different-bindings"]["equal"] is False
+    assert cases["anonymous-same-bindings"]["equal"] is True
+
+
+def test_current_ten_root_definitions_remain_parseable_and_candidate_cannot_enter_root():
+    contract = load(CONTRACT)
+    sources = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert len(sources) == 10
+    for source in sources:
+        parse_formula(source)
+    regression = contract["elaboration"]["rootRegression"]
+    assert regression["currentTenDefinitionsMustElaborateIdentically"] is True
+    assert regression["valueBundleMayAppearInCurrentRoot"] is False
+
+
+def test_effect_veto_preserves_interpret_not_realize_boundary():
+    contract = load(CONTRACT)
+    conformance = load(CONFORMANCE)
+
+    assert contract["effects"] == {
+        "interpretMayReadMemory": True,
+        "interpretMayRealize": False,
+        "interpretMayDelete": False,
+        "bundleLiteralIsCommand": False,
+        "expansionIsCommand": False,
+    }
+    assert conformance["veto"]["interpretMayRealize"] is False
+    assert conformance["veto"]["interpretMayDelete"] is False
+    assert conformance["veto"]["globalRewrite"] is False
+
+
+def test_acceptance_gate_requires_reference_core_before_normative_linking():
+    gate = load(CONTRACT)["acceptanceGate"]
+
+    assert "single reference elaborator/value evaluator in core" in gate["requires"]
+    assert "explicit proof that no current ConstraintBundle behavior changes" in gate["requires"]
+    assert "downstream aprover repin and conformance after upstream acceptance" in gate["requires"]
+    assert gate["mustVersionIfAccepted"] is True


### PR DESCRIPTION
Refs #50.

Консолидирует три прошедших non-production challenge (#111–#113) в один versioned **candidate** contract/corpus, но не подключает его к accepted `mts-contract/v0.2`.

Scope первой версии намеренно узкий:

- один glyph `{...}` статически elaborates в `ConstraintBundle|ValueBundle`;
- ValueBundle только **flat**; nested value bundles rejected/deferred;
- occurrence paths/order/multiplicity сохраняются как provenance;
- semantic bundle identity = extensional set resolved L1 LinkRefs после независимого resolution;
- cross-kind `BundleValue` vs `LinkValue` не имеет singleton coercion;
- expansion query read-only; empty endpoint bundle wildcard только в expansion position;
- missing links omit, never realize;
- current ConstraintBundle behavior и 10 root definitions не меняются.

Добавлены:
- `mts-value-bundle-v0.2.json` status `candidate-contract`, accepted=false;
- `mts-value-bundle-conformance-v0.2.json` status `candidate-conformance`;
- consistency tests against elaboration/algebra/expansion challenges and accepted root.

Acceptance gate внутри contract требует отдельный single reference core implementation + regression, после чего только возможен normative link и downstream repin. Production AST/parser/interpreter этим PR не меняются.