### PR TITLE
Реализовать production mts-proof/v0.3 для base derivation relations

### DIFF
--- a/contracts/mts-proof-conformance-v0.3.json
+++ b/contracts/mts-proof-conformance-v0.3.json
@@ -1,0 +1,227 @@
+{
+  "schema": "mts-proof-conformance/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-proof/v0.3",
+  "proofVersion": "mts-proof/v0.3",
+  "contractVersion": "mts-contract/v0.3",
+  "validJudgments": [
+    {
+      "id": "contextually-satisfies-aroot",
+      "judgment": {
+        "relation": "ContextuallySatisfies",
+        "expression": "{◁ = ∞, ▷ = ∞}",
+        "context": {"start": 1, "end": 1, "parent": null},
+        "symbols": [["∞", 1]],
+        "memory": [],
+        "expected": {"substitutions": [], "aliases": []}
+      }
+    },
+    {
+      "id": "contextually-satisfies-link-decomposition",
+      "judgment": {
+        "relation": "ContextuallySatisfies",
+        "expression": "10 = [] ⟼ []",
+        "context": {"start": 2, "end": 3, "parent": null},
+        "symbols": [["10", 10]],
+        "memory": [{"id": 10, "start": 2, "end": 3}],
+        "expected": {
+          "substitutions": [
+            {"path": [1, 0], "link": 2},
+            {"path": [1, 1], "link": 3}
+          ],
+          "aliases": []
+        }
+      }
+    },
+    {
+      "id": "opens-direct",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+        "lookupScope": [],
+        "target": "a",
+        "expected": {
+          "definitionId": {"scopePath": [], "ordinal": 0},
+          "body": "b"
+        }
+      }
+    },
+    {
+      "id": "opens-child-shadowing",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [
+          {"path": [], "parent": null, "definitions": ["a : root"]},
+          {"path": [0], "parent": [], "definitions": ["a : child"]}
+        ],
+        "lookupScope": [0],
+        "target": "a",
+        "expected": {
+          "definitionId": {"scopePath": [0], "ordinal": 0},
+          "body": "child"
+        }
+      }
+    },
+    {
+      "id": "opens-self-one-step",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [{"path": [], "parent": null, "definitions": ["a : a"]}],
+        "lookupScope": [],
+        "target": "a",
+        "expected": {
+          "definitionId": {"scopePath": [], "ordinal": 0},
+          "body": "a"
+        }
+      }
+    },
+    {
+      "id": "no-visible-definition",
+      "judgment": {
+        "relation": "NoVisibleDefinition",
+        "scopes": [{"path": [], "parent": null, "definitions": []}],
+        "lookupScope": [],
+        "target": "a"
+      }
+    },
+    {
+      "id": "definition-conflict",
+      "judgment": {
+        "relation": "DefinitionConflict",
+        "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "a : c"]}],
+        "lookupScope": [],
+        "target": "a"
+      }
+    },
+    {
+      "id": "non-addressable-target",
+      "judgment": {
+        "relation": "NonAddressableDefinitionTarget",
+        "target": "[]"
+      }
+    }
+  ],
+  "invalidArtifacts": [
+    {
+      "id": "wrong-proof-version",
+      "artifact": {"proofVersion": "mts-proof/v0.2", "contractVersion": "mts-contract/v0.3", "judgments": []}
+    },
+    {
+      "id": "wrong-contract-version",
+      "artifact": {"proofVersion": "mts-proof/v0.3", "contractVersion": "mts-contract/v0.2", "judgments": []}
+    },
+    {
+      "id": "unknown-relation",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.3",
+        "contractVersion": "mts-contract/v0.3",
+        "judgments": [{"relation": "Equality", "left": "a", "right": "b"}]
+      }
+    },
+    {
+      "id": "unexpected-proof-field",
+      "artifact": {"proofVersion": "mts-proof/v0.3", "contractVersion": "mts-contract/v0.3", "judgments": [], "searchTrace": []}
+    }
+  ],
+  "forgeries": [
+    {
+      "id": "context-counterexample-not-satisfied",
+      "sourceJudgment": "contextually-satisfies-aroot",
+      "patch": {"context.end": 2},
+      "mustReject": true
+    },
+    {
+      "id": "forged-substitution",
+      "sourceJudgment": "contextually-satisfies-link-decomposition",
+      "patch": {"expected.substitutions": [{"path": [1, 0], "link": 999}]},
+      "mustReject": true
+    },
+    {
+      "id": "forged-opening-body",
+      "sourceJudgment": "opens-direct",
+      "patch": {"expected.body": "c"},
+      "mustReject": true
+    },
+    {
+      "id": "forged-opening-id",
+      "sourceJudgment": "opens-direct",
+      "patch": {"expected.definitionId.ordinal": 9},
+      "mustReject": true
+    },
+    {
+      "id": "no-match-when-visible",
+      "sourceJudgment": "opens-direct",
+      "replaceRelation": "NoVisibleDefinition",
+      "remove": ["expected"],
+      "mustReject": true
+    },
+    {
+      "id": "conflict-with-single-definition",
+      "sourceJudgment": "opens-direct",
+      "replaceRelation": "DefinitionConflict",
+      "remove": ["expected"],
+      "mustReject": true
+    },
+    {
+      "id": "addressable-target-claimed-non-addressable",
+      "sourceJudgment": "non-addressable-target",
+      "patch": {"target": "a"},
+      "mustReject": true
+    },
+    {
+      "id": "hidden-root-injection",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [{"path": [], "parent": null, "definitions": []}],
+        "lookupScope": [],
+        "target": "∞",
+        "expected": {
+          "definitionId": {"scopePath": [], "ordinal": 0},
+          "body": "{◁ = ∞, ▷ = ∞}"
+        }
+      },
+      "mustReject": true
+    },
+    {
+      "id": "duplicate-scope",
+      "judgment": {
+        "relation": "NoVisibleDefinition",
+        "scopes": [
+          {"path": [], "parent": null, "definitions": []},
+          {"path": [], "parent": null, "definitions": []}
+        ],
+        "lookupScope": [],
+        "target": "a"
+      },
+      "mustReject": true
+    },
+    {
+      "id": "noncanonical-scope-order",
+      "judgment": {
+        "relation": "NoVisibleDefinition",
+        "scopes": [
+          {"path": [], "parent": null, "definitions": []},
+          {"path": [1], "parent": [], "definitions": []},
+          {"path": [0], "parent": [], "definitions": []}
+        ],
+        "lookupScope": [0],
+        "target": "a"
+      },
+      "mustReject": true
+    }
+  ],
+  "releaseAssertions": {
+    "allFiveAcceptedRelationsCovered": true,
+    "contextualSatisfactionRequiresSuccess": true,
+    "exactSubstitutionsAndAliasesChecked": true,
+    "openingBodyAndDefinitionIdChecked": true,
+    "negativeRelationsAreScopeBound": true,
+    "hiddenRootInjectionRejected": true,
+    "malformedScopeSnapshotsRejected": true,
+    "unknownRelationsRejected": true,
+    "v02RegressionRequired": true,
+    "genericCompositionAccepted": false,
+    "ambientSubjectOrInterpreterStateUsed": false
+  }
+}

