### PR TITLE
Восстановить консистентность main и зелёный полный CI

### DIFF
--- a/contracts/mts-proof-judgment-challenge-v0.3.json
+++ b/contracts/mts-proof-judgment-challenge-v0.3.json
@@ -1,0 +1,128 @@
+{
+  "schema": "mts-proof-judgment-challenge/v0.3",
+  "status": "candidate-challenge",
+  "issue": 122,
+  "dependsOn": [
+    "mts-proof-judgment-decision/v0.3",
+    "mts-contract/v0.3",
+    "mts-definition-opening/v0.3",
+    "mts-proof/v0.2"
+  ],
+  "conformanceCorpus": "contracts/mts-proof-judgment-conformance-v0.3.json",
+  "acceptedContractLinkAllowed": false,
+  "productionProofChangeAllowed": false,
+  "trustedRuleChangeAllowed": false,
+  "purpose": "Challenge typed operation claims as the base MTS proof judgment before defining any multi-step inference or trusted v0.3 proof rule.",
+  "judgmentUnderChallenge": {
+    "common": {
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "artifact-local opaque string",
+      "operation": ["interpret", "open-definition"],
+      "expected": "exact canonical replay result"
+    },
+    "interpret": {
+      "replaySubstrate": "existing trusted mts-proof/v0.2 interpret-step semantics",
+      "newTrustedRule": false,
+      "inputs": ["expression", "ContextFrame", "symbols", "distinguished finite memory"],
+      "expected": ["success", "substitutions", "aliases"]
+    },
+    "open-definition": {
+      "replaySubstrate": "accepted core.mtc_definitions.open_definition",
+      "newTrustedRule": false,
+      "inputs": ["target", "explicit lexical definition scopes"],
+      "expected": ["kind", "definitionId when matched", "body when matched"],
+      "ContextFrameInput": false,
+      "MemoryViewInput": false,
+      "evaluatesBody": false,
+      "assertsEquality": false
+    }
+  },
+  "independentReplay": {
+    "interpret": "map candidate claim losslessly to existing InterpretProofStep and invoke the current v0.2 trusted step checker",
+    "openDefinition": "reconstruct a fresh DefinitionEnvironment from serialized scopes and invoke open_definition exactly once",
+    "candidateSearchUsed": false,
+    "uiUsed": false,
+    "ambientRootDefinitionsInjected": false
+  },
+  "forgeryChallenge": {
+    "interpret": [
+      "flip expected success",
+      "forge substitutions",
+      "forge aliases"
+    ],
+    "openDefinition": [
+      "forge returned body",
+      "forge DefinitionId ordinal",
+      "forge match for missing target",
+      "add hidden root assumption instead of serializing root scope"
+    ],
+    "allForgedClaimsMustReject": true
+  },
+  "negativeClaimsAreFirstClass": {
+    "interpretFailure": true,
+    "openingNoMatch": true,
+    "openingConflict": true,
+    "openingNonAddressable": true,
+    "reason": "A challenge claim certifies the exact result of replay; later proof-domain decisions determine which replay results establish derivation judgments."
+  },
+  "environmentSnapshotBoundary": {
+    "scopeOrderSemantic": true,
+    "definitionOrderSemanticForReplayLocalDefinitionId": true,
+    "sourceSpanIdentity": false,
+    "displayIdentity": false,
+    "persistentStorageIdentity": false,
+    "hiddenGlobalEnvironment": false,
+    "canonicalRootMustBeExplicitWhenUsed": true
+  },
+  "cycleBoundary": {
+    "selfDefinitionOpeningSteps": 1,
+    "mutualDefinitionOpeningSteps": 1,
+    "recursiveNormalization": false,
+    "multiStepCycleSemanticsAccepted": false
+  },
+  "mutationVeto": {
+    "serializedDefinitionScopesMustRemainByteEquivalent": true,
+    "serializedMemoryMustRemainByteEquivalent": true,
+    "openDefinitionMayRealize": false,
+    "interpretMayRealize": false,
+    "checkerMayDelete": false
+  },
+  "semanticVeto": {
+    "successfulOpeningImpliesEquality": false,
+    "globalTextualSubstitution": false,
+    "globalEqualityRewrite": false,
+    "unrestrictedSymmetry": false,
+    "unrestrictedTransitivity": false,
+    "unrestrictedCongruence": false,
+    "modusPonens": false,
+    "genericStepCompositionAccepted": false
+  },
+  "requiredVectors": [
+    "lossless interpret-success replay",
+    "lossless interpret-failure replay",
+    "forged interpret result rejection",
+    "explicit-root opening replay",
+    "empty-environment infinity no-match",
+    "opening missing/conflict/non-addressable typed negatives",
+    "child shadowing with deterministic DefinitionId",
+    "self-definition one-step opening",
+    "mutual-definition one-step opening",
+    "forged opening body rejection",
+    "forged opening DefinitionId rejection",
+    "no mutation of serialized replay substrates"
+  ],
+  "challengeFindingNotYetAllowed": [
+    "accept proof judgment v0.3",
+    "publish mts-proof/v0.3",
+    "add open-definition to a trusted rule set",
+    "compose claims into inference DAG",
+    "repin aprover proof semantics"
+  ],
+  "releaseGate": [
+    "pass this corpus through independent replay",
+    "decide whether negative operation results are retained in the normative ProofJudgment domain",
+    "decide exact canonical serialization and validation errors",
+    "accept a versioned proof-judgment contract before any production checker v0.3",
+    "separately challenge every candidate composition/inference rule"
+  ]
+}

