### PR TITLE
Challenge explicit replay-to-derivation lifts v0.3

### DIFF
--- a/contracts/mts-proof-lifting-challenge-v0.3.json
+++ b/contracts/mts-proof-lifting-challenge-v0.3.json
@@ -1,0 +1,96 @@
+{
+  "schema": "mts-proof-lifting-challenge/v0.3",
+  "status": "candidate-challenge",
+  "issue": 122,
+  "dependsOn": [
+    "mts-proof-domain-decision/v0.3",
+    "mts-proof-judgment-challenge/v0.3",
+    "mts-contract/v0.3"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionProofChangeAllowed": false,
+  "trustedRuleChangeAllowed": false,
+  "purpose": "Challenge exact typed lifting relations from verified operational replay certificates into future derivation judgments without importing global truth, equality rewrite or closed-world assumptions.",
+  "candidateLifts": [
+    {
+      "id": "contextual-satisfaction",
+      "source": "verified interpret replay with success=true",
+      "targetRelation": "ContextuallySatisfies(expression, context, symbols, memorySnapshot)",
+      "verdict": "challenge",
+      "accepted": false,
+      "scope": "exact replay inputs only",
+      "doesNotMean": ["global formula truth", "truth under another ContextFrame", "materialization"]
+    },
+    {
+      "id": "definition-opens",
+      "source": "verified open-definition replay with kind=match",
+      "targetRelation": "Opens(definitionEnvironment, target, definitionId, body)",
+      "verdict": "challenge",
+      "accepted": false,
+      "scope": "exact serialized lexical environment only",
+      "doesNotMean": ["target = body", "global rewrite", "RHS interpretation"]
+    },
+    {
+      "id": "no-visible-definition",
+      "source": "verified open-definition replay with kind=no-match",
+      "targetRelation": "NoVisibleDefinition(definitionEnvironment, target)",
+      "verdict": "challenge",
+      "accepted": false,
+      "scope": "the exact explicit environment snapshot only",
+      "doesNotMean": ["definition does not exist globally", "closed-world theorem outside snapshot"]
+    },
+    {
+      "id": "definition-conflict",
+      "source": "verified open-definition replay with kind=conflict",
+      "targetRelation": "DefinitionConflict(definitionEnvironment, target)",
+      "verdict": "challenge",
+      "accepted": false,
+      "scope": "nearest conflicting lexical scope in exact environment"
+    },
+    {
+      "id": "non-addressable-target",
+      "source": "verified open-definition replay with kind=non-addressable",
+      "targetRelation": "NonAddressableDefinitionTarget(target)",
+      "verdict": "challenge",
+      "accepted": false,
+      "scope": "accepted v0.3 definition-addressability subset"
+    }
+  ],
+  "mandatoryCounterexamples": [
+    {
+      "id": "context-dependence",
+      "rejects": "interpret success implies global truth",
+      "witness": "the same contextual expression succeeds under one ContextFrame and fails under another"
+    },
+    {
+      "id": "opening-not-equality",
+      "rejects": "a : b opening implies a = b",
+      "witness": "open_definition returns typed body without invoking equality semantics or MemoryView"
+    },
+    {
+      "id": "no-match-not-global-absence",
+      "rejects": "no-match implies target has no definition anywhere",
+      "witness": "empty environment yields no-match while another explicit environment containing the same target yields match"
+    },
+    {
+      "id": "conflict-not-equality",
+      "rejects": "same-scope conflict identifies duplicate bodies",
+      "witness": "a:b and a:c produce conflict without asserting b=c"
+    }
+  ],
+  "derivationBoundary": {
+    "liftResultMayBeUsedAsPremiseOnlyAfterAcceptance": true,
+    "genericCompositionAccepted": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "searchTraceIsEvidence": false
+  },
+  "nextGate": {
+    "goal": "decide which challenged relations are admitted as primitive derivation judgments and publish a versioned judgment contract before any multi-step composition rules",
+    "mustKeepMtsProofV02Unchanged": true,
+    "mustNotAddTrustedRulesYet": true
+  }
+}

--- a/contracts/mts-proof-lifting-conformance-v0.3.json
+++ b/contracts/mts-proof-lifting-conformance-v0.3.json
@@ -1,0 +1,71 @@
+{
+  "schema": "mts-proof-lifting-conformance/v0.3",
+  "status": "candidate-challenge-corpus",
+  "contract": "mts-proof-lifting-challenge/v0.3",
+  "vectors": [
+    {
+      "id": "contextual-satisfaction-positive",
+      "lift": "contextual-satisfaction",
+      "expression": "{◁ = ∞, ▷ = ∞}",
+      "symbols": [["∞", 1]],
+      "memory": [],
+      "context": {"start": 1, "end": 1},
+      "expectInterpretSuccess": true
+    },
+    {
+      "id": "contextual-satisfaction-countercontext",
+      "lift": "contextual-satisfaction",
+      "expression": "{◁ = ∞, ▷ = ∞}",
+      "symbols": [["∞", 1]],
+      "memory": [],
+      "context": {"start": 1, "end": 2},
+      "expectInterpretSuccess": false,
+      "counterexampleTo": "global formula truth"
+    },
+    {
+      "id": "opening-match",
+      "lift": "definition-opens",
+      "definitions": ["a : b"],
+      "target": "a",
+      "expect": {"kind": "match", "body": "b"},
+      "mustNotAssertEquality": true
+    },
+    {
+      "id": "no-match-local",
+      "lift": "no-visible-definition",
+      "definitions": [],
+      "target": "a",
+      "expect": {"kind": "no-match"}
+    },
+    {
+      "id": "same-target-other-environment",
+      "definitions": ["a : b"],
+      "target": "a",
+      "expect": {"kind": "match", "body": "b"},
+      "counterexampleTo": "no-match implies global absence"
+    },
+    {
+      "id": "same-scope-conflict",
+      "lift": "definition-conflict",
+      "definitions": ["a : b", "a : c"],
+      "target": "a",
+      "expect": {"kind": "conflict"},
+      "mustNotAssertBodyEquality": true
+    },
+    {
+      "id": "anonymous-target",
+      "lift": "non-addressable-target",
+      "definitions": [],
+      "target": "[]",
+      "expect": {"kind": "non-addressable"}
+    }
+  ],
+  "forbiddenConclusions": [
+    "contextual satisfaction under one context implies satisfaction under all contexts",
+    "definition opening match implies equality",
+    "definition opening match evaluates the body",
+    "no-match in one environment implies global absence",
+    "definition conflict implies duplicate bodies are equal",
+    "a challenged lift is a trusted rule before acceptance"
+  ]
+}

--- a/tests/test_mts_proof_lifting_challenge.py
+++ b/tests/test_mts_proof_lifting_challenge.py
@@ -1,0 +1,164 @@
+"""Executable counterexamples for candidate replay-to-derivation lifts v0.3."""
+
+import json
+from pathlib import Path
+
+from core.mtc_ast import Definition, Form, format_expression
+from core.mtc_definitions import DefinitionEnvironment, DefinitionLookupKind, open_definition
+from core.mtc_interpreter import ContextFrame, DistinguishedMemory, interpret_constraints
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-proof-lifting-challenge-v0.3.json"
+CORPUS = ROOT / "contracts" / "mts-proof-lifting-conformance-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def definition(source: str) -> Definition:
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
+
+
+def target(source: str) -> Form:
+    return definition(f"{source} : __lift_query__").target
+
+
+def build_environment(definitions: list[str]) -> DefinitionEnvironment:
+    environment = DefinitionEnvironment()
+    for source in definitions:
+        environment.register(definition(source))
+    return environment
+
+
+def opening_data(definitions: list[str], target_source: str) -> dict:
+    result = open_definition(target(target_source), build_environment(definitions))
+    if result.kind is not DefinitionLookupKind.MATCH:
+        return {"kind": result.kind.value}
+    assert result.body is not None
+    return {"kind": "match", "body": format_expression(result.body)}
+
+
+def interpret_success(vector: dict) -> bool:
+    memory = DistinguishedMemory(
+        {item["id"]: (item["start"], item["end"]) for item in vector["memory"]}
+    )
+    result = interpret_constraints(
+        parse_formula(vector["expression"]),
+        ContextFrame(start=vector["context"]["start"], end=vector["context"]["end"]),
+        memory,
+        symbols=dict(vector["symbols"]),
+    )
+    return result.success
+
+
+def test_challenge_is_non_normative_and_adds_no_trusted_rules():
+    data = read(CHALLENGE)
+    proof = read(PROOF_V02)
+
+    assert data["schema"] == "mts-proof-lifting-challenge/v0.3"
+    assert data["status"] == "candidate-challenge"
+    assert data["acceptedContractLinkAllowed"] is False
+    assert data["productionProofChangeAllowed"] is False
+    assert data["trustedRuleChangeAllowed"] is False
+    assert proof["checker"]["trustedRuleSet"] == ["interpret"]
+    assert data["derivationBoundary"]["genericCompositionAccepted"] is False
+
+
+def test_contextual_satisfaction_is_context_scoped_not_global_truth():
+    vectors = {item["id"]: item for item in read(CORPUS)["vectors"]}
+    positive = vectors["contextual-satisfaction-positive"]
+    counter = vectors["contextual-satisfaction-countercontext"]
+
+    assert interpret_success(positive) is True
+    assert interpret_success(counter) is False
+    assert positive["expression"] == counter["expression"]
+    assert positive["symbols"] == counter["symbols"]
+    assert positive["context"] != counter["context"]
+
+    candidate = next(
+        item for item in read(CHALLENGE)["candidateLifts"]
+        if item["id"] == "contextual-satisfaction"
+    )
+    assert "global formula truth" in candidate["doesNotMean"]
+    assert candidate["accepted"] is False
+
+
+def test_definition_opening_match_is_exact_relation_but_not_equality():
+    vector = next(item for item in read(CORPUS)["vectors"] if item["id"] == "opening-match")
+    assert opening_data(vector["definitions"], vector["target"]) == vector["expect"]
+    assert vector["mustNotAssertEquality"] is True
+
+    candidate = next(
+        item for item in read(CHALLENGE)["candidateLifts"]
+        if item["id"] == "definition-opens"
+    )
+    assert "target = body" in candidate["doesNotMean"]
+    assert "RHS interpretation" in candidate["doesNotMean"]
+    assert candidate["accepted"] is False
+
+
+def test_no_match_is_scoped_to_exact_environment_not_global_absence():
+    vectors = {item["id"]: item for item in read(CORPUS)["vectors"]}
+    local = vectors["no-match-local"]
+    other = vectors["same-target-other-environment"]
+
+    assert opening_data(local["definitions"], local["target"]) == {"kind": "no-match"}
+    assert opening_data(other["definitions"], other["target"]) == other["expect"]
+
+    candidate = next(
+        item for item in read(CHALLENGE)["candidateLifts"]
+        if item["id"] == "no-visible-definition"
+    )
+    assert "definition does not exist globally" in candidate["doesNotMean"]
+    assert candidate["accepted"] is False
+
+
+def test_conflict_does_not_assert_duplicate_body_equality():
+    vector = next(item for item in read(CORPUS)["vectors"] if item["id"] == "same-scope-conflict")
+    assert opening_data(vector["definitions"], vector["target"]) == {"kind": "conflict"}
+    assert vector["mustNotAssertBodyEquality"] is True
+
+    witness = read(CHALLENGE)["mandatoryCounterexamples"]
+    conflict = next(item for item in witness if item["id"] == "conflict-not-equality")
+    assert "b=c" in conflict["witness"]
+
+
+def test_non_addressable_target_is_typed_relation_candidate_only():
+    vector = next(item for item in read(CORPUS)["vectors"] if item["id"] == "anonymous-target")
+    assert opening_data(vector["definitions"], vector["target"]) == {"kind": "non-addressable"}
+
+    candidate = next(
+        item for item in read(CHALLENGE)["candidateLifts"]
+        if item["id"] == "non-addressable-target"
+    )
+    assert candidate["accepted"] is False
+    assert candidate["scope"] == "accepted v0.3 definition-addressability subset"
+
+
+def test_all_lifts_stay_unaccepted_and_classical_composition_is_still_blocked():
+    data = read(CHALLENGE)
+    assert all(item["accepted"] is False for item in data["candidateLifts"])
+    boundary = data["derivationBoundary"]
+    assert boundary == {
+        "liftResultMayBeUsedAsPremiseOnlyAfterAcceptance": True,
+        "genericCompositionAccepted": False,
+        "transitivityAccepted": False,
+        "symmetryAccepted": False,
+        "congruenceAccepted": False,
+        "modusPonensAccepted": False,
+        "globalSubstitutionAccepted": False,
+        "searchTraceIsEvidence": False,
+    }
+
+
+def test_next_gate_is_relation_acceptance_decision_not_multistep_search():
+    gate = read(CHALLENGE)["nextGate"]
+    assert gate["mustKeepMtsProofV02Unchanged"] is True
+    assert gate["mustNotAddTrustedRulesYet"] is True
+    assert gate["goal"].startswith("decide which challenged relations")


### PR DESCRIPTION
Refs #122, #120.

Non-normative lifting challenge после merged proof-domain decision. Production checker и trusted rules не меняются.

## Candidate relations under challenge

- `ContextuallySatisfies(expression, context, symbols, memorySnapshot)` из verified `interpret success`;
- `Opens(environment,target,definitionId,body)` из opening `match`;
- `NoVisibleDefinition(environment,target)` из scoped `no-match`;
- `DefinitionConflict(environment,target)`;
- `NonAddressableDefinitionTarget(target)`.

Все кандидаты `accepted=false`.

## Mandatory counterexamples

Executable corpus доказывает:
- одна и та же contextual formula succeeds в одном ContextFrame и fails в другом → никакой global truth;
- `a : b` opening возвращает `b`, но не исполняет equality/RHS interpretation;
- empty env даёт no-match, другой explicit env с `a:b` даёт match → no-match не global absence;
- `a:b` + `a:c` дают conflict без `b=c`.

## Veto

Никаких symmetry/transitivity/congruence/MP/global substitution/generic composition. Challenge result нельзя использовать как derivation premise до отдельной acceptance decision.

Локально target/full pytest + Ruff green; GitHub CI остаётся merge-gate.