### PR TITLE
Опубликовать additive mts-contract/v0.4 proof umbrella

### DIFF
--- a/contracts/mts-conformance-v0.4.json
+++ b/contracts/mts-conformance-v0.4.json
@@ -1,0 +1,42 @@
+{
+  "schema": "mts-conformance/v0.4",
+  "status": "accepted",
+  "contract": "mts-contract/v0.4",
+  "composition": "all referenced accepted corpora are required; no prior vector is copied, weakened or replaced",
+  "requiredCorpora": [
+    {
+      "role": "base-v0.3",
+      "path": "contracts/mts-conformance-v0.3.json",
+      "schema": "mts-conformance/v0.3",
+      "contract": "mts-contract/v0.3"
+    },
+    {
+      "role": "proof-v0.3",
+      "path": "contracts/mts-proof-conformance-v0.3.json",
+      "schema": "mts-proof-conformance/v0.3",
+      "contract": "mts-proof/v0.3"
+    }
+  ],
+  "releaseAssertions": {
+    "allRequiredCorporaMustPass": true,
+    "mtsContractV03RemainsImmutable": true,
+    "mtsProofV03IsExactDependency": true,
+    "rootProgramRemainsTenDefinitions": true,
+    "allFiveBaseProofRelationsReplay": true,
+    "proofSearchRemainsUntrusted": true,
+    "genericCompositionAccepted": false,
+    "openingImpliesEquality": false,
+    "ambientInterpreterIdentityUsed": false,
+    "subjectFocusExtensionAccepted": false,
+    "relativeProductionRemainsRaw": true,
+    "persistentBackendAccepted": false,
+    "pmmCanonicalDependency": false
+  },
+  "downstreamAssertions": {
+    "aproverMayPinMtsContractV04": true,
+    "aproverMustPinMtsProofV03": true,
+    "aproverMustReplayBaseRelationsIndependently": true,
+    "aproverMustNotInventComposition": true,
+    "aproverMustNotAddSubjectFocusSemantics": true
+  }
+}

--- a/contracts/mts-contract-v0.4.json
+++ b/contracts/mts-contract-v0.4.json
@@ -1,0 +1,108 @@
+{
+  "schema": "mts-contract/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 153,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-proof/v0.3"
+  ],
+  "extends": "mts-contract/v0.3",
+  "baseContract": "contracts/mts-contract-v0.3.json",
+  "conformanceCorpus": "contracts/mts-conformance-v0.4.json",
+  "releaseModel": "additive proof-publication umbrella; v0.3 remains immutable and independently replayable",
+  "rootProgram": "tests/mtc_formulas.mtc",
+  "rootDefinitionCount": 10,
+  "preservedSurface": {
+    "l0ToL4": "all accepted mts-contract/v0.3 semantics remain unchanged",
+    "definitionOpening": "mts-definition-opening/v0.3 unchanged",
+    "valueBundles": "accepted v0.2 flat ValueBundle semantics unchanged",
+    "rootAndQuoteAnum": "accepted v0.2 semantics unchanged",
+    "relativeAnum": "RAW in production",
+    "inMemoryL4": "accepted v0.2 semantics unchanged",
+    "persistentL4Accepted": false,
+    "interpretMayRealize": false,
+    "openDefinitionMayRealize": false,
+    "globalRewrite": false,
+    "displayLabelIsIdentity": false
+  },
+  "l5": {
+    "proofContract": "contracts/mts-proof-v0.3.json",
+    "proofSchema": "mts-proof/v0.3",
+    "contractVersion": "mts-contract/v0.3",
+    "trustedCheckerModule": "core/proof_checker.py",
+    "trustedRelations": [
+      "ContextuallySatisfies",
+      "Opens",
+      "NoVisibleDefinition",
+      "DefinitionConflict",
+      "NonAddressableDefinitionTarget"
+    ],
+    "searchTrusted": false,
+    "checkerTrusted": true,
+    "genericCompositionAccepted": false,
+    "judgmentOrderImpliesDependency": false,
+    "openingImpliesEquality": false,
+    "globalSubstitutionAccepted": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false
+  },
+  "contextBoundary": {
+    "acceptedContextInput": "explicit ContextFrame(start,end,parent?)",
+    "ambientInterpreterIdentity": false,
+    "subjectIdentity": false,
+    "currentFocusLinkRefIdentity": false,
+    "deicticSubjectFocusExtensionAccepted": false,
+    "futureResearchIssue": 148,
+    "futureResearchVersion": "v0.5+"
+  },
+  "versionBoundaries": {
+    "v02ModifiedInPlace": false,
+    "v03ModifiedInPlace": false,
+    "v03ConformanceReplaced": false,
+    "proofV03ModifiedToFitUmbrella": false,
+    "v04ConformanceComposesPriorCorpora": true,
+    "compatibilitySemanticLayerAllowed": false
+  },
+  "excludedFromThisRelease": [
+    "multi-step proof composition or DAG dependency semantics",
+    "new inference rules beyond accepted base relation replay",
+    "subject/focus/deictic context extension from issue #148",
+    "current-focus LinkRef identity",
+    "relative Anum candidate semantics",
+    "persistent/high-performance L4 backend acceptance",
+    "PMM as canonical dependency",
+    "global textual substitution",
+    "unrestricted equality rewrite",
+    "implicit realization"
+  ],
+  "downstream": {
+    "genericConsumerMayPinV04": true,
+    "aproverProofRepinAllowed": true,
+    "requiredProofSchema": "mts-proof/v0.3",
+    "requiredProofContractVersion": "mts-contract/v0.3",
+    "consumerMustReplayIndependently": true,
+    "consumerMayInventCompositionRules": false,
+    "consumerMayUseSubjectFocusSemantics": false
+  },
+  "nextGates": {
+    "proofComposition": {
+      "issue": 122,
+      "status": "research/challenge required"
+    },
+    "deicticSubjectFocus": {
+      "issue": 148,
+      "status": "v0.5+ research"
+    },
+    "relativeAnum": {
+      "issue": 123,
+      "status": "candidate research only"
+    },
+    "persistentL4": {
+      "issue": 124,
+      "status": "persistent backend conformance required"
+    }
+  }
+}