--- a/contracts/mts-proof-v0.3.json
+++ b/contracts/mts-proof-v0.3.json
@@ -1,0 +1,129 @@
+{
+  "schema": "mts-proof/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 147,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-derivation-base/v0.3",
+    "mts-proof/v0.2"
+  ],
+  "conformanceCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "purpose": "Trusted independent replay of the five accepted base derivation relations; no multi-step composition or proof-search semantics.",
+  "proofObject": {
+    "required": ["proofVersion", "contractVersion", "judgments"],
+    "proofVersion": "mts-proof/v0.3",
+    "contractVersion": "mts-contract/v0.3",
+    "judgments": "ordered BaseJudgment[]; ordering is artifact order only and has no inference/composition meaning"
+  },
+  "trustedRelations": [
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget"
+  ],
+  "contextuallySatisfies": {
+    "required": ["relation", "expression", "context", "symbols", "memory", "expected"],
+    "context": {
+      "start": "LinkRef",
+      "end": "LinkRef",
+      "parent": "optional recursive explicit ContextFrame"
+    },
+    "expected": {
+      "substitutions": "exact sorted array of {path:int[],link:LinkRef}",
+      "aliases": "exact sorted array of {path:int[],targetPath:int[]}"
+    },
+    "replay": "canonical interpret_constraints with success required to be true",
+    "globalTruth": false,
+    "hiddenInterpreterIdentity": false,
+    "subjectOrFocusIdentity": false,
+    "materializes": false
+  },
+  "definitionEnvironment": {
+    "scope": {
+      "required": ["path", "parent", "definitions"],
+      "path": "non-negative int[]",
+      "parent": "null for root or exact parent path",
+      "definitions": "ordered canonical L2 Definition source strings"
+    },
+    "scopeOrder": "canonical order by (path length, lexicographic path)",
+    "rootScopeRequired": true,
+    "duplicateScopeRejected": true,
+    "hiddenRootInjection": false,
+    "definitionId": "replay-local DefinitionId(scopePath, successful registration ordinal)",
+    "sourceSpanIdentity": false,
+    "persistentIdentity": false
+  },
+  "opens": {
+    "required": ["relation", "scopes", "lookupScope", "target", "expected"],
+    "expected": {
+      "definitionId": {"scopePath": "int[]", "ordinal": "non-negative int"},
+      "body": "exact canonical format_expression output"
+    },
+    "replay": "open_definition exactly once and require kind=match",
+    "impliesEquality": false,
+    "evaluatesRhs": false,
+    "materializes": false
+  },
+  "noVisibleDefinition": {
+    "required": ["relation", "scopes", "lookupScope", "target"],
+    "replay": "open_definition exactly once and require kind=no-match",
+    "globalAbsence": false,
+    "closedWorldBeyondSnapshot": false
+  },
+  "definitionConflict": {
+    "required": ["relation", "scopes", "lookupScope", "target"],
+    "replay": "open_definition exactly once and require kind=conflict",
+    "impliesBodyEquality": false
+  },
+  "nonAddressableDefinitionTarget": {
+    "required": ["relation", "target"],
+    "replay": "open_definition against a fresh empty DefinitionEnvironment and require kind=non-addressable",
+    "globalSemanticInvalidity": false
+  },
+  "checker": {
+    "module": "core/proof_checker.py",
+    "singleTrustedModuleForV02AndV03": true,
+    "replaysCanonicalInterpreter": true,
+    "replaysCanonicalDefinitionOpening": true,
+    "trustsSerializedExpectedResultWithoutReplay": false,
+    "mayReadAmbientInterpreterState": false,
+    "mayInjectCanonicalRootDefinitions": false,
+    "mayMaterialize": false,
+    "mayDelete": false,
+    "unknownRelationRejected": true,
+    "wrongOrMissingVersionRejected": true,
+    "unexpectedFieldsRejected": true
+  },
+  "compositionBoundary": {
+    "judgmentOrderImpliesDependency": false,
+    "genericCompositionAccepted": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "openingToEqualityAccepted": false,
+    "recursiveNormalizationAccepted": false
+  },
+  "v02Compatibility": {
+    "mtsProofV02Modified": false,
+    "mtsProofV02Schema": "mts-proof/v0.2",
+    "mtsProofV02ContractVersion": "mts-contract/v0.2",
+    "mtsProofV02TrustedRuleSet": ["interpret"],
+    "existingV02ArtifactsReplayedByExistingApi": true,
+    "retroactiveReinterpretation": false
+  },
+  "contextVersionBoundary": {
+    "explicitContextFrameOnly": true,
+    "subjectFocusResearchIssue": 148,
+    "subjectOrFocusAddedToV03Artifact": false,
+    "futureContextSemanticsMustUseAdditiveContract": true
+  },
+  "downstream": {
+    "proofSemanticsAccepted": true,
+    "aproverRepinAllowedDirectlyFromMtsContractV03": false,
+    "reason": "mts-contract/v0.3 is immutable and predates mts-proof/v0.3 publication; downstream repin requires a later additive umbrella contract"
+  }
+}

