### PR TITLE
Интегрировать canonical DefinitionEnvironment/open_definition v0.3

### DIFF
--- a/contracts/mts-definition-opening-v0.3.json
+++ b/contracts/mts-definition-opening-v0.3.json
@@ -12,7 +12,7 @@
   ],
   "conformanceCorpus": "contracts/mts-definition-opening-conformance-v0.3.json",
   "issue": 121,
-  "scope": "normative one-step read-only definition opening semantics; production integration and trusted proof rules are separate later gates",
+  "scope": "normative one-step read-only definition opening semantics; trusted proof rules remain a separate later gate",
   "definitionEnvironment": {
     "identity": {
       "definitionId": "replay-local pair (scopePath, ordinal)",
@@ -28,11 +28,12 @@
     "ContextFrameAffectsLookup": false
   },
   "addressability": {
-    "rule": "a definition target is addressable only when its typed Form contains neither occurrence-local anonymous empty [] nor ContextPronoun nodes",
+    "rule": "a definition target is addressable only when its typed scalar Form contains neither occurrence-local anonymous empty [] nor ContextPronoun nodes",
     "ordinaryClosedTypedFormsUse": "source-span-independent structural lookup discriminant",
     "structuralLookupDiscriminantImpliesSemanticEquality": false,
     "anonymousEmptySquareTarget": "non-addressable",
     "ContextPronounTarget": "non-addressable",
+    "bundleTarget": "non-addressable under the accepted scalar definition-target boundary",
     "reason": "occurrence-local/deictic forms must not become global definition names merely because two ASTs have the same structural spelling"
   },
   "operation": {
@@ -50,8 +51,8 @@
     "results": {
       "match": ["DefinitionId", "exact typed Definition.value", "provenance"],
       "no-match": "no visible definition for addressable target",
-      "conflict": "same-scope duplicate target made environment invalid for that introduction",
-      "non-addressable": "target is occurrence-local/deictic under the accepted v0.3 subset"
+      "conflict": "same-scope duplicate target makes that nearest lexical target conflicting rather than falling back to a parent",
+      "non-addressable": "target is outside the accepted addressable subset"
     },
     "oneStep": true,
     "recursive": false,
@@ -108,28 +109,39 @@
     "conformanceCorpus": "contracts/mts-definition-opening-conformance-v0.3.json",
     "rootRegression": "tests/mtc_formulas.mtc"
   },
+  "productionIntegration": {
+    "referenceCore": "core/mtc_definitions.py",
+    "rootLibrary": "core/root_library.py",
+    "rootValidator": "core/validate_root.py",
+    "productionConformance": "tests/test_mts_definition_opening_reference.py",
+    "legacyDifferenceRegistryRetained": false,
+    "challengeOnlyEnvironmentCloneRetained": false,
+    "interpretConstraintsExecutesDefinition": false,
+    "reasonInterpretRemainsSeparate": "accepted opening is a definition operation, not a new interpretation branch"
+  },
   "integrationStatus": {
     "semanticContractAccepted": true,
-    "productionReferenceCoreImplemented": false,
-    "singleProductionInterpreterIntegrated": false,
+    "productionReferenceCoreImplemented": true,
+    "canonicalRootLibraryUsesDefinitionEnvironment": true,
+    "productionConformancePresent": true,
     "mtsContractV03Published": false,
     "trustedL5RuleAccepted": false,
     "aproverRepinAllowed": false
   },
   "nextGate": {
-    "goal": "implement the accepted DefinitionEnvironment/open_definition operation once in canonical production core and prove it against the existing language-neutral corpus",
+    "goal": "publish mts-contract/v0.3 umbrella over the accepted and production-conformant definition-opening operation without changing v0.2 contracts in place",
     "constraints": [
       "do not add a second parser or interpreter",
       "do not modify the ten root definitions",
       "do not turn Definition into Equality",
       "do not add implicit ContextFrame evaluation",
       "do not add L4 reads/effects",
-      "delete challenge-only duplicate runtime model once production conformance no longer needs it as independent replay evidence"
+      "keep mts-proof/v0.2 trusted rule set unchanged until a separate L5 decision"
     ],
-    "afterProductionConformance": "publish mts-contract/v0.3 umbrella and only then evaluate a candidate L5 definition-opening proof rule"
+    "afterUmbrella": "start #122 proof-judgment/calculus challenge; only an explicitly accepted L5 contract may add a trusted definition-opening rule"
   },
   "downstream": {
-    "directRuntimePinBeforeProductionIntegration": false,
+    "directRuntimePinBeforeV03Umbrella": false,
     "aproverMustNotInventLocalOpeningSemantics": true,
     "futureConsumerMustUseVersionedV03Umbrella": true
   }

--- a/core/mtc_definitions.py
+++ b/core/mtc_definitions.py
@@ -1,0 +1,285 @@
+"""Canonical read-only definition environment for accepted MTS v0.3 opening semantics.
+
+This module implements only the accepted one-step ``target : expression``
+opening relation. It deliberately does not interpret the returned body, assert
+an equality, create a proof step, or access associative memory.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+from core.mtc_ast import (
+    BundleForm,
+    ContextPronoun,
+    Definition,
+    EndProjection,
+    Expression,
+    Form,
+    Inversion,
+    LinkForm,
+    Literal,
+    RoundForm,
+    Sequence,
+    SquareForm,
+    StartProjection,
+    Symbol,
+    structural_key,
+)
+
+
+ScopePath: TypeAlias = tuple[int, ...]
+TargetKey: TypeAlias = tuple
+
+
+@dataclass(frozen=True, order=True)
+class DefinitionId:
+    """Replay-local identity of one successful definition introduction."""
+
+    scope_path: ScopePath
+    ordinal: int
+
+
+@dataclass(frozen=True)
+class DefinitionProvenance:
+    """Diagnostic provenance; never part of definition identity or lookup."""
+
+    source_path: str | None = None
+    line_no: int | None = None
+
+
+@dataclass(frozen=True)
+class DefinitionEntry:
+    identity: DefinitionId
+    target_key: TargetKey
+    definition: Definition
+    provenance: DefinitionProvenance
+
+
+@dataclass(frozen=True)
+class DefinitionConflict:
+    target_key: TargetKey
+    first: DefinitionEntry
+    duplicate: Definition
+    duplicate_provenance: DefinitionProvenance
+
+
+class DefinitionRegistrationKind(str, Enum):
+    REGISTERED = "registered"
+    CONFLICT = "conflict"
+    NON_ADDRESSABLE = "non-addressable"
+
+
+@dataclass(frozen=True)
+class DefinitionRegistrationResult:
+    kind: DefinitionRegistrationKind
+    entry: DefinitionEntry | None = None
+    conflict: DefinitionConflict | None = None
+
+
+class DefinitionLookupKind(str, Enum):
+    MATCH = "match"
+    NO_MATCH = "no-match"
+    CONFLICT = "conflict"
+    NON_ADDRESSABLE = "non-addressable"
+
+
+@dataclass(frozen=True)
+class DefinitionLookupResult:
+    kind: DefinitionLookupKind
+    entry: DefinitionEntry | None = None
+    conflict: DefinitionConflict | None = None
+
+
+@dataclass(frozen=True)
+class DefinitionOpeningResult:
+    """One accepted opening result; the body is never evaluated here."""
+
+    kind: DefinitionLookupKind
+    definition_id: DefinitionId | None = None
+    body: Expression | None = None
+    provenance: DefinitionProvenance | None = None
+    conflict: DefinitionConflict | None = None
+
+
+class DefinitionEnvironment:
+    """Explicit lexical definition scope with deterministic nearest lookup."""
+
+    def __init__(
+        self,
+        scope_path: ScopePath = (),
+        parent: "DefinitionEnvironment | None" = None,
+    ) -> None:
+        if any(
+            not isinstance(item, int) or isinstance(item, bool) or item < 0
+            for item in scope_path
+        ):
+            raise ValueError("definition scope path must contain non-negative integers")
+        if parent is None:
+            if scope_path:
+                raise ValueError("root definition scope path must be empty")
+        else:
+            if not scope_path or scope_path[:-1] != parent.scope_path:
+                raise ValueError("child definition scope path must extend parent by one index")
+            sibling_index = scope_path[-1]
+            if sibling_index in parent._children:
+                raise ValueError(
+                    f"definition child scope already exists: {scope_path!r}"
+                )
+
+        self.scope_path = scope_path
+        self.parent = parent
+        self._entries: dict[TargetKey, DefinitionEntry] = {}
+        self._conflicts: dict[TargetKey, DefinitionConflict] = {}
+        self._children: dict[int, DefinitionEnvironment] = {}
+        self._next_ordinal = 0
+
+        if parent is not None:
+            parent._children[scope_path[-1]] = self
+
+    def child(self, index: int) -> "DefinitionEnvironment":
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            raise ValueError("definition child index must be a non-negative integer")
+        existing = self._children.get(index)
+        if existing is not None:
+            return existing
+        return DefinitionEnvironment(self.scope_path + (index,), self)
+
+    def register(
+        self,
+        definition: Definition,
+        provenance: DefinitionProvenance | None = None,
+    ) -> DefinitionRegistrationResult:
+        provenance = provenance or DefinitionProvenance()
+        key = definition_target_key(definition.target)
+        if key is None:
+            return DefinitionRegistrationResult(DefinitionRegistrationKind.NON_ADDRESSABLE)
+
+        existing_conflict = self._conflicts.get(key)
+        if existing_conflict is not None:
+            return DefinitionRegistrationResult(
+                DefinitionRegistrationKind.CONFLICT,
+                conflict=existing_conflict,
+            )
+
+        existing = self._entries.get(key)
+        if existing is not None:
+            conflict = DefinitionConflict(
+                target_key=key,
+                first=existing,
+                duplicate=definition,
+                duplicate_provenance=provenance,
+            )
+            self._conflicts[key] = conflict
+            return DefinitionRegistrationResult(
+                DefinitionRegistrationKind.CONFLICT,
+                conflict=conflict,
+            )
+
+        entry = DefinitionEntry(
+            identity=DefinitionId(self.scope_path, self._next_ordinal),
+            target_key=key,
+            definition=definition,
+            provenance=provenance,
+        )
+        self._next_ordinal += 1
+        self._entries[key] = entry
+        return DefinitionRegistrationResult(
+            DefinitionRegistrationKind.REGISTERED,
+            entry=entry,
+        )
+
+    def lookup(self, target: Form) -> DefinitionLookupResult:
+        key = definition_target_key(target)
+        if key is None:
+            return DefinitionLookupResult(DefinitionLookupKind.NON_ADDRESSABLE)
+
+        current: DefinitionEnvironment | None = self
+        while current is not None:
+            conflict = current._conflicts.get(key)
+            if conflict is not None:
+                return DefinitionLookupResult(
+                    DefinitionLookupKind.CONFLICT,
+                    conflict=conflict,
+                )
+            entry = current._entries.get(key)
+            if entry is not None:
+                return DefinitionLookupResult(DefinitionLookupKind.MATCH, entry=entry)
+            current = current.parent
+        return DefinitionLookupResult(DefinitionLookupKind.NO_MATCH)
+
+    def entries(self) -> tuple[DefinitionEntry, ...]:
+        return tuple(
+            sorted(self._entries.values(), key=lambda item: item.identity.ordinal)
+        )
+
+    def conflicts(self) -> tuple[DefinitionConflict, ...]:
+        return tuple(
+            sorted(
+                self._conflicts.values(),
+                key=lambda item: item.first.identity.ordinal,
+            )
+        )
+
+
+def open_definition(
+    target: Form,
+    environment: DefinitionEnvironment,
+) -> DefinitionOpeningResult:
+    """Return the exact registered RHS for one visible definition and stop."""
+
+    lookup = environment.lookup(target)
+    if lookup.kind is not DefinitionLookupKind.MATCH:
+        return DefinitionOpeningResult(
+            kind=lookup.kind,
+            conflict=lookup.conflict,
+        )
+
+    assert lookup.entry is not None
+    return DefinitionOpeningResult(
+        kind=DefinitionLookupKind.MATCH,
+        definition_id=lookup.entry.identity,
+        body=lookup.entry.definition.value,
+        provenance=lookup.entry.provenance,
+    )
+
+
+def definition_target_key(target: Form) -> TargetKey | None:
+    """Return a lookup discriminant for the accepted addressable target subset.
+
+    The structural key is only an implementation discriminant. Returning the
+    same key does not assert semantic equality. Occurrence-local/deictic forms
+    are rejected before a key is formed so they cannot become global names.
+    """
+
+    if not _is_addressable_target(target):
+        return None
+    key = structural_key(target)
+    if not isinstance(key, tuple):
+        raise TypeError("addressable definition target must have a tuple structural key")
+    return key
+
+
+def _is_addressable_target(form: Form) -> bool:
+    if isinstance(form, (Symbol, Literal)):
+        return True
+    if isinstance(form, ContextPronoun):
+        return False
+    if isinstance(form, BundleForm):
+        # Accepted v0.2 definitions have scalar Form targets only.
+        return False
+    if isinstance(form, RoundForm):
+        # ``()`` is one of the ten canonical root targets and is addressable.
+        return form.content is None or (
+            isinstance(form.content, Form) and _is_addressable_target(form.content)
+        )
+    if isinstance(form, SquareForm):
+        # Empty ``[]`` is occurrence-local anonymous form and never a global key.
+        return isinstance(form.content, Form) and _is_addressable_target(form.content)
+    if isinstance(form, Sequence):
+        return bool(form.items) and all(_is_addressable_target(item) for item in form.items)
+    if isinstance(form, (StartProjection, EndProjection, Inversion)):
+        return _is_addressable_target(form.value)
+    if isinstance(form, LinkForm):
+        return _is_addressable_target(form.left) and _is_addressable_target(form.right)
+    return False

--- a/core/root_library.py
+++ b/core/root_library.py
@@ -5,8 +5,12 @@ from enum import Enum
 from pathlib import Path
 
 from core.mtc_ast import Definition, Equality, Expression, Inequality, format_expression
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionProvenance,
+    DefinitionRegistrationKind,
+)
 from core.mtc_parser import ParseDiagnostic, parse_formula, parse_formula_result
-from core.reference_model import StatementStatus
 
 
 INFINITY_SYMBOL = "∞"
@@ -39,62 +43,26 @@ class RootFormula:
 
 
 @dataclass(frozen=True)
-class DifferenceEntry:
-    """Difference introduced by a top-level ``target : expression``."""
-
-    symbol: str
-    introduction: str
-    status: StatementStatus
-    source_formula: RootFormula
-
-
-class DifferenceRegistry:
-    """Registry built only from typed top-level ``Definition`` nodes."""
-
-    def __init__(self):
-        self._entries: dict[str, DifferenceEntry] = {}
-        self._duplicates: list[
-            tuple[str, DifferenceEntry, DifferenceEntry]
-        ] = []
-
-    def register(self, entry: DifferenceEntry) -> None:
-        existing = self._entries.get(entry.symbol)
-        if existing is not None:
-            self._duplicates.append((entry.symbol, existing, entry))
-            return
-        self._entries[entry.symbol] = entry
-
-    def lookup(self, symbol: str) -> DifferenceEntry | None:
-        return self._entries.get(symbol)
-
-    def symbols(self) -> list[str]:
-        return list(self._entries)
-
-    def entries(self) -> list[DifferenceEntry]:
-        return list(self._entries.values())
-
-    def duplicates(self) -> list[tuple[str, DifferenceEntry, DifferenceEntry]]:
-        return list(self._duplicates)
-
-
-@dataclass(frozen=True)
 class RootLibrary:
     """Loaded canonical root-library surface."""
 
     formulas: tuple[RootFormula, ...]
-    registry: DifferenceRegistry
+    definitions: DefinitionEnvironment
 
     def texts(self) -> list[str]:
         return [formula.text for formula in self.formulas]
 
+    def definition_targets(self) -> list[str]:
+        return [
+            format_expression(entry.definition.target)
+            for entry in self.definitions.entries()
+        ]
+
     def square_abits(self) -> list[str]:
         """Return the four L2 forms that introduce square abits."""
 
-        return [
-            symbol
-            for symbol in SQUARE_ABIT_FORMS
-            if self.registry.lookup(symbol) is not None
-        ]
+        targets = set(self.definition_targets())
+        return [symbol for symbol in SQUARE_ABIT_FORMS if symbol in targets]
 
 
 def load_root_library(path: str | Path) -> RootLibrary:
@@ -124,30 +92,33 @@ def load_root_library(path: str | Path) -> RootLibrary:
     formula_tuple = tuple(formulas)
     return RootLibrary(
         formulas=formula_tuple,
-        registry=build_difference_registry(formula_tuple),
+        definitions=build_definition_environment(formula_tuple),
     )
 
 
-def build_difference_registry(
+def build_definition_environment(
     formulas: tuple[RootFormula, ...] | list[RootFormula],
-) -> DifferenceRegistry:
-    """Build the registry from actual ``Definition`` AST nodes only."""
+) -> DefinitionEnvironment:
+    """Build the root lexical environment from top-level typed definitions only."""
 
-    registry = DifferenceRegistry()
+    environment = DefinitionEnvironment()
     for formula in formulas:
         if not isinstance(formula.ast, Definition):
             continue
 
-        registry.register(
-            DifferenceEntry(
-                symbol=format_expression(formula.ast.target),
-                introduction=format_expression(formula.ast.value),
-                status=StatementStatus.DEFINITION,
-                source_formula=formula,
-            )
+        result = environment.register(
+            formula.ast,
+            provenance=DefinitionProvenance(
+                source_path=formula.source_path,
+                line_no=formula.line_no,
+            ),
         )
+        if result.kind is DefinitionRegistrationKind.NON_ADDRESSABLE:
+            # Root loading preserves the parsed formula; validation reports the
+            # non-addressable introduction as an invalid root definition.
+            continue
 
-    return registry
+    return environment
 
 
 def classify_formula_kind(expression: Expression | str | None) -> FormulaKind:

--- a/core/validate_root.py
+++ b/core/validate_root.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from core.mtc_ast import Definition, format_expression
+from core.mtc_definitions import definition_target_key
 from core.root_library import RootLibrary, SQUARE_ABIT_FORMS, load_root_library
 
 
@@ -30,17 +32,27 @@ def validate_root_library(path: str | Path) -> RootValidationResult:
                 f"{formula.source_path}:{formula.line_no}:"
                 f"{diagnostic.span.start}: {diagnostic.message}"
             )
+        if isinstance(formula.ast, Definition) and definition_target_key(formula.ast.target) is None:
+            messages.append(
+                f"Неадресуемая левая часть корневого определения "
+                f"{format_expression(formula.ast.target)}: "
+                f"{formula.source_path}:{formula.line_no}"
+            )
 
-    for symbol, first, second in library.registry.duplicates():
+    for conflict in library.definitions.conflicts():
+        first = conflict.first.provenance
+        second = conflict.duplicate_provenance
+        symbol = format_expression(conflict.first.definition.target)
         messages.append(
             f"Повторное введение различия {symbol}: "
-            f"{first.source_formula.source_path}:{first.source_formula.line_no} и "
-            f"{second.source_formula.source_path}:{second.source_formula.line_no}"
+            f"{first.source_path}:{first.line_no} и "
+            f"{second.source_path}:{second.line_no}"
         )
 
+    targets = set(library.definition_targets())
     required_symbols = ("∞", "()", "([)", "(])", "(⟼)", "(↛)", "[1]", "[0]", "(=)")
     for symbol in required_symbols:
-        if library.registry.lookup(symbol) is None:
+        if symbol not in targets:
             messages.append(f"Не найдено корневое различие: {symbol}")
 
     square_abits = set(library.square_abits())

--- a/core/validate_root.py
+++ b/core/validate_root.py
@@ -50,7 +50,18 @@ def validate_root_library(path: str | Path) -> RootValidationResult:
         )
 
     targets = set(library.definition_targets())
-    required_symbols = ("∞", "()", "([)", "(])", "(⟼)", "(↛)", "[1]", "[0]", "(=)")
+    required_symbols = (
+        "∞",
+        "()",
+        "([)",
+        "(])",
+        "(⟼)",
+        "(↛)",
+        "[1]",
+        "[0]",
+        "(=)",
+        "(!=)",
+    )
     for symbol in required_symbols:
         if symbol not in targets:
             messages.append(f"Не найдено корневое различие: {symbol}")

--- a/tests/test_mtc_definitions.py
+++ b/tests/test_mtc_definitions.py
@@ -1,0 +1,101 @@
+"""Focused unit tests for the canonical MTS v0.3 definition environment."""
+
+import pytest
+
+from core.mtc_ast import Definition, RoundForm, SquareForm
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    definition_target_key,
+    open_definition,
+)
+from core.mtc_parser import parse_formula
+
+
+def definition(source: str) -> Definition:
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
+
+
+def test_empty_round_root_form_is_addressable_but_empty_square_is_not():
+    round_definition = definition("() : a")
+    square_definition = definition("[] : a")
+
+    assert isinstance(round_definition.target, RoundForm)
+    assert round_definition.target.content is None
+    assert definition_target_key(round_definition.target) is not None
+
+    assert isinstance(square_definition.target, SquareForm)
+    assert square_definition.target.content is None
+    assert definition_target_key(square_definition.target) is None
+
+
+def test_root_scope_path_is_uniquely_empty():
+    root = DefinitionEnvironment()
+    assert root.scope_path == ()
+    assert root.parent is None
+
+    with pytest.raises(ValueError, match="root definition scope path must be empty"):
+        DefinitionEnvironment((7,))
+
+
+def test_child_index_denotes_one_lexical_scope_object_per_parent():
+    root = DefinitionEnvironment()
+    child = root.child(0)
+
+    assert root.child(0) is child
+    assert child.scope_path == (0,)
+    assert child.parent is root
+
+    with pytest.raises(ValueError, match="already exists"):
+        DefinitionEnvironment((0,), root)
+
+
+def test_different_sibling_indices_produce_distinct_definition_id_spaces():
+    root = DefinitionEnvironment()
+    left = root.child(0)
+    right = root.child(1)
+
+    left_registration = left.register(definition("a : left"))
+    right_registration = right.register(definition("a : right"))
+    assert left_registration.entry is not None
+    assert right_registration.entry is not None
+    assert left_registration.entry.identity.scope_path == (0,)
+    assert right_registration.entry.identity.scope_path == (1,)
+    assert left_registration.entry.identity != right_registration.entry.identity
+
+
+def test_direct_child_scope_must_extend_parent_by_exactly_one_index():
+    root = DefinitionEnvironment()
+
+    with pytest.raises(ValueError, match="extend parent"):
+        DefinitionEnvironment((), root)
+    with pytest.raises(ValueError, match="extend parent"):
+        DefinitionEnvironment((0, 1), root)
+    with pytest.raises(ValueError, match="non-negative"):
+        root.child(-1)
+
+
+def test_nearest_scope_conflict_blocks_parent_fallback():
+    root = DefinitionEnvironment()
+    assert root.register(definition("a : root")).kind is DefinitionRegistrationKind.REGISTERED
+
+    child = root.child(0)
+    assert child.register(definition("a : first")).kind is DefinitionRegistrationKind.REGISTERED
+    assert child.register(definition("a : second")).kind is DefinitionRegistrationKind.CONFLICT
+
+    result = open_definition(definition("a : query").target, child)
+    assert result.kind is DefinitionLookupKind.CONFLICT
+    assert result.body is None
+    assert result.definition_id is None
+
+
+def test_non_addressable_registration_does_not_consume_definition_ordinal():
+    environment = DefinitionEnvironment()
+    assert environment.register(definition("[] : ignored")).kind is DefinitionRegistrationKind.NON_ADDRESSABLE
+
+    registered = environment.register(definition("a : value"))
+    assert registered.entry is not None
+    assert registered.entry.identity.ordinal == 0

--- a/tests/test_mts_definition_environment_challenge.py
+++ b/tests/test_mts_definition_environment_challenge.py
@@ -1,21 +1,17 @@
-"""Non-normative executable challenge for DefinitionEnvironment v0.3."""
+"""Historical environment challenge replayed through the canonical v0.3 core."""
 
-from dataclasses import dataclass, fields, is_dataclass
 import inspect
 import json
 from pathlib import Path
 
 import pytest
 
-from core.mtc_ast import (
-    ContextPronoun,
-    Definition,
-    Expression,
-    Form,
-    SquareForm,
-    Symbol,
-    format_expression,
-    structural_key,
+from core.mtc_ast import Definition, Symbol, format_expression, structural_key
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionId,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
 )
 from core.mtc_interpreter import ContextFrame, InterpretationError, interpret_constraints
 from core.mtc_parser import parse_formula
@@ -28,99 +24,26 @@ MTS_PROOF = ROOT / "contracts" / "mts-proof-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 
-@dataclass(frozen=True, order=True)
-class ScopeId:
-    path: tuple[int, ...]
-
-
-@dataclass(frozen=True, order=True)
-class DefinitionId:
-    scope: ScopeId
-    ordinal: int
-
-
-@dataclass(frozen=True)
-class Entry:
-    identity: DefinitionId
-    definition: Definition
-
-
-class NonAddressableTarget(ValueError):
-    pass
-
-
-def _contains_non_addressable_target(value: object) -> bool:
-    if isinstance(value, ContextPronoun):
-        return True
-    if isinstance(value, SquareForm) and value.content is None:
-        return True
-    if isinstance(value, tuple):
-        return any(_contains_non_addressable_target(item) for item in value)
-    if isinstance(value, Expression) and is_dataclass(value):
-        for item in fields(value):
-            if item.name == "span":
-                continue
-            if _contains_non_addressable_target(getattr(value, item.name)):
-                return True
-    return False
-
-
-def target_key(target: Form) -> object:
-    """Challenge-only lookup key for addressable closed target forms."""
-
-    if _contains_non_addressable_target(target):
-        raise NonAddressableTarget(
-            "definition target contains occurrence-local or deictic form"
-        )
-    return structural_key(target)
-
-
-class Environment:
-    def __init__(self, scope: ScopeId, parent: "Environment | None" = None):
-        self.scope = scope
-        self.parent = parent
-        self.entries: dict[object, Entry] = {}
-
-    def child(self, index: int) -> "Environment":
-        return Environment(ScopeId(self.scope.path + (index,)), self)
-
-    def register(self, source: str) -> Entry:
-        return self.register_definition(definition(source))
-
-    def register_definition(self, value: Definition) -> Entry:
-        key = target_key(value.target)
-        if key in self.entries:
-            raise ValueError("same-scope conflict")
-        entry = Entry(DefinitionId(self.scope, len(self.entries)), value)
-        self.entries[key] = entry
-        return entry
-
-    def lookup(self, target: Form) -> Entry | None:
-        key = target_key(target)
-        current: Environment | None = self
-        while current is not None:
-            if key in current.entries:
-                return current.entries[key]
-            current = current.parent
-        return None
-
-
 def definition(source: str) -> Definition:
     value = parse_formula(source)
     assert isinstance(value, Definition)
     return value
 
 
-def target(name: str) -> Form:
+def target(name: str):
     return definition(f"{name} : x").target
 
 
-def walk(env: Environment, start: str) -> tuple[list[str], list[str], list[str]]:
-    """Challenge-only Symbol-RHS graph walk; not general body resolution."""
+def walk(
+    environment: DefinitionEnvironment,
+    start: str,
+) -> tuple[list[str], list[str], list[str]]:
+    """Challenge-only Symbol-RHS traversal over canonical environment identities."""
 
-    first = env.lookup(target(start))
-    if first is None:
+    first_lookup = environment.lookup(target(start))
+    if first_lookup.kind is not DefinitionLookupKind.MATCH:
         return [], [], []
+    assert first_lookup.entry is not None
 
     visited: list[str] = []
     active: list[DefinitionId] = []
@@ -128,22 +51,25 @@ def walk(env: Environment, start: str) -> tuple[list[str], list[str], list[str]]
     cycles: list[str] = []
     external: list[str] = []
 
-    def visit(entry: Entry) -> None:
+    def visit(entry) -> None:
         visited.append(format_expression(entry.definition.target))
         active.append(entry.identity)
         body = entry.definition.value
         if isinstance(body, Symbol):
-            next_entry = env.lookup(target(body.name))
-            if next_entry is None:
+            next_lookup = environment.lookup(target(body.name))
+            if next_lookup.kind is DefinitionLookupKind.NO_MATCH:
                 external.append(body.name)
-            elif next_entry.identity in active:
-                cycles.append(format_expression(next_entry.definition.target))
-            elif next_entry.identity not in done:
-                visit(next_entry)
+            elif next_lookup.kind is DefinitionLookupKind.MATCH:
+                assert next_lookup.entry is not None
+                next_entry = next_lookup.entry
+                if next_entry.identity in active:
+                    cycles.append(format_expression(next_entry.definition.target))
+                elif next_entry.identity not in done:
+                    visit(next_entry)
         active.pop()
         done.add(entry.identity)
 
-    visit(first)
+    visit(first_lookup.entry)
     return visited, cycles, external
 
 
@@ -152,7 +78,7 @@ class NoMemory:
         raise AssertionError(f"unexpected L4 access: {name}")
 
 
-def test_challenge_is_non_normative_unlinked_and_records_addressability_finding():
+def test_challenge_remains_historical_non_normative_evidence():
     data = json.loads(CHALLENGE.read_text(encoding="utf-8"))
     assert data["status"] == "candidate-challenge"
     assert data["productionInterpreterChangeAllowed"] is False
@@ -166,35 +92,41 @@ def test_challenge_is_non_normative_unlinked_and_records_addressability_finding(
     )
 
 
-def test_root_has_ten_distinct_definition_ids_and_all_targets_are_addressable():
+def test_root_has_ten_distinct_production_definition_ids_and_no_conflicts():
     library = load_root_library(ROOT_PROGRAM)
-    env = Environment(ScopeId(()))
-    ids = []
-    for formula in library.formulas:
-        assert isinstance(formula.ast, Definition)
-        ids.append(env.register_definition(formula.ast).identity)
-    assert len(ids) == len(set(ids)) == 10
+    entries = library.definitions.entries()
+    assert len(entries) == len({entry.identity for entry in entries}) == 10
+    assert library.definitions.conflicts() == ()
 
 
 def test_conflict_shadowing_parent_fallback_and_context_independence():
-    root = Environment(ScopeId(()))
-    root_a = root.register("a : b")
-    with pytest.raises(ValueError, match="same-scope conflict"):
-        root.register("a : c")
+    root = DefinitionEnvironment()
+    root_a = root.register(definition("a : b"))
+    assert root_a.entry is not None
+    duplicate = root.register(definition("a : c"))
+    assert duplicate.kind is DefinitionRegistrationKind.CONFLICT
+    assert root.lookup(target("a")).kind is DefinitionLookupKind.CONFLICT
 
-    child = root.child(0)
-    assert child.lookup(target("a")) == root_a
-    child_a = child.register("a : c")
-    assert child_a.identity != root_a.identity
-    assert child.lookup(target("a")) == child_a
+    clean_root = DefinitionEnvironment()
+    root_entry = clean_root.register(definition("a : b"))
+    assert root_entry.entry is not None
+    child = clean_root.child(0)
+    assert child.lookup(target("a")).entry == root_entry.entry
+    child_a = child.register(definition("a : c"))
+    assert child_a.entry is not None
+    assert child_a.entry.identity != root_entry.entry.identity
+    assert child.lookup(target("a")).entry == child_a.entry
 
-    assert set(inspect.signature(Environment.lookup).parameters) == {"self", "target"}
+    assert set(inspect.signature(DefinitionEnvironment.lookup).parameters) == {
+        "self",
+        "target",
+    }
     frames = [
         ContextFrame(1, 2),
         ContextFrame(10, 20),
         ContextFrame(100, 200, ContextFrame(1, 2)),
     ]
-    assert [child.lookup(target("a")) for _frame in frames] == [child_a] * 3
+    assert [child.lookup(target("a")).entry for _frame in frames] == [child_a.entry] * 3
 
 
 def test_source_span_is_provenance_not_addressable_target_identity():
@@ -203,34 +135,31 @@ def test_source_span_is_provenance_not_addressable_target_identity():
     assert first.target.span != shifted.target.span
     assert structural_key(first.target) == structural_key(shifted.target)
 
-    env = Environment(ScopeId(()))
-    entry = env.register_definition(first)
-    assert env.lookup(shifted.target) == entry
+    environment = DefinitionEnvironment()
+    registration = environment.register(first)
+    assert registration.entry is not None
+    assert environment.lookup(shifted.target).entry == registration.entry
 
 
-def test_anonymous_occurrence_shape_cannot_become_a_global_definition_address():
-    first = definition("[] : a")
-    shifted = definition("  [] : b")
+def test_anonymous_and_context_pronoun_targets_are_not_globalized():
+    environment = DefinitionEnvironment()
+    anonymous_a = definition("[] : a")
+    anonymous_b = definition("  [] : b")
+    assert anonymous_a.target.span != anonymous_b.target.span
+    assert structural_key(anonymous_a.target) == structural_key(anonymous_b.target)
 
-    assert first.target.span != shifted.target.span
-    assert structural_key(first.target) == structural_key(shifted.target)
-
-    env = Environment(ScopeId(()))
-    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
-        env.register_definition(first)
-    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
-        env.register_definition(shifted)
-
-
-def test_context_pronoun_target_is_not_silently_promoted_to_global_name():
-    env = Environment(ScopeId(()))
-    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
-        env.register("◁ : a")
-    with pytest.raises(NonAddressableTarget, match="occurrence-local or deictic"):
-        env.register("▷ : b")
+    for item in (
+        anonymous_a,
+        anonymous_b,
+        definition("◁ : a"),
+        definition("▷ : b"),
+    ):
+        registration = environment.register(item)
+        assert registration.kind is DefinitionRegistrationKind.NON_ADDRESSABLE
+        assert environment.lookup(item.target).kind is DefinitionLookupKind.NON_ADDRESSABLE
 
 
-def test_self_mutual_chain_and_missing_are_finite_and_deterministic():
+def test_symbol_rhs_self_mutual_chain_and_missing_traversal_is_finite_and_deterministic():
     cases = [
         (["a : a"], "a", (["a"], ["a"], [])),
         (["a : b", "b : a"], "a", (["a", "b"], ["a"], [])),
@@ -238,18 +167,26 @@ def test_self_mutual_chain_and_missing_are_finite_and_deterministic():
         (["a : b"], "z", ([], [], [])),
     ]
     for sources, start, expected in cases:
-        env = Environment(ScopeId(()))
-        ids = [env.register(source).identity for source in sources]
-        assert walk(env, start) == expected
-        assert walk(env, start) == expected
+        environment = DefinitionEnvironment()
+        ids = []
+        for source in sources:
+            registration = environment.register(definition(source))
+            assert registration.entry is not None
+            ids.append(registration.entry.identity)
+        assert walk(environment, start) == expected
+        assert walk(environment, start) == expected
 
-        replay = Environment(ScopeId(()))
-        replay_ids = [replay.register(source).identity for source in sources]
+        replay = DefinitionEnvironment()
+        replay_ids = []
+        for source in sources:
+            registration = replay.register(definition(source))
+            assert registration.entry is not None
+            replay_ids.append(registration.entry.identity)
         assert replay_ids == ids
         assert walk(replay, start) == expected
 
 
-def test_lookup_is_not_production_definition_execution_or_l4_effect():
+def test_definition_opening_does_not_turn_into_interpretation_or_l4_effect():
     expr = definition("a : b")
     with pytest.raises(InterpretationError, match="Definition"):
         interpret_constraints(

--- a/tests/test_mts_definition_environment_decision.py
+++ b/tests/test_mts_definition_environment_decision.py
@@ -1,17 +1,14 @@
-"""Executable gate for the non-normative DefinitionEnvironment v0.3 decision.
+"""Decision evidence for DefinitionEnvironment v0.3 using the canonical core."""
 
-This suite deliberately models only identity, lexical lookup and finite recursion
-state. It does not add production ``:`` semantics, form matching, proof rules or
-L4 effects.
-"""
-
-from dataclasses import dataclass
 import json
 from pathlib import Path
 
-import pytest
-
-from core.mtc_ast import Definition, Form, SourceSpan, Symbol, structural_key
+from core.mtc_ast import Definition, SourceSpan, Symbol, structural_key
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+)
 from core.mtc_interpreter import ContextFrame
 from core.mtc_parser import parse_formula
 from core.root_library import load_root_library
@@ -25,123 +22,17 @@ MTS_PROOF = ROOT / "contracts" / "mts-proof-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 
-@dataclass(frozen=True, order=True)
-class ScopeId:
-    """Challenge-only deterministic lexical scope identity."""
-
-    path: tuple[int, ...]
-
-
-@dataclass(frozen=True, order=True)
-class DefinitionId:
-    """Challenge-only introduction identity; never a target or storage identity."""
-
-    scope: ScopeId
-    ordinal: int
-
-
-@dataclass(frozen=True)
-class CandidateEntry:
-    identity: DefinitionId
-    target_key: object
-    definition: Definition
-    provenance: str
-
-
-class SameScopeConflict(ValueError):
-    pass
-
-
-class CandidateEnvironment:
-    """Tiny test-local model selected by the decision, not production semantics."""
-
-    def __init__(self, scope: ScopeId, parent: "CandidateEnvironment | None" = None):
-        self.scope = scope
-        self.parent = parent
-        self._entries: dict[object, CandidateEntry] = {}
-
-    def child(self, index: int) -> "CandidateEnvironment":
-        return CandidateEnvironment(ScopeId(self.scope.path + (index,)), parent=self)
-
-    def register(self, definition: Definition, *, provenance: str) -> CandidateEntry:
-        key = structural_key(definition.target)
-        if key in self._entries:
-            raise SameScopeConflict(f"duplicate target key in scope {self.scope.path}: {key!r}")
-
-        entry = CandidateEntry(
-            identity=DefinitionId(self.scope, len(self._entries)),
-            target_key=key,
-            definition=definition,
-            provenance=provenance,
-        )
-        self._entries[key] = entry
-        return entry
-
-    def lookup(self, target: Form) -> CandidateEntry | None:
-        key = structural_key(target)
-        scope: CandidateEnvironment | None = self
-        while scope is not None:
-            entry = scope._entries.get(key)
-            if entry is not None:
-                return entry
-            scope = scope.parent
-        return None
-
-    def entries(self) -> tuple[CandidateEntry, ...]:
-        return tuple(self._entries.values())
-
-
 def decision() -> dict:
     return json.loads(DECISION.read_text(encoding="utf-8"))
 
 
 def definition(source: str) -> Definition:
-    expression = parse_formula(source)
-    assert isinstance(expression, Definition)
-    return expression
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
 
 
-def _lookup_with_irrelevant_context(
-    environment: CandidateEnvironment,
-    target: Form,
-    frame: ContextFrame,
-) -> CandidateEntry | None:
-    """Make the candidate context boundary executable: lookup ignores ContextFrame."""
-
-    del frame
-    return environment.lookup(target)
-
-
-def _walk_definition_ids(
-    start: DefinitionId,
-    edges: dict[DefinitionId, tuple[DefinitionId, ...]],
-) -> tuple[tuple[DefinitionId, ...], tuple[tuple[DefinitionId, DefinitionId], ...]]:
-    """Finite graph replay keyed only by DefinitionId, with explicit cycle refs."""
-
-    visited: list[DefinitionId] = []
-    active: set[DefinitionId] = set()
-    completed: set[DefinitionId] = set()
-    cycles: list[tuple[DefinitionId, DefinitionId]] = []
-
-    def walk(current: DefinitionId) -> None:
-        visited.append(current)
-        active.add(current)
-        for dependency in edges.get(current, ()):  # graph edges are supplied, not inferred here
-            if dependency in active:
-                edge = (current, dependency)
-                if edge not in cycles:
-                    cycles.append(edge)
-                continue
-            if dependency not in completed:
-                walk(dependency)
-        active.remove(current)
-        completed.add(current)
-
-    walk(start)
-    return tuple(visited), tuple(cycles)
-
-
-def test_decision_is_non_normative_and_depends_on_the_merged_challenge():
+def test_decision_remains_historical_non_normative_evidence():
     data = decision()
     challenge = json.loads(CHALLENGE.read_text(encoding="utf-8"))
     mts_contract_text = MTS_CONTRACT.read_text(encoding="utf-8")
@@ -156,7 +47,7 @@ def test_decision_is_non_normative_and_depends_on_the_merged_challenge():
     assert "mts-definition-environment-decision" not in mts_proof_text
 
 
-def test_only_scoped_introduction_identity_is_the_preferred_candidate():
+def test_only_scoped_introduction_identity_was_selected_by_the_decision():
     models = {model["id"]: model for model in decision()["identityModels"]}
 
     assert set(models) == {"A", "B", "C", "D", "E"}
@@ -175,105 +66,74 @@ def test_only_scoped_introduction_identity_is_the_preferred_candidate():
     assert selected["provenance"]["participatesInDefinitionIdentity"] is False
 
 
-def test_all_ten_root_definitions_get_distinct_replay_local_definition_ids():
+def test_canonical_root_environment_now_realizes_the_selected_identity_model():
     library = load_root_library(ROOT_PROGRAM)
-    environment = CandidateEnvironment(ScopeId(()))
-
-    entries = []
-    for index, formula in enumerate(library.formulas):
-        assert isinstance(formula.ast, Definition)
-        entries.append(
-            environment.register(
-                formula.ast,
-                provenance=f"{formula.source_path}:{formula.line_no}:{index}",
-            )
-        )
+    entries = library.definitions.entries()
 
     assert len(entries) == 10
-    assert len(library.registry.entries()) == 10
-    assert library.registry.duplicates() == []
+    assert library.definitions.conflicts() == ()
     assert len({entry.identity for entry in entries}) == 10
     assert [entry.identity.ordinal for entry in entries] == list(range(10))
-    assert all(entry.identity.scope == ScopeId(()) for entry in entries)
+    assert all(entry.identity.scope_path == () for entry in entries)
 
 
-def test_target_structure_is_lookup_key_but_never_introduction_identity():
+def test_target_structure_is_lookup_discriminant_not_introduction_identity():
     left = Symbol("a", SourceSpan(0, 1))
     same_shape_different_span = Symbol("a", SourceSpan(100, 101))
-
     assert structural_key(left) == structural_key(same_shape_different_span)
 
-    root = CandidateEnvironment(ScopeId(()))
+    root = DefinitionEnvironment()
     child = root.child(0)
-    root_entry = root.register(definition("a : b"), provenance="root")
-    child_entry = child.register(definition("a : c"), provenance="child")
+    root_registration = root.register(definition("a : b"))
+    child_registration = child.register(definition("a : c"))
+    assert root_registration.entry is not None
+    assert child_registration.entry is not None
 
-    assert root_entry.target_key == child_entry.target_key
-    assert root_entry.identity != child_entry.identity
-    assert root.lookup(same_shape_different_span) == root_entry
-    assert child.lookup(same_shape_different_span) == child_entry
-
-
-def test_same_scope_duplicate_conflicts_instead_of_silently_replacing_identity():
-    environment = CandidateEnvironment(ScopeId(()))
-    first = environment.register(definition("a : b"), provenance="first")
-
-    with pytest.raises(SameScopeConflict, match="duplicate target key"):
-        environment.register(definition("a : c"), provenance="second")
-
-    assert environment.lookup(definition("a : z").target) == first
-    assert len(environment.entries()) == 1
+    assert root_registration.entry.target_key == child_registration.entry.target_key
+    assert root_registration.entry.identity != child_registration.entry.identity
+    assert root.lookup(same_shape_different_span).entry == root_registration.entry
+    assert child.lookup(same_shape_different_span).entry == child_registration.entry
 
 
-def test_explicit_child_shadowing_and_parent_fallback_are_deterministic():
-    root = CandidateEnvironment(ScopeId(()))
-    root_a = root.register(definition("a : rootValue"), provenance="root-a")
-    root_b = root.register(definition("b : rootB"), provenance="root-b")
-    child = root.child(7)
-    child_a = child.register(definition("a : childValue"), provenance="child-a")
+def test_same_scope_duplicate_is_conflict_and_child_shadowing_is_explicit():
+    root = DefinitionEnvironment()
+    first = root.register(definition("a : b"))
+    duplicate = root.register(definition("a : c"))
+    assert first.kind is DefinitionRegistrationKind.REGISTERED
+    assert duplicate.kind is DefinitionRegistrationKind.CONFLICT
+    assert root.lookup(definition("a : z").target).kind is DefinitionLookupKind.CONFLICT
 
-    assert child.lookup(definition("a : ignored").target) == child_a
-    assert child.lookup(definition("b : ignored").target) == root_b
-    assert root.lookup(definition("a : ignored").target) == root_a
-    assert child_a.identity.scope == ScopeId((7,))
-    assert root_a.identity.scope == ScopeId(())
+    clean_root = DefinitionEnvironment()
+    root_a = clean_root.register(definition("a : rootValue"))
+    root_b = clean_root.register(definition("b : rootB"))
+    child = clean_root.child(7)
+    child_a = child.register(definition("a : childValue"))
+    assert root_a.entry is not None and root_b.entry is not None and child_a.entry is not None
+    assert child.lookup(definition("a : ignored").target).entry == child_a.entry
+    assert child.lookup(definition("b : ignored").target).entry == root_b.entry
+    assert child_a.entry.identity.scope_path == (7,)
+    assert root_a.entry.identity.scope_path == ()
 
 
-def test_nested_context_frame_cannot_change_definition_lookup():
-    root = CandidateEnvironment(ScopeId(()))
+def test_contextframe_is_not_definition_scope_or_lookup_input():
+    root = DefinitionEnvironment()
+    registration = root.register(definition("a : b"))
+    assert registration.entry is not None
     child = root.child(1)
-    root_entry = root.register(definition("a : b"), provenance="root")
     target = definition("a : ignored").target
 
-    frame_a = ContextFrame(start=1, end=2)
-    frame_b = ContextFrame(start=100, end=200, parent=ContextFrame(start=10, end=20))
+    frames = [
+        ContextFrame(start=1, end=2),
+        ContextFrame(start=100, end=200, parent=ContextFrame(start=10, end=20)),
+    ]
+    for _frame in frames:
+        assert child.lookup(target).entry == registration.entry
 
-    assert _lookup_with_irrelevant_context(child, target, frame_a) == root_entry
-    assert _lookup_with_irrelevant_context(child, target, frame_b) == root_entry
     assert decision()["contextModel"]["definitionLookupDependsOnContextFrame"] is False
     assert decision()["scopeModel"]["contextFrameIsDefinitionScope"] is False
 
 
-def test_self_and_mutual_recursion_are_finite_when_state_is_definition_id():
-    root = CandidateEnvironment(ScopeId(()))
-    a = root.register(definition("a : a"), provenance="a").identity
-    b = root.register(definition("b : a"), provenance="b").identity
-
-    visited, cycles = _walk_definition_ids(a, {a: (a,)})
-    assert visited == (a,)
-    assert cycles == ((a, a),)
-
-    visited, cycles = _walk_definition_ids(a, {a: (b,), b: (a,)})
-    assert visited == (a, b)
-    assert cycles == ((b, a),)
-
-    recursion = decision()["finiteRecursionModel"]
-    assert recursion["stateKey"] == "DefinitionId"
-    assert recursion["textualUnfolding"] is False
-    assert recursion["normalFormRequired"] is False
-
-
-def test_resolution_boundary_does_not_smuggle_in_equality_proof_or_l4_effects():
+def test_decision_boundary_still_forbids_equality_proof_or_l4_effects():
     result = decision()["resolutionResultCandidate"]
     vetoes = set(decision()["negativeVetoes"])
 
@@ -284,20 +144,3 @@ def test_resolution_boundary_does_not_smuggle_in_equality_proof_or_l4_effects():
     assert "successful lookup implies A = F" in vetoes
     assert "successful lookup rewrites all A occurrences" in vetoes
     assert "definition lookup realizes missing L4 links" in vetoes
-
-
-def test_next_gate_requires_environment_challenge_before_any_semantic_acceptance():
-    gate = decision()["nextGate"]
-
-    assert gate["artifact"] == "mts-definition-environment-challenge/v0.3"
-    assert gate["status"] == "candidate-challenge"
-    assert gate["mustNotChangeProductionSemantics"] is True
-    assert {
-        "all ten canonical root definitions register with ten distinct DefinitionId values",
-        "same structural target in one scope is conflict",
-        "same structural target in child scope has distinct DefinitionId and explicit nearest-scope shadowing",
-        "nested ContextFrame does not affect definition lookup",
-        "self recursion emits cycle-ref by DefinitionId",
-        "mutual recursion emits finite cycle-ref graph by DefinitionId",
-        "no L4 reads, realize or delete",
-    }.issubset(set(gate["requiredVectors"]))

--- a/tests/test_mts_definition_opening_challenge.py
+++ b/tests/test_mts_definition_opening_challenge.py
@@ -1,20 +1,18 @@
-"""Independent executable replay for the candidate definition-opening corpus."""
+"""Historical opening challenge replayed through the canonical v0.3 core."""
 
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import fields, is_dataclass
 import inspect
 import json
 from pathlib import Path
 
 import pytest
 
-from core.mtc_ast import (
-    ContextPronoun,
-    Definition,
-    Expression,
-    Form,
-    SquareForm,
-    format_expression,
-    structural_key,
+from core.mtc_ast import ContextPronoun, Definition, Expression, Form, format_expression, structural_key
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    open_definition,
 )
 from core.mtc_interpreter import ContextFrame, InterpretationError, interpret_constraints
 from core.mtc_parser import parse_formula
@@ -30,29 +28,6 @@ MTS_PROOF = ROOT / "contracts" / "mts-proof-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 
-@dataclass(frozen=True, order=True)
-class ReplayDefinitionId:
-    scope_path: tuple[int, ...]
-    ordinal: int
-
-    def data(self) -> dict:
-        return {"scopePath": list(self.scope_path), "ordinal": self.ordinal}
-
-
-@dataclass(frozen=True)
-class ReplayEntry:
-    identity: ReplayDefinitionId
-    source: Definition
-
-
-class ReplayNonAddressable(ValueError):
-    pass
-
-
-class ReplayConflict(ValueError):
-    pass
-
-
 def challenge() -> dict:
     return json.loads(CHALLENGE.read_text(encoding="utf-8"))
 
@@ -65,137 +40,66 @@ def decision() -> dict:
     return json.loads(DECISION.read_text(encoding="utf-8"))
 
 
-def _definition(source: str) -> Definition:
+def definition(source: str) -> Definition:
     value = parse_formula(source)
     assert isinstance(value, Definition)
     return value
 
 
-def _target(source: str) -> Form:
-    return _definition(f"{source} : __query_body__").target
+def target(source: str) -> Form:
+    return definition(f"{source} : __query_body__").target
 
 
-def _contains_non_addressable(value: object) -> bool:
+def contains_context_pronoun(value: object) -> bool:
     if isinstance(value, ContextPronoun):
         return True
-    if isinstance(value, SquareForm) and value.content is None:
-        return True
     if isinstance(value, tuple):
-        return any(_contains_non_addressable(item) for item in value)
+        return any(contains_context_pronoun(item) for item in value)
     if isinstance(value, Expression) and is_dataclass(value):
         return any(
-            _contains_non_addressable(getattr(value, item.name))
+            contains_context_pronoun(getattr(value, item.name))
             for item in fields(value)
             if item.name != "span"
         )
     return False
 
 
-def _contains_context_pronoun(value: object) -> bool:
-    if isinstance(value, ContextPronoun):
-        return True
-    if isinstance(value, tuple):
-        return any(_contains_context_pronoun(item) for item in value)
-    if isinstance(value, Expression) and is_dataclass(value):
-        return any(
-            _contains_context_pronoun(getattr(value, item.name))
-            for item in fields(value)
-            if item.name != "span"
-        )
-    return False
+def opening_data(target_form: Form, environment: DefinitionEnvironment) -> dict:
+    result = open_definition(target_form, environment)
+    if result.kind is DefinitionLookupKind.MATCH:
+        assert result.definition_id is not None and result.body is not None
+        return {
+            "kind": "match",
+            "definitionId": {
+                "scopePath": list(result.definition_id.scope_path),
+                "ordinal": result.definition_id.ordinal,
+            },
+            "body": format_expression(result.body),
+        }
+    return {"kind": result.kind.value}
 
 
-def _target_key(target: Form) -> object:
-    if _contains_non_addressable(target):
-        raise ReplayNonAddressable("target is occurrence-local or deictic")
-    return structural_key(target)
-
-
-class ReplayEnvironment:
-    def __init__(
-        self,
-        scope_path: tuple[int, ...],
-        parent: "ReplayEnvironment | None" = None,
-    ) -> None:
-        self.scope_path = scope_path
-        self.parent = parent
-        self.entries: dict[object, ReplayEntry] = {}
-
-    def register(self, definition: Definition) -> ReplayEntry:
-        key = _target_key(definition.target)
-        if key in self.entries:
-            raise ReplayConflict("same-scope target conflict")
-        entry = ReplayEntry(
-            ReplayDefinitionId(self.scope_path, len(self.entries)),
-            definition,
-        )
-        self.entries[key] = entry
-        return entry
-
-    def lookup(self, target: Form) -> ReplayEntry | None:
-        key = _target_key(target)
-        current: ReplayEnvironment | None = self
-        while current is not None:
-            entry = current.entries.get(key)
-            if entry is not None:
-                return entry
-            current = current.parent
-        return None
-
-
-def replay_open_definition(target: Form, environment: ReplayEnvironment) -> dict:
-    """Independent one-step replay: lookup exact typed RHS and stop."""
-
-    try:
-        entry = environment.lookup(target)
-    except ReplayNonAddressable:
-        return {"kind": "non-addressable"}
-    if entry is None:
-        return {"kind": "no-match"}
-    return {
-        "kind": "match",
-        "definitionId": entry.identity.data(),
-        "body": format_expression(entry.source.value),
-    }
-
-
-def _build_scenario_environments(scenario: dict) -> tuple[dict[tuple[int, ...], ReplayEnvironment], str | None]:
-    environments: dict[tuple[int, ...], ReplayEnvironment] = {}
-    failure: str | None = None
-
-    for scope in sorted(scenario["scopes"], key=lambda item: (len(item["path"]), item["path"])):
+def scenario_data(scenario: dict) -> dict:
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+    for scope in sorted(
+        scenario["scopes"], key=lambda item: (len(item["path"]), item["path"])
+    ):
         path = tuple(scope["path"])
         parent_path = scope.get("parent")
         parent = environments.get(tuple(parent_path)) if parent_path is not None else None
-        environment = ReplayEnvironment(path, parent)
+        environment = DefinitionEnvironment(path, parent)
         environments[path] = environment
-
         for source in scope["definitions"]:
-            try:
-                environment.register(_definition(source))
-            except ReplayNonAddressable:
-                failure = "non-addressable"
-                break
-            except ReplayConflict:
-                failure = "conflict"
-                break
-        if failure is not None:
-            break
+            registration = environment.register(definition(source))
+            if registration.kind is DefinitionRegistrationKind.CONFLICT:
+                return {"kind": "conflict"}
+            if registration.kind is DefinitionRegistrationKind.NON_ADDRESSABLE:
+                return {"kind": "non-addressable"}
 
-    return environments, failure
-
-
-def _replay_scenario(scenario: dict) -> dict:
-    environments, failure = _build_scenario_environments(scenario)
-    if failure is not None:
-        return {"kind": failure}
-
-    environment = environments[tuple(scenario["lookupScope"])]
-    try:
-        target = _target(scenario["target"])
-    except Exception:
-        raise AssertionError(f"invalid challenge target: {scenario['target']}")
-    return replay_open_definition(target, environment)
+    return opening_data(
+        target(scenario["target"]),
+        environments[tuple(scenario["lookupScope"])],
+    )
 
 
 class NoMemory:
@@ -203,7 +107,7 @@ class NoMemory:
         raise AssertionError(f"unexpected L4 access: {name}")
 
 
-def test_challenge_and_corpus_are_non_normative_and_follow_decision_gate():
+def test_challenge_and_corpus_remain_historical_non_normative_evidence():
     data = challenge()
     vectors = corpus()
     selected = decision()["nextGate"]
@@ -220,16 +124,13 @@ def test_challenge_and_corpus_are_non_normative_and_follow_decision_gate():
     assert data["productionInterpreterChangeAllowed"] is False
     assert data["proofRuleAccepted"] is False
     assert "mts-definition-opening-challenge" not in mts_text
-    assert "mts-definition-opening-conformance" not in mts_text
     assert "mts-definition-opening-challenge" not in proof_text
 
 
-def test_root_corpus_is_exactly_the_current_ten_definition_surface():
+def test_root_corpus_is_exactly_current_ten_definition_surface_and_replays_in_core():
     library = load_root_library(ROOT_PROGRAM)
     vectors = corpus()["rootOpenings"]
-
-    assert len(library.formulas) == len(vectors) == 10
-    assert all(isinstance(formula.ast, Definition) for formula in library.formulas)
+    assert len(library.formulas) == len(library.definitions.entries()) == len(vectors) == 10
 
     corpus_sources = [
         f"{vector['target']} : {vector['expected']['body']}"
@@ -237,29 +138,18 @@ def test_root_corpus_is_exactly_the_current_ten_definition_surface():
     ]
     assert corpus_sources == [formula.text for formula in library.formulas]
 
-
-def test_every_root_opening_replays_to_exact_body_and_replay_local_id():
-    library = load_root_library(ROOT_PROGRAM)
-    environment = ReplayEnvironment(())
-    for formula in library.formulas:
-        assert isinstance(formula.ast, Definition)
-        environment.register(formula.ast)
-
-    for vector in corpus()["rootOpenings"]:
-        target = _target(vector["target"])
-        actual = replay_open_definition(target, environment)
-        assert actual == vector["expected"]
-
+    for vector in vectors:
+        query = target(vector["target"])
+        assert opening_data(query, library.definitions) == vector["expected"]
         if vector.get("mustContainUnresolvedContextPronoun"):
-            entry = environment.lookup(target)
-            assert entry is not None
-            assert _contains_context_pronoun(entry.source.value)
+            lookup = library.definitions.lookup(query)
+            assert lookup.entry is not None
+            assert contains_context_pronoun(lookup.entry.definition.value)
 
 
-def test_all_custom_positive_and_negative_vectors_replay_exactly():
+def test_all_custom_positive_and_negative_vectors_replay_exactly_in_core():
     for scenario in corpus()["scenarios"]:
-        actual = _replay_scenario(scenario)
-        assert actual == scenario["expected"], scenario["id"]
+        assert scenario_data(scenario) == scenario["expected"], scenario["id"]
 
 
 def test_one_step_vectors_do_not_recursively_follow_returned_symbol():
@@ -273,28 +163,22 @@ def test_one_step_vectors_do_not_recursively_follow_returned_symbol():
         "mutual-a-one-step",
         "mutual-b-one-step",
     }
-
     for scenario in one_step:
-        actual = _replay_scenario(scenario)
-        assert actual["body"] == scenario["expected"]["body"]
-        assert "cycle" not in actual
-        assert "steps" not in actual
+        actual = scenario_data(scenario)
+        assert actual == scenario["expected"]
+        assert "cycle" not in actual and "steps" not in actual
 
 
-def test_shadowing_and_parent_fallback_use_lexical_scope_not_contextframe():
+def test_shadowing_uses_lexical_scope_and_opening_has_no_contextframe_input():
     scenarios = {scenario["id"]: scenario for scenario in corpus()["scenarios"]}
-    shadow = _replay_scenario(scenarios["child-shadowing"])
-    fallback = _replay_scenario(scenarios["parent-fallback"])
-
+    shadow = scenario_data(scenarios["child-shadowing"])
+    fallback = scenario_data(scenarios["parent-fallback"])
     assert shadow["definitionId"] == {"scopePath": [0], "ordinal": 0}
     assert shadow["body"] == "c"
     assert fallback["definitionId"] == {"scopePath": [], "ordinal": 0}
     assert fallback["body"] == "b"
 
-    assert set(inspect.signature(replay_open_definition).parameters) == {
-        "target",
-        "environment",
-    }
+    assert set(inspect.signature(open_definition).parameters) == {"target", "environment"}
     boundary = challenge()["contextBoundary"]
     assert boundary["ContextFrameIsOpeningInput"] is False
     assert boundary["MemoryViewIsOpeningInput"] is False
@@ -302,25 +186,22 @@ def test_shadowing_and_parent_fallback_use_lexical_scope_not_contextframe():
     assert boundary["proofStateIsOpeningInput"] is False
 
 
-def test_addressable_lookup_ignores_source_span_but_anonymous_shape_is_not_globalized():
-    compact = _definition("a:b")
-    spaced = _definition("   a : c")
+def test_addressable_lookup_ignores_span_but_anonymous_shape_is_not_globalized():
+    compact = definition("a:b")
+    spaced = definition("   a : c")
     assert compact.target.span != spaced.target.span
     assert structural_key(compact.target) == structural_key(spaced.target)
 
-    environment = ReplayEnvironment(())
-    entry = environment.register(compact)
-    found = environment.lookup(spaced.target)
-    assert found == entry
+    environment = DefinitionEnvironment()
+    registration = environment.register(compact)
+    assert registration.entry is not None
+    assert environment.lookup(spaced.target).entry == registration.entry
 
-    anonymous_a = _definition("[] : a")
-    anonymous_b = _definition("   [] : b")
-    assert anonymous_a.target.span != anonymous_b.target.span
+    anonymous_a = definition("[] : a")
+    anonymous_b = definition("   [] : b")
     assert structural_key(anonymous_a.target) == structural_key(anonymous_b.target)
-    with pytest.raises(ReplayNonAddressable):
-        environment.register(anonymous_a)
-    with pytest.raises(ReplayNonAddressable):
-        environment.register(anonymous_b)
+    assert environment.register(anonymous_a).kind is DefinitionRegistrationKind.NON_ADDRESSABLE
+    assert environment.register(anonymous_b).kind is DefinitionRegistrationKind.NON_ADDRESSABLE
 
 
 def test_returned_context_pronouns_are_not_interpreted_by_opening():
@@ -329,20 +210,11 @@ def test_returned_context_pronouns_are_not_interpreted_by_opening():
         for item in corpus()["scenarios"]
         if item["id"] == "constraint-bundle-rhs"
     )
-    environments, failure = _build_scenario_environments(scenario)
-    assert failure is None
-    environment = environments[()]
-    target = _target("c")
-    entry = environment.lookup(target)
-    assert entry is not None
-    assert _contains_context_pronoun(entry.source.value)
-
-    actual = replay_open_definition(target, environment)
-    assert actual == scenario["expected"]
-    assert actual["body"] == "{◁ = c, ▷ = c}"
+    assert scenario_data(scenario) == scenario["expected"]
+    assert scenario["expected"]["body"] == "{◁ = c, ▷ = c}"
 
 
-def test_opening_has_no_l4_or_proof_effect_and_production_definition_execution_is_still_rejected():
+def test_opening_has_no_l4_or_proof_effect_and_interpret_still_rejects_definition():
     operation = challenge()["operationUnderChallenge"]
     assert operation["readsL4"] is False
     assert operation["writesL4"] is False
@@ -351,7 +223,7 @@ def test_opening_has_no_l4_or_proof_effect_and_production_definition_execution_i
     assert operation["rewritesCallerAst"] is False
     assert operation["evaluatesBody"] is False
 
-    source = _definition("a : b")
+    source = definition("a : b")
     with pytest.raises(InterpretationError, match="Definition"):
         interpret_constraints(
             source,
@@ -364,15 +236,8 @@ def test_opening_has_no_l4_or_proof_effect_and_production_definition_execution_i
 def test_corpus_has_no_storage_or_source_span_observable_identity():
     text = CORPUS.read_text(encoding="utf-8")
     non_observables = set(corpus()["nonObservables"])
-
     assert "source span offsets" in non_observables
     assert "persistent LinkRef or backend address" in non_observables
     assert "target structural-key serialization" in non_observables
     assert '"LinkRef"' not in text
     assert '"sourceSpan"' not in text
-
-
-def test_release_gate_blocks_production_and_l5_until_explicit_acceptance():
-    gate = challenge()["releaseGate"]
-    assert "publish an explicit versioned Accepted definition-opening contract before modifying production code" in gate
-    assert "only after production integration and conformance consider a trusted L5 opening rule" in gate

--- a/tests/test_mts_definition_opening_contract.py
+++ b/tests/test_mts_definition_opening_contract.py
@@ -21,7 +21,7 @@ def contract() -> dict:
     return json.loads(CONTRACT.read_text(encoding="utf-8"))
 
 
-def test_contract_is_normatively_accepted_but_does_not_retrofit_v02_umbrellas():
+def test_contract_is_accepted_integrated_but_does_not_retrofit_v02_umbrellas():
     data = contract()
     mts_v02 = MTS_V02.read_text(encoding="utf-8")
     proof_v02 = PROOF_V02.read_text(encoding="utf-8")
@@ -29,12 +29,23 @@ def test_contract_is_normatively_accepted_but_does_not_retrofit_v02_umbrellas():
     assert data["schema"] == "mts-definition-opening/v0.3"
     assert data["status"] == "accepted"
     assert data["accepted"] is True
-    assert data["integrationStatus"]["semanticContractAccepted"] is True
-    assert data["integrationStatus"]["productionReferenceCoreImplemented"] is False
-    assert data["integrationStatus"]["singleProductionInterpreterIntegrated"] is False
-    assert data["integrationStatus"]["mtsContractV03Published"] is False
-    assert data["integrationStatus"]["trustedL5RuleAccepted"] is False
-    assert data["integrationStatus"]["aproverRepinAllowed"] is False
+    status = data["integrationStatus"]
+    assert status["semanticContractAccepted"] is True
+    assert status["productionReferenceCoreImplemented"] is True
+    assert status["canonicalRootLibraryUsesDefinitionEnvironment"] is True
+    assert status["productionConformancePresent"] is True
+    assert status["mtsContractV03Published"] is False
+    assert status["trustedL5RuleAccepted"] is False
+    assert status["aproverRepinAllowed"] is False
+
+    integration = data["productionIntegration"]
+    assert integration["referenceCore"] == "core/mtc_definitions.py"
+    assert integration["rootLibrary"] == "core/root_library.py"
+    assert integration["rootValidator"] == "core/validate_root.py"
+    assert integration["productionConformance"] == "tests/test_mts_definition_opening_reference.py"
+    assert integration["legacyDifferenceRegistryRetained"] is False
+    assert integration["challengeOnlyEnvironmentCloneRetained"] is False
+    assert integration["interpretConstraintsExecutesDefinition"] is False
 
     assert "mts-definition-opening/v0.3" not in mts_v02
     assert "mts-definition-opening/v0.3" not in proof_v02
@@ -105,10 +116,11 @@ def test_definition_environment_identity_scope_and_shadowing_are_normative():
     assert environment["ContextFrameAffectsLookup"] is False
 
 
-def test_occurrence_local_and_deictic_targets_are_not_globalized():
+def test_occurrence_local_deictic_and_bundle_targets_are_not_globalized():
     addressability = contract()["addressability"]
     assert addressability["anonymousEmptySquareTarget"] == "non-addressable"
     assert addressability["ContextPronounTarget"] == "non-addressable"
+    assert addressability["bundleTarget"] == "non-addressable under the accepted scalar definition-target boundary"
     assert addressability["structuralLookupDiscriminantImpliesSemanticEquality"] is False
 
     anonymous = parse_formula("[] : a")
@@ -132,7 +144,8 @@ def test_root_program_is_still_exactly_ten_definitions_and_acceptance_does_not_c
         "allCurrentTargetsAddressable": True,
         "allOpenToExactTypedRhs": True,
     }
-    assert len(library.formulas) == 10
+    assert len(library.formulas) == len(library.definitions.entries()) == 10
+    assert library.definitions.conflicts() == ()
     assert all(isinstance(formula.ast, Definition) for formula in library.formulas)
 
     expected = [
@@ -173,15 +186,16 @@ def test_recursion_is_normatively_single_step_not_global_normalization():
     }
 
 
-def test_next_gate_requires_one_production_core_before_v03_umbrella_or_l5():
+def test_next_gate_is_v03_umbrella_then_separate_l5_work():
     gate = contract()["nextGate"]
     downstream = contract()["downstream"]
 
-    assert gate["goal"].startswith("implement the accepted DefinitionEnvironment/open_definition operation once")
+    assert gate["goal"].startswith("publish mts-contract/v0.3 umbrella")
     assert "do not add a second parser or interpreter" in gate["constraints"]
     assert "do not turn Definition into Equality" in gate["constraints"]
-    assert gate["afterProductionConformance"].startswith("publish mts-contract/v0.3 umbrella")
+    assert "keep mts-proof/v0.2 trusted rule set unchanged until a separate L5 decision" in gate["constraints"]
+    assert gate["afterUmbrella"].startswith("start #122 proof-judgment/calculus challenge")
 
-    assert downstream["directRuntimePinBeforeProductionIntegration"] is False
+    assert downstream["directRuntimePinBeforeV03Umbrella"] is False
     assert downstream["aproverMustNotInventLocalOpeningSemantics"] is True
     assert downstream["futureConsumerMustUseVersionedV03Umbrella"] is True

--- a/tests/test_mts_definition_opening_decision.py
+++ b/tests/test_mts_definition_opening_decision.py
@@ -1,22 +1,18 @@
-"""Executable evidence for the non-normative one-step definition-opening decision."""
+"""Historical opening decision evidence replayed through the canonical v0.3 core."""
 
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import fields, is_dataclass
 import inspect
 import json
 from pathlib import Path
 
 import pytest
 
-from core.mtc_ast import (
-    BundleForm,
-    ContextPronoun,
-    Definition,
-    Expression,
-    Form,
-    SquareForm,
-    Symbol,
-    format_expression,
-    structural_key,
+from core.mtc_ast import BundleForm, ContextPronoun, Definition, Expression, Symbol, format_expression
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    open_definition,
 )
 from core.mtc_interpreter import ContextFrame, InterpretationError, interpret_constraints
 from core.mtc_parser import parse_formula
@@ -30,28 +26,6 @@ MTS_PROOF = ROOT / "contracts" / "mts-proof-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 
-@dataclass(frozen=True, order=True)
-class DefinitionId:
-    scope_path: tuple[int, ...]
-    ordinal: int
-
-
-@dataclass(frozen=True)
-class OpeningMatch:
-    definition_id: DefinitionId
-    target_key: object
-    body: Expression
-    source_definition: Definition
-
-
-class NonAddressableTarget(ValueError):
-    pass
-
-
-class DefinitionConflict(ValueError):
-    pass
-
-
 def decision() -> dict:
     return json.loads(DECISION.read_text(encoding="utf-8"))
 
@@ -62,86 +36,14 @@ def definition(source: str) -> Definition:
     return value
 
 
-def _contains_non_addressable(value: object) -> bool:
-    if isinstance(value, ContextPronoun):
-        return True
-    if isinstance(value, SquareForm) and value.content is None:
-        return True
-    if isinstance(value, tuple):
-        return any(_contains_non_addressable(item) for item in value)
-    if isinstance(value, Expression) and is_dataclass(value):
-        for item in fields(value):
-            if item.name == "span":
-                continue
-            if _contains_non_addressable(getattr(value, item.name)):
-                return True
-    return False
-
-
-def target_key(target: Form) -> object:
-    if _contains_non_addressable(target):
-        raise NonAddressableTarget(
-            "definition target contains occurrence-local or deictic form"
-        )
-    return structural_key(target)
-
-
-class Environment:
-    def __init__(
-        self,
-        scope_path: tuple[int, ...] = (),
-        parent: "Environment | None" = None,
-    ) -> None:
-        self.scope_path = scope_path
-        self.parent = parent
-        self.entries: dict[object, tuple[DefinitionId, Definition]] = {}
-
-    def child(self, index: int) -> "Environment":
-        return Environment(self.scope_path + (index,), self)
-
-    def register(self, value: Definition) -> DefinitionId:
-        key = target_key(value.target)
-        if key in self.entries:
-            raise DefinitionConflict("same-scope target conflict")
-        identity = DefinitionId(self.scope_path, len(self.entries))
-        self.entries[key] = (identity, value)
-        return identity
-
-    def lookup(self, target: Form) -> tuple[DefinitionId, Definition] | None:
-        key = target_key(target)
-        current: Environment | None = self
-        while current is not None:
-            entry = current.entries.get(key)
-            if entry is not None:
-                return entry
-            current = current.parent
-        return None
-
-
-def open_definition(target: Form, environment: Environment) -> OpeningMatch | None:
-    """Challenge-only preferred model: lookup, return exact typed RHS, stop."""
-
-    key = target_key(target)
-    found = environment.lookup(target)
-    if found is None:
-        return None
-    identity, source = found
-    return OpeningMatch(
-        definition_id=identity,
-        target_key=key,
-        body=source.value,
-        source_definition=source,
-    )
-
-
-def _contains_node(value: object, node_type: type) -> bool:
+def contains_node(value: object, node_type: type) -> bool:
     if isinstance(value, node_type):
         return True
     if isinstance(value, tuple):
-        return any(_contains_node(item, node_type) for item in value)
+        return any(contains_node(item, node_type) for item in value)
     if isinstance(value, Expression) and is_dataclass(value):
         return any(
-            _contains_node(getattr(value, item.name), node_type)
+            contains_node(getattr(value, item.name), node_type)
             for item in fields(value)
             if item.name != "span"
         )
@@ -153,7 +55,7 @@ class NoMemory:
         raise AssertionError(f"unexpected L4 access: {name}")
 
 
-def test_decision_is_non_normative_and_only_model_a_is_preferred():
+def test_decision_remains_historical_non_normative_evidence():
     data = decision()
     models = {model["id"]: model for model in data["models"]}
     mts_text = MTS_CONTRACT.read_text(encoding="utf-8")
@@ -167,46 +69,34 @@ def test_decision_is_non_normative_and_only_model_a_is_preferred():
     assert models["A"]["verdict"] == "preferred-candidate"
     assert all(model["accepted"] is False for model in models.values())
     assert all(models[item]["verdict"].startswith("reject") for item in "BCDE")
-    assert "mts-definition-opening" not in mts_text
-    assert "mts-definition-opening" not in proof_text
+    assert "mts-definition-opening/v0.3" not in mts_text
+    assert "mts-definition-opening/v0.3" not in proof_text
 
 
-def test_all_ten_root_definitions_open_once_to_exact_registered_typed_rhs():
+def test_all_ten_root_definitions_open_once_through_canonical_core():
     library = load_root_library(ROOT_PROGRAM)
-    environment = Environment()
-    identities: list[DefinitionId] = []
+    assert len(library.definitions.entries()) == 10
 
     for formula in library.formulas:
         assert isinstance(formula.ast, Definition)
-        identities.append(environment.register(formula.ast))
-
-    assert len(identities) == len(set(identities)) == 10
-
-    for formula in library.formulas:
-        assert isinstance(formula.ast, Definition)
-        result = open_definition(formula.ast.target, environment)
-        assert result is not None
+        result = open_definition(formula.ast.target, library.definitions)
+        assert result.kind is DefinitionLookupKind.MATCH
         assert result.body is formula.ast.value
-        assert structural_key(result.body) == structural_key(formula.ast.value)
         assert format_expression(result.body) == format_expression(formula.ast.value)
 
 
 def test_infinity_opening_preserves_context_pronouns_without_resolving_them():
     library = load_root_library(ROOT_PROGRAM)
-    environment = Environment()
-    infinity: Definition | None = None
-
-    for formula in library.formulas:
-        assert isinstance(formula.ast, Definition)
-        environment.register(formula.ast)
-        if format_expression(formula.ast.target) == "∞":
-            infinity = formula.ast
-
-    assert infinity is not None
-    result = open_definition(infinity.target, environment)
-    assert result is not None
+    infinity = next(
+        formula.ast
+        for formula in library.formulas
+        if isinstance(formula.ast, Definition)
+        and format_expression(formula.ast.target) == "∞"
+    )
+    result = open_definition(infinity.target, library.definitions)
+    assert result.kind is DefinitionLookupKind.MATCH
     assert isinstance(result.body, BundleForm)
-    assert _contains_node(result.body, ContextPronoun)
+    assert contains_node(result.body, ContextPronoun)
 
     boundary = decision()["contextBoundary"]
     assert boundary["openingResolvesContextPronouns"] is False
@@ -214,22 +104,18 @@ def test_infinity_opening_preserves_context_pronouns_without_resolving_them():
     assert boundary["laterInterpretationIsPartOfOpening"] is False
 
 
-def test_opening_uniformly_returns_form_and_constraint_bundle_rhs_without_evaluation():
-    environment = Environment()
+def test_form_and_constraint_bundle_rhs_are_returned_without_evaluation():
+    environment = DefinitionEnvironment()
     form_definition = definition("a : b")
     bundle_definition = definition("c : {◁ = c, ▷ = c}")
-    environment.register(form_definition)
-    environment.register(bundle_definition)
+    assert environment.register(form_definition).kind is DefinitionRegistrationKind.REGISTERED
+    assert environment.register(bundle_definition).kind is DefinitionRegistrationKind.REGISTERED
 
     form_result = open_definition(form_definition.target, environment)
     bundle_result = open_definition(bundle_definition.target, environment)
-
-    assert form_result is not None
-    assert bundle_result is not None
-    assert isinstance(form_result.body, Symbol)
-    assert form_result.body.name == "b"
+    assert isinstance(form_result.body, Symbol) and form_result.body.name == "b"
     assert isinstance(bundle_result.body, BundleForm)
-    assert _contains_node(bundle_result.body, ContextPronoun)
+    assert contains_node(bundle_result.body, ContextPronoun)
 
 
 def test_opening_has_no_context_memory_symbols_or_proof_state_inputs():
@@ -249,80 +135,59 @@ def test_opening_has_no_context_memory_symbols_or_proof_state_inputs():
 
 
 def test_self_and_mutual_definitions_stop_after_exactly_one_opening():
-    environment = Environment()
-    self_definition = definition("a : a")
-    mutual_a = definition("b : c")
-    mutual_b = definition("c : b")
-    for item in (self_definition, mutual_a, mutual_b):
-        environment.register(item)
+    environment = DefinitionEnvironment()
+    definitions = [definition("a : a"), definition("b : c"), definition("c : b")]
+    for item in definitions:
+        assert environment.register(item).kind is DefinitionRegistrationKind.REGISTERED
 
-    self_result = open_definition(self_definition.target, environment)
-    b_result = open_definition(mutual_a.target, environment)
-    c_result = open_definition(mutual_b.target, environment)
+    expected = {"a": "a", "b": "c", "c": "b"}
+    for item in definitions:
+        result = open_definition(item.target, environment)
+        assert result.kind is DefinitionLookupKind.MATCH
+        assert isinstance(result.body, Symbol)
+        assert result.body.name == expected[format_expression(item.target)]
 
-    assert self_result is not None and isinstance(self_result.body, Symbol)
-    assert self_result.body.name == "a"
-    assert b_result is not None and isinstance(b_result.body, Symbol)
-    assert b_result.body.name == "c"
-    assert c_result is not None and isinstance(c_result.body, Symbol)
-    assert c_result.body.name == "b"
     assert decision()["recursionBoundary"]["singleStepNeedsCycleMarker"] is False
     assert decision()["recursionBoundary"]["multiStepTraversalMustTrackDefinitionId"] is True
 
 
-def test_lexical_shadowing_changes_definition_id_and_body_but_not_target_shape():
-    root = Environment()
-    root_definition = definition("a : b")
-    root_id = root.register(root_definition)
+def test_shadowing_missing_non_addressable_and_duplicate_results_are_explicit():
+    root = DefinitionEnvironment()
+    root_def = definition("a : b")
+    root_registration = root.register(root_def)
+    assert root_registration.entry is not None
 
     child = root.child(0)
-    inherited = open_definition(root_definition.target, child)
-    assert inherited is not None
-    assert inherited.definition_id == root_id
-    assert isinstance(inherited.body, Symbol) and inherited.body.name == "b"
+    inherited = open_definition(root_def.target, child)
+    assert inherited.definition_id == root_registration.entry.identity
 
-    child_definition = definition("a : c")
-    child_id = child.register(child_definition)
-    shadowed = open_definition(child_definition.target, child)
-    assert shadowed is not None
-    assert child_id != root_id
-    assert shadowed.definition_id == child_id
-    assert shadowed.target_key == structural_key(root_definition.target)
+    child_def = definition("a : c")
+    child_registration = child.register(child_def)
+    assert child_registration.entry is not None
+    shadowed = open_definition(child_def.target, child)
+    assert shadowed.definition_id == child_registration.entry.identity
     assert isinstance(shadowed.body, Symbol) and shadowed.body.name == "c"
 
-
-def test_missing_and_non_addressable_targets_remain_explicit_negative_results():
-    environment = Environment()
-    existing = definition("a : b")
-    environment.register(existing)
-
-    missing = definition("z : q")
-    assert open_definition(missing.target, environment) is None
+    assert open_definition(definition("z : q").target, root).kind is DefinitionLookupKind.NO_MATCH
 
     for source in ("[] : a", "◁ : a", "▷ : b"):
         item = definition(source)
-        with pytest.raises(NonAddressableTarget):
-            environment.register(item)
-        with pytest.raises(NonAddressableTarget):
-            open_definition(item.target, environment)
+        assert root.register(item).kind is DefinitionRegistrationKind.NON_ADDRESSABLE
+        assert open_definition(item.target, root).kind is DefinitionLookupKind.NON_ADDRESSABLE
+
+    duplicate_root = DefinitionEnvironment()
+    assert duplicate_root.register(definition("a : b")).kind is DefinitionRegistrationKind.REGISTERED
+    assert duplicate_root.register(definition("a : c")).kind is DefinitionRegistrationKind.CONFLICT
+    assert open_definition(definition("a : z").target, duplicate_root).kind is DefinitionLookupKind.CONFLICT
 
 
-def test_same_scope_duplicate_remains_conflict_not_implicit_redefinition():
-    environment = Environment()
-    environment.register(definition("a : b"))
-    with pytest.raises(DefinitionConflict):
-        environment.register(definition("a : c"))
-
-
-def test_successful_opening_is_not_equality_rewrite_proof_or_production_execution():
+def test_successful_opening_is_not_equality_rewrite_proof_or_interpretation():
     source = definition("a : b")
-    environment = Environment()
+    environment = DefinitionEnvironment()
     environment.register(source)
     result = open_definition(source.target, environment)
-
-    assert result is not None
-    assert isinstance(result.body, Symbol)
-    assert result.body.name == "b"
+    assert result.kind is DefinitionLookupKind.MATCH
+    assert isinstance(result.body, Symbol) and result.body.name == "b"
 
     operation = decision()["preferredOperation"]
     assert operation["returnsEquality"] is False

--- a/tests/test_mts_definition_opening_reference.py
+++ b/tests/test_mts_definition_opening_reference.py
@@ -1,0 +1,230 @@
+"""Production conformance for accepted MTS definition opening v0.3."""
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mtc_ast import ContextPronoun, Definition, Expression, Form, format_expression
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    open_definition,
+)
+from core.mtc_interpreter import ContextFrame, InterpretationError, interpret_constraints
+from core.mtc_parser import parse_formula
+from core.root_library import load_root_library
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-definition-opening-v0.3.json"
+CORPUS = ROOT / "contracts" / "mts-definition-opening-conformance-v0.3.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def corpus() -> dict:
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def definition(source: str) -> Definition:
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
+
+
+def query_target(source: str) -> Form:
+    return definition(f"{source} : __query__").target
+
+
+def result_data(target: Form, environment: DefinitionEnvironment) -> dict:
+    result = open_definition(target, environment)
+    if result.kind is DefinitionLookupKind.MATCH:
+        assert result.definition_id is not None
+        assert result.body is not None
+        return {
+            "kind": "match",
+            "definitionId": {
+                "scopePath": list(result.definition_id.scope_path),
+                "ordinal": result.definition_id.ordinal,
+            },
+            "body": format_expression(result.body),
+        }
+    return {"kind": result.kind.value}
+
+
+def build_scenario_environments(
+    scenario: dict,
+) -> tuple[dict[tuple[int, ...], DefinitionEnvironment], str | None]:
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+
+    for scope in sorted(
+        scenario["scopes"], key=lambda item: (len(item["path"]), item["path"])
+    ):
+        path = tuple(scope["path"])
+        parent_path = scope.get("parent")
+        parent = environments.get(tuple(parent_path)) if parent_path is not None else None
+        environment = DefinitionEnvironment(path, parent)
+        environments[path] = environment
+
+        for source in scope["definitions"]:
+            registration = environment.register(definition(source))
+            if registration.kind is DefinitionRegistrationKind.CONFLICT:
+                return environments, "conflict"
+            if registration.kind is DefinitionRegistrationKind.NON_ADDRESSABLE:
+                return environments, "non-addressable"
+
+    return environments, None
+
+
+def replay_scenario(scenario: dict) -> dict:
+    environments, failure = build_scenario_environments(scenario)
+    if failure is not None:
+        return {"kind": failure}
+    return result_data(
+        query_target(scenario["target"]),
+        environments[tuple(scenario["lookupScope"])],
+    )
+
+
+def contains_context_pronoun(value: object) -> bool:
+    if isinstance(value, ContextPronoun):
+        return True
+    if isinstance(value, tuple):
+        return any(contains_context_pronoun(item) for item in value)
+    fields = getattr(value, "__dataclass_fields__", None)
+    if isinstance(value, Expression) and fields:
+        return any(
+            contains_context_pronoun(getattr(value, name))
+            for name in fields
+            if name != "span"
+        )
+    return False
+
+
+class NoMemory:
+    def __getattr__(self, name):
+        raise AssertionError(f"unexpected L4 access: {name}")
+
+
+def test_production_root_environment_replays_every_portable_root_vector_exactly():
+    library = load_root_library(ROOT_PROGRAM)
+    vectors = corpus()["rootOpenings"]
+
+    assert len(library.formulas) == len(library.definitions.entries()) == len(vectors) == 10
+    assert library.definitions.conflicts() == ()
+
+    for vector in vectors:
+        target = query_target(vector["target"])
+        actual = result_data(target, library.definitions)
+        assert actual == vector["expected"]
+
+        if vector.get("mustContainUnresolvedContextPronoun"):
+            lookup = library.definitions.lookup(target)
+            assert lookup.kind is DefinitionLookupKind.MATCH
+            assert lookup.entry is not None
+            assert contains_context_pronoun(lookup.entry.definition.value)
+
+
+def test_production_environment_replays_all_custom_positive_and_negative_vectors():
+    for scenario in corpus()["scenarios"]:
+        assert replay_scenario(scenario) == scenario["expected"], scenario["id"]
+
+
+def test_one_step_opening_stops_at_exact_returned_body_for_self_and_mutual_recursion():
+    scenarios = {
+        item["id"]: item
+        for item in corpus()["scenarios"]
+        if item.get("mustStopAfterOneOpening")
+    }
+    assert set(scenarios) == {
+        "self-one-step",
+        "mutual-a-one-step",
+        "mutual-b-one-step",
+    }
+
+    for scenario in scenarios.values():
+        actual = replay_scenario(scenario)
+        assert actual == scenario["expected"]
+        assert set(actual) == {"kind", "definitionId", "body"}
+
+
+def test_opening_surface_has_no_context_memory_symbol_binding_or_proof_input():
+    assert set(inspect.signature(open_definition).parameters) == {
+        "target",
+        "environment",
+    }
+    operation = contract()["operation"]
+    assert operation["doesNotTake"] == [
+        "ContextFrame",
+        "MemoryView",
+        "symbol-to-LinkRef bindings",
+        "proof state",
+    ]
+    assert operation["readsL4"] is False
+    assert operation["writesL4"] is False
+    assert operation["evaluatesBody"] is False
+    assert operation["resolvesContextPronouns"] is False
+
+
+def test_production_opening_does_not_change_interpret_constraints_definition_boundary():
+    source = definition("a : b")
+    environment = DefinitionEnvironment()
+    registration = environment.register(source)
+    assert registration.kind is DefinitionRegistrationKind.REGISTERED
+    result = open_definition(source.target, environment)
+    assert result.kind is DefinitionLookupKind.MATCH
+    assert result.body is source.value
+
+    with pytest.raises(InterpretationError, match="Definition"):
+        interpret_constraints(
+            source,
+            ContextFrame(1, 2),
+            NoMemory(),
+            symbols={"a": 1, "b": 2},
+        )
+
+
+def test_non_addressable_target_is_rejected_before_any_global_lookup_identity():
+    environment = DefinitionEnvironment()
+    for source in ("[] : a", "◁ : a", "▷ : a"):
+        item = definition(source)
+        registration = environment.register(item)
+        assert registration.kind is DefinitionRegistrationKind.NON_ADDRESSABLE
+        result = open_definition(item.target, environment)
+        assert result.kind is DefinitionLookupKind.NON_ADDRESSABLE
+
+
+def test_conflict_in_nearest_scope_blocks_parent_fallback_and_is_not_redefinition():
+    root = DefinitionEnvironment()
+    assert root.register(definition("a : root")).kind is DefinitionRegistrationKind.REGISTERED
+
+    child = root.child(0)
+    first = child.register(definition("a : child1"))
+    duplicate = child.register(definition("a : child2"))
+    assert first.kind is DefinitionRegistrationKind.REGISTERED
+    assert duplicate.kind is DefinitionRegistrationKind.CONFLICT
+
+    result = open_definition(query_target("a"), child)
+    assert result.kind is DefinitionLookupKind.CONFLICT
+    assert result.body is None
+    assert result.definition_id is None
+
+
+def test_whitespace_and_source_span_do_not_change_closed_target_lookup():
+    environment = DefinitionEnvironment()
+    first = definition("a : b")
+    shifted = definition("   a : c")
+    assert first.target.span != shifted.target.span
+    registration = environment.register(first)
+    assert registration.kind is DefinitionRegistrationKind.REGISTERED
+
+    result = open_definition(shifted.target, environment)
+    assert result.kind is DefinitionLookupKind.MATCH
+    assert result.definition_id == registration.entry.identity
+    assert result.body is first.value

--- a/tests/test_mts_definition_resolution_challenge.py
+++ b/tests/test_mts_definition_resolution_challenge.py
@@ -1,9 +1,8 @@
-"""Executable challenge gate for controlled MTS definition resolution v0.3.
+"""Executable historical challenge for controlled MTS definition resolution v0.3.
 
-This suite deliberately does not add production definition semantics. It freezes
-v0.2 boundaries and exercises a tiny test-local finite graph model so recursive
-and mutually recursive definitions cannot be "solved" by naive infinite text
-substitution while the real identity/context semantics are still under study.
+The synthetic graph walker remains only as evidence against naive recursive text
+substitution. Canonical definition identity/lookup now comes from
+``core.mtc_definitions`` and production opening remains separate from interpret.
 """
 
 from dataclasses import fields, is_dataclass
@@ -31,7 +30,7 @@ ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 
 class NoReadMemory(MemoryView):
-    """Prove the current Definition boundary performs no hidden L4 reads."""
+    """Prove Definition interpretation performs no hidden L4 reads."""
 
     def poles(self, link: int) -> tuple[int, int]:
         raise AssertionError("definition challenge unexpectedly read L4 poles")
@@ -75,7 +74,7 @@ def _symbol_dependencies(expression: Expression) -> list[str]:
 
 
 def _walk_synthetic_definition_graph(sources: list[str], start: str) -> dict:
-    """Test-local candidate: finite DFS with explicit cycle edges, never unfolding text."""
+    """Historical finite DFS challenge; never a production definition environment."""
 
     definitions: dict[str, Definition] = {}
     for source in sources:
@@ -142,16 +141,16 @@ def test_challenge_is_non_normative_and_not_linked_from_v02_contracts():
     assert "mts-definition-resolution-challenge" not in mts_proof_text
 
 
-def test_current_root_library_remains_ten_typed_definitions_without_duplicates():
+def test_current_root_library_remains_ten_typed_definitions_without_conflicts():
     library = load_root_library(ROOT_PROGRAM)
 
     assert len(library.formulas) == 10
-    assert len(library.registry.entries()) == 10
-    assert library.registry.duplicates() == []
+    assert len(library.definitions.entries()) == 10
+    assert library.definitions.conflicts() == ()
     assert all(isinstance(formula.ast, Definition) for formula in library.formulas)
 
 
-def test_definition_is_parsed_and_registered_but_not_executed_by_current_interpreter():
+def test_definition_is_still_not_executed_by_interpret_constraints():
     expression = parse_formula("a : b")
     assert isinstance(expression, Definition)
 
@@ -205,12 +204,3 @@ def test_definition_resolution_challenge_forbids_implicit_effects():
         "lookupEqualsRealize": False,
         "interpretEqualsRealize": False,
     }
