### PR TITLE
Выбрать focused L1 carrier для relative Anum v0.3

### DIFF
--- a/contracts/anum-relative-context-decision-v0.3.json
+++ b/contracts/anum-relative-context-decision-v0.3.json
@@ -1,0 +1,143 @@
+{
+  "schema": "anum-relative-context-decision/v0.3",
+  "status": "candidate-decision",
+  "dependsOn": [
+    "anum-recursive-denotation/v0.2",
+    "anum-relative-context-challenge/v0.3"
+  ],
+  "issue": 123,
+  "acceptedContractLinkAllowed": false,
+  "productionRelativeSemanticsChangeAllowed": false,
+  "purpose": "Choose the next executable model for relative Anum context without changing accepted root/quote semantics or inventing L4 identity.",
+  "evidence": {
+    "acceptedL1": "finite CarrierGraph of LinkNode(start,end), with cycles and sharing allowed",
+    "acceptedL2Context": "ContextFrame parent ascent is explicit ↑ and therefore must not be reused for structural start/end descent",
+    "acceptedL3Relative": "RAW only in v0.2",
+    "historicalNonNormative": "old research issue #61 described [[ as start-of-start and ]] as end-of-end, but its old root 0/1 orientation is superseded and is not imported as semantics"
+  },
+  "models": [
+    {
+      "id": "A",
+      "name": "single-opaque-anchor",
+      "verdict": "reject-as-general-relative-context",
+      "accepted": false,
+      "reason": "One opaque anchor has no typed start/end topology, so bracket roles would require hidden conventions or an external lookup API."
+    },
+    {
+      "id": "B",
+      "name": "ordered-start-end-anchor-pair",
+      "verdict": "defer-as-shallow-subset",
+      "accepted": false,
+      "reason": "Makes one binary level explicit but cannot represent arbitrary nested relative traversal, cycles or sharing without recursively growing a second carrier model."
+    },
+    {
+      "id": "C",
+      "name": "parented-binary-relative-frame",
+      "verdict": "reject-as-structural-model",
+      "accepted": false,
+      "reason": "A parent pointer models context ancestry, while relative bracket nesting is being challenged as descent through start/end roles. Reusing parent would conflate L3 structure with L2 ↑ context ascent."
+    },
+    {
+      "id": "D",
+      "name": "external-AnumDenotation-with-focus",
+      "verdict": "defer-for-occurrence-tree-subsets",
+      "accepted": false,
+      "reason": "Current structural AnumDenotation is topological occurrence-tree IR and intentionally rejects shared/cyclic node references, so it is too narrow as the general relative context carrier."
+    },
+    {
+      "id": "E",
+      "name": "persistent-LinkRef-context",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Persistent/backend link identity belongs to L4 and would violate storage-neutral L3 denotation."
+    },
+    {
+      "id": "F",
+      "name": "focused-finite-L1-carrier",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "shape": "RelativeCarrierContext(graph: CarrierGraph, focus: node-index)",
+      "reason": "Reuses the already accepted finite cyclic L1 topology. Start/end traversal is explicit, cycles and sharing need no unfolding, focus is description-local, and no L4 backend identity is introduced."
+    }
+  ],
+  "preferredCandidate": {
+    "context": {
+      "graph": "finite accepted L1 CarrierGraph",
+      "focus": "valid description-local node index in graph",
+      "persistentIdentity": false,
+      "ownsGraph": false
+    },
+    "firstChallengeSubset": {
+      "rawAlphabet": ["[", "]"],
+      "readDirection": "left-to-right from current focus",
+      "candidateStep": {
+        "[": "focus := graph.nodes[focus].start",
+        "]": "focus := graph.nodes[focus].end"
+      },
+      "examplesToChallenge": {
+        "[": "start(focus)",
+        "]": "end(focus)",
+        "[[": "start(start(focus))",
+        "]]": "end(end(focus))",
+        "[]": "end(start(focus))",
+        "][": "start(end(focus))"
+      },
+      "terminatesByRawLength": true,
+      "cycleUnfoldingRequired": false,
+      "accepted": false
+    },
+    "explicitlyDeferred": [
+      "relative meaning of 0",
+      "relative meaning of 1",
+      "mixed bracket/0/1 carriers",
+      "whether a relative result is a selected node, selected rooted subcarrier, or another denotation type",
+      "whether traversal path is semantic or only provenance",
+      "canonical inverse when multiple paths in a cyclic/shared carrier select the same node"
+    ]
+  },
+  "identityBoundary": {
+    "focusNodeIndexIsDescriptionLocal": true,
+    "focusNodeIndexIsPersistentLinkId": false,
+    "equalSubgraphsNeedNotIntern": true,
+    "carrierIsomorphismIsNotL2Equality": true,
+    "displayGlyphIsIdentity": false
+  },
+  "contextSeparation": {
+    "relativeStructuralTraversalUsesL2ContextFrameParent": false,
+    "relativeStructuralTraversalUsesMemoryView": false,
+    "relativeStructuralTraversalMayMaterialize": false,
+    "rootOpeningCollapseAppliesToRelativeCandidate": false,
+    "quoteEnvelopeRemovalAppliesToRelativeCandidate": false
+  },
+  "inverseBoundary": {
+    "canonicalInverseAccepted": false,
+    "reason": "cycles/sharing can make multiple finite bracket paths select the same node; challenge must decide whether path is part of denotation before choosing an inverse",
+    "mustNotChooseShortestPathImplicitly": true,
+    "mustNotUseBackendIdentityToDisambiguate": true
+  },
+  "nextGate": {
+    "artifact": "anum-relative-carrier-path-challenge/v0.3",
+    "status": "candidate-challenge",
+    "mustNotChangeProductionRelativeSemantics": true,
+    "requiredVectors": [
+      "single [ and ] over focused finite carrier",
+      "[[ and ]] as two explicit role steps",
+      "[] and ][ role composition",
+      "cycles terminate by finite raw path without graph unfolding",
+      "sharing may make distinct raw paths select the same node without declaring those raw paths identical",
+      "invalid focus is typed failure",
+      "0/1 and mixed carriers stay explicitly unresolved in this challenge subset",
+      "root and quote observations remain unchanged",
+      "current production RELATIVE remains RAW",
+      "no L4 reads, LinkRef identity or materialization",
+      "inverse ambiguity is reported rather than guessed"
+    ]
+  },
+  "releaseGate": [
+    "pass focused-carrier path challenge",
+    "decide result type and path/provenance boundary",
+    "decide inverse domain explicitly",
+    "publish language-neutral positive/negative conformance",
+    "accept a versioned relative-denotation contract before changing production RELATIVE behavior"
+  ]
+}

