### PR TITLE
Опубликовать additive mts-contract/v0.3 umbrella

### DIFF
--- a/contracts/mts-conformance-v0.3.json
+++ b/contracts/mts-conformance-v0.3.json
@@ -1,0 +1,50 @@
+{
+  "schema": "mts-conformance/v0.3",
+  "contract": "mts-contract/v0.3",
+  "status": "accepted",
+  "composition": "all referenced accepted corpora are required; no vector is copied or replaced",
+  "requiredCorpora": [
+    {
+      "role": "base-v0.2",
+      "path": "contracts/mts-conformance-v0.2.json",
+      "schema": "mts-conformance/v0.2",
+      "contract": "mts-contract/v0.2"
+    },
+    {
+      "role": "definition-opening-v0.3",
+      "path": "contracts/mts-definition-opening-conformance-v0.3.json",
+      "schema": "mts-definition-opening-conformance/v0.3",
+      "contract": "mts-definition-opening/v0.3"
+    }
+  ],
+  "requiredReferenceChecks": [
+    "tests/test_repository_contract.py",
+    "tests/test_mts_contract_v03.py",
+    "tests/test_mts_definition_opening_reference.py"
+  ],
+  "releaseAssertions": {
+    "allRequiredCorporaMustPass": true,
+    "baseV02VectorsRemainAuthoritative": true,
+    "definitionOpeningUsesCanonicalProductionCore": true,
+    "rootProgramRemainsTenDefinitions": true,
+    "interpretRemainsReadOnly": true,
+    "openDefinitionRemainsReadOnly": true,
+    "openDefinitionDoesNotEvaluateBody": true,
+    "openDefinitionDoesNotAssertEquality": true,
+    "openDefinitionDoesNotProduceProofStep": true,
+    "relativeProductionRemainsRaw": true,
+    "persistentBackendCandidateNotPromoted": true,
+    "trustedProofRulesRemainInterpretOnly": true
+  },
+  "forbiddenReleaseRegressions": [
+    "editing mts-contract/v0.2 semantics in place",
+    "replacing mts-conformance/v0.2 with v0.3 vectors",
+    "reintroducing DifferenceRegistry or another executable definition environment",
+    "adding ContextFrame or MemoryView as implicit open_definition inputs",
+    "making successful definition opening imply equality",
+    "making definition opening recursively normalize self/mutual definitions",
+    "making relative Anum candidate semantics production behavior",
+    "making PMM or persistent addresses part of canonical L2/L3 identity",
+    "adding trusted L5 rules beyond interpret through the umbrella release"
+  ]
+}

