### PR TITLE
Выбрать typed operation claim как proof judgment МТС v0.3

### DIFF
--- a/contracts/mts-proof-judgment-decision-v0.3.json
+++ b/contracts/mts-proof-judgment-decision-v0.3.json
@@ -1,0 +1,161 @@
+{
+  "schema": "mts-proof-judgment-decision/v0.3",
+  "status": "candidate-decision",
+  "issue": 122,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-definition-opening/v0.3",
+    "mts-proof/v0.2"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionProofChangeAllowed": false,
+  "trustedRuleChangeAllowed": false,
+  "question": "What exact typed relation does an MTS proof artifact certify before any new inference rule is considered?",
+  "models": [
+    {
+      "id": "A",
+      "name": "formula-is-globally-true",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Current MTS contracts define contextual operations and local constraints, not a context-free global truth predicate over every Expression."
+    },
+    {
+      "id": "B",
+      "name": "global-equality-theorem-database",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Accepted equality is local contextual unification and successful definition opening does not assert A = F."
+    },
+    {
+      "id": "C",
+      "name": "typed-operation-claim",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "reason": "A claim can certify an exact result of an already accepted canonical read-only operation under explicit replay inputs without inventing truth, rewrite or hidden state."
+    },
+    {
+      "id": "D",
+      "name": "textual-rewrite-reachability",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Global textual substitution and recursive normalization are outside accepted definition/equality semantics."
+    },
+    {
+      "id": "E",
+      "name": "generic-inference-dag-before-judgment",
+      "verdict": "defer",
+      "accepted": false,
+      "reason": "Step composition cannot be defined soundly before the type and replay meaning of one claim are fixed."
+    }
+  ],
+  "preferredCandidate": {
+    "name": "ProofJudgment",
+    "kind": "typed operation claim with exact replay result",
+    "commonFields": {
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "artifact-local opaque identifier",
+      "operation": ["interpret", "open-definition"],
+      "expectedResult": "exact canonical operation result required for replay"
+    },
+    "successMeaning": "the trusted checker independently replays the declared canonical operation from explicit immutable inputs and obtains the exact declared result without mutating the supplied substrate",
+    "notEquivalentTo": [
+      "global formula truth",
+      "A = F merely because A : F opens",
+      "a mutable theorem database",
+      "proof-search success",
+      "textual normal form"
+    ],
+    "proofSearchIsPartOfJudgment": false,
+    "compositionRuleAccepted": false
+  },
+  "goalKinds": {
+    "interpret": {
+      "operation": "canonical v0.2 interpret",
+      "expression": "canonical L2 source parsed through the single parser",
+      "inputs": [
+        "ContextFrame snapshot",
+        "symbol -> LinkRef bindings",
+        "distinguished finite MemoryView snapshot"
+      ],
+      "expected": ["success", "local substitutions", "local aliases"],
+      "inheritsCurrentTrustedReplay": true,
+      "introducesNewInferenceRule": false
+    },
+    "open-definition": {
+      "operation": "canonical v0.3 open_definition",
+      "target": "canonical L2 source for one typed Form",
+      "inputs": ["explicit serialized lexical DefinitionEnvironment"],
+      "expected": ["kind", "DefinitionId when matched", "exact canonical RHS when matched"],
+      "takesContextFrame": false,
+      "takesMemoryView": false,
+      "assertsEquality": false,
+      "evaluatesReturnedBody": false,
+      "producesTrustedRuleByItself": false
+    }
+  },
+  "definitionEnvironmentSnapshot": {
+    "shape": "ordered array of lexical scopes",
+    "scope": {
+      "path": "int[]",
+      "parent": "null or parent int[]",
+      "definitions": "ordered canonical Definition source strings"
+    },
+    "replay": "reparse definitions and register them in order through canonical DefinitionEnvironment",
+    "definitionIdDerivation": "scope path + successful registration ordinal",
+    "hiddenCanonicalRootInjection": false,
+    "rootUse": "when root definitions are needed they are serialized explicitly in scope [] in canonical order",
+    "sourceSpanIsIdentity": false,
+    "displayTextIsDefinitionIdentity": false,
+    "persistentLinkIdIsDefinitionIdentity": false
+  },
+  "environmentBoundary": {
+    "environmentSnapshotIsTheoremPremise": false,
+    "environmentSnapshotRole": "explicit immutable replay substrate",
+    "ContextFrameOnlyForInterpretGoal": true,
+    "MemoryViewOnlyForInterpretGoal": true,
+    "DefinitionEnvironmentOnlyForOpeningGoal": true,
+    "implicitGlobalStateAllowed": false
+  },
+  "cycleBoundary": {
+    "openingIsOneStep": true,
+    "selfDefinitionTerminatesWithoutUnfolding": true,
+    "mutualDefinitionsTerminateWithoutUnfolding": true,
+    "futureMultiStepTraversalMustTrackDefinitionId": true,
+    "cyclicL1CarrierMayBeFiniteSnapshot": true
+  },
+  "trustedBoundary": {
+    "search": "untrusted",
+    "artifact": "untrusted input",
+    "checker": "trusted replay kernel",
+    "canonicalOperations": "trusted substrate only after their own accepted contracts",
+    "ui": "untrusted",
+    "trustedRulesAddedByThisDecision": []
+  },
+  "explicitlyRejectedOrDeferred": [
+    "successful opening implies equality",
+    "unrestricted symmetry",
+    "unrestricted transitivity",
+    "unrestricted congruence",
+    "global substitution",
+    "modus ponens",
+    "proof by textual normalization",
+    "generic step composition before a separate soundness challenge"
+  ],
+  "nextGate": {
+    "artifact": "mts-proof-judgment-challenge/v0.3",
+    "status": "candidate-challenge",
+    "mustNotChangeProductionProofSemantics": true,
+    "requiredVectors": [
+      "existing mts-proof/v0.2 interpret replay maps losslessly to an interpret ProofJudgment candidate",
+      "canonical root definition opening replays from an explicitly serialized root lexical scope",
+      "missing, conflict and non-addressable opening results remain exact replay claims",
+      "forged expected opening body is rejected by independent replay",
+      "forged interpret success/substitutions/aliases are rejected by independent replay",
+      "opening goal has no ContextFrame or MemoryView inputs",
+      "checker does not inject hidden root definitions",
+      "scope ordering deterministically reconstructs replay-local DefinitionId",
+      "self and mutual recursive definitions remain finite under one opening",
+      "memory and definition snapshots are unchanged by replay"
+    ]
+  }
+}

