### PR TITLE
Добавить language-neutral L4 backend conformance driver v0.3

### DIFF
--- a/contracts/mts-l4-backend-driver-conformance-v0.3.json
+++ b/contracts/mts-l4-backend-driver-conformance-v0.3.json
@@ -1,0 +1,114 @@
+{
+  "schema": "mts-l4-backend-driver-conformance/v0.3",
+  "status": "candidate-challenge-corpus",
+  "contract": "mts-l4-backend-driver/v0.3",
+  "sourceCorpus": "contracts/mts-l4-backend-conformance-v0.3.json",
+  "protocolVectors": [
+    {
+      "id": "hello-reference-capabilities",
+      "request": {"id": "hello-0", "op": "hello"},
+      "expect": {
+        "id": "hello-0",
+        "ok": true,
+        "result": {
+          "protocol": "mts-l4-backend-driver/v0.3",
+          "capabilities": {
+            "exact-pair": true,
+            "incidence": true,
+            "explicit-delete": true,
+            "atomic-multi-link-realize": true,
+            "enumeration": true,
+            "persistence": false,
+            "crash-recovery": false
+          }
+        }
+      }
+    },
+    {
+      "id": "unknown-op-is-normalized-error",
+      "request": {"id": "bad-op", "op": "invent-mts-semantics"},
+      "expect": {
+        "id": "bad-op",
+        "ok": false,
+        "error": {"code": "invalid-request"}
+      }
+    },
+    {
+      "id": "persistence-command-is-capability-error",
+      "request": {"id": "close-0", "op": "close"},
+      "expect": {
+        "id": "close-0",
+        "ok": false,
+        "error": {"code": "capability-not-supported"}
+      }
+    }
+  ],
+  "referenceAssignments": [
+    {"root": 0, "zero": 1, "one": 2},
+    {"root": 10, "zero": 20, "one": 30}
+  ],
+  "coreReplay": {
+    "scenarioIds": [
+      "read-missing-pair",
+      "realize-exact-pair",
+      "realize-idempotent",
+      "delete-safety",
+      "closed-cycle-bootstrap",
+      "structural-denotation-atomicity"
+    ],
+    "mustMatchSourceCorpusExactly": true,
+    "runAgainstEveryReferenceAssignment": true,
+    "normalizedObservationsMustMatchAcrossAssignments": true
+  },
+  "fixtureCompilation": {
+    "sourceScenario": "structural-denotation-atomicity",
+    "sourceRaw": "[01]1",
+    "sourceContext": "root",
+    "driverRequestMustContain": ["kind", "anchors", "nodes", "root"],
+    "driverRequestMustNotContain": ["sourceRaw", "context", "ProjectionContext"],
+    "nodeBindingPattern": "@<scenario-id>:node:<id>",
+    "rootBinding": "denotationRoot"
+  },
+  "normalizationVectors": [
+    {
+      "id": "snapshot-never-contains-backend-handles",
+      "expect": "all live links are represented only by scenario-local symbolic names"
+    },
+    {
+      "id": "new-handle-values-may-differ",
+      "expect": "realize-exact-pair returns different native refs under the two reference assignments while normalized result stays equal"
+    },
+    {
+      "id": "sets-ignore-native-enumeration-order",
+      "expect": "outgoing/incoming/all_links responses sort symbolic names"
+    }
+  ],
+  "capabilityVectors": {
+    "referenceUnsupportedPersistentScenarios": [
+      "clean-reopen",
+      "realize-after-reopen",
+      "index-consistency-after-reopen",
+      "interrupted-atomic-commit"
+    ],
+    "unsupportedIsNotSemanticPass": true,
+    "futurePersistentDriverMustRun": [
+      "clean-reopen",
+      "realize-after-reopen",
+      "index-consistency-after-reopen"
+    ],
+    "futureCrashRecoveryDriverMustRun": ["interrupted-atomic-commit"]
+  },
+  "mutationVeto": {
+    "findSnapshotUnchanged": true,
+    "rejectedDeleteSnapshotUnchanged": true,
+    "missingAnchorSnapshotUnchanged": true,
+    "repeatRealizeSnapshotUnchanged": true
+  },
+  "wireVeto": {
+    "rawBackendHandle": false,
+    "physicalAddress": false,
+    "rawAnum": false,
+    "projectionContext": false,
+    "L2Expression": false
+  }
+}