--- a/contracts/mts-proof-judgment-conformance-v0.3.json
+++ b/contracts/mts-proof-judgment-conformance-v0.3.json
@@ -1,0 +1,191 @@
+{
+  "schema": "mts-proof-judgment-conformance/v0.3",
+  "status": "candidate-challenge-corpus",
+  "contract": "mts-proof-judgment-challenge/v0.3",
+  "contractVersion": "mts-contract/v0.3",
+  "interpretJudgments": [
+    {
+      "id": "interpret-local-alias-success",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-interpret-0",
+      "operation": "interpret",
+      "expression": "[] = []",
+      "context": {"start": 1, "end": 1, "parent": null},
+      "symbols": [],
+      "memory": [],
+      "expected": {
+        "success": true,
+        "substitutions": [],
+        "aliases": [{"path": [1], "targetPath": [0]}]
+      }
+    },
+    {
+      "id": "interpret-aroot-negative-result",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-interpret-1",
+      "operation": "interpret",
+      "expression": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 2, "parent": null},
+      "symbols": [["∞", 1]],
+      "memory": [],
+      "expected": {"success": false, "substitutions": [], "aliases": []}
+    },
+    {
+      "id": "interpret-link-decomposition",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-interpret-2",
+      "operation": "interpret",
+      "expression": "10 = [] ⟼ []",
+      "context": {"start": 2, "end": 3, "parent": null},
+      "symbols": [["10", 10]],
+      "memory": [{"id": 10, "start": 2, "end": 3}],
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [1, 0], "link": 2},
+          {"path": [1, 1], "link": 3}
+        ],
+        "aliases": []
+      }
+    }
+  ],
+  "openingJudgments": [
+    {
+      "id": "open-explicit-root-infinity",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-0",
+      "operation": "open-definition",
+      "scopes": [
+        {
+          "path": [],
+          "parent": null,
+          "definitions": [
+            "∞ : {◁ = ∞, ▷ = ∞}",
+            "() : ♀() ⟼ ()♂",
+            "([) : (♀∞)",
+            "(]) : (∞♂)",
+            "(⟼) : (♀∞ ⟼ ∞♂)",
+            "(↛) : (∞♂ ⟼ ♀∞)",
+            "[1] : (⟼)",
+            "[0] : (↛)",
+            "(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}",
+            "(!=) : ¬(=)"
+          ]
+        }
+      ],
+      "lookupScope": [],
+      "target": "∞",
+      "expected": {
+        "kind": "match",
+        "definitionId": {"scopePath": [], "ordinal": 0},
+        "body": "{◁ = ∞, ▷ = ∞}"
+      }
+    },
+    {
+      "id": "open-no-hidden-root",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-1",
+      "operation": "open-definition",
+      "scopes": [{"path": [], "parent": null, "definitions": []}],
+      "lookupScope": [],
+      "target": "∞",
+      "expected": {"kind": "no-match"}
+    },
+    {
+      "id": "open-missing",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-2",
+      "operation": "open-definition",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "target": "z",
+      "expected": {"kind": "no-match"}
+    },
+    {
+      "id": "open-conflict",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-3",
+      "operation": "open-definition",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "a : c"]}],
+      "lookupScope": [],
+      "target": "a",
+      "expected": {"kind": "conflict"}
+    },
+    {
+      "id": "open-non-addressable",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-4",
+      "operation": "open-definition",
+      "scopes": [{"path": [], "parent": null, "definitions": []}],
+      "lookupScope": [],
+      "target": "[]",
+      "expected": {"kind": "non-addressable"}
+    },
+    {
+      "id": "open-child-shadowing",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-5",
+      "operation": "open-definition",
+      "scopes": [
+        {"path": [], "parent": null, "definitions": ["a : root"]},
+        {"path": [0], "parent": [], "definitions": ["a : child"]}
+      ],
+      "lookupScope": [0],
+      "target": "a",
+      "expected": {
+        "kind": "match",
+        "definitionId": {"scopePath": [0], "ordinal": 0},
+        "body": "child"
+      }
+    },
+    {
+      "id": "open-self-one-step",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-6",
+      "operation": "open-definition",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : a"]}],
+      "lookupScope": [],
+      "target": "a",
+      "expected": {
+        "kind": "match",
+        "definitionId": {"scopePath": [], "ordinal": 0},
+        "body": "a"
+      }
+    },
+    {
+      "id": "open-mutual-a-one-step",
+      "contractVersion": "mts-contract/v0.3",
+      "goalId": "g-open-7",
+      "operation": "open-definition",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : a"]}],
+      "lookupScope": [],
+      "target": "a",
+      "expected": {
+        "kind": "match",
+        "definitionId": {"scopePath": [], "ordinal": 0},
+        "body": "b"
+      }
+    }
+  ],
+  "forgeries": [
+    {"id": "forge-interpret-success", "sourceJudgment": "interpret-local-alias-success", "patch": {"expected.success": false}, "mustReject": true},
+    {"id": "forge-interpret-alias", "sourceJudgment": "interpret-local-alias-success", "patch": {"expected.aliases": []}, "mustReject": true},
+    {"id": "forge-interpret-substitution", "sourceJudgment": "interpret-link-decomposition", "patch": {"expected.substitutions": [{"path": [1, 0], "link": 999}]}, "mustReject": true},
+    {"id": "forge-opening-body", "sourceJudgment": "open-explicit-root-infinity", "patch": {"expected.body": "∞"}, "mustReject": true},
+    {"id": "forge-opening-definition-id", "sourceJudgment": "open-explicit-root-infinity", "patch": {"expected.definitionId": {"scopePath": [], "ordinal": 9}}, "mustReject": true},
+    {
+      "id": "forge-hidden-root-match",
+      "sourceJudgment": "open-no-hidden-root",
+      "patch": {"expected": {"kind": "match", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "{◁ = ∞, ▷ = ∞}"}},
+      "mustReject": true
+    }
+  ],
+  "nonObservables": [
+    "proof-search trace",
+    "UI state",
+    "source span identity",
+    "persistent definition identity",
+    "ambient root environment",
+    "L4 mutations"
+  ]
+}