--- a/tests/test_mts_contract_v04.py
+++ b/tests/test_mts_contract_v04.py
@@ -1,0 +1,142 @@
+"""Acceptance checks for additive MTS v0.4 proof-publication umbrella."""
+
+import json
+from pathlib import Path
+
+from core.proof_checker import check_proof_v03_data
+
+
+ROOT = Path(__file__).parents[1]
+V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
+V03_CONFORMANCE = ROOT / "contracts" / "mts-conformance-v0.3.json"
+V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+V04_CONFORMANCE = ROOT / "contracts" / "mts-conformance-v0.4.json"
+PROOF = ROOT / "contracts" / "mts-proof-v0.3.json"
+PROOF_CONFORMANCE = ROOT / "contracts" / "mts-proof-conformance-v0.3.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_v04_is_additive_accepted_umbrella_over_immutable_v03():
+    v03 = read(V03)
+    v04 = read(V04)
+
+    assert v03["schema"] == "mts-contract/v0.3"
+    assert v03["status"] == "accepted"
+    assert v04["schema"] == "mts-contract/v0.4"
+    assert v04["status"] == "accepted"
+    assert v04["accepted"] is True
+    assert v04["extends"] == v03["schema"]
+    assert v04["dependsOn"] == [v03["schema"], "mts-proof/v0.3"]
+    assert v04["baseContract"] == "contracts/mts-contract-v0.3.json"
+    assert v04["versionBoundaries"]["v03ModifiedInPlace"] is False
+    assert v04["versionBoundaries"]["v03ConformanceReplaced"] is False
+    assert v04["versionBoundaries"]["compatibilitySemanticLayerAllowed"] is False
+
+
+def test_v04_conformance_composes_v03_and_proof_v03_without_copying_vectors():
+    base = read(V03_CONFORMANCE)
+    proof = read(PROOF_CONFORMANCE)
+    corpus = read(V04_CONFORMANCE)
+
+    assert corpus["schema"] == "mts-conformance/v0.4"
+    assert corpus["contract"] == "mts-contract/v0.4"
+    assert corpus["status"] == "accepted"
+    required = {item["role"]: item for item in corpus["requiredCorpora"]}
+    assert set(required) == {"base-v0.3", "proof-v0.3"}
+    assert required["base-v0.3"]["schema"] == base["schema"]
+    assert required["base-v0.3"]["contract"] == base["contract"]
+    assert required["proof-v0.3"]["schema"] == proof["schema"]
+    assert required["proof-v0.3"]["contract"] == proof["contract"]
+    assert corpus["releaseAssertions"]["allRequiredCorporaMustPass"] is True
+
+
+def test_v04_publishes_exactly_the_accepted_proof_v03_base_surface():
+    v04 = read(V04)
+    proof = read(PROOF)
+
+    assert proof["schema"] == "mts-proof/v0.3"
+    assert proof["status"] == "accepted"
+    assert proof["accepted"] is True
+    assert v04["l5"]["proofContract"] == "contracts/mts-proof-v0.3.json"
+    assert v04["l5"]["proofSchema"] == proof["schema"]
+    assert v04["l5"]["trustedRelations"] == proof["trustedRelations"]
+    assert set(v04["l5"]["trustedRelations"]) == {
+        "ContextuallySatisfies",
+        "Opens",
+        "NoVisibleDefinition",
+        "DefinitionConflict",
+        "NonAddressableDefinitionTarget",
+    }
+    assert v04["l5"]["searchTrusted"] is False
+    assert v04["l5"]["checkerTrusted"] is True
+
+
+def test_every_published_proof_v03_conformance_judgment_replays_in_release():
+    corpus = read(PROOF_CONFORMANCE)
+
+    for vector in corpus["validJudgments"]:
+        artifact = {
+            "proofVersion": corpus["proofVersion"],
+            "contractVersion": corpus["contractVersion"],
+            "judgments": [vector["judgment"]],
+        }
+        assert check_proof_v03_data(artifact), vector["id"]
+
+
+def test_v04_does_not_accept_multistep_classical_or_opening_equality_rules():
+    boundary = read(V04)["l5"]
+
+    assert boundary["genericCompositionAccepted"] is False
+    assert boundary["judgmentOrderImpliesDependency"] is False
+    assert boundary["openingImpliesEquality"] is False
+    assert boundary["globalSubstitutionAccepted"] is False
+    assert boundary["transitivityAccepted"] is False
+    assert boundary["symmetryAccepted"] is False
+    assert boundary["congruenceAccepted"] is False
+    assert boundary["modusPonensAccepted"] is False
+
+
+def test_v04_keeps_explicit_contextframe_and_excludes_subject_focus_research():
+    context = read(V04)["contextBoundary"]
+
+    assert context["acceptedContextInput"] == "explicit ContextFrame(start,end,parent?)"
+    assert context["ambientInterpreterIdentity"] is False
+    assert context["subjectIdentity"] is False
+    assert context["currentFocusLinkRefIdentity"] is False
+    assert context["deicticSubjectFocusExtensionAccepted"] is False
+    assert context["futureResearchIssue"] == 148
+    assert context["futureResearchVersion"] == "v0.5+"
+
+
+def test_v04_preserves_l3_l4_boundaries_and_ten_root_definitions():
+    v04 = read(V04)
+    lines = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert len(lines) == 10
+    assert v04["rootDefinitionCount"] == 10
+    assert v04["preservedSurface"]["relativeAnum"] == "RAW in production"
+    assert v04["preservedSurface"]["persistentL4Accepted"] is False
+    assert v04["preservedSurface"]["interpretMayRealize"] is False
+    assert v04["preservedSurface"]["openDefinitionMayRealize"] is False
+
+
+def test_v04_changes_downstream_pin_boundary_without_rewriting_v03_history():
+    v03 = read(V03)
+    v04 = read(V04)
+
+    assert v03["downstream"]["aproverProofRepinAllowed"] is False
+    assert v03["l5Boundary"]["currentProofContract"] == "contracts/mts-proof-v0.2.json"
+    assert v04["downstream"]["aproverProofRepinAllowed"] is True
+    assert v04["downstream"]["requiredProofSchema"] == "mts-proof/v0.3"
+    assert v04["downstream"]["requiredProofContractVersion"] == "mts-contract/v0.3"
+    assert v04["downstream"]["consumerMustReplayIndependently"] is True
+    assert v04["downstream"]["consumerMayInventCompositionRules"] is False
+    assert v04["downstream"]["consumerMayUseSubjectFocusSemantics"] is False

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -15,6 +15,8 @@ MTS_CONTRACT_V02 = ROOT / "contracts/mts-contract-v0.2.json"
 MTS_CONFORMANCE_V02 = ROOT / "contracts/mts-conformance-v0.2.json"
 MTS_CONTRACT_V03 = ROOT / "contracts/mts-contract-v0.3.json"
 MTS_CONFORMANCE_V03 = ROOT / "contracts/mts-conformance-v0.3.json"
