### PR TITLE
Challenge DefinitionEnvironment v0.3

### DIFF
--- a/contracts/mts-definition-environment-challenge-v0.3.json
+++ b/contracts/mts-definition-environment-challenge-v0.3.json
@@ -1,0 +1,158 @@
+{
+  "schema": "mts-definition-environment-challenge/v0.3",
+  "status": "candidate-challenge",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "mts-definition-resolution-challenge/v0.3",
+    "mts-definition-environment-decision/v0.3"
+  ],
+  "issue": 121,
+  "acceptedContractLinkAllowed": false,
+  "productionInterpreterChangeAllowed": false,
+  "purpose": "Executable challenge of the selected scoped DefinitionEnvironment identity/lookup/cycle model before any accepted colon semantics.",
+  "modelUnderChallenge": {
+    "definitionId": "DefinitionId(scopePath, ordinal)",
+    "targetKey": "source-span-independent typed structural key used only as lookup discriminant for addressable targets",
+    "scope": "explicit lexical scope tree",
+    "sameScopeDuplicate": "conflict",
+    "childSameTarget": "nearest-scope shadowing",
+    "lookupOrder": "current scope then lexical parents",
+    "contextFrameAffectsLookup": false,
+    "cycleStateKey": "DefinitionId",
+    "activeRepeat": "cycle-ref",
+    "completedRepeat": "reuse-node"
+  },
+  "challengeFinding": {
+    "genericStructuralKeyForEveryFormIsSufficient": false,
+    "reason": "Occurrence-local anonymous [] forms intentionally share the same source-span-independent structural shape while remaining distinct occurrences, so a raw structural_key cannot become a global address for every possible Definition target.",
+    "refinement": "Only addressable closed targets may receive a structural lookup discriminant in this challenge. Targets containing occurrence-local anonymous [] or deictic ContextPronoun nodes are rejected by the challenge environment rather than silently globalized.",
+    "acceptedProductionRule": false
+  },
+  "identityVeto": {
+    "displayTextIsDefinitionIdentity": false,
+    "sourceSpanIsDefinitionIdentity": false,
+    "targetStructuralKeyIsDefinitionIdentity": false,
+    "l1LinkRefIsDefinitionIdentity": false,
+    "definitionIdIsPersistentStorageIdentity": false,
+    "structuralKeyImpliesSemanticEquality": false,
+    "anonymousOccurrenceMayBecomeGlobalByStructuralShape": false,
+    "contextPronounMayBecomeGlobalDefinitionName": false
+  },
+  "semanticVeto": {
+    "lookupImpliesEquality": false,
+    "lookupImpliesProofStep": false,
+    "lookupRewritesCallerAst": false,
+    "resolutionMayRealize": false,
+    "resolutionMayDelete": false,
+    "globalTextualSubstitution": false,
+    "eagerRecursiveNormalization": false
+  },
+  "requiredVectors": [
+    {
+      "id": "root-ten-distinct-ids",
+      "expect": "the ten canonical root Definition nodes register as ten distinct DefinitionId values and all current root targets are addressable"
+    },
+    {
+      "id": "same-scope-conflict",
+      "definitions": ["a : b", "a : c"],
+      "expect": "conflict"
+    },
+    {
+      "id": "child-shadowing",
+      "rootDefinitions": ["a : b"],
+      "childDefinitions": ["a : c"],
+      "lookupScope": "child",
+      "target": "a",
+      "expectBody": "c"
+    },
+    {
+      "id": "lexical-parent-fallback",
+      "rootDefinitions": ["a : b"],
+      "childDefinitions": [],
+      "lookupScope": "child",
+      "target": "a",
+      "expectBody": "b"
+    },
+    {
+      "id": "missing-target",
+      "rootDefinitions": ["a : b"],
+      "lookupScope": "root",
+      "target": "z",
+      "expect": "no-match"
+    },
+    {
+      "id": "anonymous-target-not-globalized",
+      "definitions": ["[] : a", "[] : b"],
+      "expect": "typed non-addressable-target rejection before structural-key collision can become definition lookup identity"
+    },
+    {
+      "id": "deictic-target-not-globalized",
+      "definitions": ["◁ : a", "▷ : b"],
+      "expect": "typed non-addressable-target rejection; ContextPronoun remains contextual rather than a global definition name"
+    },
+    {
+      "id": "self-cycle",
+      "definitions": ["a : a"],
+      "start": "a",
+      "expectVisited": ["a"],
+      "expectCycleRefs": ["a"]
+    },
+    {
+      "id": "mutual-cycle",
+      "definitions": ["a : b", "b : a"],
+      "start": "a",
+      "expectVisited": ["a", "b"],
+      "expectCycleRefs": ["a"]
+    },
+    {
+      "id": "finite-chain",
+      "definitions": ["a : b", "b : c", "c : d"],
+      "start": "a",
+      "expectVisited": ["a", "b", "c"],
+      "expectExternalLeaves": ["d"]
+    }
+  ],
+  "contextVectors": {
+    "sameLookupAcrossFrames": [
+      {"start": 1, "end": 2},
+      {"start": 10, "end": 20},
+      {"start": 100, "end": 200, "parent": {"start": 1, "end": 2}}
+    ],
+    "expect": "identical DefinitionId for identical environment and addressable target",
+    "contextFrameIsNotDefinitionScope": true
+  },
+  "provenanceVectors": {
+    "sameAddressableTargetDifferentSourceSpansRemainLookupEquivalent": true,
+    "sameAddressableTargetDifferentScopesRemainDistinctIntroductions": true,
+    "sourceSpanMayBeRecordedForDiagnostics": true,
+    "sourceSpanMayAffectIdentity": false,
+    "anonymousOccurrenceIdentityCannotBeRecoveredFromSourceSpan": true
+  },
+  "recursionBoundary": {
+    "challengeDependencySubset": "Symbol-only RHS dependency lookup",
+    "generalStructuralBodyDependencyMatchingAccepted": false,
+    "bodyInterpretationAgainstCallerContextAccepted": false,
+    "reason": "This gate validates finite identity/cycle state without smuggling a general rewrite or proof relation into the environment model."
+  },
+  "effectGate": {
+    "memoryReadsRequired": false,
+    "memoryWritesAllowed": false,
+    "realizeAllowed": false,
+    "deleteAllowed": false
+  },
+  "determinismGate": {
+    "sameScopeTreeAndRegistrationOrderProduceSameDefinitionIds": true,
+    "sameLookupProducesSameNearestDefinition": true,
+    "finiteGraphReplayProducesSameVisitedAndCycleRefs": true
+  },
+  "rootProgramMustRemainUnchanged": true,
+  "releaseGate": [
+    "challenge passes against current root program",
+    "carry the addressable-target refinement into the next candidate semantic contract instead of treating raw structural_key as a universal definition address",
+    "define exact body-resolution/context relation without treating lookup as equality",
+    "publish language-neutral positive and negative conformance corpus",
+    "make explicit Accepted decision in a versioned semantic contract",
+    "only then change the single production interpreter",
+    "only after accepted interpreter semantics expose a candidate L5 proof rule"
+  ]
+}

