### PR TITLE
Добавить single reference core для flat ValueBundle v0.2

### DIFF
--- a/contracts/mts-value-bundle-conformance-v0.2.json
+++ b/contracts/mts-value-bundle-conformance-v0.2.json
@@ -54,6 +54,31 @@
       "source": "{x, y}",
       "context": "constraint-entry",
       "error": "bundle-role-mismatch"
+    },
+    {
+      "id": "bundle-valued-definition-deferred",
+      "source": "b : {x, y}",
+      "error": "bundle-valued-definition-deferred"
+    },
+    {
+      "id": "bundle-explicit-link-pole-deferred",
+      "source": "{x, y} ⟼ z",
+      "error": "bundle-not-supported-in-scalar-operator"
+    },
+    {
+      "id": "bundle-projection-deferred",
+      "source": "♀{x, y}",
+      "error": "bundle-not-supported-in-scalar-operator"
+    },
+    {
+      "id": "bundle-inversion-deferred",
+      "source": "¬{x, y}",
+      "error": "bundle-not-supported-in-scalar-operator"
+    },
+    {
+      "id": "bundle-expansion-as-explicit-link-pole-deferred",
+      "source": "a{b, c} ⟼ z",
+      "error": "bundle-not-supported-in-scalar-operator"
     }
   ],
   "valueEquality": [
@@ -187,6 +212,8 @@
     "constraintBundleBehaviorChanged": false,
     "deduplicateSourceOccurrences": false,
     "nestedValueBundleAccepted": false,
+    "bundleValuedDefinitionAccepted": false,
+    "scalarOperatorLiftingAccepted": false,
     "interpretMayRealize": false,
     "interpretMayDelete": false,
     "globalRewrite": false

--- a/contracts/mts-value-bundle-v0.2.json
+++ b/contracts/mts-value-bundle-v0.2.json
@@ -14,6 +14,8 @@
     "valueBundle": "flat only",
     "constraintBundle": "existing accepted behavior unchanged",
     "nestedValueBundle": "rejected/deferred",
+    "bundleValuedDefinition": "rejected/deferred",
+    "scalarOperatorLifting": "rejected/deferred",
     "materialization": "out-of-scope",
     "persistentStorage": "out-of-scope"
   },
@@ -32,13 +34,25 @@
       "ConstraintBundle",
       "ValueBundle"
     ],
+    "operatorDomains": {
+      "constraintEntry": "ConstraintBundle or existing Judgment semantics",
+      "standaloneValueEntry": "flat ValueBundle allowed when value context is explicit",
+      "equalityOperands": "LinkValue or flat ValueBundle",
+      "inequalityOperands": "LinkValue or flat ValueBundle",
+      "sequenceWithBundleOperand": "bundle expansion query",
+      "linkFormOperands": "scalar LinkValue only",
+      "projectionOperand": "scalar LinkValue only",
+      "inversionOperand": "scalar LinkValue only",
+      "definitionTarget": "scalar LinkValue form only",
+      "definitionRhs": "existing scalar Form or ConstraintBundle only; ValueBundle deferred"
+    },
     "rules": [
       {
         "when": "all non-empty direct items are Judgments",
         "result": "ConstraintBundle"
       },
       {
-        "when": "all non-empty direct items are non-bundle Forms",
+        "when": "all non-empty direct items are non-bundle Forms in a value-capable context",
         "result": "ValueBundle"
       },
       {
@@ -46,7 +60,7 @@
         "result": "static-error:mixed-bundle-role-evidence"
       },
       {
-        "when": "empty {} occurs in statically Form-required position",
+        "when": "empty {} occurs in a statically value-capable position",
         "result": "ValueBundle"
       },
       {
@@ -54,8 +68,16 @@
         "result": "ConstraintBundle"
       },
       {
-        "when": "empty {} is a definition RHS with no stronger Form evidence",
+        "when": "empty {} is a definition RHS",
         "result": "ConstraintBundle"
+      },
+      {
+        "when": "non-empty ValueBundle is a definition RHS",
+        "result": "static-error:bundle-valued-definition-deferred"
+      },
+      {
+        "when": "ValueBundle appears under scalar-only ⟼/♀/♂/¬ operand position",
+        "result": "static-error:bundle-not-supported-in-scalar-operator"
       },
       {
         "when": "empty {} has no static role context",
@@ -108,7 +130,7 @@
     }
   },
   "expansionQuery": {
-    "trigger": "Sequence/juxtaposition with at least one statically elaborated ValueBundle operand",
+    "trigger": "Sequence/juxtaposition with exactly two endpoints and at least one statically elaborated ValueBundle operand",
     "result": "flat ValueBundle of existing Link identities",
     "readOnly": true,
     "endpointDomains": {
@@ -139,6 +161,9 @@
       "flatten/union",
       "other construction"
     ],
+    "bundleValuedDefinitions": "requires a tagged value environment/binding contract",
+    "bundleProjectionOrInversion": "requires an explicit lifting rule or rejection in a later version",
+    "bundleAsExplicitLinkFormPole": "requires a separate lifting decision; current expansion uses juxtaposition only",
     "syntheticMissingLinkForms": "not part of current candidate",
     "explicitBundleMaterialization": "separate L4 operation if ever needed"
   },