--- a/contracts/mts-l4-backend-driver-v0.3.json
+++ b/contracts/mts-l4-backend-driver-v0.3.json
@@ -1,0 +1,155 @@
+{
+  "schema": "mts-l4-backend-driver/v0.3",
+  "status": "candidate-challenge",
+  "issue": 141,
+  "parentIssue": 124,
+  "dependsOn": [
+    "mts-l4-backend-decision/v0.3",
+    "mts-l4-backend-challenge/v0.3",
+    "mts-l4-backend-conformance/v0.3",
+    "anum-denotation/v0.2"
+  ],
+  "conformanceCorpus": "contracts/mts-l4-backend-driver-conformance-v0.3.json",
+  "acceptedContractLinkAllowed": false,
+  "productionBackendContractAccepted": false,
+  "purpose": "Define a language-neutral conformance-driver boundary so the exact #130 symbolic traces can be replayed against Python AnumMemory, a future PMM adapter, and other backends without putting L2/L3 semantics or physical identity into the storage driver.",
+  "architecture": {
+    "layers": [
+      "canonical #130 trace corpus",
+      "common conformance runner",
+      "L3 fixture compiler only when a trace references sourceRaw/context",
+      "language-neutral driver request/response protocol",
+      "backend adapter",
+      "storage engine"
+    ],
+    "driverParsesRawAnum": false,
+    "driverRunsL2Interpreter": false,
+    "driverReceivesOnlyStructuralDenotationIR": true,
+    "fixtureCompilerUsesCanonicalL3": true,
+    "backendSpecificVocabularyAllowedInCanonicalCorpus": false
+  },
+  "wire": {
+    "transportCandidate": "deterministic UTF-8 JSON objects; JSONL process framing is the first external-driver candidate",
+    "request": {
+      "required": ["id", "op"],
+      "optional": ["args"],
+      "id": "caller-chosen opaque string used only to correlate response",
+      "op": "one operation from operationSurface"
+    },
+    "successResponse": {"required": ["id", "ok", "result"], "ok": true},
+    "errorResponse": {"required": ["id", "ok", "error"], "ok": false},
+    "deterministicEncoding": true,
+    "backendHandleMayAppear": false,
+    "physicalAddressMayAppear": false
+  },
+  "capabilities": {
+    "requiredCore": [
+      "exact-pair",
+      "incidence",
+      "explicit-delete",
+      "atomic-multi-link-realize"
+    ],
+    "optional": [
+      "enumeration",
+      "persistence",
+      "crash-recovery"
+    ],
+    "negotiation": "hello response returns booleans for the complete known capability set",
+    "missingOptionalCapabilityIsPass": false,
+    "persistentAcceptanceRequiresPersistenceCapability": true,
+    "crashRecoveryVectorRequiresCrashRecoveryCapability": true
+  },
+  "operationSurface": {
+    "hello": "return protocol schema and capabilities; no state mutation",
+    "create": "initialize one workspace from a closed symbolic seed graph",
+    "snapshot": "return normalized symbolic live topology; no backend handles",
+    "poles": "read ordered symbolic start/end names",
+    "find_link": "read exact pair; return symbolic binding or null; never realize",
+    "outgoing": "read normalized set of symbolic link names",
+    "incoming": "read normalized set of symbolic link names",
+    "all_links": "optional normalized enumeration",
+    "realize_link": "explicit exact-pair realization and scenario-local symbolic bind",
+    "realize_structural_denotation": "explicit atomic realization from anum-denotation/v0.2 structural IR, external anchor-name bindings and deterministic scenario-local node bindings",
+    "delete_link": "explicit non-cascading delete",
+    "close": "persistent capability only",
+    "reopen": "persistent capability only"
+  },
+  "symbolicBinding": {
+    "scope": "one conformance scenario/workspace",
+    "meaning": "driver-side alias from scenario-local name to opaque backend handle",
+    "semanticIdentity": false,
+    "persistentIdentity": false,
+    "multipleNamesMayAliasOneHandle": true,
+    "normalizedRef": "lexicographically smallest currently bound scenario name for a live handle",
+    "unboundLiveHandleInObservation": "driver-protocol-error"
+  },
+  "snapshotNormalization": {
+    "shape": "sorted array of {ref,start,end} using normalized symbolic names",
+    "sortKey": "ref then start then end as Unicode strings",
+    "nativeEnumerationOrderSemantic": false,
+    "backendHandleValueSemantic": false,
+    "rawStorePayloadIncluded": false
+  },
+  "structuralDenotationBoundary": {
+    "wireInput": "canonical data shape from anum-denotation/v0.2 with kind=structural",
+    "sourceRawAllowedOnDriverWire": false,
+    "projectionContextAllowedOnDriverWire": false,
+    "commonRunnerMayCompileSourceFixture": true,
+    "compilePipeline": "parse_raw_quaternary -> denotate_recursive_anum(explicit context) -> canonical structural IR before driver dispatch",
+    "nodeBindings": "request supplies deterministic scenario-local names for every description-local node id so newly realized internal links are observable without exposing backend handles",
+    "rootBinding": "request may add a scenario-local alias for the resolved denotation root",
+    "atomicity": "backend adapter must not expose partial new links if validation/anchor resolution/write fails"
+  },
+  "normalizedErrors": [
+    "invalid-request",
+    "workspace-not-open",
+    "capability-not-supported",
+    "unknown-binding",
+    "binding-conflict",
+    "unknown-link",
+    "link-in-use",
+    "missing-anchor",
+    "non-structural-denotation",
+    "driver-protocol-error",
+    "backend-error"
+  ],
+  "lifecycle": {
+    "referenceAnumMemory": {
+      "persistence": false,
+      "crashRecovery": false,
+      "closeReopenImplemented": false
+    },
+    "persistentDriver": {
+      "workspacePathIsExplicitInput": true,
+      "closeFlushSemanticsOwnedByBackendAdapter": true,
+      "reopenMayReturnDifferentOpaqueHandles": true,
+      "normalizedTopologyMustRemainEquivalent": true
+    }
+  },
+  "referenceImplementation": {
+    "path": "converters/l4_backend_driver.py",
+    "backend": "core.anum_memory.AnumMemory",
+    "purpose": "challenge protocol and normalization only; not a second L4 semantics",
+    "sameCoreCorpusRequired": true,
+    "differentOpaqueSeedAssignmentsRequired": true
+  },
+  "vetoes": [
+    "raw [ ] 1 0 appears on driver request wire",
+    "ProjectionContext appears on driver request wire",
+    "driver reparses Anum",
+    "driver contains L2 interpretation semantics",
+    "raw backend handle appears in normalized response",
+    "physical pointer/offset/record id becomes expected identity",
+    "read operation implicitly realizes",
+    "test harness fakes persistence for a non-persistent backend",
+    "driver buffers writes so backend partial-commit bugs are hidden from crash-recovery tests",
+    "PMM-specific field is added to canonical #130 traces"
+  ],
+  "nextGate": {
+    "artifact": "PMM-backed external driver using this protocol",
+    "mustReplaySameCoreCorpus": true,
+    "mustReplayPersistentOnlyVectors": true,
+    "mayRequestGenericPmmPrimitiveOnlyAfterConcreteFailure": true,
+    "mustNotChangeCanonicalContractToFitPmmInternals": true
+  }
+}

--- a/contracts/mts-l4-backend-driver-v0.3.json
+++ b/contracts/mts-l4-backend-driver-v0.3.json
@@ -81,7 +81,9 @@
     "persistentIdentity": false,
     "multipleNamesMayAliasOneHandle": true,
     "normalizedRef": "lexicographically smallest currently bound scenario name for a live handle",