+MTS_CONTRACT_V04 = ROOT / "contracts/mts-contract-v0.4.json"
+MTS_CONFORMANCE_V04 = ROOT / "contracts/mts-conformance-v0.4.json"
 ACTIVE_THEORY = {"Основания МТС.md", "Система аксиом МТС.md", "Пучки связей МТС.md"}
 ACTIVE_SPECS = {
     "Reference model МТС v0.2.md",
@@ -99,6 +101,8 @@ def test_versioned_machine_contract_and_conformance_chain_is_exact():
         MTS_CONFORMANCE_V02,
         MTS_CONTRACT_V03,
         MTS_CONFORMANCE_V03,
+        MTS_CONTRACT_V04,
+        MTS_CONFORMANCE_V04,
     ):
         assert path.is_file()
 
@@ -106,6 +110,8 @@ def test_versioned_machine_contract_and_conformance_chain_is_exact():
     v02_corpus = json.loads(MTS_CONFORMANCE_V02.read_text(encoding="utf-8"))
     v03 = json.loads(MTS_CONTRACT_V03.read_text(encoding="utf-8"))
     v03_corpus = json.loads(MTS_CONFORMANCE_V03.read_text(encoding="utf-8"))
+    v04 = json.loads(MTS_CONTRACT_V04.read_text(encoding="utf-8"))
+    v04_corpus = json.loads(MTS_CONFORMANCE_V04.read_text(encoding="utf-8"))
 
     assert v02["schema"] == "mts-contract/v0.2"
     assert v02["status"] == "accepted"