--- a/tests/test_anum_relative_context_decision.py
+++ b/tests/test_anum_relative_context_decision.py
@@ -1,0 +1,162 @@
+"""Executable evidence for the non-normative relative-context decision v0.3."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_denotation import DenotationKind
+from core.anum_model import Abit, ProjectionContext
+from core.anum_parser import parse_raw_quaternary
+from core.anum_recursive_denotation import denotate_recursive_anum
+from core.semantic_carrier import CarrierGraph, LinkNode
+
+
+ROOT = Path(__file__).parents[1]
+DECISION = ROOT / "contracts" / "anum-relative-context-decision-v0.3.json"
+CHALLENGE = ROOT / "contracts" / "anum-relative-context-challenge-v0.3.json"
+RECURSIVE = ROOT / "contracts" / "anum-recursive-denotation-v0.2.json"
+
+
+class RelativeCandidateError(ValueError):
+    pass
+
+
+def decision() -> dict:
+    return json.loads(DECISION.read_text(encoding="utf-8"))
+
+
+def carrier() -> CarrierGraph:
+    """Finite cyclic/shared graph with distinct observations for all short paths."""
+
+    return CarrierGraph(
+        nodes=(
+            LinkNode(start=1, end=2),
+            LinkNode(start=3, end=0),
+            LinkNode(start=0, end=4),
+            LinkNode(start=3, end=1),
+            LinkNode(start=2, end=4),
+        ),
+        root=0,
+    )
+
+
+def candidate_traverse(raw: str, graph: CarrierGraph, focus: int) -> int:
+    """Decision-only bracket path model; production RELATIVE remains RAW."""
+
+    if focus < 0 or focus >= len(graph.nodes):
+        raise RelativeCandidateError("relative focus is outside carrier graph")
+    form = parse_raw_quaternary(raw)
+    current = focus
+    for token in form.tokens:
+        if token.abit is Abit.OPEN:
+            current = graph.nodes[current].start
+        elif token.abit is Abit.CLOSE:
+            current = graph.nodes[current].end
+        else:
+            raise RelativeCandidateError("0/1 are unresolved in bracket-path challenge subset")
+    return current
+
+
+def test_decision_is_non_normative_and_selects_only_focused_l1_carrier():
+    data = decision()
+    challenge = json.loads(CHALLENGE.read_text(encoding="utf-8"))
+    recursive = json.loads(RECURSIVE.read_text(encoding="utf-8"))
+    models = {model["id"]: model for model in data["models"]}
+
+    assert data["schema"] == "anum-relative-context-decision/v0.3"
+    assert data["status"] == "candidate-decision"
+    assert data["dependsOn"] == [recursive["schema"], challenge["schema"]]
+    assert data["acceptedContractLinkAllowed"] is False
+    assert data["productionRelativeSemanticsChangeAllowed"] is False
+    assert set(models) == {"A", "B", "C", "D", "E", "F"}
+    assert models["F"]["verdict"] == "preferred-candidate"
+    assert all(model["accepted"] is False for model in models.values())
+    assert models["C"]["verdict"] == "reject-as-structural-model"
+    assert models["E"]["verdict"] == "reject"
+
+
+def test_bracket_path_candidate_has_expected_role_composition():
+    graph = carrier()
+    expected = {
+        "[": 1,
+        "]": 2,
+        "[[": 3,
+        "]]": 4,
+        "[]": 0,
+        "][": 0,
+    }
+    for raw, selected in expected.items():
+        assert candidate_traverse(raw, graph, graph.root) == selected
+
+
+def test_cycles_terminate_by_finite_raw_length_without_graph_unfolding():
+    graph = carrier()
+
+    assert candidate_traverse("[[[[", graph, 0) == 3
+    assert candidate_traverse("]]]]", graph, 0) == 4
+    assert candidate_traverse("[][][][]", graph, 0) == 0
+
+    preferred = decision()["preferredCandidate"]["firstChallengeSubset"]
+    assert preferred["terminatesByRawLength"] is True
+    assert preferred["cycleUnfoldingRequired"] is False
+    assert preferred["accepted"] is False
+
+
+def test_distinct_paths_may_select_same_node_without_becoming_identical_raw():
+    graph = carrier()
+
+    assert candidate_traverse("[]", graph, 0) == 0
+    assert candidate_traverse("][", graph, 0) == 0
+    assert "[]" != "]["
+
+    inverse = decision()["inverseBoundary"]
+    assert inverse["canonicalInverseAccepted"] is False
+    assert inverse["mustNotChooseShortestPathImplicitly"] is True
+    assert inverse["mustNotUseBackendIdentityToDisambiguate"] is True
+
+
+def test_invalid_focus_and_0_1_are_explicit_candidate_failures():
+    graph = carrier()
+    with pytest.raises(RelativeCandidateError, match="outside carrier"):
+        candidate_traverse("[", graph, 99)
+
+    for raw in ("0", "1", "[0", "1]"):
+        with pytest.raises(RelativeCandidateError, match="0/1 are unresolved"):
+            candidate_traverse(raw, graph, graph.root)
+
+
+def test_current_production_relative_semantics_remain_raw_for_decision_vectors():
+    for raw in ("[", "]", "[[", "]]", "[]", "][", "0", "1", "[0", "1]"):
+        value = denotate_recursive_anum(
+            parse_raw_quaternary(raw),
+            ProjectionContext.RELATIVE,
+        )
+        assert value.kind is DenotationKind.RAW
+        assert value.raw == raw
+
+
+def test_focused_carrier_is_l1_description_local_not_l4_identity():
+    graph = carrier()
+    assert graph.root == 0
+    assert graph.nodes[graph.root] == LinkNode(start=1, end=2)
+
+    identity = decision()["identityBoundary"]
+    assert identity["focusNodeIndexIsDescriptionLocal"] is True
+    assert identity["focusNodeIndexIsPersistentLinkId"] is False
+    assert identity["equalSubgraphsNeedNotIntern"] is True
+    assert identity["carrierIsomorphismIsNotL2Equality"] is True
+
+    separation = decision()["contextSeparation"]
+    assert separation["relativeStructuralTraversalUsesL2ContextFrameParent"] is False
+    assert separation["relativeStructuralTraversalUsesMemoryView"] is False
+    assert separation["relativeStructuralTraversalMayMaterialize"] is False
+
+
+def test_next_gate_is_non_production_focused_carrier_path_challenge():
+    gate = decision()["nextGate"]
+    assert gate["artifact"] == "anum-relative-carrier-path-challenge/v0.3"
+    assert gate["status"] == "candidate-challenge"
+    assert gate["mustNotChangeProductionRelativeSemantics"] is True
+    assert "current production RELATIVE remains RAW" in gate["requiredVectors"]
+    assert "inverse ambiguity is reported rather than guessed" in gate["requiredVectors"]


### PR DESCRIPTION
Refs #123, #120.

Non-normative decision after merged relative-context challenge #127. Production `ProjectionContext.RELATIVE` remains RAW.

## Main decision

Preferred next challenge model: `RelativeCarrierContext(graph: CarrierGraph, focus: node-index)` over the already accepted finite cyclic L1 carrier.

Why:
- a single anchor has no typed start/end topology;
- a start/end pair is only one shallow level;
- a parented frame conflates structural descent with L2 `↑` context ascent;
- current `AnumDenotation` occurrence-tree IR cannot represent general cycles/sharing;
- persistent `LinkRef` violates the L3/L4 boundary;
- L1 `CarrierGraph` already gives finite cycles/sharing and description-local node identity.

## First challenge subset

Only bracket paths are selected for the next challenge, still `accepted=false`:
- `[` candidate step = start;
- `]` candidate step = end;
- `[[`, `]]`, `[]`, `][` are finite left-to-right role paths.

`0`, `1`, mixed carriers, result type and canonical inverse are explicitly deferred. In particular, distinct paths may select the same node in cyclic/shared topology; the decision forbids silently choosing a shortest-path inverse or using backend identity to disambiguate.

Executable evidence uses a finite cyclic/shared `CarrierGraph` and proves path traversal terminates by raw length while the current production RELATIVE denotation remains RAW.

Next gate: `anum-relative-carrier-path-challenge/v0.3`, still non-production.