--- a/contracts/mts-contract-v0.3.json
+++ b/contracts/mts-contract-v0.3.json
@@ -1,0 +1,103 @@
+{
+  "schema": "mts-contract/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 120,
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "mts-definition-opening/v0.3"
+  ],
+  "extends": "mts-contract/v0.2",
+  "baseContract": "contracts/mts-contract-v0.2.json",
+  "conformanceCorpus": "contracts/mts-conformance-v0.3.json",
+  "releaseModel": "additive versioned umbrella; v0.2 remains immutable and independently replayable",
+  "rootProgram": "tests/mtc_formulas.mtc",
+  "rootDefinitionCount": 10,
+  "preservedBaseSurface": {
+    "formalNotation": "all accepted mts-contract/v0.2 L2 semantics remain unchanged unless explicitly extended below",
+    "valueBundle": "contracts/mts-value-bundle-v0.2.json",
+    "anumRawAndRootDenotation": "accepted v0.2 contract graph remains unchanged",
+    "memory": "accepted v0.2 read/effect boundary remains unchanged",
+    "interpretMayMaterialize": false,
+    "globalRewrite": false,
+    "displayLabelIsIdentity": false
+  },
+  "formalNotationExtensions": {
+    "definitionOpening": {
+      "contract": "contracts/mts-definition-opening-v0.3.json",
+      "conformanceCorpus": "contracts/mts-definition-opening-conformance-v0.3.json",
+      "referenceCore": "core/mtc_definitions.py",
+      "operation": "open_definition",
+      "effect": "none",
+      "oneStep": true,
+      "evaluatesBody": false,
+      "definitionIsEquality": false,
+      "openingIsInterpretation": false,
+      "openingIsProofStep": false,
+      "readsL4": false,
+      "writesL4": false
+    }
+  },
+  "operationBoundary": {
+    "parse": "inherited from mts-contract/v0.2",
+    "interpret": "inherited from mts-contract/v0.2 and remains read-only",
+    "openDefinition": "accepted v0.3 one-step lexical definition opening",
+    "realize": "explicit L4 effect only; never implied by parse/interpret/openDefinition/find"
+  },
+  "definitionEnvironment": {
+    "identity": "DefinitionId(scopePath, ordinal), replay-local",
+    "scope": "explicit lexical tree",
+    "sameScopeDuplicate": "conflict",
+    "childSameTarget": "nearest-scope shadowing",
+    "ContextFrameAffectsLookup": false,
+    "persistentStorageIdentity": false
+  },
+  "versionBoundaries": {
+    "v02ModifiedInPlace": false,
+    "v02ConformanceReplaced": false,
+    "v03ConformanceComposesV02": true,
+    "compatibilitySemanticLayerAllowed": false
+  },
+  "l3Status": {
+    "rootAndQuote": "unchanged accepted v0.2 semantics",
+    "relative": "still RAW in production",
+    "relativeV03ResearchAccepted": false,
+    "relativeCandidateArtifactsAreNormativeDependencies": false
+  },
+  "l4Status": {
+    "canonicalInMemorySemantics": "unchanged accepted v0.2",
+    "persistentBackendContractAccepted": false,
+    "backendCandidateArtifactsAreNormativeDependencies": false,
+    "PMMIsCanonicalDependency": false
+  },
+  "l5Boundary": {
+    "currentProofContract": "contracts/mts-proof-v0.2.json",
+    "currentTrustedRuleSet": ["interpret"],
+    "definitionOpeningTrustedRuleAccepted": false,
+    "proofJudgmentV03Accepted": false,
+    "nextIssue": 122,
+    "searchRemainsUntrusted": true,
+    "checkerRemainsTrusted": true
+  },
+  "excludedFromThisRelease": [
+    "relative Anum v0.3 candidate semantics",
+    "persistent/high-performance L4 backend candidate semantics",
+    "new trusted L5 inference rules",
+    "proof by global textual substitution",
+    "unrestricted equality rewrite",
+    "implicit realization from definition opening"
+  ],
+  "downstream": {
+    "genericL2ConsumerMayPinV03": true,
+    "aproverProofRepinAllowed": false,
+    "aproverMustNotInventTrustedOpeningRule": true,
+    "futureProofConsumerMustWaitForVersionedL5Acceptance": true
+  },
+  "nextGate": {
+    "issue": 122,
+    "artifactClass": "non-normative proof-judgment/calculus challenge",
+    "mustKeepMtsProofV02Unchanged": true,
+    "mustNotTreatSuccessfulOpeningAsEquality": true,
+    "mustNotAddTrustedRuleWithoutExecutableEvidence": true
+  }
+}

--- a/contracts/mts-definition-opening-conformance-v0.3.json
+++ b/contracts/mts-definition-opening-conformance-v0.3.json
@@ -1,7 +1,10 @@
 {
   "schema": "mts-definition-opening-conformance/v0.3",
-  "status": "candidate-challenge-corpus",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-definition-opening/v0.3",
   "dependsOn": "mts-definition-opening-challenge/v0.3",
+  "promotion": "same challenged vectors promoted after semantic acceptance and production conformance; vector contents are unchanged",
   "resultEncoding": {
     "match": {
       "kind": "match",

--- a/contracts/mts-definition-opening-v0.3.json
+++ b/contracts/mts-definition-opening-v0.3.json
@@ -124,25 +124,25 @@
     "productionReferenceCoreImplemented": true,
     "canonicalRootLibraryUsesDefinitionEnvironment": true,
     "productionConformancePresent": true,
-    "mtsContractV03Published": false,
+    "mtsContractV03Published": true,
     "trustedL5RuleAccepted": false,
     "aproverRepinAllowed": false
   },
   "nextGate": {
-    "goal": "publish mts-contract/v0.3 umbrella over the accepted and production-conformant definition-opening operation without changing v0.2 contracts in place",
+    "issue": 122,
+    "goal": "define a typed MTS proof judgment and challenge the minimal trusted calculus without treating opening as equality",
     "constraints": [
-      "do not add a second parser or interpreter",
-      "do not modify the ten root definitions",
-      "do not turn Definition into Equality",
-      "do not add implicit ContextFrame evaluation",
-      "do not add L4 reads/effects",
-      "keep mts-proof/v0.2 trusted rule set unchanged until a separate L5 decision"
-    ],
-    "afterUmbrella": "start #122 proof-judgment/calculus challenge; only an explicitly accepted L5 contract may add a trusted definition-opening rule"
+      "keep mts-proof/v0.2 unchanged and interpret-only",
+      "do not turn successful open_definition into A = F",
+      "do not add global textual substitution",
+      "do not add trusted rules without executable soundness evidence",
+      "keep search untrusted and checker independently replayable"
+    ]
   },
   "downstream": {
-    "directRuntimePinBeforeV03Umbrella": false,
+    "genericL2ConsumerMayPinMtsContractV03": true,
+    "aproverProofRepinAllowed": false,
     "aproverMustNotInventLocalOpeningSemantics": true,
-    "futureConsumerMustUseVersionedV03Umbrella": true
+    "futureProofConsumerMustWaitForVersionedL5Acceptance": true
   }
 }