-    "unboundLiveHandleInObservation": "driver-protocol-error"
+    "unboundLiveHandleInObservation": "driver-protocol-error",
+    "bindingConflictMustBeDetectedBeforeBackendMutation": true,
+    "reason": "harness metadata must never create a backend write that is later reported as a protocol-level binding failure"
   },
   "snapshotNormalization": {
     "shape": "sorted array of {ref,start,end} using normalized symbolic names",
@@ -98,6 +100,7 @@
     "compilePipeline": "parse_raw_quaternary -> denotate_recursive_anum(explicit context) -> canonical structural IR before driver dispatch",
     "nodeBindings": "request supplies deterministic scenario-local names for every description-local node id so newly realized internal links are observable without exposing backend handles",
     "rootBinding": "request may add a scenario-local alias for the resolved denotation root",
+    "bindingPreflight": "existing scenario names are validated against an already-complete read-only denotation lookup before realization; inconsistent metadata fails before write",
     "atomicity": "backend adapter must not expose partial new links if validation/anchor resolution/write fails"
   },
   "normalizedErrors": [
@@ -141,6 +144,7 @@
     "raw backend handle appears in normalized response",
     "physical pointer/offset/record id becomes expected identity",
     "read operation implicitly realizes",
+    "binding conflict is detected only after a backend write",
     "test harness fakes persistence for a non-persistent backend",
     "driver buffers writes so backend partial-commit bugs are hidden from crash-recovery tests",
     "PMM-specific field is added to canonical #130 traces"

--- a/converters/l4_backend_driver.py
+++ b/converters/l4_backend_driver.py
@@ -1,0 +1,373 @@
+"""Language-neutral L4 backend-driver challenge implementation.
+
+The driver is intentionally thin: it delegates link semantics to the canonical
+``AnumMemory`` reference backend and adds only scenario-local symbolic bindings,
+normalized observations/errors, and a JSON-shaped request/response boundary.
+
+Raw Anum parsing is *not* part of the driver wire. ``compile_l3_fixture`` is a
+runner-side helper used to compile #130 fixtures into accepted storage-neutral
+``anum-denotation/v0.2`` structural IR before dispatch to any backend driver.
+"""
+
+from collections.abc import Mapping
+import json
+
+from core.anum_denotation import (
+    AnumDenotation,
+    DenotationRef,
+    DenotationRefKind,
+    canonical_denotation_json,
+    denotation_from_data,
+)
+from core.anum_memory import (
+    AnumMemory,
+    InvalidInitialGraphError,
+    LinkInUseError,
+    MissingAnchorError,
+    NonStructuralDenotationError,
+    UnknownLinkRefError,
+)
+from core.anum_model import ProjectionContext
+from core.anum_parser import parse_raw_quaternary
+from core.anum_recursive_denotation import denotate_recursive_anum
+
+
+PROTOCOL_SCHEMA = "mts-l4-backend-driver/v0.3"
+
+
+class DriverRequestError(ValueError):
+    """Protocol-level failure normalized independently of backend exceptions."""
+
+    def __init__(self, code: str, message: str = "") -> None:
+        super().__init__(message or code)
+        self.code = code
+
+
+class ReferenceL4BackendDriver:
+    """Reference protocol adapter over ``AnumMemory``.
+
+    ``seed_handle_assignment`` exists only to challenge handle normalization.
+    It is constructor/test harness state and is never accepted through the
+    language-neutral request wire.
+    """
+
+    CAPABILITIES = {
+        "exact-pair": True,
+        "incidence": True,
+        "explicit-delete": True,
+        "atomic-multi-link-realize": True,
+        "enumeration": True,
+        "persistence": False,
+        "crash-recovery": False,
+    }
+
+    def __init__(
+        self,
+        seed_handle_assignment: Mapping[str, int] | None = None,
+    ) -> None:
+        self._seed_handle_assignment = (
+            dict(seed_handle_assignment) if seed_handle_assignment is not None else None
+        )
+        self._store: AnumMemory | None = None
+        self._bindings: dict[str, int] = {}
+
+    def dispatch(self, request: object) -> dict:
+        """Execute one JSON-shaped request and return a normalized response."""
+
+        request_id = None
+        try:
+            if not isinstance(request, dict):
+                raise DriverRequestError("invalid-request", "request must be an object")
+            request_id = request.get("id")
+            if not isinstance(request_id, str) or not request_id:
+                raise DriverRequestError("invalid-request", "request id must be a non-empty string")
+            if set(request) - {"id", "op", "args"}:
+                raise DriverRequestError("invalid-request", "unexpected request fields")
+            op = request.get("op")
+            if not isinstance(op, str) or not op:
+                raise DriverRequestError("invalid-request", "op must be a non-empty string")
+            args = request.get("args", {})
+            if not isinstance(args, dict):
+                raise DriverRequestError("invalid-request", "args must be an object")
+
+            result = self._dispatch_operation(op, args)
+            return {"id": request_id, "ok": True, "result": result}
+        except DriverRequestError as exc:
+            return self._error_response(request_id, exc.code)
+        except LinkInUseError:
+            return self._error_response(request_id, "link-in-use")
+        except MissingAnchorError:
+            return self._error_response(request_id, "missing-anchor")
+        except NonStructuralDenotationError:
+            return self._error_response(request_id, "non-structural-denotation")
+        except UnknownLinkRefError:
+            return self._error_response(request_id, "unknown-link")
+        except InvalidInitialGraphError:
+            return self._error_response(request_id, "invalid-request")
+        except (KeyError, TypeError, ValueError):
+            return self._error_response(request_id, "invalid-request")
+        except RuntimeError:
+            return self._error_response(request_id, "backend-error")
+
+    def _dispatch_operation(self, op: str, args: dict) -> dict:
+        if op == "hello":
+            self._require_no_args(args)
+            return {
+                "protocol": PROTOCOL_SCHEMA,
+                "capabilities": dict(self.CAPABILITIES),
+            }
+        if op == "create":
+            return self._create(args)
+        if op in {"close", "reopen"}:
+            raise DriverRequestError("capability-not-supported")
+
+        store = self._require_store()
+        if op == "snapshot":
+            self._require_no_args(args)
+            return {"links": self._normalized_snapshot(store)}
+        if op == "poles":
+            ref = self._bound_ref(self._required_name(args, "ref"))
+            self._require_exact_fields(args, {"ref"})
+            start, end = store.poles(ref)
+            return {"poles": [self._normalized_name(start), self._normalized_name(end)]}
+        if op == "find_link":
+            self._require_exact_fields(args, {"start", "end"})
+            start = self._bound_ref(self._required_name(args, "start"))
+            end = self._bound_ref(self._required_name(args, "end"))
+            found = store.find_link(start, end)
+            return {"ref": None if found is None else self._normalized_name(found)}
+        if op == "outgoing":
+            self._require_exact_fields(args, {"ref"})
+            ref = self._bound_ref(self._required_name(args, "ref"))
+            return {"refs": sorted(self._normalized_name(item) for item in store.outgoing(ref))}
+        if op == "incoming":
+            self._require_exact_fields(args, {"ref"})
+            ref = self._bound_ref(self._required_name(args, "ref"))
+            return {"refs": sorted(self._normalized_name(item) for item in store.incoming(ref))}
+        if op == "all_links":
+            self._require_no_args(args)
+            return {"refs": sorted(self._normalized_name(item) for item in store.all_links())}
+        if op == "realize_link":
+            self._require_exact_fields(args, {"start", "end", "bind"})
+            start = self._bound_ref(self._required_name(args, "start"))
+            end = self._bound_ref(self._required_name(args, "end"))
+            bind = self._required_name(args, "bind")
+            ref = store.intern_link(start, end)
+            self._bind(bind, ref)
+            return {"ref": bind}
+        if op == "realize_structural_denotation":
+            return self._realize_structural_denotation(store, args)
+        if op == "delete_link":
+            self._require_exact_fields(args, {"ref"})
+            store.delete_link(self._bound_ref(self._required_name(args, "ref")))
+            return {}
+        raise DriverRequestError("invalid-request", f"unknown operation: {op}")
+
+    def _create(self, args: dict) -> dict:
+        self._require_exact_fields(args, {"seedGraph"})
+        seed_graph = args["seedGraph"]
+        if not isinstance(seed_graph, dict) or set(seed_graph) != {"links"}:
+            raise DriverRequestError("invalid-request", "seedGraph must contain only links")
+        links = seed_graph["links"]
+        if not isinstance(links, dict) or not links:
+            raise DriverRequestError("invalid-request", "seed links must be a non-empty object")
+
+        names = list(links)
+        assignment = self._seed_handle_assignment
+        if assignment is None:
+            assignment = {name: index for index, name in enumerate(names)}
+        if set(assignment) != set(names):
+            raise DriverRequestError(
+                "invalid-request", "seed handle assignment must cover seed names exactly"
+            )
+        if any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in assignment.values()
+        ) or len(set(assignment.values())) != len(assignment):
+            raise DriverRequestError("invalid-request", "seed handles must be distinct non-negative integers")
+
+        initial: dict[int, tuple[int, int]] = {}
+        for name, record in links.items():
+            if not isinstance(record, dict) or set(record) != {"start", "end"}:
+                raise DriverRequestError("invalid-request", "seed link must contain start/end")
+            start = record["start"]
+            end = record["end"]
+            if start not in assignment or end not in assignment:
+                raise DriverRequestError("invalid-request", "seed link points outside symbolic graph")
+            initial[assignment[name]] = (assignment[start], assignment[end])
+
+        self._store = AnumMemory(initial_links=initial)
+        self._bindings = dict(assignment)
+        return {"created": True}
+
+    def _realize_structural_denotation(self, store: AnumMemory, args: dict) -> dict:
+        self._require_exact_fields(
+            args,
+            {"denotation", "anchors", "nodeBindings", "bind"},
+        )
+        denotation_data = args["denotation"]
+        if not isinstance(denotation_data, dict):
+            raise DriverRequestError("invalid-request", "denotation must be an object")
+        # The protocol accepts only storage-neutral IR. Raw/context fixtures belong
+        # to the common runner and are forbidden on the driver wire.
+        if "sourceRaw" in denotation_data or "context" in denotation_data:
+            raise DriverRequestError("invalid-request", "raw/context are not driver inputs")
+        denotation = denotation_from_data(denotation_data)
+        if denotation.structural is None:
+            raise NonStructuralDenotationError("driver requires structural denotation")
+
+        anchors_data = args["anchors"]
+        if not isinstance(anchors_data, dict):
+            raise DriverRequestError("invalid-request", "anchors must be an object")
+        anchor_refs = {
+            key: self._bound_ref(name)
+            for key, name in anchors_data.items()
+            if isinstance(key, str) and isinstance(name, str)
+        }
+        if len(anchor_refs) != len(anchors_data):
+            raise DriverRequestError("invalid-request", "anchor names must be strings")
+
+        node_bindings = args["nodeBindings"]
+        if not isinstance(node_bindings, dict):
+            raise DriverRequestError("invalid-request", "nodeBindings must be an object")
+        expected_node_keys = {str(node.id) for node in denotation.structural.nodes}
+        if set(node_bindings) != expected_node_keys or not all(
+            isinstance(name, str) and name for name in node_bindings.values()
+        ):
+            raise DriverRequestError(
+                "invalid-request", "nodeBindings must name every structural node exactly"
+            )
+        root_bind = self._required_name(args, "bind")
+
+        root = store.realize_denotation(denotation, anchor_refs)
+        local_nodes: dict[int, int] = {}
+        for node in denotation.structural.nodes:
+            start = self._resolve_denotation_ref(node.start, anchor_refs, local_nodes)
+            end = self._resolve_denotation_ref(node.end, anchor_refs, local_nodes)
+            ref = store.find_link(start, end)
+            if ref is None:
+                raise DriverRequestError(
+                    "driver-protocol-error", "realized structural node cannot be found"
+                )
+            local_nodes[node.id] = ref
+            self._bind(node_bindings[str(node.id)], ref)
+
+        resolved_root = self._resolve_denotation_ref(
+            denotation.structural.root,
+            anchor_refs,
+            local_nodes,
+        )
+        if resolved_root != root:
+            raise DriverRequestError("driver-protocol-error", "backend returned wrong denotation root")
+        self._bind(root_bind, root)
+        return {"ref": root_bind}
+
+    @staticmethod
+    def _resolve_denotation_ref(
+        ref: DenotationRef,
+        anchors: Mapping[str, int],
+        local_nodes: Mapping[int, int],
+    ) -> int:
+        if ref.kind is DenotationRefKind.ANCHOR:
+            assert ref.anchor is not None
+            return anchors[ref.anchor]
+        assert ref.node is not None
+        return local_nodes[ref.node]
+
+    def _normalized_snapshot(self, store: AnumMemory) -> list[dict]:
+        links: list[dict] = []
+        for ref in store.all_links():
+            start, end = store.poles(ref)
+            links.append(
+                {
+                    "ref": self._normalized_name(ref),
+                    "start": self._normalized_name(start),
+                    "end": self._normalized_name(end),
+                }
+            )
+        return sorted(links, key=lambda item: (item["ref"], item["start"], item["end"]))
+
+    def _normalized_name(self, ref: int) -> str:
+        names = sorted(name for name, value in self._bindings.items() if value == ref)
+        if not names:
+            raise DriverRequestError(
+                "driver-protocol-error", "live backend handle has no symbolic binding"
+            )
+        return names[0]
+
+    def _bound_ref(self, name: str) -> int:
+        try:
+            return self._bindings[name]
+        except KeyError as exc:
+            raise DriverRequestError("unknown-binding", f"unknown binding: {name}") from exc
+
+    def _bind(self, name: str, ref: int) -> None:
+        existing = self._bindings.get(name)
+        if existing is not None and existing != ref:
+            raise DriverRequestError("binding-conflict", f"binding {name!r} changed handle")
+        self._bindings[name] = ref
+
+    def _require_store(self) -> AnumMemory:
+        if self._store is None:
+            raise DriverRequestError("workspace-not-open")
+        return self._store
+
+    @staticmethod
+    def _required_name(args: dict, key: str) -> str:
+        value = args.get(key)
+        if not isinstance(value, str) or not value:
+            raise DriverRequestError("invalid-request", f"{key} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _require_no_args(args: dict) -> None:
+        if args:
+            raise DriverRequestError("invalid-request", "operation does not accept args")
+
+    @staticmethod
+    def _require_exact_fields(args: dict, expected: set[str]) -> None:
+        if set(args) != expected:
+            raise DriverRequestError(
+                "invalid-request",
+                f"expected args {sorted(expected)}, got {sorted(args)}",
+            )
+
+    @staticmethod
+    def _error_response(request_id: object, code: str) -> dict:
+        return {
+            "id": request_id if isinstance(request_id, str) else "",
+            "ok": False,
+            "error": {"code": code},
+        }
+
+
+def compile_l3_fixture(source_raw: str, context: str) -> dict:
+    """Compile one #130 raw fixture into canonical structural IR outside driver.
+
+    This helper belongs to the common runner side of the protocol. External
+    storage drivers receive its resulting IR object and never ``source_raw`` or
+    ``ProjectionContext``.
+    """
+
+    try:
+        projection_context = ProjectionContext(context)
+    except ValueError as exc:
+        raise ValueError(f"unsupported fixture context: {context}") from exc
+    denotation = denotate_recursive_anum(
+        parse_raw_quaternary(source_raw),
+        projection_context,
+    )
+    if denotation.structural is None:
+        raise ValueError("driver fixture must compile to structural denotation")
+    return json.loads(canonical_denotation_json(denotation))
+
+
+def canonical_wire_json(value: object) -> str:
+    """Deterministic JSON encoding for future JSONL process framing."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )

--- a/converters/l4_backend_driver.py
+++ b/converters/l4_backend_driver.py
@@ -13,7 +13,6 @@ from collections.abc import Mapping
 import json
 
 from core.anum_denotation import (
-    AnumDenotation,
     DenotationRef,
     DenotationRefKind,
     canonical_denotation_json,
@@ -126,8 +125,8 @@ class ReferenceL4BackendDriver:
             self._require_no_args(args)
             return {"links": self._normalized_snapshot(store)}
         if op == "poles":
-            ref = self._bound_ref(self._required_name(args, "ref"))
             self._require_exact_fields(args, {"ref"})
+            ref = self._bound_ref(self._required_name(args, "ref"))
             start, end = store.poles(ref)
             return {"poles": [self._normalized_name(start), self._normalized_name(end)]}
         if op == "find_link":
@@ -152,6 +151,7 @@ class ReferenceL4BackendDriver:
             start = self._bound_ref(self._required_name(args, "start"))
             end = self._bound_ref(self._required_name(args, "end"))
             bind = self._required_name(args, "bind")
+            self._preflight_pair_binding(store, bind, start, end)
             ref = store.intern_link(start, end)
             self._bind(bind, ref)
             return {"ref": bind}
@@ -200,6 +200,23 @@ class ReferenceL4BackendDriver:
         self._bindings = dict(assignment)
         return {"created": True}
 
+    def _preflight_pair_binding(
+        self,
+        store: AnumMemory,
+        bind: str,
+        start: int,
+        end: int,
+    ) -> None:
+        existing_binding = self._bindings.get(bind)
+        if existing_binding is None:
+            return
+        existing_pair = store.find_link(start, end)
+        if existing_pair is None or existing_pair != existing_binding:
+            raise DriverRequestError(
+                "binding-conflict",
+                f"binding {bind!r} already denotes another backend link",
+            )
+
     def _realize_structural_denotation(self, store: AnumMemory, args: dict) -> dict:
         self._require_exact_fields(
             args,
@@ -238,20 +255,28 @@ class ReferenceL4BackendDriver:
                 "invalid-request", "nodeBindings must name every structural node exactly"
             )
         root_bind = self._required_name(args, "bind")
+        requested_names = list(node_bindings.values()) + [root_bind]
+        if len(set(requested_names)) != len(requested_names):
+            raise DriverRequestError(
+                "invalid-request", "structural node/root binding names must be distinct"
+            )
 
+        self._preflight_structural_bindings(
+            store,
+            denotation,
+            anchor_refs,
+            node_bindings,
+            root_bind,
+        )
         root = store.realize_denotation(denotation, anchor_refs)
-        local_nodes: dict[int, int] = {}
-        for node in denotation.structural.nodes:
-            start = self._resolve_denotation_ref(node.start, anchor_refs, local_nodes)
-            end = self._resolve_denotation_ref(node.end, anchor_refs, local_nodes)
-            ref = store.find_link(start, end)
-            if ref is None:
-                raise DriverRequestError(
-                    "driver-protocol-error", "realized structural node cannot be found"
-                )
-            local_nodes[node.id] = ref
-            self._bind(node_bindings[str(node.id)], ref)
+        local_nodes = self._resolve_existing_structural_nodes(store, denotation, anchor_refs)
+        if local_nodes is None:
+            raise DriverRequestError(
+                "driver-protocol-error", "realized structural nodes cannot be reconstructed"
+            )
 
+        for node_id, ref in local_nodes.items():
+            self._bind(node_bindings[str(node_id)], ref)
         resolved_root = self._resolve_denotation_ref(
             denotation.structural.root,
             anchor_refs,
@@ -261,6 +286,54 @@ class ReferenceL4BackendDriver:
             raise DriverRequestError("driver-protocol-error", "backend returned wrong denotation root")
         self._bind(root_bind, root)
         return {"ref": root_bind}
+
+    def _preflight_structural_bindings(
+        self,
+        store: AnumMemory,
+        denotation,
+        anchor_refs: Mapping[str, int],
+        node_bindings: Mapping[str, str],
+        root_bind: str,
+    ) -> None:
+        requested = list(node_bindings.values()) + [root_bind]
+        if not any(name in self._bindings for name in requested):
+            return
+
+        existing_root = store.find_denotation(denotation, anchor_refs)
+        if existing_root is None:
+            raise DriverRequestError(
+                "binding-conflict",
+                "existing symbolic binding cannot be reused for a not-yet-realized denotation",
+            )
+        local_nodes = self._resolve_existing_structural_nodes(store, denotation, anchor_refs)
+        if local_nodes is None:
+            raise DriverRequestError("driver-protocol-error")
+
+        for node_id, name in node_bindings.items():
+            existing = self._bindings.get(name)
+            if existing is not None and existing != local_nodes[int(node_id)]:
+                raise DriverRequestError("binding-conflict")
+        existing = self._bindings.get(root_bind)
+        if existing is not None and existing != existing_root:
+            raise DriverRequestError("binding-conflict")
+
+    def _resolve_existing_structural_nodes(
+        self,
+        store: AnumMemory,
+        denotation,
+        anchor_refs: Mapping[str, int],
+    ) -> dict[int, int] | None:
+        structural = denotation.structural
+        assert structural is not None
+        local_nodes: dict[int, int] = {}
+        for node in structural.nodes:
+            start = self._resolve_denotation_ref(node.start, anchor_refs, local_nodes)
+            end = self._resolve_denotation_ref(node.end, anchor_refs, local_nodes)
+            ref = store.find_link(start, end)
+            if ref is None:
+                return None
+            local_nodes[node.id] = ref
+        return local_nodes
 
     @staticmethod
     def _resolve_denotation_ref(

--- a/tests/test_mts_l4_backend_driver.py
+++ b/tests/test_mts_l4_backend_driver.py
@@ -1,0 +1,313 @@
+"""Executable challenge for the language-neutral L4 backend driver protocol."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from converters.l4_backend_driver import (
+    PROTOCOL_SCHEMA,
+    ReferenceL4BackendDriver,
+    canonical_wire_json,
+    compile_l3_fixture,
+)
+
+
+ROOT = Path(__file__).parents[1]
+PROTOCOL = ROOT / "contracts" / "mts-l4-backend-driver-v0.3.json"
+DRIVER_CORPUS = ROOT / "contracts" / "mts-l4-backend-driver-conformance-v0.3.json"
+SOURCE_CORPUS = ROOT / "contracts" / "mts-l4-backend-conformance-v0.3.json"
+BACKEND_CHALLENGE = ROOT / "contracts" / "mts-l4-backend-challenge-v0.3.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def request(driver: ReferenceL4BackendDriver, counter: list[int], op: str, args: dict | None = None) -> tuple[dict, dict]:
+    current = {"id": f"r{counter[0]}", "op": op}
+    counter[0] += 1
+    if args is not None:
+        current["args"] = args
+    return current, driver.dispatch(current)
+
+
+def create_driver(assignment: dict[str, int]) -> tuple[ReferenceL4BackendDriver, list[dict]]:
+    driver = ReferenceL4BackendDriver(assignment)
+    sent: list[dict] = []
+    req = {
+        "id": "create",
+        "op": "create",
+        "args": {"seedGraph": {"links": read(SOURCE_CORPUS)["seedGraph"]["links"]}},
+    }
+    sent.append(deepcopy(req))
+    assert driver.dispatch(req) == {"id": "create", "ok": True, "result": {"created": True}}
+    return driver, sent
+
+
+def normalized_snapshot_pairs(expectation: object) -> list[tuple[str, str]]:
+    if not isinstance(expectation, list):
+        return []
+    if len(expectation) == 2 and all(isinstance(item, str) for item in expectation):
+        return [(expectation[0], expectation[1])]
+    pairs: list[tuple[str, str]] = []
+    for item in expectation:
+        assert isinstance(item, list) and len(item) == 2
+        left, right = item
+        assert isinstance(left, str) and isinstance(right, str)
+        pairs.append((left, right))
+    return pairs
+
+
+def run_core_scenario(scenario: dict, assignment: dict[str, int]) -> dict:
+    driver, sent = create_driver(assignment)
+    counter = [0]
+    snapshots: dict[str, dict] = {}
+    observations: list[dict] = []
+    compiled_denotation = None
+    node_bindings = None
+    if "denotation" in scenario:
+        fixture = scenario["denotation"]
+        compiled_denotation = compile_l3_fixture(
+            fixture["sourceRaw"],
+            fixture["context"],
+        )
+        node_bindings = {
+            str(node["id"]): f"@{scenario['id']}:node:{node['id']}"
+            for node in compiled_denotation["nodes"]
+        }
+
+    for operation in scenario["operations"]:
+        op = operation["op"]
+        args: dict | None
+        if op == "snapshot":
+            args = None
+        elif op == "find_link":
+            args = {"start": operation["start"], "end": operation["end"]}
+        elif op in {"poles", "outgoing", "incoming", "delete_link"}:
+            args = {"ref": operation["ref"]}
+        elif op == "realize_link":
+            bind = operation.get("bind") or operation.get("expectBinding")
+            assert isinstance(bind, str)
+            args = {
+                "start": operation["start"],
+                "end": operation["end"],
+                "bind": bind,
+            }
+        elif op == "realize_structural_denotation":
+            assert compiled_denotation is not None and node_bindings is not None
+            bind = operation.get("bind") or operation.get("expectBinding")
+            assert isinstance(bind, str)
+            args = {
+                "denotation": deepcopy(compiled_denotation),
+                "anchors": deepcopy(operation["anchors"]),
+                "nodeBindings": deepcopy(node_bindings),
+                "bind": bind,
+            }
+        else:
+            raise AssertionError(f"unsupported #130 core op in driver runner: {op}")
+
+        req, response = request(driver, counter, op, args)
+        sent.append(deepcopy(req))
+        observations.append(deepcopy(response))
+
+        expected_error = operation.get("expectError")
+        if expected_error is not None:
+            assert response == {
+                "id": req["id"],
+                "ok": False,
+                "error": {"code": expected_error},
+            }
+            continue
+
+        assert response["ok"] is True, (scenario["id"], operation, response)
+        result = response["result"]
+        if op == "snapshot":
+            snapshots[operation["bind"]] = deepcopy(result)
+        if "expect" in operation:
+            if op == "find_link":
+                assert result["ref"] == operation["expect"]
+            elif op == "poles":
+                assert result["poles"] == operation["expect"]
+            else:
+                raise AssertionError(f"unexpected scalar expectation for {op}")
+        if "expectBinding" in operation:
+            assert result["ref"] == operation["expectBinding"]
+        if "expectSet" in operation:
+            assert result["refs"] == sorted(operation["expectSet"])
+        if "bind" in operation and op in {"realize_link", "realize_structural_denotation"}:
+            assert result["ref"] == operation["bind"]
+
+    expectation = scenario.get("expect", {})
+    for left, right in normalized_snapshot_pairs(expectation.get("snapshotsEqual")):
+        assert snapshots[left] == snapshots[right], scenario["id"]
+
+    return {
+        "scenario": scenario["id"],
+        "observations": observations,
+        "snapshots": snapshots,
+        "sent": sent,
+        # Test-only inspection proves native values actually differ while the
+        # wire/observations above never expose them.
+        "nativeBindings": dict(driver._bindings),
+    }
+
+
+def test_protocol_is_non_normative_and_preserves_backend_challenge_boundary():
+    protocol = read(PROTOCOL)
+    challenge = read(BACKEND_CHALLENGE)
+    corpus = read(DRIVER_CORPUS)
+
+    assert protocol["schema"] == PROTOCOL_SCHEMA
+    assert protocol["status"] == "candidate-challenge"
+    assert protocol["issue"] == 141
+    assert protocol["parentIssue"] == 124
+    assert protocol["acceptedContractLinkAllowed"] is False
+    assert protocol["productionBackendContractAccepted"] is False
+    assert challenge["status"] == "candidate-challenge"
+    assert corpus["status"] == "candidate-challenge-corpus"
+    assert corpus["sourceCorpus"] == "contracts/mts-l4-backend-conformance-v0.3.json"
+    assert protocol["architecture"]["driverParsesRawAnum"] is False
+    assert protocol["architecture"]["driverRunsL2Interpreter"] is False
+
+
+def test_protocol_vectors_have_exact_normalized_reference_responses():
+    driver = ReferenceL4BackendDriver()
+    for vector in read(DRIVER_CORPUS)["protocolVectors"]:
+        assert driver.dispatch(vector["request"]) == vector["expect"], vector["id"]
+
+
+def test_every_source_core_scenario_is_selected_exactly_once_for_driver_replay():
+    source_ids = [item["id"] for item in read(SOURCE_CORPUS)["scenarios"]]
+    driver_ids = read(DRIVER_CORPUS)["coreReplay"]["scenarioIds"]
+
+    assert driver_ids == source_ids
+    assert len(driver_ids) == len(set(driver_ids)) == 6
+
+
+def test_all_six_core_scenarios_replay_through_driver_under_both_handle_assignments():
+    source = read(SOURCE_CORPUS)
+    scenarios = {item["id"]: item for item in source["scenarios"]}
+    assignments = read(DRIVER_CORPUS)["referenceAssignments"]
+
+    runs: dict[str, list[dict]] = {}
+    for scenario_id in read(DRIVER_CORPUS)["coreReplay"]["scenarioIds"]:
+        runs[scenario_id] = [
+            run_core_scenario(scenarios[scenario_id], assignment)
+            for assignment in assignments
+        ]
+        # Remove the private/native evidence before comparing portable results.
+        left = {key: value for key, value in runs[scenario_id][0].items() if key != "nativeBindings"}
+        right = {key: value for key, value in runs[scenario_id][1].items() if key != "nativeBindings"}
+        assert left == right, scenario_id
+
+    pair_refs = [runs["realize-exact-pair"][index]["nativeBindings"]["pair"] for index in (0, 1)]
+    assert pair_refs[0] != pair_refs[1]
+
+
+def test_structural_fixture_is_compiled_before_driver_wire_and_never_sends_raw_context():
+    source = read(SOURCE_CORPUS)
+    scenario = next(item for item in source["scenarios"] if item["id"] == "structural-denotation-atomicity")
+    run = run_core_scenario(scenario, read(DRIVER_CORPUS)["referenceAssignments"][0])
+
+    structural_requests = [
+        item for item in run["sent"] if item["op"] == "realize_structural_denotation"
+    ]
+    assert len(structural_requests) == 3
+    for item in structural_requests:
+        data = item["args"]["denotation"]
+        assert data["kind"] == "structural"
+        assert set(data) == {"kind", "anchors", "nodes", "root"}
+        wire = canonical_wire_json(item)
+        assert "sourceRaw" not in wire
+        assert "ProjectionContext" not in wire
+        assert '"context"' not in wire
+
+    fixture_contract = read(DRIVER_CORPUS)["fixtureCompilation"]
+    assert fixture_contract["sourceRaw"] == scenario["denotation"]["sourceRaw"]
+    assert fixture_contract["sourceContext"] == scenario["denotation"]["context"]
+    assert set(fixture_contract["driverRequestMustContain"]) == {"kind", "anchors", "nodes", "root"}
+
+
+def test_normalized_snapshots_and_responses_contain_no_native_handle_values():
+    source = read(SOURCE_CORPUS)
+    assignment = read(DRIVER_CORPUS)["referenceAssignments"][1]
+    native_values = set(assignment.values())
+
+    for scenario in source["scenarios"]:
+        run = run_core_scenario(scenario, assignment)
+        portable_json = canonical_wire_json(
+            {
+                "observations": run["observations"],
+                "snapshots": run["snapshots"],
+            }
+        )
+        for value in native_values:
+            assert f'":{value}' not in portable_json
+            assert f'[{value}' not in portable_json
+
+    protocol = read(PROTOCOL)
+    assert protocol["wire"]["backendHandleMayAppear"] is False
+    assert protocol["wire"]["physicalAddressMayAppear"] is False
+
+
+def test_find_and_error_paths_keep_normalized_snapshots_unchanged():
+    source = {item["id"]: item for item in read(SOURCE_CORPUS)["scenarios"]}
+    assignment = read(DRIVER_CORPUS)["referenceAssignments"][0]
+
+    read_run = run_core_scenario(source["read-missing-pair"], assignment)
+    assert read_run["snapshots"]["before"] == read_run["snapshots"]["after"]
+
+    delete_run = run_core_scenario(source["delete-safety"], assignment)
+    assert delete_run["snapshots"]["beforeRejectedDelete"] == delete_run["snapshots"]["afterRejectedDelete"]
+
+    structural = run_core_scenario(source["structural-denotation-atomicity"], assignment)
+    assert structural["snapshots"]["beforeMissingAnchor"] == structural["snapshots"]["afterMissingAnchor"]
+    assert structural["snapshots"]["afterFirstRealize"] == structural["snapshots"]["afterSecondRealize"]
+
+
+def test_reference_driver_declares_persistence_vectors_unsupported_not_passed():
+    hello = ReferenceL4BackendDriver().dispatch({"id": "h", "op": "hello"})
+    capabilities = hello["result"]["capabilities"]
+    persistent = read(SOURCE_CORPUS)["persistentOnlyScenarios"]
+    gate = read(DRIVER_CORPUS)["capabilityVectors"]
+
+    assert capabilities["persistence"] is False
+    assert capabilities["crash-recovery"] is False
+    assert gate["unsupportedIsNotSemanticPass"] is True
+    assert {item["id"] for item in persistent} == set(gate["referenceUnsupportedPersistentScenarios"])
+    assert set(gate["futurePersistentDriverMustRun"]) == {
+        "clean-reopen",
+        "realize-after-reopen",
+        "index-consistency-after-reopen",
+    }
+    assert gate["futureCrashRecoveryDriverMustRun"] == ["interrupted-atomic-commit"]
+
+
+def test_driver_binding_conflict_cannot_turn_adapter_metadata_into_backend_mutation():
+    assignment = read(DRIVER_CORPUS)["referenceAssignments"][0]
+    driver, _sent = create_driver(assignment)
+    counter = [0]
+
+    # First bind one exact pair to a stable scenario name.
+    _req, first = request(
+        driver,
+        counter,
+        "realize_link",
+        {"start": "zero", "end": "one", "bind": "pair"},
+    )
+    assert first["ok"] is True
+    before_req, before = request(driver, counter, "snapshot")
+    assert before["ok"] is True
+
+    # Reusing that name for a different pair must fail without changing store.
+    _req, rejected = request(
+        driver,
+        counter,
+        "realize_link",
+        {"start": "root", "end": "zero", "bind": "pair"},
+    )
+    assert rejected["ok"] is False
+    assert rejected["error"]["code"] == "binding-conflict"
+    after_req, after = request(driver, counter, "snapshot")
+    assert before_req["op"] == after_req["op"] == "snapshot"
+    assert before["result"] == after["result"]