-
-
-def test_release_gate_requires_acceptance_before_production_or_l5_rule_changes():
-    data = challenge()
-    release_gate = data["releaseGate"]
-
-    assert data["rootProgramMustRemainUnchanged"] is True
-    assert "accept a versioned semantic contract before modifying the single production interpreter" in release_gate
-    assert "only then expose the accepted operation as a candidate L5 proof rule" in release_gate

--- a/tests/test_root_library.py
+++ b/tests/test_root_library.py
@@ -1,9 +1,9 @@
-"""Tests for the typed canonical MTS v0.2 root library."""
+"""Tests for the typed canonical MTS root library."""
 
 from pathlib import Path
 
-from core.mtc_ast import Definition, RoundForm
-from core.reference_model import StatementStatus
+from core.mtc_ast import Definition, RoundForm, format_expression
+from core.mtc_definitions import DefinitionLookupKind, open_definition
 from core.root_library import FormulaKind, SQUARE_ABIT_FORMS, load_root_library
 from core.validate_root import validate_root_library
 
@@ -58,18 +58,31 @@ def test_root_contains_only_canonical_named_definitions():
     assert "{} != []" not in texts
 
 
-def test_difference_registry_matches_canonical_definition_surface():
-    registry = load_root_library(ROOT_FORMULAS).registry
+def test_definition_environment_matches_canonical_definition_surface():
+    library = load_root_library(ROOT_FORMULAS)
+    entries = library.definitions.entries()
 