--- a/converters/l4_backend_driver.py
+++ b/converters/l4_backend_driver.py
@@ -60,6 +60,18 @@ class ReferenceL4BackendDriver:
         "crash-recovery": False,
     }
 
+    STATEFUL_OPERATIONS = {
+        "snapshot",
+        "poles",
+        "find_link",
+        "outgoing",
+        "incoming",
+        "all_links",
+        "realize_link",
+        "realize_structural_denotation",
+        "delete_link",
+    }
+
     def __init__(
         self,
         seed_handle_assignment: Mapping[str, int] | None = None,
@@ -119,6 +131,8 @@ class ReferenceL4BackendDriver:
             return self._create(args)
         if op in {"close", "reopen"}:
             raise DriverRequestError("capability-not-supported")
+        if op not in self.STATEFUL_OPERATIONS:
+            raise DriverRequestError("invalid-request", f"unknown operation: {op}")
 
         store = self._require_store()
         if op == "snapshot":
@@ -161,7 +175,7 @@ class ReferenceL4BackendDriver:
             self._require_exact_fields(args, {"ref"})
             store.delete_link(self._bound_ref(self._required_name(args, "ref")))
             return {}
-        raise DriverRequestError("invalid-request", f"unknown operation: {op}")
+        raise AssertionError(f"validated stateful operation was not dispatched: {op}")
 
     def _create(self, args: dict) -> dict:
         self._require_exact_fields(args, {"seedGraph"})

--- a/tests/test_mts_l4_backend_driver.py
+++ b/tests/test_mts_l4_backend_driver.py
@@ -95,8 +95,11 @@ def run_core_scenario(scenario: dict, assignment: dict[str, int]) -> dict:
             }
         elif op == "realize_structural_denotation":
             assert compiled_denotation is not None and node_bindings is not None