--- a/core/proof_checker.py
+++ b/core/proof_checker.py
@@ -1,18 +1,35 @@
-"""Minimal trusted proof replay kernel for MTS v0.2.
+"""Trusted proof replay kernels for versioned MTS proof artifacts.
 
-The kernel deliberately trusts only one rule: replay of the already accepted
-read-only contextual ``interpret`` semantics.  It does not implement proof
-search and does not promote legacy equality/congruence/Modus-Ponens rules to
-trusted MTS semantics.
+v0.2 deliberately trusts only replay of the accepted read-only contextual
+``interpret`` semantics.
+
+v0.3 adds replay of the five already accepted base derivation relations from
+``mts-derivation-base/v0.3``.  It still does not implement proof search,
+multi-step composition, global rewriting, classical inference rules, hidden
+root injection, or ambient interpreter/subject access.
 """
 
 from dataclasses import dataclass
+import json
+from typing import TypeAlias
 
+from core.mtc_ast import Definition, Form, format_expression
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    open_definition,
+)
 from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
 from core.mtc_parser import parse_formula
 
+
+# Existing v0.2 public constants remain unchanged for compatibility.
 CONTRACT_VERSION = "mts-contract/v0.2"
 PROOF_SCHEMA = "mts-proof/v0.2"
+
+CONTRACT_VERSION_V03 = "mts-contract/v0.3"
+PROOF_SCHEMA_V03 = "mts-proof/v0.3"
 
 
 @dataclass(frozen=True)
@@ -141,8 +158,639 @@ def check_interpret_step(step: InterpretProofStep) -> bool:
 
 
 def check_proof(proof: ProofObject) -> bool:
-    """Independently replay every trusted step in a proof object."""
+    """Independently replay every trusted v0.2 step in a proof object."""
 
     if proof.schema != PROOF_SCHEMA or proof.contract_version != CONTRACT_VERSION:
         return False
     return all(check_interpret_step(step) for step in proof.steps)
+
+
+@dataclass(frozen=True)
+class DefinitionScopeSnapshot:
+    path: tuple[int, ...]
+    parent: tuple[int, ...] | None
+    definitions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExpectedDefinitionId:
+    scope_path: tuple[int, ...]
+    ordinal: int
+
+
+@dataclass(frozen=True)
+class ContextuallySatisfiesJudgment:
+    expression: str
+    context: ProofContext
+    distinguished_memory: tuple[DistinguishedLink, ...] = ()
+    symbols: tuple[tuple[str, int], ...] = ()
+    expected_substitutions: tuple[ExpectedSubstitution, ...] = ()
+    expected_aliases: tuple[ExpectedAlias, ...] = ()
+    relation: str = "ContextuallySatisfies"
+
+
+@dataclass(frozen=True)
+class OpensJudgment:
+    scopes: tuple[DefinitionScopeSnapshot, ...]
+    lookup_scope: tuple[int, ...]
+    target: str
+    expected_definition_id: ExpectedDefinitionId
+    expected_body: str
+    relation: str = "Opens"
+
+
+@dataclass(frozen=True)
+class NoVisibleDefinitionJudgment:
+    scopes: tuple[DefinitionScopeSnapshot, ...]
+    lookup_scope: tuple[int, ...]
+    target: str
+    relation: str = "NoVisibleDefinition"
+
+
+@dataclass(frozen=True)
+class DefinitionConflictJudgment:
+    scopes: tuple[DefinitionScopeSnapshot, ...]
+    lookup_scope: tuple[int, ...]
+    target: str
+    relation: str = "DefinitionConflict"
+
+
+@dataclass(frozen=True)
+class NonAddressableDefinitionTargetJudgment:
+    target: str
+    relation: str = "NonAddressableDefinitionTarget"
+
+
+V03Judgment: TypeAlias = (
+    ContextuallySatisfiesJudgment
+    | OpensJudgment
+    | NoVisibleDefinitionJudgment
+    | DefinitionConflictJudgment
+    | NonAddressableDefinitionTargetJudgment
+)
+
+
+@dataclass(frozen=True)
+class ProofObjectV03:
+    judgments: tuple[V03Judgment, ...]
+    contract_version: str = CONTRACT_VERSION_V03
+    proof_version: str = PROOF_SCHEMA_V03
+
+
+def _is_non_negative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _validate_path(path: tuple[int, ...]) -> None:
+    if any(not _is_non_negative_int(item) for item in path):
+        raise ValueError("path must contain only non-negative integers")
+
+
+def _parse_definition(source: str) -> Definition:
+    value = parse_formula(source)
+    if not isinstance(value, Definition):
+        raise ValueError("definition scope item must parse as Definition")
+    return value
+
+
+def _parse_definition_target(source: str) -> Form:
+    value = parse_formula(f"{source} : __proof_v03_query__")
+    if not isinstance(value, Definition):
+        raise ValueError("definition target must parse as Form")
+    return value.target
+
+
+def _build_definition_environments(
+    scopes: tuple[DefinitionScopeSnapshot, ...],
+) -> dict[tuple[int, ...], DefinitionEnvironment]:
+    if not scopes:
+        raise ValueError("definition environment must contain explicit root scope")
+
+    canonical = tuple(sorted(scopes, key=lambda item: (len(item.path), item.path)))
+    if scopes != canonical:
+        raise ValueError("definition scopes must use canonical order")
+
+    paths = [scope.path for scope in scopes]
+    if len(paths) != len(set(paths)):
+        raise ValueError("duplicate definition scope path")
+
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+    for scope in scopes:
+        _validate_path(scope.path)
+        if scope.parent is not None:
+            _validate_path(scope.parent)
+
+        if scope.parent is None:
+            if scope.path != () or environments:
+                raise ValueError("exactly one root scope must be first")
+            environment = DefinitionEnvironment()
+        else:
+            if not scope.path or scope.path[:-1] != scope.parent:
+                raise ValueError("scope path must extend declared parent by one index")
+            parent = environments.get(scope.parent)
+            if parent is None:
+                raise ValueError("definition scope parent must precede child")
+            environment = parent.child(scope.path[-1])
+
+        environments[scope.path] = environment
+        for source in scope.definitions:
+            registration = environment.register(_parse_definition(source))
+            if registration.kind not in {
+                DefinitionRegistrationKind.REGISTERED,
+                DefinitionRegistrationKind.CONFLICT,
+                DefinitionRegistrationKind.NON_ADDRESSABLE,
+            }:
+                raise ValueError("unknown definition registration result")
+
+    if () not in environments:
+        raise ValueError("explicit root definition scope is required")
+    return environments
+
+
+def _replay_definition_opening(
+    scopes: tuple[DefinitionScopeSnapshot, ...],
+    lookup_scope: tuple[int, ...],
+    target: str,
+):
+    _validate_path(lookup_scope)
+    environments = _build_definition_environments(scopes)
+    environment = environments.get(lookup_scope)
+    if environment is None:
+        raise ValueError("lookupScope must name a serialized scope")
+    return open_definition(_parse_definition_target(target), environment)
+
+
+def check_contextually_satisfies(judgment: ContextuallySatisfiesJudgment) -> bool:
+    """Replay the accepted context-scoped satisfaction relation."""
+
+    if judgment.relation != "ContextuallySatisfies":
+        return False
+    step = InterpretProofStep(
+        expression=judgment.expression,
+        context=judgment.context,
+        distinguished_memory=judgment.distinguished_memory,
+        symbols=judgment.symbols,
+        expected_success=True,
+        expected_substitutions=judgment.expected_substitutions,
+        expected_aliases=judgment.expected_aliases,
+    )
+    return check_interpret_step(step)
+
+
+def check_opens(judgment: OpensJudgment) -> bool:
+    """Replay one accepted lexical definition opening without evaluating RHS."""
+
+    if judgment.relation != "Opens":
+        return False
+    try:
+        _validate_path(judgment.expected_definition_id.scope_path)
+        if not _is_non_negative_int(judgment.expected_definition_id.ordinal):
+            return False
+        result = _replay_definition_opening(
+            judgment.scopes,
+            judgment.lookup_scope,
+            judgment.target,
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+
+    if result.kind is not DefinitionLookupKind.MATCH:
+        return False
+    if result.definition_id is None or result.body is None:
+        return False
+    return (
+        result.definition_id.scope_path == judgment.expected_definition_id.scope_path
+        and result.definition_id.ordinal == judgment.expected_definition_id.ordinal
+        and format_expression(result.body) == judgment.expected_body
+    )
+
+
+def check_no_visible_definition(judgment: NoVisibleDefinitionJudgment) -> bool:
+    if judgment.relation != "NoVisibleDefinition":
+        return False
+    try:
+        result = _replay_definition_opening(
+            judgment.scopes,
+            judgment.lookup_scope,
+            judgment.target,
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+    return result.kind is DefinitionLookupKind.NO_MATCH
+
+
+def check_definition_conflict(judgment: DefinitionConflictJudgment) -> bool:
+    if judgment.relation != "DefinitionConflict":
+        return False
+    try:
+        result = _replay_definition_opening(
+            judgment.scopes,
+            judgment.lookup_scope,
+            judgment.target,
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+    return result.kind is DefinitionLookupKind.CONFLICT
+
+
+def check_non_addressable_definition_target(
+    judgment: NonAddressableDefinitionTargetJudgment,
+) -> bool:
+    if judgment.relation != "NonAddressableDefinitionTarget":
+        return False
+    try:
+        target = _parse_definition_target(judgment.target)
+        result = open_definition(target, DefinitionEnvironment())
+    except (KeyError, TypeError, ValueError):
+        return False
+    return result.kind is DefinitionLookupKind.NON_ADDRESSABLE
+
+
+def check_v03_judgment(judgment: V03Judgment) -> bool:
+    if isinstance(judgment, ContextuallySatisfiesJudgment):
+        return check_contextually_satisfies(judgment)
+    if isinstance(judgment, OpensJudgment):
+        return check_opens(judgment)
+    if isinstance(judgment, NoVisibleDefinitionJudgment):
+        return check_no_visible_definition(judgment)
+    if isinstance(judgment, DefinitionConflictJudgment):
+        return check_definition_conflict(judgment)
+    if isinstance(judgment, NonAddressableDefinitionTargetJudgment):
+        return check_non_addressable_definition_target(judgment)
+    return False
+
+
+def check_proof_v03(proof: ProofObjectV03) -> bool:
+    """Independently replay every v0.3 base judgment; order has no inference meaning."""
+
+    if (
+        proof.proof_version != PROOF_SCHEMA_V03
+        or proof.contract_version != CONTRACT_VERSION_V03
+    ):
+        return False
+    return all(check_v03_judgment(judgment) for judgment in proof.judgments)
+
+
+def _require_exact_keys(data: dict, expected: set[str], label: str) -> None:
+    if set(data) != expected:
+        raise ValueError(f"{label} has unexpected or missing fields")
+
+
+def _int_from_data(value: object, label: str) -> int:
+    if not _is_non_negative_int(value):
+        raise ValueError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _path_from_data(value: object, label: str) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an integer array")
+    result = tuple(_int_from_data(item, label) for item in value)
+    _validate_path(result)
+    return result
+
+
+def _context_from_data(data: object) -> ProofContext:
+    if not isinstance(data, dict):
+        raise ValueError("context must be an object")
+    _require_exact_keys(data, {"start", "end", "parent"}, "context")
+    parent = data["parent"]
+    return ProofContext(
+        start=_int_from_data(data["start"], "context.start"),
+        end=_int_from_data(data["end"], "context.end"),
+        parent=_context_from_data(parent) if parent is not None else None,
+    )
+
+
+def _memory_from_data(data: object) -> tuple[DistinguishedLink, ...]:
+    if not isinstance(data, list):
+        raise ValueError("memory must be an array")
+    result: list[DistinguishedLink] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("memory item must be an object")
+        _require_exact_keys(item, {"id", "start", "end"}, "memory item")
+        result.append(
+            DistinguishedLink(
+                id=_int_from_data(item["id"], "memory.id"),
+                start=_int_from_data(item["start"], "memory.start"),
+                end=_int_from_data(item["end"], "memory.end"),
+            )
+        )
+    # ProofMemory performs the semantic duplicate/ambiguity validation.
+    ProofMemory(tuple(result))
+    return tuple(result)
+
+
+def _symbols_from_data(data: object) -> tuple[tuple[str, int], ...]:
+    if not isinstance(data, list):
+        raise ValueError("symbols must be an array")
+    result: list[tuple[str, int]] = []
+    seen: set[str] = set()
+    for item in data:
+        if not isinstance(item, list) or len(item) != 2:
+            raise ValueError("symbol binding must be [name, LinkRef]")
+        name, link = item
+        if not isinstance(name, str) or not name:
+            raise ValueError("symbol name must be a non-empty string")
+        if name in seen:
+            raise ValueError("duplicate symbol binding")
+        seen.add(name)
+        result.append((name, _int_from_data(link, "symbol LinkRef")))
+    if result != sorted(result):
+        raise ValueError("symbol bindings must use deterministic lexical order")
+    return tuple(result)
+
+
+def _substitutions_from_data(data: object) -> tuple[ExpectedSubstitution, ...]:
+    if not isinstance(data, list):
+        raise ValueError("substitutions must be an array")
+    result: list[ExpectedSubstitution] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("substitution must be an object")
+        _require_exact_keys(item, {"path", "link"}, "substitution")
+        result.append(
+            ExpectedSubstitution(
+                path=_path_from_data(item["path"], "substitution.path"),
+                link=_int_from_data(item["link"], "substitution.link"),
+            )
+        )
+    if result != sorted(result) or len({item.path for item in result}) != len(result):
+        raise ValueError("substitutions must be unique and canonically ordered")
+    return tuple(result)
+
+
+def _aliases_from_data(data: object) -> tuple[ExpectedAlias, ...]:
+    if not isinstance(data, list):
+        raise ValueError("aliases must be an array")
+    result: list[ExpectedAlias] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("alias must be an object")
+        _require_exact_keys(item, {"path", "targetPath"}, "alias")
+        result.append(
+            ExpectedAlias(
+                path=_path_from_data(item["path"], "alias.path"),
+                target_path=_path_from_data(item["targetPath"], "alias.targetPath"),
+            )
+        )
+    if result != sorted(result) or len({item.path for item in result}) != len(result):
+        raise ValueError("aliases must be unique and canonically ordered")
+    return tuple(result)
+
+
+def _scopes_from_data(data: object) -> tuple[DefinitionScopeSnapshot, ...]:
+    if not isinstance(data, list):
+        raise ValueError("scopes must be an array")
+    result: list[DefinitionScopeSnapshot] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("scope must be an object")
+        _require_exact_keys(item, {"path", "parent", "definitions"}, "scope")
+        parent = item["parent"]
+        definitions = item["definitions"]
+        if not isinstance(definitions, list) or not all(
+            isinstance(source, str) for source in definitions
+        ):
+            raise ValueError("scope definitions must be a string array")
+        result.append(
+            DefinitionScopeSnapshot(
+                path=_path_from_data(item["path"], "scope.path"),
+                parent=(
+                    _path_from_data(parent, "scope.parent")
+                    if parent is not None
+                    else None
+                ),
+                definitions=tuple(definitions),
+            )
+        )
+    scopes = tuple(result)
+    _build_definition_environments(scopes)
+    return scopes
+
+
+def _definition_id_from_data(data: object) -> ExpectedDefinitionId:
+    if not isinstance(data, dict):
+        raise ValueError("definitionId must be an object")
+    _require_exact_keys(data, {"scopePath", "ordinal"}, "definitionId")
+    return ExpectedDefinitionId(
+        scope_path=_path_from_data(data["scopePath"], "definitionId.scopePath"),
+        ordinal=_int_from_data(data["ordinal"], "definitionId.ordinal"),
+    )
+
+
+def _judgment_from_data(data: object) -> V03Judgment:
+    if not isinstance(data, dict):
+        raise ValueError("judgment must be an object")
+    relation = data.get("relation")
+    if relation == "ContextuallySatisfies":
+        _require_exact_keys(
+            data,
+            {"relation", "expression", "context", "symbols", "memory", "expected"},
+            relation,
+        )
+        if not isinstance(data["expression"], str):
+            raise ValueError("expression must be a string")
+        expected = data["expected"]
+        if not isinstance(expected, dict):
+            raise ValueError("expected must be an object")
+        _require_exact_keys(expected, {"substitutions", "aliases"}, "expected")
+        return ContextuallySatisfiesJudgment(
+            expression=data["expression"],
+            context=_context_from_data(data["context"]),
+            symbols=_symbols_from_data(data["symbols"]),
+            distinguished_memory=_memory_from_data(data["memory"]),
+            expected_substitutions=_substitutions_from_data(expected["substitutions"]),
+            expected_aliases=_aliases_from_data(expected["aliases"]),
+        )
+
+    if relation == "Opens":
+        _require_exact_keys(
+            data,
+            {"relation", "scopes", "lookupScope", "target", "expected"},
+            relation,
+        )
+        if not isinstance(data["target"], str):
+            raise ValueError("target must be a string")
+        expected = data["expected"]
+        if not isinstance(expected, dict):
+            raise ValueError("expected must be an object")
+        _require_exact_keys(expected, {"definitionId", "body"}, "expected")
+        if not isinstance(expected["body"], str):
+            raise ValueError("expected body must be a string")
+        return OpensJudgment(
+            scopes=_scopes_from_data(data["scopes"]),
+            lookup_scope=_path_from_data(data["lookupScope"], "lookupScope"),
+            target=data["target"],
+            expected_definition_id=_definition_id_from_data(expected["definitionId"]),
+            expected_body=expected["body"],
+        )
+
+    if relation in {"NoVisibleDefinition", "DefinitionConflict"}:
+        _require_exact_keys(
+            data,
+            {"relation", "scopes", "lookupScope", "target"},
+            str(relation),
+        )
+        if not isinstance(data["target"], str):
+            raise ValueError("target must be a string")
+        common = {
+            "scopes": _scopes_from_data(data["scopes"]),
+            "lookup_scope": _path_from_data(data["lookupScope"], "lookupScope"),
+            "target": data["target"],
+        }
+        if relation == "NoVisibleDefinition":
+            return NoVisibleDefinitionJudgment(**common)
+        return DefinitionConflictJudgment(**common)
+
+    if relation == "NonAddressableDefinitionTarget":
+        _require_exact_keys(data, {"relation", "target"}, relation)
+        if not isinstance(data["target"], str):
+            raise ValueError("target must be a string")
+        return NonAddressableDefinitionTargetJudgment(target=data["target"])
+
+    raise ValueError("unknown v0.3 proof relation")
+
+
+def proof_v03_from_data(data: object) -> ProofObjectV03:
+    """Strictly parse one portable mts-proof/v0.3 JSON-shaped artifact."""
+
+    if not isinstance(data, dict):
+        raise ValueError("proof must be an object")
+    _require_exact_keys(
+        data,
+        {"proofVersion", "contractVersion", "judgments"},
+        "proof",
+    )
+    if data["proofVersion"] != PROOF_SCHEMA_V03:
+        raise ValueError("unsupported proofVersion")
+    if data["contractVersion"] != CONTRACT_VERSION_V03:
+        raise ValueError("unsupported contractVersion")
+    if not isinstance(data["judgments"], list):
+        raise ValueError("judgments must be an array")
+    return ProofObjectV03(
+        judgments=tuple(_judgment_from_data(item) for item in data["judgments"]),
+    )
+
+
+def check_proof_v03_data(data: object) -> bool:
+    """Strictly parse then independently replay one portable v0.3 artifact."""
+
+    try:
+        return check_proof_v03(proof_v03_from_data(data))
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def _context_to_data(context: ProofContext) -> dict:
+    return {
+        "start": context.start,
+        "end": context.end,
+        "parent": _context_to_data(context.parent) if context.parent is not None else None,
+    }
+
+
+def _memory_to_data(memory: tuple[DistinguishedLink, ...]) -> list[dict]:
+    return [
+        {"id": item.id, "start": item.start, "end": item.end}
+        for item in memory
+    ]
+
+
+def _symbols_to_data(symbols: tuple[tuple[str, int], ...]) -> list[list[object]]:
+    return [[name, link] for name, link in symbols]
+
+
+def _substitutions_to_data(
+    substitutions: tuple[ExpectedSubstitution, ...],
+) -> list[dict]:
+    return [
+        {"path": list(item.path), "link": item.link}
+        for item in substitutions
+    ]
+
+
+def _aliases_to_data(aliases: tuple[ExpectedAlias, ...]) -> list[dict]:
+    return [
+        {"path": list(item.path), "targetPath": list(item.target_path)}
+        for item in aliases
+    ]
+
+
+def _scopes_to_data(scopes: tuple[DefinitionScopeSnapshot, ...]) -> list[dict]:
+    return [
+        {
+            "path": list(item.path),
+            "parent": list(item.parent) if item.parent is not None else None,
+            "definitions": list(item.definitions),
+        }
+        for item in scopes
+    ]
+
+
+def _judgment_to_data(judgment: V03Judgment) -> dict:
+    if isinstance(judgment, ContextuallySatisfiesJudgment):
+        return {
+            "relation": judgment.relation,
+            "expression": judgment.expression,
+            "context": _context_to_data(judgment.context),
+            "symbols": _symbols_to_data(judgment.symbols),
+            "memory": _memory_to_data(judgment.distinguished_memory),
+            "expected": {
+                "substitutions": _substitutions_to_data(judgment.expected_substitutions),
+                "aliases": _aliases_to_data(judgment.expected_aliases),
+            },
+        }
+    if isinstance(judgment, OpensJudgment):
+        return {
+            "relation": judgment.relation,
+            "scopes": _scopes_to_data(judgment.scopes),
+            "lookupScope": list(judgment.lookup_scope),
+            "target": judgment.target,
+            "expected": {
+                "definitionId": {
+                    "scopePath": list(judgment.expected_definition_id.scope_path),
+                    "ordinal": judgment.expected_definition_id.ordinal,
+                },
+                "body": judgment.expected_body,
+            },
+        }
+    if isinstance(judgment, NoVisibleDefinitionJudgment):
+        return {
+            "relation": judgment.relation,
+            "scopes": _scopes_to_data(judgment.scopes),
+            "lookupScope": list(judgment.lookup_scope),
+            "target": judgment.target,
+        }
+    if isinstance(judgment, DefinitionConflictJudgment):
+        return {
+            "relation": judgment.relation,
+            "scopes": _scopes_to_data(judgment.scopes),
+            "lookupScope": list(judgment.lookup_scope),
+            "target": judgment.target,
+        }
+    if isinstance(judgment, NonAddressableDefinitionTargetJudgment):
+        return {"relation": judgment.relation, "target": judgment.target}
+    raise TypeError("unknown v0.3 proof judgment")
+
+
+def proof_v03_to_data(proof: ProofObjectV03) -> dict:
+    """Serialize one typed v0.3 proof object to the canonical portable shape."""
+
+    if not check_proof_v03(proof):
+        raise ValueError("cannot serialize invalid v0.3 proof object")
+    return {
+        "proofVersion": proof.proof_version,
+        "contractVersion": proof.contract_version,
+        "judgments": [_judgment_to_data(item) for item in proof.judgments],
+    }
+
+
+def canonical_proof_v03_json(proof: ProofObjectV03) -> str:
+    return json.dumps(
+        proof_v03_to_data(proof),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )

--- a/tests/test_mts_proof_v03.py
+++ b/tests/test_mts_proof_v03.py
@@ -1,0 +1,239 @@
+"""Production conformance for accepted mts-proof/v0.3 base-relation replay."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from core.proof_checker import (
+    CONTRACT_VERSION,
+    PROOF_SCHEMA,
+    PROOF_SCHEMA_V03,
+    CONTRACT_VERSION_V03,
+    ExpectedAlias,
+    InterpretProofStep,
+    ProofContext,
+    ProofObject,
+    canonical_proof_v03_json,
+    check_proof,
+    check_proof_v03,
+    check_proof_v03_data,
+    proof_v03_from_data,
+    proof_v03_to_data,
+)
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-proof-v0.3.json"
+CORPUS = ROOT / "contracts" / "mts-proof-conformance-v0.3.json"
+DERIVATION = ROOT / "contracts" / "mts-derivation-base-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+MTS_V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def artifact(judgment: dict) -> dict:
+    return {
+        "proofVersion": PROOF_SCHEMA_V03,
+        "contractVersion": CONTRACT_VERSION_V03,
+        "judgments": [deepcopy(judgment)],
+    }
+
+
+def valid_judgments() -> dict[str, dict]:
+    return {
+        item["id"]: item["judgment"]
+        for item in read(CORPUS)["validJudgments"]
+    }
+
+
+def patch_dotted(value: dict, patch: dict) -> dict:
+    result = deepcopy(value)
+    for dotted_path, replacement in patch.items():
+        parts = dotted_path.split(".")
+        current = result
+        for part in parts[:-1]:
+            current = current[part]
+        current[parts[-1]] = deepcopy(replacement)
+    return result
+
+
+def forged_judgment(vector: dict) -> dict:
+    if "judgment" in vector:
+        return deepcopy(vector["judgment"])
+
+    source = deepcopy(valid_judgments()[vector["sourceJudgment"]])
+    if "patch" in vector:
+        source = patch_dotted(source, vector["patch"])
+    if "replaceRelation" in vector:
+        source["relation"] = vector["replaceRelation"]
+    for key in vector.get("remove", []):
+        source.pop(key, None)
+    return source
+
+
+def test_contract_accepts_exactly_the_five_preaccepted_base_relations():
+    contract = read(CONTRACT)
+    derivation = read(DERIVATION)
+
+    assert contract["schema"] == PROOF_SCHEMA_V03
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert contract["dependsOn"] == [
+        "mts-contract/v0.3",
+        derivation["schema"],
+        "mts-proof/v0.2",
+    ]
+    assert set(contract["trustedRelations"]) == {
+        "ContextuallySatisfies",
+        "Opens",
+        "NoVisibleDefinition",
+        "DefinitionConflict",
+        "NonAddressableDefinitionTarget",
+    }
+
+
+def test_all_valid_conformance_judgments_strictly_parse_and_replay():
+    for vector in read(CORPUS)["validJudgments"]:
+        data = artifact(vector["judgment"])
+        proof = proof_v03_from_data(data)
+
+        assert check_proof_v03(proof), vector["id"]
+        assert check_proof_v03_data(data), vector["id"]
+        assert proof_v03_to_data(proof) == data
+        assert json.loads(canonical_proof_v03_json(proof)) == data
+
+
+def test_contextually_satisfies_is_explicit_context_scoped_not_global_truth():
+    source = valid_judgments()["contextually-satisfies-aroot"]
+    counter = patch_dotted(source, {"context.end": 2})
+
+    assert check_proof_v03_data(artifact(source))
+    assert not check_proof_v03_data(artifact(counter))
+
+    contract = read(CONTRACT)
+    relation = contract["contextuallySatisfies"]
+    assert relation["globalTruth"] is False
+    assert relation["hiddenInterpreterIdentity"] is False
+    assert relation["subjectOrFocusIdentity"] is False
+
+
+def test_every_forged_relation_or_result_is_rejected():
+    for vector in read(CORPUS)["forgeries"]:
+        assert vector["mustReject"] is True
+        assert not check_proof_v03_data(artifact(forged_judgment(vector))), vector["id"]
+
+
+def test_wrong_versions_unknown_relation_and_unexpected_fields_are_rejected():
+    for vector in read(CORPUS)["invalidArtifacts"]:
+        assert not check_proof_v03_data(vector["artifact"]), vector["id"]
+
+
+def test_definition_environment_is_explicit_canonical_and_has_no_hidden_root():
+    judgments = valid_judgments()
+
+    assert check_proof_v03_data(artifact(judgments["opens-direct"]))
+    assert check_proof_v03_data(artifact(judgments["opens-child-shadowing"]))
+    assert check_proof_v03_data(artifact(judgments["opens-self-one-step"]))
+
+    hidden_root = next(
+        item for item in read(CORPUS)["forgeries"] if item["id"] == "hidden-root-injection"
+    )
+    assert not check_proof_v03_data(artifact(hidden_root["judgment"]))
+
+    contract = read(CONTRACT)
+    environment = contract["definitionEnvironment"]
+    assert environment["rootScopeRequired"] is True
+    assert environment["duplicateScopeRejected"] is True
+    assert environment["hiddenRootInjection"] is False
+
+
+def test_negative_relations_stay_bound_to_exact_replay_scope():
+    judgments = valid_judgments()
+    for vector_id in (
+        "no-visible-definition",
+        "definition-conflict",
+        "non-addressable-target",
+    ):
+        assert check_proof_v03_data(artifact(judgments[vector_id])), vector_id
+
+    visible_as_no_match = next(
+        item for item in read(CORPUS)["forgeries"] if item["id"] == "no-match-when-visible"
+    )
+    assert not check_proof_v03_data(artifact(forged_judgment(visible_as_no_match)))
+
+    contract = read(CONTRACT)
+    assert contract["noVisibleDefinition"]["globalAbsence"] is False
+    assert contract["noVisibleDefinition"]["closedWorldBeyondSnapshot"] is False
+    assert contract["definitionConflict"]["impliesBodyEquality"] is False
+    assert contract["nonAddressableDefinitionTarget"]["globalSemanticInvalidity"] is False
+
+
+def test_v03_artifact_order_has_no_composition_or_inference_semantics():
+    judgments = valid_judgments()
+    data = {
+        "proofVersion": PROOF_SCHEMA_V03,
+        "contractVersion": CONTRACT_VERSION_V03,
+        "judgments": [
+            deepcopy(judgments["opens-direct"]),
+            deepcopy(judgments["no-visible-definition"]),
+        ],
+    }
+    assert check_proof_v03_data(data)
+
+    boundary = read(CONTRACT)["compositionBoundary"]
+    assert boundary == {
+        "judgmentOrderImpliesDependency": False,
+        "genericCompositionAccepted": False,
+        "transitivityAccepted": False,
+        "symmetryAccepted": False,
+        "congruenceAccepted": False,
+        "modusPonensAccepted": False,
+        "globalSubstitutionAccepted": False,
+        "openingToEqualityAccepted": False,
+        "recursiveNormalizationAccepted": False,
+    }
+
+
+def test_v02_public_constants_artifact_and_checker_semantics_are_unchanged():
+    proof_v02 = read(PROOF_V02)
+
+    assert CONTRACT_VERSION == "mts-contract/v0.2"
+    assert PROOF_SCHEMA == "mts-proof/v0.2"
+    assert proof_v02["checker"]["trustedRuleSet"] == ["interpret"]
+
+    step = InterpretProofStep(
+        expression="[] = []",
+        context=ProofContext(start=1, end=1),
+        expected_aliases=(ExpectedAlias(path=(1,), target_path=(0,)),),
+    )
+    proof = ProofObject(steps=(step,))
+    assert check_proof(proof)
+
+    compatibility = read(CONTRACT)["v02Compatibility"]
+    assert compatibility["mtsProofV02Modified"] is False
+    assert compatibility["mtsProofV02TrustedRuleSet"] == ["interpret"]
+    assert compatibility["retroactiveReinterpretation"] is False
+
+
+def test_v03_does_not_smuggle_subject_focus_research_into_current_proof_artifact():
+    boundary = read(CONTRACT)["contextVersionBoundary"]
+    mts_v03 = read(MTS_V03)
+
+    assert boundary["explicitContextFrameOnly"] is True
+    assert boundary["subjectFocusResearchIssue"] == 148
+    assert boundary["subjectOrFocusAddedToV03Artifact"] is False
+    assert boundary["futureContextSemanticsMustUseAdditiveContract"] is True
+    assert mts_v03["l5Boundary"]["currentProofContract"] == "contracts/mts-proof-v0.2.json"
+
+
+def test_downstream_repin_waits_for_additive_umbrella_not_mutated_mts_contract_v03():
+    downstream = read(CONTRACT)["downstream"]
+    mts_v03 = read(MTS_V03)
+
+    assert downstream["proofSemanticsAccepted"] is True
+    assert downstream["aproverRepinAllowedDirectlyFromMtsContractV03"] is False
+    assert mts_v03["downstream"]["aproverProofRepinAllowed"] is False
+    assert "additive umbrella" in downstream["reason"]


