### PR TITLE
Разделить operational replay certificates и MTS derivation judgments

### DIFF
--- a/contracts/mts-proof-domain-decision-v0.3.json
+++ b/contracts/mts-proof-domain-decision-v0.3.json
@@ -1,0 +1,152 @@
+{
+  "schema": "mts-proof-domain-decision/v0.3",
+  "status": "candidate-decision",
+  "issue": 122,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-proof-judgment-decision/v0.3",
+    "mts-proof-judgment-challenge/v0.3",
+    "mts-proof/v0.2"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionProofChangeAllowed": false,
+  "trustedRuleChangeAllowed": false,
+  "question": "Does exact replayability itself make an operation result a proof judgment, or must operational certificates be separated from MTS derivation judgments?",
+  "evidence": {
+    "challengeFinding": "#139 independently replays exact interpret/open-definition results, including negative results, and rejects forged results",
+    "currentProofKernel": "mts-proof/v0.2 replays only interpret steps",
+    "definitionOpening": "successful open_definition returns an exact RHS but explicitly does not assert equality or produce a proof step",
+    "negativeResults": ["interpret failure", "no-match", "conflict", "non-addressable"]
+  },
+  "models": [
+    {
+      "id": "A",
+      "name": "every-exact-replay-result-is-proof-judgment",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Replayability proves that an operation returned a result. It does not by itself define what MTS proposition or derivation relation that result establishes."
+    },
+    {
+      "id": "B",
+      "name": "only-operation-success-is-proof-judgment",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Generic success/match is operation-specific and still does not define a theorem relation. In particular open-definition match is not A = F."
+    },
+    {
+      "id": "C",
+      "name": "two-layer-operational-certificate-and-derivation-judgment",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "reason": "Keep exact operation replay as a typed certificate layer. Define MTS derivation judgments separately and require an explicit accepted lifting/inference rule before operational evidence can establish a derivation claim."
+    },
+    {
+      "id": "D",
+      "name": "reuse-classical-theorem-judgment",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Importing a conventional theorem/truth judgment would bypass the still-open MTS-specific semantics of goals, premises, equality and composition."
+    }
+  ],
+  "preferredCandidate": {
+    "operationalReplayClaim": {
+      "role": "exact certificate of one accepted canonical operation result",
+      "includesNegativeResults": true,
+      "examples": [
+        "InterpretResult(expression, context, memory, symbols, success/substitutions/aliases)",
+        "OpenDefinitionResult(environment, target, match/no-match/conflict/non-addressable, optional DefinitionId/RHS)"
+      ],
+      "trustedValidation": "independent replay of the referenced accepted canonical operation",
+      "compositionSemantics": "none",
+      "isTheoremByItself": false,
+      "isDerivationPremiseByItself": false
+    },
+    "derivationJudgment": {
+      "role": "future MTS-specific claim established by accepted lifting/inference rules",
+      "acceptedInThisDecision": false,
+      "mustHaveExplicitTypedSubject": true,
+      "mustHaveExplicitRelation": true,
+      "mustNotDefaultToGlobalTruth": true,
+      "mayReferenceReplayCertificateOnlyThroughAcceptedRule": true
+    },
+    "boundary": "certificate validity and derivation validity are different questions"
+  },
+  "v02Compatibility": {
+    "mtsProofV02FileNameUnchanged": true,
+    "mtsProofV02TrustedRuleSetUnchanged": ["interpret"],
+    "interpretStepMayBeViewedAsOperationalCertificate": true,
+    "reinterpretV02InterpretAsGeneralTheorem": false,
+    "retroactiveArtifactRewriteRequired": false
+  },
+  "definitionOpeningBoundary": {
+    "openingMatchCanBeCertified": true,
+    "openingNegativeResultCanBeCertified": true,
+    "openingMatchEstablishesEquality": false,
+    "openingMatchEstablishesGlobalRewrite": false,
+    "openingMatchIsTrustedDerivationRule": false,
+    "returnedRhsEvaluationImplicit": false
+  },
+  "negativeResultBoundary": {
+    "negativeReplayClaimCanBeValid": true,
+    "negativeReplayClaimAutomaticallyBecomesTheorem": false,
+    "absenceOrConflictCanBeUsedAsPremiseWithoutRule": false,
+    "reason": "Exact knowledge that an operation failed/missed/conflicted is operational evidence; how such evidence participates in MTS derivation requires its own rule."
+  },
+  "futureDerivationShapeConstraints": {
+    "genericGammaTurnstileImported": false,
+    "globalFormulaTruthImported": false,
+    "goalMustNameItsRelation": true,
+    "premisesMustNameAcceptedEvidenceOrJudgments": true,
+    "contextAndMemoryMustNotBeHidden": true,
+    "proofSearchTraceIsNotPremise": true,
+    "cyclesMustRemainFinite": true
+  },
+  "candidateLiftFamiliesForNextChallenge": [
+    {
+      "id": "interpret-result-relation",
+      "question": "Can a verified interpret replay establish a typed relation such as Interprets(input,result) without turning successful interpretation into global formula truth?",
+      "accepted": false
+    },
+    {
+      "id": "definition-opening-relation",
+      "question": "Can a verified opening replay establish Opens(environment,target,result) while remaining distinct from equality and RHS evaluation?",
+      "accepted": false
+    },
+    {
+      "id": "constraint-satisfaction-lift",
+      "question": "Under which exact preconditions, if any, can successful contextual interpretation establish a derivation-level constraint-satisfaction judgment?",
+      "accepted": false
+    },
+    {
+      "id": "negative-evidence-lift",
+      "question": "Can no-match/conflict/failure evidence participate in derivation, and under what explicit relation, without closed-world assumptions?",
+      "accepted": false
+    }
+  ],
+  "stillRejectedOrDeferred": [
+    "successful opening implies equality",
+    "all successful operations are theorems",
+    "all replayable negative results are theorems",
+    "global textual substitution",
+    "unrestricted symmetry",
+    "unrestricted transitivity",
+    "unrestricted congruence",
+    "modus ponens",
+    "generic proof DAG composition",
+    "proof by recursive textual normalization"
+  ],
+  "nextGate": {
+    "artifact": "mts-proof-lifting-challenge/v0.3",
+    "status": "candidate-challenge",
+    "mustNotChangeProductionProofSemantics": true,
+    "requiredQuestions": [
+      "exact typed subject/relation for an interpret-derived judgment",
+      "exact typed subject/relation for an opening-derived judgment",
+      "whether successful interpretation means anything beyond a replayed operation result",
+      "whether negative evidence requires an explicit open-world/closed-world premise",
+      "how a replay certificate is referenced without trusting search trace",
+      "how self/mutual recursion and cyclic carriers remain finite",
+      "which proposed lifts have counterexamples on small finite carriers"
+    ]
+  }
+}