-            bind = operation.get("bind") or operation.get("expectBinding")
-            assert isinstance(bind, str)
+            bind = (
+                operation.get("bind")
+                or operation.get("expectBinding")
+                or f"@{scenario['id']}:root"
+            )
             args = {
                 "denotation": deepcopy(compiled_denotation),
                 "anchors": deepcopy(operation["anchors"]),

--- a/tests/test_mts_proof_judgment_challenge.py
+++ b/tests/test_mts_proof_judgment_challenge.py
@@ -1,0 +1,316 @@
+"""Executable challenge for candidate typed-operation MTS proof judgments v0.3."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from core.mtc_ast import Definition, Form, format_expression
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionLookupKind,
+    DefinitionRegistrationKind,
+    open_definition,
+)
+from core.mtc_parser import parse_formula
+from core.proof_checker import (
+    DistinguishedLink,
+    ExpectedAlias,
+    ExpectedSubstitution,
+    InterpretProofStep,
+    ProofContext,
+    ProofObject,
+    check_interpret_step,
+    check_proof,
+)
+
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-proof-judgment-challenge-v0.3.json"
+CORPUS = ROOT / "contracts" / "mts-proof-judgment-conformance-v0.3.json"
+DECISION = ROOT / "contracts" / "mts-proof-judgment-decision-v0.3.json"
+MTS_V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
+PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
+CONTRACT_VERSION = "mts-contract/v0.3"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def definition(source: str) -> Definition:
+    value = parse_formula(source)
+    assert isinstance(value, Definition)
+    return value
+
+
+def target(source: str) -> Form:
+    return definition(f"{source} : __proof_judgment_query__").target
+
+
+def proof_context(data: dict) -> ProofContext:
+    parent = data.get("parent")
+    return ProofContext(
+        start=data["start"],
+        end=data["end"],
+        parent=proof_context(parent) if parent is not None else None,
+    )
+
+
+def interpret_step(claim: dict) -> InterpretProofStep:
+    expected = claim["expected"]
+    return InterpretProofStep(
+        expression=claim["expression"],
+        context=proof_context(claim["context"]),
+        distinguished_memory=tuple(
+            DistinguishedLink(id=item["id"], start=item["start"], end=item["end"])
+            for item in claim["memory"]
+        ),
+        symbols=tuple((name, link) for name, link in claim["symbols"]),
+        expected_success=expected["success"],
+        expected_substitutions=tuple(
+            ExpectedSubstitution(path=tuple(item["path"]), link=item["link"])
+            for item in expected["substitutions"]
+        ),
+        expected_aliases=tuple(
+            ExpectedAlias(
+                path=tuple(item["path"]),
+                target_path=tuple(item["targetPath"]),
+            )
+            for item in expected["aliases"]
+        ),
+    )
+
+
+def reconstruct_environments(scopes: list[dict]) -> dict[tuple[int, ...], DefinitionEnvironment]:
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+    for scope in sorted(scopes, key=lambda item: (len(item["path"]), item["path"])):
+        path = tuple(scope["path"])
+        parent_path = scope["parent"]
+        if parent_path is None:
+            assert path == ()
+            environment = DefinitionEnvironment()
+        else:
+            parent = environments[tuple(parent_path)]
+            assert path[:-1] == parent.scope_path
+            environment = parent.child(path[-1])
+        environments[path] = environment
+
+        for source in scope["definitions"]:
+            registration = environment.register(definition(source))
+            assert registration.kind in {
+                DefinitionRegistrationKind.REGISTERED,
+                DefinitionRegistrationKind.CONFLICT,
+                DefinitionRegistrationKind.NON_ADDRESSABLE,
+            }
+    return environments
+
+
+def opening_result(claim: dict) -> dict:
+    environments = reconstruct_environments(claim["scopes"])
+    environment = environments[tuple(claim["lookupScope"])]
+    result = open_definition(target(claim["target"]), environment)
+
+    if result.kind is not DefinitionLookupKind.MATCH:
+        return {"kind": result.kind.value}
+
+    assert result.definition_id is not None
+    assert result.body is not None
+    return {
+        "kind": "match",
+        "definitionId": {
+            "scopePath": list(result.definition_id.scope_path),
+            "ordinal": result.definition_id.ordinal,
+        },
+        "body": format_expression(result.body),
+    }
+
+
+def check_candidate_judgment(claim: dict) -> bool:
+    if claim.get("contractVersion") != CONTRACT_VERSION:
+        return False
+    if claim.get("operation") == "interpret":
+        try:
+            return check_interpret_step(interpret_step(claim))
+        except (AssertionError, KeyError, TypeError, ValueError):
+            return False
+    if claim.get("operation") == "open-definition":
+        try:
+            return opening_result(claim) == claim["expected"]
+        except (AssertionError, KeyError, TypeError, ValueError):
+            return False
+    return False
+
+
+def patched_claim(source: dict, patch: dict) -> dict:
+    result = deepcopy(source)
+    for dotted_path, value in patch.items():
+        parts = dotted_path.split(".")
+        current = result
+        for part in parts[:-1]:
+            current = current[part]
+        current[parts[-1]] = deepcopy(value)
+    return result
+
+
+def claims_by_id() -> dict[str, dict]:
+    data = read(CORPUS)
+    claims = data["interpretJudgments"] + data["openingJudgments"]
+    return {claim["id"]: claim for claim in claims}
+
+
+def test_challenge_is_non_normative_and_does_not_expand_trusted_v02_kernel():
+    challenge = read(CHALLENGE)
+    decision = read(DECISION)
+    mts_v03_text = MTS_V03.read_text(encoding="utf-8")
+    proof_v02 = read(PROOF_V02)
+
+    assert challenge["schema"] == "mts-proof-judgment-challenge/v0.3"
+    assert challenge["status"] == "candidate-challenge"
+    assert challenge["acceptedContractLinkAllowed"] is False
+    assert challenge["productionProofChangeAllowed"] is False
+    assert challenge["trustedRuleChangeAllowed"] is False
+    assert challenge["schema"] not in mts_v03_text
+    assert decision["nextGate"]["artifact"] == challenge["schema"]
+    assert proof_v02["checker"]["trustedRuleSet"] == ["interpret"]
+
+
+def test_corpus_is_candidate_only_version_self_describing_and_has_both_operations():
+    corpus = read(CORPUS)
+    claims = corpus["interpretJudgments"] + corpus["openingJudgments"]
+
+    assert corpus["schema"] == "mts-proof-judgment-conformance/v0.3"
+    assert corpus["status"] == "candidate-challenge-corpus"
+    assert corpus["contract"] == "mts-proof-judgment-challenge/v0.3"
+    assert corpus["contractVersion"] == CONTRACT_VERSION
+    assert {item["contractVersion"] for item in claims} == {CONTRACT_VERSION}
+    assert {item["operation"] for item in corpus["interpretJudgments"]} == {"interpret"}
+    assert {item["operation"] for item in corpus["openingJudgments"]} == {"open-definition"}
+    assert {item["goalId"] for item in claims} == {
+        "g-interpret-0",
+        "g-interpret-1",
+        "g-interpret-2",
+        "g-open-0",
+        "g-open-1",
+        "g-open-2",
+        "g-open-3",
+        "g-open-4",
+        "g-open-5",
+        "g-open-6",
+        "g-open-7",
+    }
+
+
+def test_all_interpret_claims_losslessly_replay_through_existing_v02_checker():
+    for claim in read(CORPUS)["interpretJudgments"]:
+        step = interpret_step(claim)
+        assert check_interpret_step(step), claim["id"]
+        assert check_proof(ProofObject(steps=(step,))), claim["id"]
+        assert check_candidate_judgment(claim), claim["id"]
+
+
+def test_all_opening_claims_replay_exactly_through_canonical_one_step_operation():
+    for claim in read(CORPUS)["openingJudgments"]:
+        assert opening_result(claim) == claim["expected"], claim["id"]
+        assert check_candidate_judgment(claim), claim["id"]
+
+
+def test_negative_opening_results_are_exact_replay_claims_not_hidden_failures():
+    claims = claims_by_id()
+
+    assert opening_result(claims["open-no-hidden-root"]) == {"kind": "no-match"}
+    assert opening_result(claims["open-missing"]) == {"kind": "no-match"}
+    assert opening_result(claims["open-conflict"]) == {"kind": "conflict"}
+    assert opening_result(claims["open-non-addressable"]) == {"kind": "non-addressable"}
+
+    boundary = read(CHALLENGE)["negativeClaimsAreFirstClass"]
+    assert boundary["openingNoMatch"] is True
+    assert boundary["openingConflict"] is True
+    assert boundary["openingNonAddressable"] is True
+
+
+def test_root_definitions_are_not_injected_when_the_serialized_scope_is_empty():
+    claims = claims_by_id()
+
+    explicit = opening_result(claims["open-explicit-root-infinity"])
+    empty = opening_result(claims["open-no-hidden-root"])
+
+    assert explicit == {
+        "kind": "match",
+        "definitionId": {"scopePath": [], "ordinal": 0},
+        "body": "{◁ = ∞, ▷ = ∞}",
+    }
+    assert empty == {"kind": "no-match"}
+    assert read(CHALLENGE)["independentReplay"]["ambientRootDefinitionsInjected"] is False
+
+
+def test_shadowing_and_recursion_vectors_remain_finite_and_replay_local():
+    claims = claims_by_id()
+
+    shadow = opening_result(claims["open-child-shadowing"])
+    self_open = opening_result(claims["open-self-one-step"])
+    mutual_open = opening_result(claims["open-mutual-a-one-step"])
+
+    assert shadow["definitionId"] == {"scopePath": [0], "ordinal": 0}
+    assert shadow["body"] == "child"
+    assert self_open["body"] == "a"
+    assert mutual_open["body"] == "b"
+    assert "steps" not in self_open and "cycle" not in self_open
+    assert "steps" not in mutual_open and "cycle" not in mutual_open
+
+    cycle = read(CHALLENGE)["cycleBoundary"]
+    assert cycle["selfDefinitionOpeningSteps"] == 1
+    assert cycle["mutualDefinitionOpeningSteps"] == 1
+    assert cycle["recursiveNormalization"] is False
+
+
+def test_every_forged_expected_result_is_rejected_by_independent_replay():
+    claims = claims_by_id()
+    corpus = read(CORPUS)
+
+    for forgery in corpus["forgeries"]:
+        source = claims[forgery["sourceJudgment"]]
+        forged = patched_claim(source, forgery["patch"])
+        assert forgery["mustReject"] is True
+        assert not check_candidate_judgment(forged), forgery["id"]
+
+
+def test_wrong_or_missing_contract_version_is_rejected_before_operation_replay():
+    source = claims_by_id()["open-explicit-root-infinity"]
+
+    wrong = patched_claim(source, {"contractVersion": "mts-contract/v0.2"})
+    missing = deepcopy(source)
+    del missing["contractVersion"]
+
+    assert not check_candidate_judgment(wrong)
+    assert not check_candidate_judgment(missing)
+
+
+def test_replay_does_not_mutate_serialized_claims_or_substrates():
+    corpus = read(CORPUS)
+    original = deepcopy(corpus)
+
+    for claim in corpus["interpretJudgments"] + corpus["openingJudgments"]:
+        assert check_candidate_judgment(claim)
+
+    assert corpus == original
+    veto = read(CHALLENGE)["mutationVeto"]
+    assert veto["serializedDefinitionScopesMustRemainByteEquivalent"] is True
+    assert veto["serializedMemoryMustRemainByteEquivalent"] is True
+    assert veto["openDefinitionMayRealize"] is False
+    assert veto["interpretMayRealize"] is False
+    assert veto["checkerMayDelete"] is False
+
+
+def test_challenge_does_not_accept_composition_or_classical_rules_by_default():
+    veto = read(CHALLENGE)["semanticVeto"]
+
+    assert veto == {
+        "successfulOpeningImpliesEquality": False,
+        "globalTextualSubstitution": False,
+        "globalEqualityRewrite": False,
+        "unrestrictedSymmetry": False,
+        "unrestrictedTransitivity": False,
+        "unrestrictedCongruence": False,
+        "modusPonens": False,
+        "genericStepCompositionAccepted": False,
+    }

--- a/tests/test_mts_proof_lifting_challenge.py
+++ b/tests/test_mts_proof_lifting_challenge.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from core.mtc_ast import Definition, Form, format_expression
 from core.mtc_definitions import DefinitionEnvironment, DefinitionLookupKind, open_definition
-from core.mtc_interpreter import ContextFrame, DistinguishedMemory, interpret_constraints
+from core.mtc_interpreter import ContextFrame, interpret_constraints
 from core.mtc_parser import parse_formula
+from core.proof_checker import DistinguishedLink, ProofMemory
 
 
 ROOT = Path(__file__).parents[1]
@@ -45,8 +46,11 @@ def opening_data(definitions: list[str], target_source: str) -> dict:
 
 
 def interpret_success(vector: dict) -> bool:
-    memory = DistinguishedMemory(
-        {item["id"]: (item["start"], item["end"]) for item in vector["memory"]}
+    memory = ProofMemory(
+        tuple(
+            DistinguishedLink(id=item["id"], start=item["start"], end=item["end"])
+            for item in vector["memory"]
+        )
     )
     result = interpret_constraints(
         parse_formula(vector["expression"]),


### PR DESCRIPTION
CI-recovery integration gate. Этот PR намеренно объединяет три **уже локализованных, независимых от новой semantics** repairs, потому что текущий `main` одновременно сломан всеми тремя и отдельные focused PR не могут сами получить green full-suite.

## 1. Восстановить missing proof-judgment evidence (#139)

В `main` уже есть `mts-proof-domain-decision/v0.3`, который явно зависит от `mts-proof-judgment-challenge/v0.3`, но исторический PR #139 остался открытым после squash/rebase и три artifact отсутствуют.

Добавляются ровно:
- `contracts/mts-proof-judgment-challenge-v0.3.json`;
- `contracts/mts-proof-judgment-conformance-v0.3.json`;
- `tests/test_mts_proof_judgment_challenge.py`.

Они остаются non-normative historical/challenge evidence и не расширяют trusted rules.

## 2. Исправить stale memory fixture (#150)

`tests/test_mts_proof_lifting_challenge.py` импортировал несуществующий `DistinguishedMemory`. Используется существующий immutable `ProofMemory` + `DistinguishedLink` из trusted v0.2 checker. Semantics challenge не меняется.

## 3. Исправить L4 driver harness (#151)

- unknown op валидируется до workspace access и возвращает protocol-level `invalid-request`;
- structural expected-error vector без user bind получает deterministic service binding `@<scenario>:root` в common runner.

Canonical #130 corpus и L4 semantics не меняются.

## Veto

PR не:
- меняет 10 root definitions;
- меняет `mts-contract/v0.3`/`mts-proof/v0.2` in-place;
- добавляет proof composition/trusted rules;
- добавляет subject/focus semantics из #148;
- меняет persistent L4 contract;
- меняет aprover.

## Merge gate

Merge только если:
- full pytest green;
- Ruff/structure/readonly/file limits green;
- `behind_by=0`;
- diff остаётся ровно этими 6 файлами.

После merge focused PR #139/#150/#151 будут закрыты как superseded-by-recovery, и #149 (`mts-proof/v0.3`) будет чисто перебазирован на восстановленный `main`.