-    assert set(registry.symbols()) == set(CANONICAL_DEFINITIONS)
-    assert registry.duplicates() == []
+    assert set(library.definition_targets()) == set(CANONICAL_DEFINITIONS)
+    assert library.definitions.conflicts() == ()
+    assert len(entries) == 10
 
-    for symbol, introduction in CANONICAL_DEFINITIONS.items():
-        entry = registry.lookup(symbol)
-        assert entry is not None
-        assert entry.status is StatementStatus.DEFINITION
-        assert entry.introduction == introduction
-        assert isinstance(entry.source_formula.ast, Definition)
+    by_target = {
+        format_expression(entry.definition.target): entry
+        for entry in entries
+    }
+    for ordinal, (target, introduction) in enumerate(CANONICAL_DEFINITIONS.items()):
+        entry = by_target[target]
+        assert entry.identity.scope_path == ()
+        assert entry.identity.ordinal == ordinal
+        assert format_expression(entry.definition.value) == introduction
+        assert isinstance(entry.definition, Definition)
+        assert entry.provenance.source_path is not None
+        assert entry.provenance.line_no is not None
+
+        opening = open_definition(entry.definition.target, library.definitions)
+        assert opening.kind is DefinitionLookupKind.MATCH
+        assert opening.definition_id == entry.identity
+        assert opening.body is entry.definition.value
 
 
 def test_square_abit_forms_are_exactly_four_and_infinity_is_not_one():