--- a/core/mtc_value_bundle.py
+++ b/core/mtc_value_bundle.py
@@ -1,0 +1,369 @@
+"""Reference core for the *candidate* flat ValueBundle v0.2 semantics.
+
+This module is intentionally not wired into the accepted MTS interpreter yet.
+It provides one executable candidate implementation for the versioned
+``mts-value-bundle/v0.2`` contract:
+
+* static elaboration of curly syntax into ConstraintBundle or ValueBundle;
+* flat ValueBundle resolution and tagged value comparison;
+* read-only expansion queries over an explicit query-memory protocol.
+
+No function here can realize or delete links.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, TypeAlias
+
+from core.mtc_ast import (
+    BundleForm,
+    Definition,
+    EndProjection,
+    Equality,
+    Expression,
+    Form,
+    Inequality,
+    Inversion,
+    Judgment,
+    LinkForm,
+    RoundForm,
+    Sequence,
+    SquareForm,
+    StartProjection,
+)
+
+
+LinkRef: TypeAlias = int
+OccurrencePath: TypeAlias = tuple[int, ...]
+FormResolver: TypeAlias = Callable[[Form, OccurrencePath], LinkRef]
+
+
+class BundleRole(str, Enum):
+    CONSTRAINT = "ConstraintBundle"
+    VALUE = "ValueBundle"
+
+
+class ExpectedRole(str, Enum):
+    NONE = "none"
+    CONSTRAINT = "constraint"
+    VALUE = "value"
+    SCALAR = "scalar"
+    DEFINITION_RHS = "definition-rhs"
+
+
+class BundleElaborationError(ValueError):
+    def __init__(self, code: str, path: OccurrencePath):
+        super().__init__(f"{code} at {path}")
+        self.code = code
+        self.path = path
+
+
+class BundleEvaluationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class BundleRoleAt:
+    path: OccurrencePath
+    role: BundleRole
+
+
+@dataclass(frozen=True)
+class BundleElaboration:
+    roles: tuple[BundleRoleAt, ...]
+
+    def role_at(self, path: OccurrencePath) -> BundleRole | None:
+        for item in self.roles:
+            if item.path == path:
+                return item.role
+        return None
+
+
+@dataclass(frozen=True)
+class ResolvedOccurrence:
+    path: OccurrencePath
+    link: LinkRef
+
+
+@dataclass(frozen=True)
+class LinkValue:
+    identity: LinkRef
+
+
+@dataclass(frozen=True)
+class BundleValue:
+    identities: tuple[LinkRef, ...]
+    occurrences: tuple[ResolvedOccurrence, ...] = ()
+
+
+MtsValue: TypeAlias = LinkValue | BundleValue
+
+
+class BundleQueryMemory(Protocol):
+    """Read-only memory surface needed by bundle expansion."""
+
+    def find_link(self, start: LinkRef, end: LinkRef) -> LinkRef | None: ...
+
+    def outgoing(self, start: LinkRef) -> tuple[LinkRef, ...]: ...
+
+    def incoming(self, end: LinkRef) -> tuple[LinkRef, ...]: ...
+
+    def all_links(self) -> tuple[LinkRef, ...]: ...
+
+
+def elaborate_bundles(
+    expression: Expression,
+    *,
+    entry: ExpectedRole = ExpectedRole.NONE,
+) -> BundleElaboration:
+    """Statically elaborate curly syntax without consulting runtime memory."""
+
+    roles: list[BundleRoleAt] = []
+    _elaborate_expression(expression, (), entry, roles)
+    return BundleElaboration(tuple(roles))
+
+
+def evaluate_flat_value_bundle(
+    bundle: BundleForm,
+    *,
+    path: OccurrencePath,
+    elaboration: BundleElaboration,
+    resolve_form: FormResolver,
+) -> BundleValue:
+    """Resolve every flat ValueBundle element independently, then deduplicate.
+
+    Source occurrence provenance remains ordered and complete. Semantic bundle
+    identity is the sorted unique set of resolved LinkRefs.
+    """
+
+    if elaboration.role_at(path) is not BundleRole.VALUE:
+        raise BundleEvaluationError(f"bundle at {path} is not elaborated as ValueBundle")
+
+    occurrences: list[ResolvedOccurrence] = []
+    for index, item in enumerate(bundle.items):
+        if isinstance(item, BundleForm):
+            raise BundleEvaluationError("nested ValueBundle is not supported in v0.2 candidate")
+        if not isinstance(item, Form) or isinstance(item, Judgment):
+            raise BundleEvaluationError("ValueBundle item must be a Form")
+        item_path = path + (index,)
+        occurrences.append(ResolvedOccurrence(item_path, resolve_form(item, item_path)))
+
+    return BundleValue(
+        identities=tuple(sorted({item.link for item in occurrences})),
+        occurrences=tuple(occurrences),
+    )
+
+
+def values_equal(left: MtsValue, right: MtsValue) -> bool:
+    """Tagged local value equality; there is no singleton bundle coercion."""
+
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, LinkValue):
+        assert isinstance(right, LinkValue)
+        return left.identity == right.identity
+    assert isinstance(left, BundleValue) and isinstance(right, BundleValue)
+    return left.identities == right.identities
+
+
+def expand_bundle_query(
+    sequence: Sequence,
+    *,
+    path: OccurrencePath,
+    elaboration: BundleElaboration,
+    resolve_form: FormResolver,
+    memory: BundleQueryMemory,
+) -> BundleValue:
+    """Evaluate a two-endpoint bundle expansion as a read-only L4 query."""
+
+    if len(sequence.items) != 2:
+        raise BundleEvaluationError("bundle expansion requires exactly two endpoints in v0.2 candidate")
+
+    left_expr, right_expr = sequence.items
+    if not isinstance(left_expr, BundleForm) and not isinstance(right_expr, BundleForm):
+        raise BundleEvaluationError("bundle expansion requires at least one ValueBundle operand")
+
+    left = _endpoint_domain(
+        left_expr,
+        path + (0,),
+        elaboration=elaboration,
+        resolve_form=resolve_form,
+    )
+    right = _endpoint_domain(
+        right_expr,
+        path + (1,),
+        elaboration=elaboration,
+        resolve_form=resolve_form,
+    )
+
+    if left is None and right is None:
+        identities = set(memory.all_links())
+    elif left is None:
+        assert right is not None
+        identities = {ref for end in right for ref in memory.incoming(end)}
+    elif right is None:
+        identities = {ref for start in left for ref in memory.outgoing(start)}
+    else:
+        identities = set()
+        for start in left:
+            for end in right:
+                ref = memory.find_link(start, end)
+                if ref is not None:
+                    identities.add(ref)
+
+    return BundleValue(identities=tuple(sorted(identities)))
+
+
+def _intrinsic_bundle_evidence(bundle: BundleForm) -> str | None:
+    evidence: set[str] = set()
+    for item in bundle.items:
+        if isinstance(item, BundleForm):
+            child = _intrinsic_bundle_evidence(item)
+            if child is not None:
+                evidence.add(child)
+        elif isinstance(item, Judgment):
+            evidence.add("constraint")
+        elif isinstance(item, Form):
+            evidence.add("value")
+        else:
+            raise BundleElaborationError("unsupported-bundle-item", ())
+
+    if len(evidence) > 1:
+        return "mixed"
+    return next(iter(evidence), None)
+
+
+def _elaborate_bundle(
+    bundle: BundleForm,
+    path: OccurrencePath,
+    expected: ExpectedRole,
+    roles: list[BundleRoleAt],
+) -> None:
+    evidence = _intrinsic_bundle_evidence(bundle)
+    if evidence == "mixed":
+        raise BundleElaborationError("mixed-bundle-role-evidence", path)
+
+    if expected is ExpectedRole.SCALAR:
+        raise BundleElaborationError("bundle-not-supported-in-scalar-operator", path)
+
+    if expected is ExpectedRole.DEFINITION_RHS:
+        if evidence == "value":
+            raise BundleElaborationError("bundle-valued-definition-deferred", path)
+        role = BundleRole.CONSTRAINT
+    elif expected is ExpectedRole.CONSTRAINT:
+        if evidence == "value":
+            raise BundleElaborationError("bundle-role-mismatch", path)
+        role = BundleRole.CONSTRAINT
+    elif expected is ExpectedRole.VALUE:
+        if evidence == "constraint":
+            raise BundleElaborationError("bundle-role-mismatch", path)
+        role = BundleRole.VALUE
+    elif evidence == "constraint":
+        role = BundleRole.CONSTRAINT
+    elif evidence == "value":
+        role = BundleRole.VALUE
+    else:
+        raise BundleElaborationError("ambiguous-empty-bundle-role", path)
+
+    if role is BundleRole.VALUE and any(isinstance(item, BundleForm) for item in bundle.items):
+        raise BundleElaborationError("nested-value-bundle-not-supported", path)
+
+    roles.append(BundleRoleAt(path, role))
+    child_expected = (
+        ExpectedRole.CONSTRAINT if role is BundleRole.CONSTRAINT else ExpectedRole.SCALAR
+    )
+    for index, item in enumerate(bundle.items):
+        _elaborate_expression(item, path + (index,), child_expected, roles)
+
+
+def _elaborate_expression(
+    expression: Expression,
+    path: OccurrencePath,
+    expected: ExpectedRole,
+    roles: list[BundleRoleAt],
+) -> None:
+    if isinstance(expression, BundleForm):
+        _elaborate_bundle(expression, path, expected, roles)
+        return
+
+    if isinstance(expression, Definition):
+        if expected in {ExpectedRole.SCALAR, ExpectedRole.VALUE, ExpectedRole.CONSTRAINT}:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        _elaborate_expression(expression.target, path + (0,), ExpectedRole.SCALAR, roles)
+        _elaborate_expression(
+            expression.value,
+            path + (1,),
+            ExpectedRole.DEFINITION_RHS,
+            roles,
+        )
+        return
+
+    if isinstance(expression, (Equality, Inequality)):
+        if expected is ExpectedRole.SCALAR:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        _elaborate_expression(expression.left, path + (0,), ExpectedRole.VALUE, roles)
+        _elaborate_expression(expression.right, path + (1,), ExpectedRole.VALUE, roles)
+        return
+
+    if isinstance(expression, Sequence):
+        if expected is ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        for index, item in enumerate(expression.items):
+            _elaborate_expression(item, path + (index,), ExpectedRole.VALUE, roles)
+        return
+
+    if isinstance(expression, LinkForm):
+        if expected is ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        _elaborate_expression(expression.left, path + (0,), ExpectedRole.SCALAR, roles)
+        _elaborate_expression(expression.right, path + (1,), ExpectedRole.SCALAR, roles)
+        return
+
+    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
+        if expected is ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        _elaborate_expression(expression.value, path + (0,), ExpectedRole.SCALAR, roles)
+        return
+
+    if isinstance(expression, RoundForm):
+        if expected is ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        if expression.content is not None:
+            _elaborate_expression(expression.content, path + (0,), expected, roles)
+        return
+
+    if isinstance(expression, SquareForm):
+        if expected is ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        return
+
+    if isinstance(expression, Form):
+        if expected is ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        return
+
+    if isinstance(expression, Judgment):
+        if expected is not ExpectedRole.CONSTRAINT:
+            raise BundleElaborationError("expression-role-mismatch", path)
+        return
+
+    raise BundleElaborationError("unsupported-expression", path)
+
+
+def _endpoint_domain(
+    expression: Form,
+    path: OccurrencePath,
+    *,
+    elaboration: BundleElaboration,
+    resolve_form: FormResolver,
+) -> frozenset[LinkRef] | None:
+    if isinstance(expression, BundleForm):
+        value = evaluate_flat_value_bundle(
+            expression,
+            path=path,
+            elaboration=elaboration,
+            resolve_form=resolve_form,
+        )
+        return None if not value.identities else frozenset(value.identities)
+    return frozenset({resolve_form(expression, path)})

--- a/core/mtc_value_bundle.py
+++ b/core/mtc_value_bundle.py
@@ -234,6 +234,20 @@ def _intrinsic_bundle_evidence(bundle: BundleForm) -> str | None:
     return next(iter(evidence), None)
 
 
+def _contains_bundle(expression: Expression) -> bool:
+    if isinstance(expression, BundleForm):
+        return True
+    if isinstance(expression, Sequence):
+        return any(_contains_bundle(item) for item in expression.items)
+    if isinstance(expression, LinkForm):
+        return _contains_bundle(expression.left) or _contains_bundle(expression.right)
+    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
+        return _contains_bundle(expression.value)
+    if isinstance(expression, RoundForm) and expression.content is not None:
+        return _contains_bundle(expression.content)
+    return False
+
+
 def _elaborate_bundle(
     bundle: BundleForm,
     path: OccurrencePath,
@@ -309,6 +323,10 @@ def _elaborate_expression(
     if isinstance(expression, Sequence):
         if expected is ExpectedRole.CONSTRAINT:
             raise BundleElaborationError("expression-role-mismatch", path)
+        if expected is ExpectedRole.SCALAR and _contains_bundle(expression):
+            raise BundleElaborationError("bundle-not-supported-in-scalar-operator", path)
+        if expected is ExpectedRole.DEFINITION_RHS and _contains_bundle(expression):
+            raise BundleElaborationError("bundle-valued-definition-deferred", path)
         for index, item in enumerate(expression.items):
             _elaborate_expression(item, path + (index,), ExpectedRole.VALUE, roles)
         return

--- a/tests/test_mtc_value_bundle_reference.py
+++ b/tests/test_mtc_value_bundle_reference.py
@@ -1,0 +1,248 @@
+"""Execute the candidate flat ValueBundle corpus through one reference core."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_memory import AnumMemory
+from core.mtc_ast import BundleForm, Sequence, SquareForm, Symbol
+from core.mtc_interpreter import ContextFrame, interpret_constraints
+from core.mtc_parser import parse_formula
+from core.mtc_value_bundle import (
+    BundleElaborationError,
+    BundleQueryMemory,
+    BundleRole,
+    BundleValue,
+    ExpectedRole,
+    LinkValue,
+    elaborate_bundles,
+    evaluate_flat_value_bundle,
+    expand_bundle_query,
+    values_equal,
+)
+
+
+ROOT = Path(__file__).parents[1]
+CORPUS = ROOT / "contracts" / "mts-value-bundle-conformance-v0.2.json"
+CONTRACT = ROOT / "contracts" / "mts-value-bundle-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+INTERPRETER = ROOT / "core" / "mtc_interpreter.py"
+
+
+def corpus() -> dict:
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def _entry(case: dict) -> ExpectedRole:
+    if case.get("context") == "constraint-entry":
+        return ExpectedRole.CONSTRAINT
+    if case.get("context") in {"form-required", "value-entry"}:
+        return ExpectedRole.VALUE
+    return ExpectedRole.NONE
+
+
+def _path(case: dict) -> tuple[int, ...]:
+    return tuple(case.get("bundlePath", ()))
+
+
+def _resolver(symbols: dict[str, int], holes: dict[str, int]):
+    def resolve(form, path: tuple[int, ...]) -> int:
+        if isinstance(form, Symbol):
+            if form.name not in symbols:
+                raise ValueError(f"unbound symbol: {form.name}")
+            return symbols[form.name]
+        if isinstance(form, SquareForm) and form.content is None:
+            key = ".".join(str(part) for part in path)
+            if key not in holes:
+                raise ValueError(f"unbound anonymous occurrence: {key}")
+            return holes[key]
+        raise ValueError(f"unsupported candidate test form: {type(form).__name__}")
+
+    return resolve
+
+
+def _bundle_value(source: str, symbols: dict[str, int], holes: dict[str, int]) -> BundleValue:
+    ast = parse_formula(source)
+    assert isinstance(ast, BundleForm)
+    entry = ExpectedRole.VALUE if not ast.items else ExpectedRole.NONE
+    elaboration = elaborate_bundles(ast, entry=entry)
+    return evaluate_flat_value_bundle(
+        ast,
+        path=(),
+        elaboration=elaboration,
+        resolve_form=_resolver(symbols, holes),
+    )
+
+
+class QueryView(BundleQueryMemory):
+    def __init__(self, memory: AnumMemory):
+        self.memory = memory
+
+    def find_link(self, start: int, end: int) -> int | None:
+        return self.memory.find_link(start, end)
+
+    def outgoing(self, start: int) -> tuple[int, ...]:
+        return self.memory.outgoing(start)
+
+    def incoming(self, end: int) -> tuple[int, ...]:
+        return self.memory.incoming(end)
+
+    def all_links(self) -> tuple[int, ...]:
+        return tuple(ref for ref, _record in self.memory.snapshot().links)
+
+
+def _query_fixture() -> tuple[AnumMemory, QueryView, dict[str, int]]:
+    fixture = corpus()["expansionMemory"]
+    initial = {int(ref): tuple(pair) for ref, pair in fixture["links"].items()}
+    memory = AnumMemory(initial_links=initial)
+    return memory, QueryView(memory), fixture["symbols"]
+
+
+def test_reference_module_is_still_candidate_and_not_wired_into_accepted_interpreter():
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    interpreter_source = INTERPRETER.read_text(encoding="utf-8")
+
+    assert contract["status"] == "candidate-contract"
+    assert contract["accepted"] is False
+    assert "mtc_value_bundle" not in interpreter_source
+
+
+def test_elaboration_section_runs_through_single_reference_core():
+    for case in corpus()["elaboration"]:
+        ast = parse_formula(case["source"])
+        elaboration = elaborate_bundles(ast, entry=_entry(case))
+        role = elaboration.role_at(_path(case))
+        assert role is not None, case["id"]
+        assert role.value == case["expectedRole"], case["id"]
+
+
+def test_every_static_rejection_has_the_declared_reference_error_code():
+    for case in corpus()["staticRejections"]:
+        ast = parse_formula(case["source"])
+        with pytest.raises(BundleElaborationError) as caught:
+            elaborate_bundles(ast, entry=_entry(case))
+        assert caught.value.code == case["error"], case["id"]
+
+
+def test_flat_value_equality_corpus_preserves_occurrences_and_compares_resolved_sets():
+    for case in corpus()["valueEquality"]:
+        left = _bundle_value(case["left"], case["symbols"], case["leftHoles"])
+        right = _bundle_value(case["right"], case["symbols"], case["rightHoles"])
+
+        assert list(left.identities) == case["leftSet"], case["id"]
+        assert list(right.identities) == case["rightSet"], case["id"]
+        assert values_equal(left, right) is case["equal"], case["id"]
+
+        if case["leftHoles"]:
+            assert len(left.occurrences) == len(parse_formula(case["left"]).items)
+
+
+def test_cross_kind_comparison_has_no_singleton_coercion():
+    for case in corpus()["crossKindComparison"]:
+        bundle = _bundle_value(case["bundle"], case["symbols"], {})
+        scalar = LinkValue(case["scalarIdentity"])
+
+        assert list(bundle.identities) == case["bundleSet"]
+        assert values_equal(bundle, scalar) is case["equal"]
+        assert (not values_equal(bundle, scalar)) is case["notEqual"]
+
+
+def test_unresolved_anonymous_value_occurrence_never_selects_an_arbitrary_identity():
+    ast = parse_formula("{[]}")
+    assert isinstance(ast, BundleForm)
+    elaboration = elaborate_bundles(ast)
+
+    with pytest.raises(ValueError, match="unbound anonymous occurrence"):
+        evaluate_flat_value_bundle(
+            ast,
+            path=(),
+            elaboration=elaboration,
+            resolve_form=_resolver({}, {}),
+        )
+
+
+def test_expansion_corpus_uses_read_only_l4_query_surface_and_never_realizes():
+    memory, query_view, symbols = _query_fixture()
+    before = memory.snapshot()
+    resolver = _resolver(symbols, {})
+
+    for case in corpus()["expansion"]:
+        ast = parse_formula(case["source"])
+        assert isinstance(ast, Sequence), case["id"]
+        elaboration = elaborate_bundles(ast)
+        value = expand_bundle_query(
+            ast,
+            path=(),
+            elaboration=elaboration,
+            resolve_form=resolver,
+            memory=query_view,
+        )
+        assert list(value.identities) == case["expectedLinks"], case["id"]
+        assert memory.snapshot() == before, case["id"]
+
+
+def test_missing_expansion_pair_is_not_materialized():
+    memory, query_view, symbols = _query_fixture()
+    before = memory.snapshot()
+    before_count = memory.link_count
+    ast = parse_formula("a{e}")
+    assert isinstance(ast, Sequence)
+
+    value = expand_bundle_query(
+        ast,
+        path=(),
+        elaboration=elaborate_bundles(ast),
+        resolve_form=_resolver(symbols, {}),
+        memory=query_view,
+    )
+
+    assert value.identities == ()
+    assert memory.link_count == before_count
+    assert memory.snapshot() == before
+
+
+def test_current_root_program_elaborates_without_any_value_bundle_role():
+    roles: list[BundleRole] = []
+    sources = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert len(sources) == 10
+    for source in sources:
+        elaboration = elaborate_bundles(parse_formula(source))
+        roles.extend(item.role for item in elaboration.roles)
+
+    assert roles
+    assert set(roles) == {BundleRole.CONSTRAINT}
+
+
+def test_existing_constraint_bundle_interpreter_behavior_is_unchanged():
+    class NoMemoryNeeded:
+        def poles(self, _link: int):
+            raise AssertionError("poles must not be needed")
+
+        def find_link(self, _start: int, _end: int):
+            raise AssertionError("find_link must not be needed")
+
+        def find_start_projection(self, _form: int):
+            raise AssertionError("projection must not be needed")
+
+        def find_end_projection(self, _form: int):
+            raise AssertionError("projection must not be needed")
+
+    frame = ContextFrame(start=10, end=12)
+
+    empty = interpret_constraints(parse_formula("{}"), frame, NoMemoryNeeded())
+    same_poles = interpret_constraints(
+        parse_formula("{◁ = ◁, ▷ = ▷}"),
+        frame,
+        NoMemoryNeeded(),
+    )
+
+    assert empty.success is True
+    assert same_poles.success is True
+    assert empty.holes == ()
+    assert same_poles.holes == ()