--- a/tests/test_mts_proof_judgment_decision.py
+++ b/tests/test_mts_proof_judgment_decision.py
@@ -1,0 +1,204 @@
+"""Executable evidence for the non-normative MTS proof-judgment decision v0.3."""
+
+import json
+from pathlib import Path
+
+from core.mtc_ast import Definition, Form, format_expression
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    open_definition,
+)
+from core.mtc_parser import parse_formula
+from core.root_library import load_root_library
+
+
+ROOT = Path(__file__).parents[1]
+DECISION = ROOT / "contracts" / "mts-proof-judgment-decision-v0.3.json"
+MTS_V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
+OPENING = ROOT / "contracts" / "mts-definition-opening-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def definition(source: str) -> Definition:
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
+
+
+def target(source: str) -> Form:
+    return definition(f"{source} : __proof_query__").target
+
+
+def reconstruct_scopes(scopes: list[dict]) -> dict[tuple[int, ...], DefinitionEnvironment]:
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+    for scope in sorted(scopes, key=lambda item: (len(item["path"]), item["path"])):
+        path = tuple(scope["path"])
+        parent_path = scope["parent"]
+        if parent_path is None:
+            assert path == ()
+            environment = DefinitionEnvironment()
+        else:
+            parent = environments[tuple(parent_path)]
+            assert path[:-1] == parent.scope_path
+            environment = parent.child(path[-1])
+        environments[path] = environment
+        for source in scope["definitions"]:
+            result = environment.register(definition(source))
+            assert result.kind is DefinitionRegistrationKind.REGISTERED
+    return environments
+
+
+def test_decision_is_non_normative_over_released_v03_and_current_v02_kernel():
+    data = read(DECISION)
+    mts_v03 = read(MTS_V03)
+    proof_v02 = read(PROOF_V02)
+
+    assert data["schema"] == "mts-proof-judgment-decision/v0.3"
+    assert data["status"] == "candidate-decision"
+    assert data["dependsOn"] == [
+        mts_v03["schema"],
+        "mts-definition-opening/v0.3",
+        proof_v02["schema"],
+    ]
+    assert data["acceptedContractLinkAllowed"] is False
+    assert data["productionProofChangeAllowed"] is False
+    assert data["trustedRuleChangeAllowed"] is False
+    assert proof_v02["checker"]["trustedRuleSet"] == ["interpret"]
+    assert data["trustedBoundary"]["trustedRulesAddedByThisDecision"] == []
+    assert data["schema"] not in MTS_V03.read_text(encoding="utf-8")
+
+
+def test_only_typed_operation_claim_is_preferred_and_no_composition_is_accepted():
+    models = {model["id"]: model for model in read(DECISION)["models"]}
+
+    assert models["A"]["verdict"] == "reject"
+    assert models["B"]["verdict"] == "reject"
+    assert models["C"]["verdict"] == "preferred-candidate"
+    assert models["D"]["verdict"] == "reject"
+    assert models["E"]["verdict"] == "defer"
+    assert all(model["accepted"] is False for model in models.values())
+
+    candidate = read(DECISION)["preferredCandidate"]
+    assert candidate["kind"] == "typed operation claim with exact replay result"
+    assert candidate["commonFields"]["contractVersion"] == "mts-contract/v0.3"
+    assert candidate["proofSearchIsPartOfJudgment"] is False
+    assert candidate["compositionRuleAccepted"] is False
+    assert "A = F merely because A : F opens" in candidate["notEquivalentTo"]
+
+
+def test_existing_interpret_replay_is_goal_kind_without_new_rule():
+    proof_v02 = read(PROOF_V02)
+    goal = read(DECISION)["goalKinds"]["interpret"]
+
+    assert proof_v02["checker"]["trustedRuleSet"] == ["interpret"]
+    assert goal["operation"] == "canonical v0.2 interpret"
+    assert goal["inheritsCurrentTrustedReplay"] is True
+    assert goal["introducesNewInferenceRule"] is False
+    assert goal["inputs"] == [
+        "ContextFrame snapshot",
+        "symbol -> LinkRef bindings",
+        "distinguished finite MemoryView snapshot",
+    ]
+
+
+def test_opening_goal_is_not_equality_interpretation_or_l4_execution():
+    opening = read(OPENING)
+    goal = read(DECISION)["goalKinds"]["open-definition"]
+
+    assert opening["operation"]["assertsEquality"] is False
+    assert opening["operation"]["evaluatesBody"] is False
+    assert opening["operation"]["readsL4"] is False
+    assert opening["operation"]["writesL4"] is False
+    assert goal["takesContextFrame"] is False
+    assert goal["takesMemoryView"] is False
+    assert goal["assertsEquality"] is False
+    assert goal["evaluatesReturnedBody"] is False
+    assert goal["producesTrustedRuleByItself"] is False
+
+
+def test_root_opening_replays_only_when_root_scope_is_explicit():
+    library = load_root_library(ROOT_PROGRAM)
+    root_sources = [formula.text for formula in library.formulas]
+    environments = reconstruct_scopes(
+        [{"path": [], "parent": None, "definitions": root_sources}]
+    )
+    root = environments[()]
+
+    assert len(root.entries()) == 10
+    for ordinal, formula in enumerate(library.formulas):
+        assert isinstance(formula.ast, Definition)
+        result = open_definition(formula.ast.target, root)
+        assert result.kind is DefinitionLookupKind.MATCH
+        assert result.definition_id is not None
+        assert result.definition_id.scope_path == ()
+        assert result.definition_id.ordinal == ordinal
+        assert result.body is not None
+        assert format_expression(result.body) == format_expression(formula.ast.value)
+
+    empty = DefinitionEnvironment()
+    assert open_definition(target("∞"), empty).kind is DefinitionLookupKind.NO_MATCH
+    snapshot = read(DECISION)["definitionEnvironmentSnapshot"]
+    assert snapshot["hiddenCanonicalRootInjection"] is False
+
+
+def test_scope_order_deterministically_reconstructs_definition_ids():
+    scopes = [
+        {"path": [], "parent": None, "definitions": ["a : b", "b : c"]},
+        {"path": [0], "parent": [], "definitions": ["a : child"]},
+    ]
+    left = reconstruct_scopes(scopes)
+    right = reconstruct_scopes(scopes)
+
+    left_root = open_definition(target("a"), left[()])
+    left_child = open_definition(target("a"), left[(0,)])
+    right_root = open_definition(target("a"), right[()])
+    right_child = open_definition(target("a"), right[(0,)])
+
+    assert left_root.definition_id == right_root.definition_id
+    assert left_child.definition_id == right_child.definition_id
+    assert left_root.definition_id != left_child.definition_id
+    assert left_root.definition_id is not None and left_root.definition_id.scope_path == ()
+    assert left_child.definition_id is not None and left_child.definition_id.scope_path == (0,)
+
+
+def test_self_and_mutual_definitions_remain_one_step_and_finite():
+    environment = DefinitionEnvironment()
+    for source in ("a : a", "b : c", "c : b"):
+        assert environment.register(definition(source)).kind is DefinitionRegistrationKind.REGISTERED
+
+    self_result = open_definition(target("a"), environment)
+    b_result = open_definition(target("b"), environment)
+    c_result = open_definition(target("c"), environment)
+    assert self_result.body is not None and format_expression(self_result.body) == "a"
+    assert b_result.body is not None and format_expression(b_result.body) == "c"
+    assert c_result.body is not None and format_expression(c_result.body) == "b"
+
+    cycle = read(DECISION)["cycleBoundary"]
+    assert cycle["openingIsOneStep"] is True
+    assert cycle["futureMultiStepTraversalMustTrackDefinitionId"] is True
+
+
+def test_environment_is_replay_substrate_not_hidden_theorem_premise():
+    boundary = read(DECISION)["environmentBoundary"]
+    assert boundary["environmentSnapshotIsTheoremPremise"] is False
+    assert boundary["environmentSnapshotRole"] == "explicit immutable replay substrate"
+    assert boundary["ContextFrameOnlyForInterpretGoal"] is True
+    assert boundary["MemoryViewOnlyForInterpretGoal"] is True
+    assert boundary["DefinitionEnvironmentOnlyForOpeningGoal"] is True
+    assert boundary["implicitGlobalStateAllowed"] is False
+
+
+def test_next_gate_is_challenge_not_production_checker_change():
+    gate = read(DECISION)["nextGate"]
+    assert gate["artifact"] == "mts-proof-judgment-challenge/v0.3"
+    assert gate["status"] == "candidate-challenge"
+    assert gate["mustNotChangeProductionProofSemantics"] is True
+    assert "forged expected opening body is rejected by independent replay" in gate["requiredVectors"]
+    assert "checker does not inject hidden root definitions" in gate["requiredVectors"]


### PR DESCRIPTION
Refs #122, #120.

После merge `mts-contract/v0.3` (#137) ветка чисто перебазирована на текущий `main`. Diff снова состоит только из двух non-normative decision-файлов.

## Решение под challenge

Предпочтительный кандидат базового ProofJudgment — **typed operation claim with exact replay result**, а не глобальная истина формулы и не equality theorem database.

Candidate goal kinds:
- `interpret`: существующий trusted replay `mts-proof/v0.2`, без нового правила;
- `open-definition`: точный replay принятого `open_definition`, но **не** утверждение `A = F`.

Definition environment сериализуется явно как ordered lexical scopes. Корневые definitions checker не подмешивает скрыто: если они нужны claim, они присутствуют явно в root scope.

Self/mutual recursion остаётся конечной, потому что один opening claim = один opening.

## Veto

Этот PR не:
- меняет production proof checker;
- расширяет `trustedRuleSet=[interpret]`;
- принимает symmetry/transitivity/congruence/MP/global substitution;
- принимает composition/DAG;
- разрешает aprover proof repin.

Следующий gate — отдельный executable `mts-proof-judgment-challenge/v0.3`. Merge только после свежего green CI и `behind_by=0`.