### PR DESCRIPTION
Closes #147. Refs #122, #120, #148.

Production integration уже принятой `mts-derivation-base/v0.3` semantics. Никаких новых inference/composition rules этот PR не вводит.

## Что добавлено

- `contracts/mts-proof-v0.3.json` — versioned accepted artifact contract;
- `contracts/mts-proof-conformance-v0.3.json` — portable positive/negative/forgery corpus;
- `core/proof_checker.py` — тот же trusted module теперь replay-ит и v0.2, и v0.3;
- `tests/test_mts_proof_v03.py` — strict parsing, replay, forgeries, round-trip, v0.2 regression.

## Ровно пять v0.3 base relations

- `ContextuallySatisfies`;
- `Opens`;
- `NoVisibleDefinition`;
- `DefinitionConflict`;
- `NonAddressableDefinitionTarget`.

Каждая independently replay-ится через уже accepted canonical operation.

## Context boundary после #148

`ContextuallySatisfies` в v0.3 содержит **только explicit `ContextFrame(start,end,parent)`**. Ни subject identity, ни current-focus LinkRef, ни host/session/interpreter identity не являются скрытыми inputs. Новая deictic subject/focus модель из #148 — только v0.4+ research и не протаскивается задним числом.

## Strict artifact boundary

Отвергаются:
- wrong/missing proof/contract version;
- unknown relation;
- unexpected fields;
- malformed/duplicate/noncanonical scopes;
- duplicate symbol bindings;
- forged substitutions/aliases/body/DefinitionId;
- hidden root injection;
- scope-relative negative claim, не совпадающий с replay.

## Compatibility / veto

- `mts-proof/v0.2` не меняется;
- старые `CONTRACT_VERSION`, `PROOF_SCHEMA`, `ProofObject`, `check_proof()` сохраняют v0.2 semantics;
- один trusted module, не второй checker;
- `opening != equality`;
- no RHS evaluation;
- no global truth;
- no transitivity/symmetry/congruence/MP/global substitution;
- no generic composition/DAG;
- no proof-search dependency;
- checker read-only.

## Versioning

`mts-contract/v0.3` не редактируется: он уже immutable и содержит прежнюю downstream boundary. После принятия `mts-proof/v0.3` потребуется новый additive umbrella (`mts-contract/v0.4` или следующий version) перед repin aprover.

Этот PR остаётся draft до:
1. consistency repair #139 merged;
2. fresh GitHub CI green;
3. branch current относительно `main`;
4. review diff подтверждает только intended production slice.