--- a/tests/test_mts_proof_domain_decision.py
+++ b/tests/test_mts_proof_domain_decision.py
@@ -1,0 +1,150 @@
+"""Executable guards for the non-normative MTS proof-domain decision v0.3."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+DECISION = ROOT / "contracts" / "mts-proof-domain-decision-v0.3.json"
+JUDGMENT_DECISION = ROOT / "contracts" / "mts-proof-judgment-decision-v0.3.json"
+JUDGMENT_CHALLENGE = ROOT / "contracts" / "mts-proof-judgment-challenge-v0.3.json"
+JUDGMENT_CORPUS = ROOT / "contracts" / "mts-proof-judgment-conformance-v0.3.json"
+MTS_V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+OPENING = ROOT / "contracts" / "mts-definition-opening-v0.3.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_decision_is_non_normative_and_depends_on_green_replay_challenge_surface():
+    data = read(DECISION)
+    challenge = read(JUDGMENT_CHALLENGE)
+    proof = read(PROOF_V02)
+
+    assert data["schema"] == "mts-proof-domain-decision/v0.3"
+    assert data["status"] == "candidate-decision"
+    assert data["dependsOn"] == [
+        "mts-contract/v0.3",
+        "mts-proof-judgment-decision/v0.3",
+        challenge["schema"],
+        proof["schema"],
+    ]
+    assert data["acceptedContractLinkAllowed"] is False
+    assert data["productionProofChangeAllowed"] is False
+    assert data["trustedRuleChangeAllowed"] is False
+    assert proof["checker"]["trustedRuleSet"] == ["interpret"]
+    assert data["schema"] not in MTS_V03.read_text(encoding="utf-8")
+
+
+def test_only_two_layer_model_is_preferred_and_nothing_is_accepted_yet():
+    models = {item["id"]: item for item in read(DECISION)["models"]}
+
+    assert set(models) == {"A", "B", "C", "D"}
+    assert models["A"]["verdict"] == "reject"
+    assert models["B"]["verdict"] == "reject"
+    assert models["C"]["verdict"] == "preferred-candidate"
+    assert models["D"]["verdict"] == "reject"
+    assert all(item["accepted"] is False for item in models.values())
+
+    preferred = read(DECISION)["preferredCandidate"]
+    assert preferred["boundary"] == "certificate validity and derivation validity are different questions"
+    assert preferred["operationalReplayClaim"]["compositionSemantics"] == "none"
+    assert preferred["operationalReplayClaim"]["isTheoremByItself"] is False
+    assert preferred["operationalReplayClaim"]["isDerivationPremiseByItself"] is False
+    assert preferred["derivationJudgment"]["acceptedInThisDecision"] is False
+    assert preferred["derivationJudgment"]["mustNotDefaultToGlobalTruth"] is True
+
+
+def test_replay_challenge_really_contains_positive_and_negative_exact_claims():
+    corpus = read(JUDGMENT_CORPUS)
+    interpret = {item["id"]: item for item in corpus["interpretJudgments"]}
+    opening = {item["id"]: item for item in corpus["openingJudgments"]}
+
+    assert interpret["interpret-local-alias-success"]["expected"]["success"] is True
+    assert interpret["interpret-aroot-negative-result"]["expected"]["success"] is False
+    assert opening["open-explicit-root-infinity"]["expected"]["kind"] == "match"
+    assert opening["open-no-hidden-root"]["expected"] == {"kind": "no-match"}
+    assert opening["open-conflict"]["expected"] == {"kind": "conflict"}
+    assert opening["open-non-addressable"]["expected"] == {"kind": "non-addressable"}
+
+    boundary = read(DECISION)["negativeResultBoundary"]
+    assert boundary["negativeReplayClaimCanBeValid"] is True
+    assert boundary["negativeReplayClaimAutomaticallyBecomesTheorem"] is False
+    assert boundary["absenceOrConflictCanBeUsedAsPremiseWithoutRule"] is False
+
+
+def test_open_definition_match_still_does_not_become_equality_or_trusted_rule():
+    opening = read(OPENING)
+    boundary = read(DECISION)["definitionOpeningBoundary"]
+
+    assert opening["operation"]["assertsEquality"] is False
+    assert opening["operation"]["producesProofStep"] is False
+    assert boundary["openingMatchCanBeCertified"] is True
+    assert boundary["openingNegativeResultCanBeCertified"] is True
+    assert boundary["openingMatchEstablishesEquality"] is False
+    assert boundary["openingMatchEstablishesGlobalRewrite"] is False
+    assert boundary["openingMatchIsTrustedDerivationRule"] is False
+    assert boundary["returnedRhsEvaluationImplicit"] is False
+
+
+def test_v02_compatibility_reframes_replay_without_rewriting_artifacts():
+    proof = read(PROOF_V02)
+    compatibility = read(DECISION)["v02Compatibility"]
+
+    assert proof["schema"] == "mts-proof/v0.2"
+    assert proof["checker"]["trustedRuleSet"] == ["interpret"]
+    assert compatibility["mtsProofV02FileNameUnchanged"] is True
+    assert compatibility["mtsProofV02TrustedRuleSetUnchanged"] == ["interpret"]
+    assert compatibility["interpretStepMayBeViewedAsOperationalCertificate"] is True
+    assert compatibility["reinterpretV02InterpretAsGeneralTheorem"] is False
+    assert compatibility["retroactiveArtifactRewriteRequired"] is False
+
+
+def test_future_derivation_judgment_cannot_hide_relation_context_or_search_trace():
+    constraints = read(DECISION)["futureDerivationShapeConstraints"]
+
+    assert constraints["genericGammaTurnstileImported"] is False
+    assert constraints["globalFormulaTruthImported"] is False
+    assert constraints["goalMustNameItsRelation"] is True
+    assert constraints["premisesMustNameAcceptedEvidenceOrJudgments"] is True
+    assert constraints["contextAndMemoryMustNotBeHidden"] is True
+    assert constraints["proofSearchTraceIsNotPremise"] is True
+    assert constraints["cyclesMustRemainFinite"] is True
+
+
+def test_all_next_lift_families_remain_unaccepted_and_require_soundness_challenge():
+    families = {item["id"]: item for item in read(DECISION)["candidateLiftFamiliesForNextChallenge"]}
+
+    assert set(families) == {
+        "interpret-result-relation",
+        "definition-opening-relation",
+        "constraint-satisfaction-lift",
+        "negative-evidence-lift",
+    }
+    assert all(item["accepted"] is False for item in families.values())
+    assert "A = F" not in families["definition-opening-relation"]["question"]
+
+    gate = read(DECISION)["nextGate"]
+    assert gate["artifact"] == "mts-proof-lifting-challenge/v0.3"
+    assert gate["status"] == "candidate-challenge"
+    assert gate["mustNotChangeProductionProofSemantics"] is True
+    assert "which proposed lifts have counterexamples on small finite carriers" in gate["requiredQuestions"]
+
+
+def test_classical_and_global_rules_are_still_rejected_or_deferred():
+    rejected = set(read(DECISION)["stillRejectedOrDeferred"])
+
+    assert {
+        "successful opening implies equality",
+        "all successful operations are theorems",
+        "all replayable negative results are theorems",
+        "global textual substitution",
+        "unrestricted symmetry",
+        "unrestricted transitivity",
+        "unrestricted congruence",
+        "modus ponens",
+        "generic proof DAG composition",
+        "proof by recursive textual normalization",
+    } == rejected


### PR DESCRIPTION
Refs #122, #120.

Следующий non-normative decision после merged #138/#139. Production proof checker и `mts-proof/v0.2` не меняются.

## Проблема

#139 показал, что exact operation results хорошо replay/check-ятся, включая:
- interpret failure;
- opening `no-match`;
- `conflict`;
- `non-addressable`.

Но техническая replayability ещё не определяет, что является **доказательством** в МТС.

## Предпочтительный candidate

Два слоя:

```text
OperationalReplayClaim
    exact certificate одной accepted canonical operation
    composition semantics = none
    сам по себе не theorem и не derivation premise

DerivationJudgment
    будущая MTS-specific relation
    принимается только отдельным contract/rule lifecycle
```

Operational certificate может содержать и положительный, и отрицательный result. Чтобы он участвовал в derivation, нужен явный accepted lifting/inference rule.

Это не даёт автоматически превратить:
- `open_definition match` в `A = F`;
- `no-match/conflict` в theorem;
- successful interpret в global truth.

## v0.2 compatibility

`mts-proof/v0.2` и `[interpret]` остаются неизменными. Его interpret step можно рассматривать как operational replay certificate, но артефакты задним числом не переписываются и general theorem semantics им не приписывается.

## Следующий gate

`mts-proof-lifting-challenge/v0.3` должен отдельно challenge-ить typed relations для:
- interpret result;
- definition opening result;
- constraint-satisfaction lift;
- negative evidence.

Никаких composition/DAG/classical rules до этого PR не принимается.