### PR TITLE
Принять replay-backed base derivation relations v0.3

### DIFF
--- a/contracts/mts-derivation-base-conformance-v0.3.json
+++ b/contracts/mts-derivation-base-conformance-v0.3.json
@@ -1,0 +1,29 @@
+{
+  "schema": "mts-derivation-base-conformance/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-derivation-base/v0.3",
+  "sourceChallenge": "contracts/mts-proof-lifting-conformance-v0.3.json",
+  "acceptedVectors": {
+    "ContextuallySatisfies": ["contextual-satisfaction-positive"],
+    "Opens": ["opening-match"],
+    "NoVisibleDefinition": ["no-match-local", "same-target-other-environment"],
+    "DefinitionConflict": ["same-scope-conflict"],
+    "NonAddressableDefinitionTarget": ["anonymous-target"]
+  },
+  "requiredCounterexamples": [
+    "contextual-satisfaction-countercontext",
+    "same-target-other-environment",
+    "same-scope-conflict"
+  ],
+  "releaseAssertions": {
+    "contextualSatisfactionIsContextScoped": true,
+    "openingDoesNotImplyEquality": true,
+    "openingDoesNotEvaluateRhs": true,
+    "noVisibleDefinitionIsEnvironmentScoped": true,
+    "conflictDoesNotImplyBodyEquality": true,
+    "negativeRelationsDoNotCreateGlobalClosedWorld": true,
+    "allRelationsRequireIndependentReplay": true,
+    "genericCompositionStillForbidden": true
+  }
+}

--- a/contracts/mts-derivation-base-v0.3.json
+++ b/contracts/mts-derivation-base-v0.3.json
@@ -1,0 +1,111 @@
+{
+  "schema": "mts-derivation-base/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 122,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-proof-domain-decision/v0.3",
+    "mts-proof-lifting-challenge/v0.3"
+  ],
+  "conformanceCorpus": "contracts/mts-derivation-base-conformance-v0.3.json",
+  "scope": "accepted primitive typed derivation relations backed by independent replay of already accepted canonical operations; no multi-step composition rules",
+  "judgmentShape": {
+    "relation": "explicit tagged relation name",
+    "subject": "all operation inputs required by the relation",
+    "evidence": "validated OperationalReplayClaim for the exact accepted canonical operation",
+    "hiddenGlobalStateAllowed": false,
+    "globalTruthPredicateIntroduced": false
+  },
+  "relations": [
+    {
+      "id": "ContextuallySatisfies",
+      "sourceOperation": "interpret",
+      "precondition": "independent replay returns success=true",
+      "arguments": ["expression", "ContextFrame", "symbol bindings", "finite MemoryView snapshot"],
+      "meaning": "the expression satisfies the accepted contextual interpretation semantics under exactly these replay inputs",
+      "globalTruth": false,
+      "materializes": false
+    },
+    {
+      "id": "Opens",
+      "sourceOperation": "open_definition",
+      "precondition": "independent replay returns kind=match",
+      "arguments": ["DefinitionEnvironment snapshot", "target", "DefinitionId", "exact typed RHS"],
+      "meaning": "the visible definition selected by this exact lexical environment opens the target once to this exact RHS",
+      "impliesEquality": false,
+      "evaluatesRhs": false,
+      "materializes": false
+    },
+    {
+      "id": "NoVisibleDefinition",
+      "sourceOperation": "open_definition",
+      "precondition": "independent replay returns kind=no-match",
+      "arguments": ["DefinitionEnvironment snapshot", "target"],
+      "meaning": "no visible definition for the target exists in this exact finite lexical environment snapshot",
+      "globalAbsence": false,
+      "closedWorldBeyondSnapshot": false
+    },
+    {
+      "id": "DefinitionConflict",
+      "sourceOperation": "open_definition",
+      "precondition": "independent replay returns kind=conflict",
+      "arguments": ["DefinitionEnvironment snapshot", "target"],
+      "meaning": "the nearest relevant lexical scope in this environment contains a same-target definition conflict",
+      "impliesBodyEquality": false
+    },
+    {
+      "id": "NonAddressableDefinitionTarget",
+      "sourceOperation": "open_definition",
+      "precondition": "independent replay returns kind=non-addressable",
+      "arguments": ["target"],
+      "meaning": "the target is outside the accepted v0.3 definition-addressability subset",
+      "globalSemanticInvalidity": false
+    }
+  ],
+  "evidenceBoundary": {
+    "replayCertificateIsTrustedWithoutReplay": false,
+    "checkerMustReplayCanonicalOperation": true,
+    "searchTraceIsEvidence": false,
+    "uiStateIsEvidence": false,
+    "sourceSpanIsSemanticIdentity": false,
+    "persistentBackendIdentityIsSemanticIdentity": false
+  },
+  "negativeRelationBoundary": {
+    "negativeRelationsAccepted": [
+      "NoVisibleDefinition",
+      "DefinitionConflict",
+      "NonAddressableDefinitionTarget"
+    ],
+    "reason": "each accepted negative relation names the exact finite scope/subset in which the negative result was replayed; no global absence or closed-world conclusion is introduced"
+  },
+  "compositionBoundary": {
+    "genericCompositionAccepted": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "openingToEqualityAccepted": false,
+    "recursiveNormalizationAccepted": false
+  },
+  "proofVersionBoundary": {
+    "mtsProofV02Modified": false,
+    "mtsProofV02TrustedRuleSet": ["interpret"],
+    "mtsProofV03Published": false,
+    "productionV03CheckerImplemented": false,
+    "aproverProofRepinAllowed": false
+  },
+  "nextGate": {
+    "goal": "define a versioned mts-proof/v0.3 artifact/checker that can independently validate these accepted base relations while preserving v0.2 replay compatibility",
+    "requirements": [
+      "each step names one accepted relation",
+      "step contains complete explicit replay substrate",
+      "checker independently replays the corresponding canonical operation",
+      "forged relation/arguments/results are rejected",
+      "no generic step composition yet",
+      "no proof-search dependency",
+      "cycles remain finite"
+    ]
+  }
+}

