### PR TITLE
Выбрать focused-carrier result и explicit undefined inverse для relative Anum

### DIFF
--- a/contracts/anum-relative-result-decision-v0.3.json
+++ b/contracts/anum-relative-result-decision-v0.3.json
@@ -26,10 +26,10 @@
     },
     {
       "id": "C",
-      "name": "focused-rooted-l1-carrier-with-separate-provenance",
+      "name": "canonical-focused-rooted-l1-subcarrier-with-separate-provenance",
       "verdict": "preferred-candidate",
       "accepted": false,
-      "reason": "Reuse the accepted finite L1 carrier with root reset to the selected focus. Preserve the consumed raw path separately as source/replay provenance, not denotation identity."
+      "reason": "After traversal, keep only nodes reachable from the selected focus and deterministically reindex them by ordered BFS (root, then start/end). This removes context nodes that are no longer semantically observable and yields a portable finite rooted payload. Preserve the consumed raw path separately as source/replay provenance, not denotation identity."
     },
     {
       "id": "D",
@@ -42,19 +42,20 @@
   "preferredCandidate": {
     "result": {
       "kind": "relative-focused-carrier",
-      "denotationPayload": "same finite L1 CarrierGraph viewed with root = selected focus",
+      "denotationPayload": "canonical reachable rooted L1 subcarrier from selected focus",
+      "canonicalization": "deterministic BFS from selected focus, visiting start before end; drop unreachable context nodes; reindex visited nodes from 0; result root is 0",
       "sourceProvenance": "consumed raw bracket path",
       "pathParticipatesInDenotationIdentity": false,
-      "nodeIndexParticipatesInCrossLanguageIdentity": false,
+      "originalNodeIndexParticipatesInCrossLanguageIdentity": false,
       "persistentIdentity": false
     },
-    "equivalenceForConformance": "focus-rooted carrier topology must be isomorphic under ordered start/end edges; this is an engineering conformance equivalence, not L2 equality",
-    "sameFocusDifferentPaths": "same denotation payload, distinct provenance",
-    "unreachableContextNodes": "not observable through the focus-rooted denotation payload"
+    "equivalenceForConformance": "canonical payloads must be exactly equal after deterministic rooted reindex; rooted carrier isomorphism is a supporting engineering check, not L2 equality",
+    "sameFocusDifferentPaths": "same canonical denotation payload, distinct provenance",
+    "unreachableContextNodes": "removed from canonical denotation payload"
   },
   "inverseDecision": {
     "generalCanonicalSemanticInverse": "undefined in this candidate",
-    "reason": "cyclic/shared carriers can have multiple finite bracket paths selecting the same focused carrier; the denotation payload does not determine one path",
+    "reason": "cyclic/shared carriers can have multiple finite bracket paths selecting the same canonical focused carrier; the denotation payload does not determine one path",
     "sourcePreservingReplaySerialization": "allowed only when path provenance is retained",
     "sourceReplayIsCanonicalSemanticInverse": false,
     "shortestPathSelection": "forbidden unless separately justified and accepted",
@@ -82,12 +83,13 @@
     "status": "candidate-challenge",
     "mustNotChangeProductionRelativeSemantics": true,
     "requiredVectors": [
-      "same symbolic carrier under two local index assignments yields isomorphic focused result",
-      "[] and ][ selecting one focus yield same denotation payload but distinct path provenance",
+      "same symbolic carrier under two local index assignments yields byte-equivalent canonical focused payload",
+      "unreachable context nodes are removed by deterministic rooted canonicalization",
+      "[] and ][ selecting one focus yield same canonical denotation payload but distinct path provenance",
       "source replay reproduces each original bracket path when provenance exists",
       "dropping provenance makes general inverse explicitly undefined",
       "no shortest or lexicographic path is synthesized",
-      "cycles and sharing stay finite",
+      "cycles and sharing stay finite and preserve topology",
       "0/1 and mixed carriers remain unresolved",
       "production RELATIVE remains RAW",
       "no L4 or persistent identity"

--- a/contracts/anum-relative-result-decision-v0.3.json
+++ b/contracts/anum-relative-result-decision-v0.3.json
@@ -1,0 +1,96 @@
+{
+  "schema": "anum-relative-result-decision/v0.3",
+  "status": "candidate-decision",
+  "issue": 123,
+  "dependsOn": [
+    "anum-relative-context-decision/v0.3",
+    "anum-relative-carrier-path-challenge/v0.3"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionRelativeSemanticsChangeAllowed": false,
+  "question": "What is the typed result of bracket-only relative traversal, and what inverse is justified on cyclic/shared carriers?",
+  "models": [
+    {
+      "id": "A",
+      "name": "raw-node-index",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Description-local node numbers are not portable identity."
+    },
+    {
+      "id": "B",
+      "name": "selected-node-with-semantic-path",
+      "verdict": "reject-as-identity-model",
+      "accepted": false,
+      "reason": "The carrier-path challenge shows distinct paths may select one node; promoting path spelling into semantic identity would make source route rather than selected structure the denotation."
+    },
+    {
+      "id": "C",
+      "name": "focused-rooted-l1-carrier-with-separate-provenance",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "reason": "Reuse the accepted finite L1 carrier with root reset to the selected focus. Preserve the consumed raw path separately as source/replay provenance, not denotation identity."
+    },
+    {
+      "id": "D",
+      "name": "persistent-linkref-result",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Persistent/backend identity belongs to L4 and cannot define storage-neutral L3 relative denotation."
+    }
+  ],
+  "preferredCandidate": {
+    "result": {
+      "kind": "relative-focused-carrier",
+      "denotationPayload": "same finite L1 CarrierGraph viewed with root = selected focus",
+      "sourceProvenance": "consumed raw bracket path",
+      "pathParticipatesInDenotationIdentity": false,
+      "nodeIndexParticipatesInCrossLanguageIdentity": false,
+      "persistentIdentity": false
+    },
+    "equivalenceForConformance": "focus-rooted carrier topology must be isomorphic under ordered start/end edges; this is an engineering conformance equivalence, not L2 equality",
+    "sameFocusDifferentPaths": "same denotation payload, distinct provenance",
+    "unreachableContextNodes": "not observable through the focus-rooted denotation payload"
+  },
+  "inverseDecision": {
+    "generalCanonicalSemanticInverse": "undefined in this candidate",
+    "reason": "cyclic/shared carriers can have multiple finite bracket paths selecting the same focused carrier; the denotation payload does not determine one path",
+    "sourcePreservingReplaySerialization": "allowed only when path provenance is retained",
+    "sourceReplayIsCanonicalSemanticInverse": false,
+    "shortestPathSelection": "forbidden unless separately justified and accepted",
+    "lexicographicPathSelection": "forbidden unless separately justified and accepted",
+    "backendIdentityDisambiguation": false
+  },
+  "scope": {
+    "bracketOnlyForwardTraversal": true,
+    "relative0": "deferred",
+    "relative1": "deferred",
+    "mixedBracketBitCarriers": "deferred",
+    "relativeEquality": "deferred",
+    "productionRelativeRemainsRaw": true
+  },
+  "semanticSeparation": {
+    "rawPathIsDenotation": false,
+    "rawPathIsProvenance": true,
+    "carrierIsomorphismIsL2Equality": false,
+    "resultMayMaterialize": false,
+    "resultUsesMemoryView": false,
+    "resultUsesContextFrameParent": false
+  },
+  "nextGate": {
+    "artifact": "anum-relative-result-inverse-challenge/v0.3",
+    "status": "candidate-challenge",
+    "mustNotChangeProductionRelativeSemantics": true,
+    "requiredVectors": [
+      "same symbolic carrier under two local index assignments yields isomorphic focused result",
+      "[] and ][ selecting one focus yield same denotation payload but distinct path provenance",
+      "source replay reproduces each original bracket path when provenance exists",
+      "dropping provenance makes general inverse explicitly undefined",
+      "no shortest or lexicographic path is synthesized",
+      "cycles and sharing stay finite",
+      "0/1 and mixed carriers remain unresolved",
+      "production RELATIVE remains RAW",
+      "no L4 or persistent identity"
+    ]
+  }
+}

--- a/tests/test_anum_relative_result_decision.py
+++ b/tests/test_anum_relative_result_decision.py
@@ -1,0 +1,187 @@
+"""Executable evidence for the non-normative relative-result decision v0.3."""
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+from core.anum_denotation import DenotationKind
+from core.anum_model import Abit, ProjectionContext
+from core.anum_parser import parse_raw_quaternary
+from core.anum_recursive_denotation import denotate_recursive_anum
+from core.semantic_carrier import CarrierGraph, LinkNode, carrier_isomorphic
+
+
+ROOT = Path(__file__).parents[1]
+DECISION = ROOT / "contracts" / "anum-relative-result-decision-v0.3.json"
+PATH_CHALLENGE = ROOT / "contracts" / "anum-relative-carrier-path-challenge-v0.3.json"
+PATH_CORPUS = ROOT / "contracts" / "anum-relative-carrier-path-conformance-v0.3.json"
+
+
+@dataclass(frozen=True)
+class CandidateRelativeResult:
+    focused: CarrierGraph
+    raw_path_provenance: str
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_carrier(assignment: dict[str, int]) -> CarrierGraph:
+    symbolic = read(PATH_CORPUS)["symbolicCarrier"]
+    nodes: list[LinkNode | None] = [None] * len(assignment)
+    for name, poles in symbolic["nodes"].items():
+        nodes[assignment[name]] = LinkNode(
+            start=assignment[poles["start"]],
+            end=assignment[poles["end"]],
+        )
+    assert all(node is not None for node in nodes)
+    return CarrierGraph(
+        nodes=tuple(node for node in nodes if node is not None),
+        root=assignment[symbolic["focus"]],
+    )
+
+
+def candidate_select(raw: str, graph: CarrierGraph) -> CandidateRelativeResult:
+    form = parse_raw_quaternary(raw)
+    selected = graph.root
+    for token in form.tokens:
+        if token.abit is Abit.OPEN:
+            selected = graph.nodes[selected].start
+        elif token.abit is Abit.CLOSE:
+            selected = graph.nodes[selected].end
+        else:
+            raise ValueError("relative 0/1 are deferred")
+    return CandidateRelativeResult(
+        focused=CarrierGraph(nodes=graph.nodes, root=selected),
+        raw_path_provenance=raw,
+    )
+
+
+def replay_serialize(result: CandidateRelativeResult) -> str:
+    """Source replay from provenance; deliberately not a semantic inverse."""
+
+    return result.raw_path_provenance
+
+
+def semantic_inverse_without_provenance(_focused: CarrierGraph) -> None:
+    """The candidate explicitly has no general canonical inverse."""
+
+    return None
+
+
+def test_decision_is_non_normative_and_selects_focused_carrier_with_provenance():
+    data = read(DECISION)
+    challenge = read(PATH_CHALLENGE)
+    models = {model["id"]: model for model in data["models"]}
+
+    assert data["schema"] == "anum-relative-result-decision/v0.3"
+    assert data["status"] == "candidate-decision"
+    assert data["dependsOn"] == [
+        "anum-relative-context-decision/v0.3",
+        challenge["schema"],
+    ]
+    assert data["acceptedContractLinkAllowed"] is False
+    assert data["productionRelativeSemanticsChangeAllowed"] is False
+    assert models["A"]["verdict"] == "reject"
+    assert models["B"]["verdict"] == "reject-as-identity-model"
+    assert models["C"]["verdict"] == "preferred-candidate"
+    assert models["D"]["verdict"] == "reject"
+    assert all(model["accepted"] is False for model in models.values())
+
+
+def test_same_symbolic_selection_is_portable_across_local_node_numberings():
+    assignments = read(PATH_CORPUS)["indexAssignments"]
+    left = build_carrier(assignments[0])
+    right = build_carrier(assignments[1])
+
+    for vector in read(PATH_CORPUS)["positivePaths"]:
+        left_result = candidate_select(vector["raw"], left)
+        right_result = candidate_select(vector["raw"], right)
+        assert carrier_isomorphic(left_result.focused, right_result.focused), vector["raw"]
+        assert left_result.raw_path_provenance == right_result.raw_path_provenance == vector["raw"]
+
+
+def test_distinct_paths_to_same_focus_share_denotation_payload_but_not_provenance():
+    graph = build_carrier(read(PATH_CORPUS)["indexAssignments"][0])
+    results = [candidate_select(raw, graph) for raw in ("[]", "][", "[][]")]
+
+    assert all(carrier_isomorphic(results[0].focused, result.focused) for result in results[1:])
+    assert [result.raw_path_provenance for result in results] == ["[]", "][", "[][]"]
+
+    preferred = read(DECISION)["preferredCandidate"]
+    assert preferred["sameFocusDifferentPaths"] == "same denotation payload, distinct provenance"
+    assert preferred["result"]["pathParticipatesInDenotationIdentity"] is False
+
+
+def test_source_replay_is_available_from_provenance_but_is_not_semantic_inverse():
+    graph = build_carrier(read(PATH_CORPUS)["indexAssignments"][0])
+
+    for raw in ("[", "]", "[[", "]]", "[]", "][", "[][]"):
+        result = candidate_select(raw, graph)
+        assert replay_serialize(result) == raw
+        assert semantic_inverse_without_provenance(result.focused) is None
+
+    inverse = read(DECISION)["inverseDecision"]
+    assert inverse["generalCanonicalSemanticInverse"] == "undefined in this candidate"
+    assert inverse["sourcePreservingReplaySerialization"] == "allowed only when path provenance is retained"
+    assert inverse["sourceReplayIsCanonicalSemanticInverse"] is False
+    assert inverse["shortestPathSelection"].startswith("forbidden")
+    assert inverse["lexicographicPathSelection"].startswith("forbidden")
+    assert inverse["backendIdentityDisambiguation"] is False
+
+
+def test_focused_payload_ignores_unreachable_context_nodes_for_conformance():
+    graph = build_carrier(read(PATH_CORPUS)["indexAssignments"][0])
+    result = candidate_select("[[", graph)
+
+    # The selected SS node reaches only SS and S, despite the original context
+    # also containing F/E/EE. Carrier conformance is rooted at the selection.
+    reachable_variant = CarrierGraph(
+        nodes=(
+            LinkNode(start=0, end=1),
+            LinkNode(start=0, end=1),
+        ),
+        root=0,
+    )
+    assert carrier_isomorphic(result.focused, reachable_variant)
+    assert read(DECISION)["preferredCandidate"]["unreachableContextNodes"] == "not observable through the focus-rooted denotation payload"
+
+
+def test_relative_bits_and_mixed_carriers_remain_deferred():
+    graph = build_carrier(read(PATH_CORPUS)["indexAssignments"][0])
+    for raw in read(PATH_CORPUS)["unresolvedPaths"]:
+        try:
+            candidate_select(raw, graph)
+        except ValueError as error:
+            assert "0/1 are deferred" in str(error)
+        else:
+            raise AssertionError(f"relative path unexpectedly accepted: {raw}")
+
+    scope = read(DECISION)["scope"]
+    assert scope["relative0"] == "deferred"
+    assert scope["relative1"] == "deferred"
+    assert scope["mixedBracketBitCarriers"] == "deferred"
+    assert scope["relativeEquality"] == "deferred"
+
+
+def test_production_relative_semantics_remain_raw():
+    for raw in ("[", "]", "[[", "]]", "[]", "][", "0", "1", "[0"):
+        result = denotate_recursive_anum(
+            parse_raw_quaternary(raw),
+            ProjectionContext.RELATIVE,
+        )
+        assert result.kind is DenotationKind.RAW
+        assert result.raw == raw
+
+    assert read(DECISION)["scope"]["productionRelativeRemainsRaw"] is True
+
+
+def test_next_gate_challenges_result_and_undefined_inverse_before_production():
+    gate = read(DECISION)["nextGate"]
+
+    assert gate["artifact"] == "anum-relative-result-inverse-challenge/v0.3"
+    assert gate["status"] == "candidate-challenge"
+    assert gate["mustNotChangeProductionRelativeSemantics"] is True
+    assert "dropping provenance makes general inverse explicitly undefined" in gate["requiredVectors"]
+    assert "no shortest or lexicographic path is synthesized" in gate["requiredVectors"]

--- a/tests/test_anum_relative_result_decision.py
+++ b/tests/test_anum_relative_result_decision.py
@@ -131,20 +131,20 @@ def test_source_replay_is_available_from_provenance_but_is_not_semantic_inverse(
     assert inverse["backendIdentityDisambiguation"] is False
 
 
-def test_focused_payload_ignores_unreachable_context_nodes_for_conformance():
-    graph = build_carrier(read(PATH_CORPUS)["indexAssignments"][0])
-    result = candidate_select("[[", graph)
-
-    # The selected SS node reaches only SS and S, despite the original context
-    # also containing F/E/EE. Carrier conformance is rooted at the selection.
-    reachable_variant = CarrierGraph(
+def test_focused_payload_ignores_truly_unreachable_context_nodes_for_conformance():
+    focused_with_extra = CarrierGraph(
         nodes=(
-            LinkNode(start=0, end=1),
-            LinkNode(start=0, end=1),
+            LinkNode(start=0, end=0),
+            LinkNode(start=1, end=1),
         ),
         root=0,
     )
-    assert carrier_isomorphic(result.focused, reachable_variant)
+    focused_without_extra = CarrierGraph(
+        nodes=(LinkNode(start=0, end=0),),
+        root=0,
+    )
+
+    assert carrier_isomorphic(focused_with_extra, focused_without_extra)
     assert read(DECISION)["preferredCandidate"]["unreachableContextNodes"] == "not observable through the focus-rooted denotation payload"
 
 

--- a/tests/test_anum_relative_result_decision.py
+++ b/tests/test_anum_relative_result_decision.py
@@ -8,7 +8,12 @@ from core.anum_denotation import DenotationKind
 from core.anum_model import Abit, ProjectionContext
 from core.anum_parser import parse_raw_quaternary
 from core.anum_recursive_denotation import denotate_recursive_anum
-from core.semantic_carrier import CarrierGraph, LinkNode, carrier_isomorphic
+from core.semantic_carrier import (
+    CarrierGraph,
+    LinkNode,
+    carrier_isomorphic,
+    reachable_indices,
+)
 
 
 ROOT = Path(__file__).parents[1]
@@ -42,6 +47,22 @@ def build_carrier(assignment: dict[str, int]) -> CarrierGraph:
     )
 
 
+def canonical_rooted_subcarrier(graph: CarrierGraph, root: int) -> CarrierGraph:
+    """Drop unreachable context and deterministically reindex rooted topology."""
+
+    rooted = CarrierGraph(nodes=graph.nodes, root=root)
+    order = reachable_indices(rooted)
+    mapping = {old: new for new, old in enumerate(order)}
+    nodes = tuple(
+        LinkNode(
+            start=mapping[graph.nodes[old].start],
+            end=mapping[graph.nodes[old].end],
+        )
+        for old in order
+    )
+    return CarrierGraph(nodes=nodes, root=0)
+
+
 def candidate_select(raw: str, graph: CarrierGraph) -> CandidateRelativeResult:
     form = parse_raw_quaternary(raw)
     selected = graph.root
@@ -53,7 +74,7 @@ def candidate_select(raw: str, graph: CarrierGraph) -> CandidateRelativeResult:
         else:
             raise ValueError("relative 0/1 are deferred")
     return CandidateRelativeResult(
-        focused=CarrierGraph(nodes=graph.nodes, root=selected),
+        focused=canonical_rooted_subcarrier(graph, selected),
         raw_path_provenance=raw,
     )
 
@@ -70,7 +91,7 @@ def semantic_inverse_without_provenance(_focused: CarrierGraph) -> None:
     return None
 
 
-def test_decision_is_non_normative_and_selects_focused_carrier_with_provenance():
+def test_decision_is_non_normative_and_selects_canonical_focused_carrier():
     data = read(DECISION)
     challenge = read(PATH_CHALLENGE)
     models = {model["id"]: model for model in data["models"]}
@@ -89,8 +110,13 @@ def test_decision_is_non_normative_and_selects_focused_carrier_with_provenance()
     assert models["D"]["verdict"] == "reject"
     assert all(model["accepted"] is False for model in models.values())
 
+    result = data["preferredCandidate"]["result"]
+    assert result["denotationPayload"] == "canonical reachable rooted L1 subcarrier from selected focus"
+    assert "deterministic BFS" in result["canonicalization"]
+    assert result["pathParticipatesInDenotationIdentity"] is False
 
-def test_same_symbolic_selection_is_portable_across_local_node_numberings():
+
+def test_same_symbolic_selection_has_exact_canonical_payload_across_node_numberings():
     assignments = read(PATH_CORPUS)["indexAssignments"]
     left = build_carrier(assignments[0])
     right = build_carrier(assignments[1])
@@ -98,19 +124,20 @@ def test_same_symbolic_selection_is_portable_across_local_node_numberings():
     for vector in read(PATH_CORPUS)["positivePaths"]:
         left_result = candidate_select(vector["raw"], left)
         right_result = candidate_select(vector["raw"], right)
+        assert left_result.focused == right_result.focused, vector["raw"]
         assert carrier_isomorphic(left_result.focused, right_result.focused), vector["raw"]
         assert left_result.raw_path_provenance == right_result.raw_path_provenance == vector["raw"]
 
 
-def test_distinct_paths_to_same_focus_share_denotation_payload_but_not_provenance():
+def test_distinct_paths_to_same_focus_share_canonical_payload_but_not_provenance():
     graph = build_carrier(read(PATH_CORPUS)["indexAssignments"][0])
     results = [candidate_select(raw, graph) for raw in ("[]", "][", "[][]")]
 
-    assert all(carrier_isomorphic(results[0].focused, result.focused) for result in results[1:])
+    assert all(results[0].focused == result.focused for result in results[1:])
     assert [result.raw_path_provenance for result in results] == ["[]", "][", "[][]"]
 
     preferred = read(DECISION)["preferredCandidate"]
-    assert preferred["sameFocusDifferentPaths"] == "same denotation payload, distinct provenance"
+    assert preferred["sameFocusDifferentPaths"] == "same canonical denotation payload, distinct provenance"
     assert preferred["result"]["pathParticipatesInDenotationIdentity"] is False
 
 
@@ -131,21 +158,43 @@ def test_source_replay_is_available_from_provenance_but_is_not_semantic_inverse(
     assert inverse["backendIdentityDisambiguation"] is False
 
 
-def test_focused_payload_ignores_truly_unreachable_context_nodes_for_conformance():
-    focused_with_extra = CarrierGraph(
+def test_canonical_payload_drops_unreachable_context_nodes():
+    with_extra = CarrierGraph(
         nodes=(
             LinkNode(start=0, end=0),
             LinkNode(start=1, end=1),
         ),
         root=0,
     )
-    focused_without_extra = CarrierGraph(
+    without_extra = CarrierGraph(
         nodes=(LinkNode(start=0, end=0),),
         root=0,
     )
 
-    assert carrier_isomorphic(focused_with_extra, focused_without_extra)
-    assert read(DECISION)["preferredCandidate"]["unreachableContextNodes"] == "not observable through the focus-rooted denotation payload"
+    canonical_extra = canonical_rooted_subcarrier(with_extra, with_extra.root)
+    canonical_plain = canonical_rooted_subcarrier(without_extra, without_extra.root)
+    assert canonical_extra == canonical_plain == without_extra
+    assert read(DECISION)["preferredCandidate"]["unreachableContextNodes"] == "removed from canonical denotation payload"
+
+
+def test_canonicalization_preserves_cycles_and_sharing():
+    graph = CarrierGraph(
+        nodes=(
+            LinkNode(start=1, end=1),
+            LinkNode(start=1, end=2),
+            LinkNode(start=1, end=2),
+        ),
+        root=0,
+    )
+    canonical = canonical_rooted_subcarrier(graph, graph.root)
+
+    assert canonical.root == 0
+    assert canonical.nodes == (
+        LinkNode(start=1, end=1),
+        LinkNode(start=1, end=2),
+        LinkNode(start=1, end=2),
+    )
+    assert carrier_isomorphic(graph, canonical)
 
 
 def test_relative_bits_and_mixed_carriers_remain_deferred():
@@ -177,11 +226,13 @@ def test_production_relative_semantics_remain_raw():
     assert read(DECISION)["scope"]["productionRelativeRemainsRaw"] is True
 
 
-def test_next_gate_challenges_result_and_undefined_inverse_before_production():
+def test_next_gate_challenges_canonical_result_and_undefined_inverse_before_production():
     gate = read(DECISION)["nextGate"]
 
     assert gate["artifact"] == "anum-relative-result-inverse-challenge/v0.3"
     assert gate["status"] == "candidate-challenge"
     assert gate["mustNotChangeProductionRelativeSemantics"] is True
+    assert "same symbolic carrier under two local index assignments yields byte-equivalent canonical focused payload" in gate["requiredVectors"]
+    assert "unreachable context nodes are removed by deterministic rooted canonicalization" in gate["requiredVectors"]
     assert "dropping provenance makes general inverse explicitly undefined" in gate["requiredVectors"]
     assert "no shortest or lexicographic path is synthesized" in gate["requiredVectors"]


### PR DESCRIPTION
Refs #123, #120.

Stacked on #136. Это non-normative decision; production `ProjectionContext.RELATIVE` остаётся RAW.

## Result model

После carrier-path challenge предпочтительный кандидат:
- после traversal берётся только подграф, достижимый от выбранного focus;
- он детерминированно перенумеровывается BFS: root, затем start перед end; итоговый root = 0;
- недостижимые context-nodes физически удаляются из denotation payload;
- consumed bracket path хранится отдельно как source/replay provenance;
- path **не** входит в denotation identity;
- исходный node index и persistent LinkRef не являются identity.

Для cross-language conformance два изоморфных focused carriers после canonicalization должны давать **точно одинаковый payload**. `carrier_isomorphic` остаётся supporting engineering check, не оператором L2 `=`.

## Collision finding

`[]`, `][` и `[][]` в challenge могут выбрать один focus. В выбранной модели это:
- один canonical denotation payload;
- разная provenance.

Так маршрут чтения не превращается в смысл результата.

## Inverse

General canonical semantic inverse для cyclic/shared relative context **явно undefined** в этом candidate. Если provenance сохранена, raw path можно воспроизвести byte-for-byte, но это source replay, не canonical inverse denotation.

Запрещено молча выбирать shortest/lexicographic path или использовать backend identity.

`0/1`, mixed carriers и relative equality остаются deferred. Следующий gate — отдельный result/inverse challenge; production semantics не меняется.