### PR DESCRIPTION
Refs #141, #124, #120.

Non-normative implementation/challenge поверх уже merged #129/#130. Canonical L4 semantics и #130 corpus не меняются.

## Architecture

```text
#130 symbolic trace corpus
→ common conformance runner
→ canonical L3 fixture compilation only when sourceRaw/context appears in fixture
→ language-neutral JSON-shaped driver protocol
→ backend adapter
→ storage engine
```

Driver **никогда не получает raw Anum или ProjectionContext**. Structural fixture `[01]1` сначала компилируется canonical L3 path в `anum-denotation/v0.2` IR; только IR уходит storage driver-у.

## Reference driver

`converters/l4_backend_driver.py` — thin adapter над canonical `AnumMemory`:
- symbolic scenario bindings вместо backend handles;
- normalized topology/errors;
- exact-pair/incidence/read/delete/realize operations;
- structural denotation realization только из storage-neutral IR;
- explicit capability negotiation;
- persistence/crash-recovery честно объявлены unsupported.

Это не вторая L4 semantics: link behavior делегируется `AnumMemory`.

## Portable replay

`tests/test_mts_l4_backend_driver.py` исполняет все 6 core scenarios из `mts-l4-backend-conformance/v0.3` под двумя различными opaque seed-handle assignments и требует одинаковых normalized observations.

Проверяются:
- missing pair read-only;
- exact pair realize + idempotence;
- incidence;
- delete safety;
- closed cycle;
- structural-denotation atomicity;
- отсутствие raw/backend handles на wire;
- persistence-only scenarios не засчитываются reference backend-у как semantic pass.

Adapter-level symbolic binding conflict должен определяться до backend mutation, чтобы сам harness не создавал partial state.

## Next gate

После green challenge следующий внешний consumer protocol — PMM-backed driver. Только его реальные persistent/reopen/crash vectors могут разблокировать #124 acceptance; canonical corpus не будет адаптироваться под PMM internals.