--- a/tests/test_mts_derivation_base_contract.py
+++ b/tests/test_mts_derivation_base_contract.py
@@ -1,0 +1,131 @@
+"""Acceptance checks for replay-backed primitive MTS derivation relations v0.3."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-derivation-base-v0.3.json"
+CONFORMANCE = ROOT / "contracts" / "mts-derivation-base-conformance-v0.3.json"
+DOMAIN_DECISION = ROOT / "contracts" / "mts-proof-domain-decision-v0.3.json"
+LIFTING_CHALLENGE = ROOT / "contracts" / "mts-proof-lifting-challenge-v0.3.json"
+LIFTING_CORPUS = ROOT / "contracts" / "mts-proof-lifting-conformance-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_contract_is_accepted_only_after_domain_decision_and_lifting_challenge():
+    contract = read(CONTRACT)
+    decision = read(DOMAIN_DECISION)
+    challenge = read(LIFTING_CHALLENGE)
+
+    assert contract["schema"] == "mts-derivation-base/v0.3"
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert contract["dependsOn"] == [
+        "mts-contract/v0.3",
+        decision["schema"],
+        challenge["schema"],
+    ]
+    assert contract["conformanceCorpus"] == "contracts/mts-derivation-base-conformance-v0.3.json"
+
+
+def test_exact_five_relations_are_accepted_and_all_name_explicit_scope():
+    contract = read(CONTRACT)
+    relations = {item["id"]: item for item in contract["relations"]}
+
+    assert set(relations) == {
+        "ContextuallySatisfies",
+        "Opens",
+        "NoVisibleDefinition",
+        "DefinitionConflict",
+        "NonAddressableDefinitionTarget",
+    }
+    assert relations["ContextuallySatisfies"]["globalTruth"] is False
+    assert "ContextFrame" in relations["ContextuallySatisfies"]["arguments"]
+    assert relations["Opens"]["impliesEquality"] is False
+    assert relations["Opens"]["evaluatesRhs"] is False
+    assert relations["NoVisibleDefinition"]["globalAbsence"] is False
+    assert relations["NoVisibleDefinition"]["closedWorldBeyondSnapshot"] is False
+    assert relations["DefinitionConflict"]["impliesBodyEquality"] is False
+    assert relations["NonAddressableDefinitionTarget"]["globalSemanticInvalidity"] is False
+
+
+def test_accepted_conformance_selects_challenged_vectors_without_erasing_counterexamples():
+    conformance = read(CONFORMANCE)
+    challenge_corpus = read(LIFTING_CORPUS)
+    challenge_ids = {item["id"] for item in challenge_corpus["vectors"]}
+
+    assert conformance["schema"] == "mts-derivation-base-conformance/v0.3"
+    assert conformance["status"] == "accepted"
+    assert conformance["accepted"] is True
+    assert conformance["contract"] == "mts-derivation-base/v0.3"
+    assert conformance["sourceChallenge"] == "contracts/mts-proof-lifting-conformance-v0.3.json"
+
+    selected = {
+        item
+        for values in conformance["acceptedVectors"].values()
+        for item in values
+    }
+    assert selected.issubset(challenge_ids)
+    assert set(conformance["requiredCounterexamples"]).issubset(challenge_ids)
+    assert "contextual-satisfaction-countercontext" in conformance["requiredCounterexamples"]
+    assert "same-target-other-environment" in conformance["requiredCounterexamples"]
+
+
+def test_independent_replay_remains_part_of_trusted_boundary():
+    contract = read(CONTRACT)
+    evidence = contract["evidenceBoundary"]
+
+    assert evidence["replayCertificateIsTrustedWithoutReplay"] is False
+    assert evidence["checkerMustReplayCanonicalOperation"] is True
+    assert evidence["searchTraceIsEvidence"] is False
+    assert evidence["uiStateIsEvidence"] is False
+    assert evidence["sourceSpanIsSemanticIdentity"] is False
+    assert evidence["persistentBackendIdentityIsSemanticIdentity"] is False
+
+
+def test_negative_relations_are_scoped_facts_not_global_closed_world_theorems():
+    boundary = read(CONTRACT)["negativeRelationBoundary"]
+    assert set(boundary["negativeRelationsAccepted"]) == {
+        "NoVisibleDefinition",
+        "DefinitionConflict",
+        "NonAddressableDefinitionTarget",
+    }
+    assert "no global absence" in boundary["reason"]
+    assert read(CONFORMANCE)["releaseAssertions"]["negativeRelationsDoNotCreateGlobalClosedWorld"] is True
+
+
+def test_no_composition_or_classical_rule_is_accepted_by_base_contract():
+    boundary = read(CONTRACT)["compositionBoundary"]
+    assert boundary == {
+        "genericCompositionAccepted": False,
+        "transitivityAccepted": False,
+        "symmetryAccepted": False,
+        "congruenceAccepted": False,
+        "modusPonensAccepted": False,
+        "globalSubstitutionAccepted": False,
+        "openingToEqualityAccepted": False,
+        "recursiveNormalizationAccepted": False,
+    }
+
+
+def test_v02_proof_kernel_stays_unchanged_and_v03_checker_is_next_gate():
+    contract = read(CONTRACT)
+    proof_v02 = read(PROOF_V02)
+    boundary = contract["proofVersionBoundary"]
+
+    assert proof_v02["checker"]["trustedRuleSet"] == ["interpret"]
+    assert boundary["mtsProofV02Modified"] is False
+    assert boundary["mtsProofV02TrustedRuleSet"] == ["interpret"]
+    assert boundary["mtsProofV03Published"] is False
+    assert boundary["productionV03CheckerImplemented"] is False
+    assert boundary["aproverProofRepinAllowed"] is False
+
+    gate = contract["nextGate"]
+    assert gate["goal"].startswith("define a versioned mts-proof/v0.3 artifact/checker")
+    assert "no generic step composition yet" in gate["requirements"]
+    assert "no proof-search dependency" in gate["requirements"]


### PR DESCRIPTION
Refs #122, #120.

Semantic acceptance после merged proof-domain decision и lifting counterexample challenge. Production proof checker пока не меняется.

## Accepted base relations

Ровно пять tagged relations:

- `ContextuallySatisfies(expression, ContextFrame, symbols, memorySnapshot)`;
- `Opens(environment,target,DefinitionId,RHS)`;
- `NoVisibleDefinition(environment,target)`;
- `DefinitionConflict(environment,target)`;
- `NonAddressableDefinitionTarget(target)`.

Каждая relation принимается только в точной области replay inputs.

## Что принципиально НЕ принимается

- global truth;
- opening => equality;
- RHS evaluation;
- global absence из scoped no-match;
- body equality из conflict;
- symmetry/transitivity/congruence/MP/global substitution;
- generic proof DAG composition.

Negative relations допустимы только потому, что явно содержат конечный environment/subset scope; closed-world вывод за его пределы запрещён.

## Trusted boundary

Replay certificate не доверяется сам по себе: будущий checker обязан независимо выполнить canonical operation.

`mts-proof/v0.2` остаётся неизменным с `trustedRuleSet=[interpret]`. `mts-proof/v0.3`, production v0.3 checker и aprover proof repin всё ещё false.

Следующий gate после acceptance — versioned `mts-proof/v0.3` artifact/checker для этих base relations, всё ещё без multi-step composition.

Локально target/full pytest + Ruff green; GitHub CI остаётся merge gate.