@@ -128,10 +134,31 @@ def test_versioned_machine_contract_and_conformance_chain_is_exact():
     assert v03_corpus["contract"] == v03["schema"]
     assert v03_corpus["status"] == "accepted"
 
+    assert v04["schema"] == "mts-contract/v0.4"
+    assert v04["status"] == "accepted"
+    assert v04["extends"] == v03["schema"]
+    assert v04["baseContract"] == "contracts/mts-contract-v0.3.json"
+    assert v04["rootProgram"] == v03["rootProgram"]
+    assert v04["conformanceCorpus"] == "contracts/mts-conformance-v0.4.json"
+    assert v04["dependsOn"] == [v03["schema"], "mts-proof/v0.3"]
+    assert v04_corpus["schema"] == "mts-conformance/v0.4"
+    assert v04_corpus["contract"] == v04["schema"]
+    assert v04_corpus["status"] == "accepted"
+    required_v04 = {item["role"]: item for item in v04_corpus["requiredCorpora"]}
+    assert set(required_v04) == {"base-v0.3", "proof-v0.3"}
+    assert required_v04["base-v0.3"]["schema"] == v03_corpus["schema"]
+    assert required_v04["base-v0.3"]["contract"] == v03_corpus["contract"]
+    assert required_v04["proof-v0.3"]["schema"] == "mts-proof-conformance/v0.3"
+    assert required_v04["proof-v0.3"]["contract"] == "mts-proof/v0.3"
+
     contract_files = sorted((ROOT / "contracts").glob("mts-contract-*.json"))
     conformance_files = sorted((ROOT / "contracts").glob("mts-conformance-*.json"))
-    assert contract_files == [MTS_CONTRACT_V02, MTS_CONTRACT_V03]
-    assert conformance_files == [MTS_CONFORMANCE_V02, MTS_CONFORMANCE_V03]
+    assert contract_files == [MTS_CONTRACT_V02, MTS_CONTRACT_V03, MTS_CONTRACT_V04]
+    assert conformance_files == [
+        MTS_CONFORMANCE_V02,
+        MTS_CONFORMANCE_V03,
+        MTS_CONFORMANCE_V04,
+    ]
 
 
 def test_candidate_runtime_fixture_and_reference_paths_are_removed_after_promotion():


### PR DESCRIPTION
Closes #153. Refs #120, #122, #148, netkeep80/aprover#139.

Additive release поверх immutable `mts-contract/v0.3`.

## Что публикуется

```text
mts-contract/v0.3
+
mts-proof/v0.3
→ mts-contract/v0.4
```

`mts-conformance/v0.4` композиционно требует:
- `mts-conformance/v0.3`;
- `mts-proof-conformance/v0.3`.

Ни один старый vector/contract не копируется и не переписывается.

## L5 boundary

v0.4 публикует ровно пять accepted base relations из `mts-proof/v0.3` и разрешает downstream exact pin.

Не принимаются:
- generic multi-step composition/DAG;
- symmetry/transitivity/congruence/MP/global substitution;
- opening => equality;
- proof-search semantics.

#122 остаётся open.

## Context boundary

Остаётся только explicit `ContextFrame(start,end,parent?)` baseline. Subject/focus/deixis research из #148 исключён и перенесён в v0.5+.

## Other boundaries

- 10 root definitions unchanged;
- relative Anum остаётся RAW;
- persistent L4 остаётся candidate-only;
- PMM не canonical dependency;
- no implicit realization.

## Downstream

Только после этого umbrella aprover может pin:

```text
mts-contract/v0.4
mts-proof/v0.3
```

но не может invent composition rules или subject/focus semantics.

Merge только после full green CI и `behind_by=0`.