--- a/tests/test_mts_contract_v03.py
+++ b/tests/test_mts_contract_v03.py
@@ -1,0 +1,159 @@
+"""Acceptance checks for the additive MTS v0.3 machine-contract umbrella."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+V02 = ROOT / "contracts" / "mts-contract-v0.2.json"
+V02_CONFORMANCE = ROOT / "contracts" / "mts-conformance-v0.2.json"
+V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
+V03_CONFORMANCE = ROOT / "contracts" / "mts-conformance-v0.3.json"
+OPENING = ROOT / "contracts" / "mts-definition-opening-v0.3.json"
+OPENING_CONFORMANCE = ROOT / "contracts" / "mts-definition-opening-conformance-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def all_strings(value: object) -> list[str]:
+    result: list[str] = []
+    if isinstance(value, str):
+        result.append(value)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            result.extend(all_strings(key))
+            result.extend(all_strings(item))
+    elif isinstance(value, list):
+        for item in value:
+            result.extend(all_strings(item))
+    return result
+
+
+def test_v03_is_additive_accepted_umbrella_over_unmodified_v02_contract():
+    v02 = read(V02)
+    v03 = read(V03)
+
+    assert v02["schema"] == "mts-contract/v0.2"
+    assert v02["status"] == "accepted"
+    assert v03["schema"] == "mts-contract/v0.3"
+    assert v03["status"] == "accepted"
+    assert v03["accepted"] is True
+    assert v03["dependsOn"] == [v02["schema"], "mts-definition-opening/v0.3"]
+    assert v03["extends"] == v02["schema"]
+    assert v03["baseContract"] == "contracts/mts-contract-v0.2.json"
+    assert v03["versionBoundaries"] == {
+        "v02ModifiedInPlace": False,
+        "v02ConformanceReplaced": False,
+        "v03ConformanceComposesV02": True,
+        "compatibilitySemanticLayerAllowed": False,
+    }
+
+
+def test_v03_conformance_composes_base_and_accepted_definition_opening_corpora():
+    v02_corpus = read(V02_CONFORMANCE)
+    opening_corpus = read(OPENING_CONFORMANCE)
+    v03_corpus = read(V03_CONFORMANCE)
+
+    assert v02_corpus["status"] == "accepted"
+    assert opening_corpus["status"] == "accepted"
+    assert opening_corpus["accepted"] is True
+    assert opening_corpus["contract"] == "mts-definition-opening/v0.3"
+    assert v03_corpus["schema"] == "mts-conformance/v0.3"
+    assert v03_corpus["contract"] == "mts-contract/v0.3"
+    assert v03_corpus["status"] == "accepted"
+
+    required = {item["role"]: item for item in v03_corpus["requiredCorpora"]}
+    assert set(required) == {"base-v0.2", "definition-opening-v0.3"}
+    assert required["base-v0.2"]["schema"] == v02_corpus["schema"]
+    assert required["base-v0.2"]["contract"] == v02_corpus["contract"]
+    assert required["definition-opening-v0.3"]["schema"] == opening_corpus["schema"]
+    assert required["definition-opening-v0.3"]["contract"] == opening_corpus["contract"]
+    assert v03_corpus["releaseAssertions"]["allRequiredCorporaMustPass"] is True
+    assert v03_corpus["releaseAssertions"]["baseV02VectorsRemainAuthoritative"] is True
+
+
+def test_v03_adds_only_the_production_conformant_one_step_opening_operation():
+    v03 = read(V03)
+    opening = read(OPENING)
+    extension = v03["formalNotationExtensions"]["definitionOpening"]
+
+    assert opening["status"] == "accepted"
+    assert opening["integrationStatus"]["productionReferenceCoreImplemented"] is True
+    assert opening["integrationStatus"]["canonicalRootLibraryUsesDefinitionEnvironment"] is True
+    assert opening["integrationStatus"]["productionConformancePresent"] is True
+    assert opening["integrationStatus"]["mtsContractV03Published"] is True
+
+    assert extension["contract"] == "contracts/mts-definition-opening-v0.3.json"
+    assert extension["conformanceCorpus"] == opening["conformanceCorpus"]
+    assert extension["referenceCore"] == "core/mtc_definitions.py"
+    assert extension["operation"] == "open_definition"
+    assert extension["effect"] == "none"
+    assert extension["oneStep"] is True
+    assert extension["evaluatesBody"] is False
+    assert extension["definitionIsEquality"] is False
+    assert extension["openingIsInterpretation"] is False
+    assert extension["openingIsProofStep"] is False
+    assert extension["readsL4"] is False
+    assert extension["writesL4"] is False
+
+
+def test_v03_does_not_promote_relative_or_persistent_backend_candidates():
+    v03 = read(V03)
+    strings = all_strings(v03)
+
+    assert v03["l3Status"]["relative"] == "still RAW in production"
+    assert v03["l3Status"]["relativeV03ResearchAccepted"] is False
+    assert v03["l3Status"]["relativeCandidateArtifactsAreNormativeDependencies"] is False
+    assert v03["l4Status"]["persistentBackendContractAccepted"] is False
+    assert v03["l4Status"]["backendCandidateArtifactsAreNormativeDependencies"] is False
+    assert v03["l4Status"]["PMMIsCanonicalDependency"] is False
+
+    assert not any("anum-relative-context-decision/v0.3" in item for item in strings)
+    assert not any("anum-relative-carrier-path-challenge/v0.3" in item for item in strings)
+    assert not any("mts-l4-backend" in item for item in strings)
+
+
+def test_v03_keeps_l5_trusted_boundary_interpret_only():
+    v03 = read(V03)
+    proof = read(PROOF_V02)
+    l5 = v03["l5Boundary"]
+
+    assert proof["schema"] == "mts-proof/v0.2"
+    assert proof["checker"]["trustedRuleSet"] == ["interpret"]
+    assert l5["currentProofContract"] == "contracts/mts-proof-v0.2.json"
+    assert l5["currentTrustedRuleSet"] == ["interpret"]
+    assert l5["definitionOpeningTrustedRuleAccepted"] is False
+    assert l5["proofJudgmentV03Accepted"] is False
+    assert l5["nextIssue"] == 122
+    assert l5["searchRemainsUntrusted"] is True
+    assert l5["checkerRemainsTrusted"] is True
+    assert v03["downstream"]["aproverProofRepinAllowed"] is False
+
+
+def test_v03_preserves_exact_ten_definition_root_program():
+    v03 = read(V03)
+    definitions = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert v03["rootProgram"] == "tests/mtc_formulas.mtc"
+    assert v03["rootDefinitionCount"] == 10
+    assert len(definitions) == 10
+    assert definitions[-1] == "(!=) : ¬(=)"
+
+
+def test_v03_next_gate_is_non_normative_l5_judgment_challenge():
+    v03 = read(V03)
+    gate = v03["nextGate"]
+
+    assert gate["issue"] == 122
+    assert gate["artifactClass"] == "non-normative proof-judgment/calculus challenge"
+    assert gate["mustKeepMtsProofV02Unchanged"] is True
+    assert gate["mustNotTreatSuccessfulOpeningAsEquality"] is True
+    assert gate["mustNotAddTrustedRuleWithoutExecutableEvidence"] is True

--- a/tests/test_mts_definition_opening_challenge.py
+++ b/tests/test_mts_definition_opening_challenge.py
@@ -107,7 +107,7 @@ class NoMemory:
         raise AssertionError(f"unexpected L4 access: {name}")
 
 
-def test_challenge_and_corpus_remain_historical_non_normative_evidence():
+def test_challenge_remains_historical_while_its_vectors_are_promoted_to_conformance():
     data = challenge()
     vectors = corpus()
     selected = decision()["nextGate"]
@@ -117,7 +117,9 @@ def test_challenge_and_corpus_remain_historical_non_normative_evidence():
     assert data["schema"] == "mts-definition-opening-challenge/v0.3"
     assert data["status"] == "candidate-challenge"
     assert vectors["schema"] == "mts-definition-opening-conformance/v0.3"
-    assert vectors["status"] == "candidate-challenge-corpus"
+    assert vectors["status"] == "accepted"
+    assert vectors["accepted"] is True
+    assert vectors["contract"] == "mts-definition-opening/v0.3"
     assert selected["artifact"] == data["schema"]
     assert data["conformanceCorpus"] == "contracts/mts-definition-opening-conformance-v0.3.json"
     assert data["acceptedContractLinkAllowed"] is False

--- a/tests/test_mts_definition_opening_contract.py
+++ b/tests/test_mts_definition_opening_contract.py
@@ -11,6 +11,7 @@ from core.root_library import load_root_library
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-definition-opening-v0.3.json"
 MTS_V02 = ROOT / "contracts" / "mts-contract-v0.2.json"
+MTS_V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
 PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
 CORPUS = ROOT / "contracts" / "mts-definition-opening-conformance-v0.3.json"
 CHALLENGE = ROOT / "contracts" / "mts-definition-opening-challenge-v0.3.json"
@@ -21,9 +22,10 @@ def contract() -> dict:
     return json.loads(CONTRACT.read_text(encoding="utf-8"))
 
 
-def test_contract_is_accepted_integrated_but_does_not_retrofit_v02_umbrellas():
+def test_contract_is_accepted_integrated_and_published_only_through_v03_umbrella():
     data = contract()
     mts_v02 = MTS_V02.read_text(encoding="utf-8")
+    mts_v03 = json.loads(MTS_V03.read_text(encoding="utf-8"))
     proof_v02 = PROOF_V02.read_text(encoding="utf-8")
 
     assert data["schema"] == "mts-definition-opening/v0.3"
@@ -34,7 +36,7 @@ def test_contract_is_accepted_integrated_but_does_not_retrofit_v02_umbrellas():
     assert status["productionReferenceCoreImplemented"] is True
     assert status["canonicalRootLibraryUsesDefinitionEnvironment"] is True
     assert status["productionConformancePresent"] is True
-    assert status["mtsContractV03Published"] is False
+    assert status["mtsContractV03Published"] is True
     assert status["trustedL5RuleAccepted"] is False
     assert status["aproverRepinAllowed"] is False
 
@@ -49,6 +51,7 @@ def test_contract_is_accepted_integrated_but_does_not_retrofit_v02_umbrellas():
 
     assert "mts-definition-opening/v0.3" not in mts_v02
     assert "mts-definition-opening/v0.3" not in proof_v02
+    assert mts_v03["formalNotationExtensions"]["definitionOpening"]["contract"] == "contracts/mts-definition-opening-v0.3.json"
 
 
 def test_acceptance_depends_on_the_full_decision_and_challenge_chain():
@@ -66,7 +69,9 @@ def test_acceptance_depends_on_the_full_decision_and_challenge_chain():
     challenge = json.loads(CHALLENGE.read_text(encoding="utf-8"))
     corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
     assert challenge["status"] == "candidate-challenge"
-    assert corpus["status"] == "candidate-challenge-corpus"
+    assert corpus["status"] == "accepted"
+    assert corpus["accepted"] is True
+    assert corpus["contract"] == data["schema"]
     assert challenge["conformanceCorpus"] == "contracts/mts-definition-opening-conformance-v0.3.json"
 
 
@@ -186,16 +191,17 @@ def test_recursion_is_normatively_single_step_not_global_normalization():
     }
 
 
-def test_next_gate_is_v03_umbrella_then_separate_l5_work():
+def test_next_gate_is_separate_l5_judgment_challenge():
     gate = contract()["nextGate"]
     downstream = contract()["downstream"]
 
-    assert gate["goal"].startswith("publish mts-contract/v0.3 umbrella")
-    assert "do not add a second parser or interpreter" in gate["constraints"]
-    assert "do not turn Definition into Equality" in gate["constraints"]
-    assert "keep mts-proof/v0.2 trusted rule set unchanged until a separate L5 decision" in gate["constraints"]
-    assert gate["afterUmbrella"].startswith("start #122 proof-judgment/calculus challenge")
+    assert gate["issue"] == 122
+    assert gate["goal"].startswith("define a typed MTS proof judgment")
+    assert "keep mts-proof/v0.2 unchanged and interpret-only" in gate["constraints"]
+    assert "do not turn successful open_definition into A = F" in gate["constraints"]
+    assert "do not add trusted rules without executable soundness evidence" in gate["constraints"]
 
-    assert downstream["directRuntimePinBeforeV03Umbrella"] is False
+    assert downstream["genericL2ConsumerMayPinMtsContractV03"] is True
+    assert downstream["aproverProofRepinAllowed"] is False
     assert downstream["aproverMustNotInventLocalOpeningSemantics"] is True
-    assert downstream["futureConsumerMustUseVersionedV03Umbrella"] is True
+    assert downstream["futureProofConsumerMustWaitForVersionedL5Acceptance"] is True

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -11,8 +11,10 @@ from core.validate_root import validate_root_library
 
 ROOT = Path(__file__).resolve().parents[1]
 ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
-MTS_CONTRACT = ROOT / "contracts/mts-contract-v0.2.json"
-MTS_CONFORMANCE = ROOT / "contracts/mts-conformance-v0.2.json"
+MTS_CONTRACT_V02 = ROOT / "contracts/mts-contract-v0.2.json"
+MTS_CONFORMANCE_V02 = ROOT / "contracts/mts-conformance-v0.2.json"
+MTS_CONTRACT_V03 = ROOT / "contracts/mts-contract-v0.3.json"
+MTS_CONFORMANCE_V03 = ROOT / "contracts/mts-conformance-v0.3.json"
 ACTIVE_THEORY = {"Основания МТС.md", "Система аксиом МТС.md", "Пучки связей МТС.md"}
 ACTIVE_SPECS = {
     "Reference model МТС v0.2.md",
@@ -91,29 +93,45 @@ def test_root_fixture_is_exact_and_excludes_protocol_hypotheses():
     assert len([line for line in formula_text.splitlines() if line]) == 10
 
 
-def test_v02_machine_contract_and_conformance_are_single_active_pair():
-    assert MTS_CONTRACT.is_file()
-    assert MTS_CONFORMANCE.is_file()
+def test_versioned_machine_contract_and_conformance_chain_is_exact():
+    for path in (
+        MTS_CONTRACT_V02,
+        MTS_CONFORMANCE_V02,
+        MTS_CONTRACT_V03,
+        MTS_CONFORMANCE_V03,
+    ):
+        assert path.is_file()
 
-    contract = json.loads(MTS_CONTRACT.read_text(encoding="utf-8"))
-    corpus = json.loads(MTS_CONFORMANCE.read_text(encoding="utf-8"))
+    v02 = json.loads(MTS_CONTRACT_V02.read_text(encoding="utf-8"))
+    v02_corpus = json.loads(MTS_CONFORMANCE_V02.read_text(encoding="utf-8"))
+    v03 = json.loads(MTS_CONTRACT_V03.read_text(encoding="utf-8"))
+    v03_corpus = json.loads(MTS_CONFORMANCE_V03.read_text(encoding="utf-8"))
 
-    assert contract["schema"] == "mts-contract/v0.2"
-    assert contract["status"] == "accepted"
-    assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
-    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
-    assert contract["formalNotation"]["context"]["atomicPronouns"] is True
-    assert contract["formalNotation"]["context"]["bracketOverloading"] is False
-    assert contract["formalNotation"]["valueBundle"]["contract"] == "contracts/mts-value-bundle-v0.2.json"
+    assert v02["schema"] == "mts-contract/v0.2"
+    assert v02["status"] == "accepted"
+    assert v02["rootProgram"] == "tests/mtc_formulas.mtc"
+    assert v02["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
+    assert v02["formalNotation"]["context"]["atomicPronouns"] is True
+    assert v02["formalNotation"]["context"]["bracketOverloading"] is False
+    assert v02["formalNotation"]["valueBundle"]["contract"] == "contracts/mts-value-bundle-v0.2.json"
+    assert v02_corpus["schema"] == "mts-conformance/v0.2"
+    assert v02_corpus["contract"] == v02["schema"]
+    assert v02_corpus["status"] == "accepted"
 
-    assert corpus["schema"] == "mts-conformance/v0.2"
-    assert corpus["contract"] == contract["schema"]
-    assert corpus["status"] == "accepted"
+    assert v03["schema"] == "mts-contract/v0.3"
+    assert v03["status"] == "accepted"
+    assert v03["extends"] == v02["schema"]
+    assert v03["baseContract"] == "contracts/mts-contract-v0.2.json"
+    assert v03["rootProgram"] == v02["rootProgram"]
+    assert v03["conformanceCorpus"] == "contracts/mts-conformance-v0.3.json"
+    assert v03_corpus["schema"] == "mts-conformance/v0.3"
+    assert v03_corpus["contract"] == v03["schema"]
+    assert v03_corpus["status"] == "accepted"
 
     contract_files = sorted((ROOT / "contracts").glob("mts-contract-*.json"))
     conformance_files = sorted((ROOT / "contracts").glob("mts-conformance-*.json"))
-    assert contract_files == [MTS_CONTRACT]
-    assert conformance_files == [MTS_CONFORMANCE]
+    assert contract_files == [MTS_CONTRACT_V02, MTS_CONTRACT_V03]
+    assert conformance_files == [MTS_CONFORMANCE_V02, MTS_CONFORMANCE_V03]
 
 
 def test_candidate_runtime_fixture_and_reference_paths_are_removed_after_promotion():
@@ -121,6 +139,7 @@ def test_candidate_runtime_fixture_and_reference_paths_are_removed_after_promoti
     assert leftovers == []
     assert (ROOT / "core/mtc_interpreter.py").is_file()
     assert (ROOT / "core/mtc_value_bundle.py").is_file()
+    assert (ROOT / "core/mtc_definitions.py").is_file()
     assert (ROOT / "tests/test_mtc_interpreter.py").is_file()
 
 


### PR DESCRIPTION
Refs #120, #121, #122.

После merge #134 ветка чисто перебазирована на `main`; diff содержит только versioned umbrella и его guards.

## Versioned umbrella

Новый `mts-contract/v0.3` **не копирует и не редактирует v0.2 semantics**. Он явно `extends mts-contract/v0.2`, имеет `dependsOn=[mts-contract/v0.2, mts-definition-opening/v0.3]` и добавляет только уже accepted + production-conformant `mts-definition-opening/v0.3`.

Новый `mts-conformance/v0.3` композиционно требует два accepted corpus:
- полный `mts-conformance/v0.2`;
- `mts-definition-opening-conformance/v0.3`.

Opening corpus promotion меняет только normative metadata (`accepted` + contract back-reference); challenge vectors не меняются.

## Boundaries preserved

Umbrella явно фиксирует:
- root program остаётся теми же 10 definitions;
- `parse/interpret` semantics v0.2 не меняются;
- `open_definition` read-only, one-step, не equality/interpret/proof/realize;
- production relative Anum остаётся RAW; #123 candidate artifacts не становятся normative dependencies;
- persistent L4 backend остаётся candidate; PMM не становится canonical dependency;
- `mts-proof/v0.2` остаётся с `trustedRuleSet=[interpret]`;
- trusted definition-opening rule и proof judgment v0.3 **не приняты**;
- aprover proof repin ещё запрещён.

## Repository guard

`tests/test_repository_contract.py` проверяет точную versioned chain `[v0.2, v0.3]` вместо исторического предположения «существует только один contract file».

`tests/test_mts_contract_v03.py` проверяет dependency/composition graph, L3/L4/L5 negative boundaries и то, что следующий gate — non-normative #122 proof-judgment/calculus challenge.

Merge только при свежем green CI, `behind_by=0` и неизменном 8-file diff.