--- a/tests/test_mts_definition_environment_challenge.py
+++ b/tests/test_mts_definition_environment_challenge.py
@@ -1,0 +1,260 @@
+"""Non-normative executable challenge for DefinitionEnvironment v0.3."""
+
+from dataclasses import dataclass, fields, is_dataclass
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mtc_ast import (
+    ContextPronoun,
+    Definition,
+    Expression,
+    Form,
+    SquareForm,
+    Symbol,
+    format_expression,
+    structural_key,
+)
+from core.mtc_interpreter import ContextFrame, InterpretationError, interpret_constraints
+from core.mtc_parser import parse_formula
+from core.root_library import load_root_library
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-definition-environment-challenge-v0.3.json"
+MTS_CONTRACT = ROOT / "contracts" / "mts-contract-v0.2.json"
+MTS_PROOF = ROOT / "contracts" / "mts-proof-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+@dataclass(frozen=True, order=True)
+class ScopeId:
+    path: tuple[int, ...]
+
+
+@dataclass(frozen=True, order=True)
+class DefinitionId:
+    scope: ScopeId
+    ordinal: int
+
+
+@dataclass(frozen=True)
+class Entry:
+    identity: DefinitionId
+    definition: Definition
+
+
+class NonAddressableTarget(ValueError):
+    pass
+
+
+def _contains_non_addressable_target(value: object) -> bool:
+    if isinstance(value, ContextPronoun):
+        return True
+    if isinstance(value, SquareForm) and value.content is None:
+        return True
+    if isinstance(value, tuple):
+        return any(_contains_non_addressable_target(item) for item in value)
+    if isinstance(value, Expression) and is_dataclass(value):
+        for item in fields(value):
+            if item.name == "span":
+                continue
+            if _contains_non_addressable_target(getattr(value, item.name)):
+                return True
+    return False
+
+
+def target_key(target: Form) -> object:
+    """Challenge-only lookup key for addressable closed target forms."""
+
+    if _contains_non_addressable_target(target):
+        raise NonAddressableTarget(
+            "definition target contains occurrence-local or deictic form"
+        )
+    return structural_key(target)
+
+
+class Environment:
+    def __init__(self, scope: ScopeId, parent: "Environment | None" = None):
+        self.scope = scope
+        self.parent = parent
+        self.entries: dict[object, Entry] = {}
+
+    def child(self, index: int) -> "Environment":
+        return Environment(ScopeId(self.scope.path + (index,)), self)
+
+    def register(self, source: str) -> Entry:
+        return self.register_definition(definition(source))
+
+    def register_definition(self, value: Definition) -> Entry:
+        key = target_key(value.target)
+        if key in self.entries:
+            raise ValueError("same-scope conflict")
+        entry = Entry(DefinitionId(self.scope, len(self.entries)), value)
+        self.entries[key] = entry
+        return entry
+
+    def lookup(self, target: Form) -> Entry | None:
+        key = target_key(target)
+        current: Environment | None = self
+        while current is not None:
+            if key in current.entries:
+                return current.entries[key]
+            current = current.parent
+        return None
+
+
+def definition(source: str) -> Definition:
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
+
+
+def target(name: str) -> Form:
+    return definition(f"{name} : x").target
+
+
+def walk(env: Environment, start: str) -> tuple[list[str], list[str], list[str]]:
+    """Challenge-only Symbol-RHS graph walk; not general body resolution."""
+
+    first = env.lookup(target(start))
+    if first is None:
+        return [], [], []
+
+    visited: list[str] = []
+    active: list[DefinitionId] = []
+    done: set[DefinitionId] = set()
+    cycles: list[str] = []
+    external: list[str] = []
+
+    def visit(entry: Entry) -> None:
+        visited.append(format_expression(entry.definition.target))
+        active.append(entry.identity)
+        body = entry.definition.value
+        if isinstance(body, Symbol):
+            next_entry = env.lookup(target(body.name))
+            if next_entry is None:
+                external.append(body.name)
+            elif next_entry.identity in active:
+                cycles.append(format_expression(next_entry.definition.target))
+            elif next_entry.identity not in done:
+                visit(next_entry)
+        active.pop()
+        done.add(entry.identity)
+
+    visit(first)
+    return visited, cycles, external
+
+
+class NoMemory:
+    def __getattr__(self, name):
+        raise AssertionError(f"unexpected L4 access: {name}")
+
+
+def test_challenge_is_non_normative_unlinked_and_records_addressability_finding():
+    data = json.loads(CHALLENGE.read_text(encoding="utf-8"))
+    assert data["status"] == "candidate-challenge"
+    assert data["productionInterpreterChangeAllowed"] is False
+    assert data["challengeFinding"]["genericStructuralKeyForEveryFormIsSufficient"] is False
+    assert data["challengeFinding"]["acceptedProductionRule"] is False
+    assert "mts-definition-environment-challenge" not in MTS_CONTRACT.read_text(
+        encoding="utf-8"
+    )
+    assert "mts-definition-environment-challenge" not in MTS_PROOF.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_root_has_ten_distinct_definition_ids_and_all_targets_are_addressable():
+    library = load_root_library(ROOT_PROGRAM)
+    env = Environment(ScopeId(()))
+    ids = []
+    for formula in library.formulas:
+        assert isinstance(formula.ast, Definition)
+        ids.append(env.register_definition(formula.ast).identity)
+    assert len(ids) == len(set(ids)) == 10
+
+
+def test_conflict_shadowing_parent_fallback_and_context_independence():
+    root = Environment(ScopeId(()))
+    root_a = root.register("a : b")
+    with pytest.raises(ValueError, match="same-scope conflict"):
+        root.register("a : c")
+
+    child = root.child(0)
+    assert child.lookup(target("a")) == root_a
+    child_a = child.register("a : c")
+    assert child_a.identity != root_a.identity
+    assert child.lookup(target("a")) == child_a
+
+    assert set(inspect.signature(Environment.lookup).parameters) == {"self", "target"}
+    frames = [
+        ContextFrame(1, 2),
+        ContextFrame(10, 20),
+        ContextFrame(100, 200, ContextFrame(1, 2)),
+    ]
+    assert [child.lookup(target("a")) for _frame in frames] == [child_a] * 3
+
+
+def test_source_span_is_provenance_not_addressable_target_identity():
+    first = definition("a : b")
+    shifted = definition("  a : c")
+    assert first.target.span != shifted.target.span
+    assert structural_key(first.target) == structural_key(shifted.target)
+
+    env = Environment(ScopeId(()))
+    entry = env.register_definition(first)
+    assert env.lookup(shifted.target) == entry
+
+
+def test_anonymous_occurrence_shape_cannot_become_a_global_definition_address():
+    first = definition("[] : a")
+    shifted = definition("  [] : b")
+
+    assert first.target.span != shifted.target.span
+    assert structural_key(first.target) == structural_key(shifted.target)
+
+    env = Environment(ScopeId(()))
+    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
+        env.register_definition(first)
+    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
+        env.register_definition(shifted)
+
+
+def test_context_pronoun_target_is_not_silently_promoted_to_global_name():
+    env = Environment(ScopeId(()))
+    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
+        env.register("◁ : a")
+    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
+        env.register("▷ : b")
+
+
+def test_self_mutual_chain_and_missing_are_finite_and_deterministic():
+    cases = [
+        (["a : a"], "a", (["a"], ["a"], [])),
+        (["a : b", "b : a"], "a", (["a", "b"], ["a"], [])),
+        (["a : b", "b : c", "c : d"], "a", (["a", "b", "c"], [], ["d"])),
+        (["a : b"], "z", ([], [], [])),
+    ]
+    for sources, start, expected in cases:
+        env = Environment(ScopeId(()))
+        ids = [env.register(source).identity for source in sources]
+        assert walk(env, start) == expected
+        assert walk(env, start) == expected
+
+        replay = Environment(ScopeId(()))
+        replay_ids = [replay.register(source).identity for source in sources]
+        assert replay_ids == ids
+        assert walk(replay, start) == expected
+
+
+def test_lookup_is_not_production_definition_execution_or_l4_effect():
+    expr = definition("a : b")
+    with pytest.raises(InterpretationError, match="Definition"):
+        interpret_constraints(
+            expr,
+            ContextFrame(1, 2),
+            NoMemory(),
+            symbols={"a": 1, "b": 2},
+        )