### PR DESCRIPTION
Refs #50.

Выполняет последний upstream acceptance gate candidate `mts-value-bundle/v0.2`, но **ещё не подключает** feature к accepted `mts-contract/v0.2` и текущему `mtc_interpreter.py`.

Добавлен один `core/mtc_value_bundle.py`:

- `elaborate_bundles()` — static role elaboration без runtime/memory guessing;
- `evaluate_flat_value_bundle()` — occurrence-preserving resolution → extensional resolved set;
- tagged `LinkValue|BundleValue` comparison без singleton coercion;
- `expand_bundle_query()` — read-only L4 query surface, missing pairs never materialize.

Во время reference-core audit candidate contract дополнительно сужен:

- nested ValueBundle rejected/deferred;
- non-empty bundle-valued RHS `:` deferred;
- bundle as explicit `⟼` pole, projection or inversion operand rejected/deferred;
- expansion remains only two-endpoint juxtaposition with >=1 ValueBundle.

Tests execute the consolidated candidate corpus through this one core implementation, verify unresolved `[]` never gets arbitrary identity, query snapshot immutability, exact current root regression, and separately execute the existing `interpret_constraints()` ConstraintBundle path to prove it remains unchanged.

PR draft до полного CI. Normative acceptance и downstream repin — отдельный следующий PR only after this gate is green/current.