@@ -95,14 +108,18 @@ def test_colon_inside_round_form_is_not_registered_as_top_level_definition(tmp_p
     assert library.formulas[0].kind is FormulaKind.EXPRESSION
     assert isinstance(library.formulas[0].ast, RoundForm)
     assert isinstance(library.formulas[0].ast.content, Definition)
-    assert library.registry.symbols() == []
+    assert library.definitions.entries() == ()
 
 
 def test_literal_square_abit_definitions_keep_canonical_text():
-    registry = load_root_library(ROOT_FORMULAS).registry
+    library = load_root_library(ROOT_FORMULAS)
+    by_target = {
+        format_expression(entry.definition.target): entry
+        for entry in library.definitions.entries()
+    }
 
-    assert registry.lookup("([)").introduction == "(♀∞)"
-    assert registry.lookup("(])").introduction == "(∞♂)"
+    assert format_expression(by_target["([)"].definition.value) == "(♀∞)"
+    assert format_expression(by_target["(])"].definition.value) == "(∞♂)"
 
 
 def test_root_library_validates():
@@ -123,6 +140,16 @@ def test_duplicate_definitions_are_reported(tmp_path):
 
     assert not result.is_valid
     assert any("Повторное введение различия" in message for message in result.messages)
+
+
+def test_non_addressable_root_definition_is_reported(tmp_path):
+    formula_path = tmp_path / "non_addressable.mtc"
+    formula_path.write_text("[] : a\n", encoding="utf-8")
+
+    result = validate_root_library(formula_path)
+
+    assert not result.is_valid
+    assert any("Неадресуемая левая часть" in message for message in result.messages)
 
 
 def test_parser_errors_are_aggregated_with_source_location(tmp_path):

--- a/tests/test_root_library.py
+++ b/tests/test_root_library.py
@@ -129,6 +129,24 @@ def test_root_library_validates():
     assert result.status == "valid"
 
 
+def test_validator_requires_all_ten_canonical_definitions(tmp_path):
+    formula_path = tmp_path / "missing_not_equal.mtc"
+    formula_path.write_text(
+        "\n".join(
+            f"{target} : {value}"
+            for target, value in CANONICAL_DEFINITIONS.items()
+            if target != "(!=)"
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = validate_root_library(formula_path)
+
+    assert not result.is_valid
+    assert "Не найдено корневое различие: (!=)" in result.messages
+
+
 def test_duplicate_definitions_are_reported(tmp_path):
     formula_path = tmp_path / "duplicate_defs.mtc"
     formula_path.write_text(


### PR DESCRIPTION
Refs #121, #120.

Production integration принятого `mts-definition-opening/v0.3` после merged #133.

## Один canonical core

Добавлен `core/mtc_definitions.py`:
- replay-local `DefinitionId(scope_path, ordinal)`;
- explicit lexical `DefinitionEnvironment`;
- typed registration/lookup/opening results: `registered/conflict/non-addressable`, `match/no-match/conflict/non-addressable`;
- same-scope conflict блокирует fallback к parent для этого nearest lexical target;
- child shadowing explicit;
- `open_definition` возвращает exact typed RHS + provenance и делает ровно один шаг;
- no ContextFrame, MemoryView, equality, proof, recursive normalization или L4 effects.

## Legacy удалён в том же PR

`DifferenceRegistry`/`DifferenceEntry` удалены из `root_library.py`; root library и validator переведены на единственный `DefinitionEnvironment`. Compatibility alias не оставлен.

Challenge/decision tests больше не содержат копии `CandidateEnvironment`, `Environment` или `ReplayEnvironment`: исторические contracts остаются evidence, но исполняемая identity/lookup/opening semantics берётся только из `core.mtc_definitions`.

## Portable conformance

Новый `tests/test_mts_definition_opening_reference.py` прогоняет production core против существующего language-neutral `mts-definition-opening-conformance/v0.3`:
- все 10 root openings;
- Form/bundle RHS;
- self/mutual one-step;
- shadowing/fallback;
- missing/conflict/non-addressable;
- source-span independence;
- no implicit interpret/L4 effects.

`interpret_constraints` намеренно продолжает отвергать `Definition`: accepted opening является отдельной canonical operation, а не второй веткой interpreter.

## Contract status

`mts-definition-opening/v0.3` обновляет только integration metadata: production core/root integration + conformance now present; `mts-contract/v0.3` umbrella, trusted L5 rule и aprover repin всё ещё false.

После зелёного CI следующий gate: publish `mts-contract/v0.3` umbrella, затем переходить к #122. Никаких изменений 10 root definitions или `mts-proof/v0.2`.