### PR DESCRIPTION
Refs #121, #120.

Следующий executable gate после merged #126. PR остаётся полностью non-normative: production parser/interpreter/proof checker не меняются, `mts-contract/v0.2` и `mts-proof/v0.2` не ссылаются на challenge.

Проверяется выбранная candidate-модель:
- replay-local `DefinitionId(scopePath, ordinal)` отдельно от target lookup discriminant;
- same-scope duplicate => conflict;
- child scope => nearest-scope shadowing, затем lexical parent fallback;
- `ContextFrame` не влияет на definition lookup;
- self/mutual recursion завершаются через active `DefinitionId` cycle-ref;
- missing target остаётся no-match;
- lookup не становится equality/proof step/AST rewrite/L4 effect;
- 10 canonical root definitions остаются неизменными и получают 10 distinct replay-local IDs.

## Существенное уточнение challenge

Первоначальная версия была недостаточной: она применяла `structural_key` как lookup discriminant ко всем `Form`. Но уже принятая semantics `[]` делает анонимную квадратную форму occurrence-local. Два разных `[]` имеют одинаковую structural shape и **не должны** превращаться в одно глобально адресуемое различие.

Поэтому challenge теперь специально доказывает отрицательный случай:
- raw `structural_key` не является универсальным definition address;
- targets с occurrence-local `[]` отвергаются challenge-моделью как non-addressable, а не глобализуются;
- `ContextPronoun` targets также не превращаются в global names;
- current 10 root targets остаются addressable;
- это пока challenge finding, а не accepted production rule.

Veto: no production semantics, no accepted contract link, no SourceSpan/display/L1 LinkRef identity, no global substitution, no realize/delete.