### PR TITLE
Challenge deictic ContextFrame / interpreter-focus semantics v0.5

### DIFF
--- a/contracts/mts-deictic-context-challenge-v0.5.json
+++ b/contracts/mts-deictic-context-challenge-v0.5.json
@@ -8,7 +8,7 @@
   ],
   "acceptedContractLinkAllowed": false,
   "productionSemanticChangeAllowed": false,
-  "purpose": "Separate the already accepted explicit ContextFrame semantics from candidate subject/focus/deictic runtime bindings before introducing any new pronoun, focus identity or interpreter introspection.",
+  "purpose": "Separate the already accepted explicit ContextFrame semantics from candidate interpreter-focus/deictic runtime bindings before introducing any new pronoun, focus identity or interpreter introspection.",
   "currentAcceptedBaseline": {
     "semanticInput": "explicit ContextFrame(start,end,parent?)",
     "startPronoun": "◁ reads current ContextFrame.start",
@@ -16,15 +16,14 @@
     "parentAscent": "↑ traverses the explicit parent chain one frame per prefix",
     "contextMustBeMaterialized": false,
     "currentRelationIdentityObservable": false,
-    "subjectIdentityObservable": false,
     "interpreterIdentityObservable": false,
     "ambientSessionStateObservable": false,
+    "separateSubjectConceptIntroduced": false,
     "proofReplayUsesExplicitContext": true,
     "missingParentCurrentBehavior": "ValueError; challenged, not promoted as final v0.5 semantics"
   },
   "requiredDistinctions": [
-    "interpreter/runtime",
-    "subject",
+    "interpreter/runtime as a link",
     "focus/current relation",
     "explicit semantic ContextFrame",
     "security/capability policy"
@@ -34,7 +33,7 @@
       "id": "hidden-interpreter-introspection",
       "verdict": "reject",
       "accepted": false,
-      "shape": "formula may inspect arbitrary host/interpreter/session state",
+      "shape": "formula may inspect arbitrary interpreter/host/session state",
       "reason": "introduces hidden replay inputs and ties semantics to runtime implementation"
     },
     {
@@ -45,17 +44,17 @@
       "reason": "this is already the versioned v0.3/v0.4 baseline, not a new v0.5 decision"
     },
     {
-      "id": "subject-focus-binds-context",
+      "id": "interpreter-focus-binds-context",
       "verdict": "challenge",
       "accepted": false,
-      "shape": "Focus(subject, context) is a separate binding relation; formula still consumes only context",
-      "reason": "explains where runtime context comes from without changing pronoun character or adding hidden host state"
+      "shape": "Focus(interpreterLink,currentFocus) is a separate binding relation; formula still consumes only explicit ContextFrame",
+      "reason": "models the interpreter itself as a link and explains where runtime context comes from without exposing arbitrary interpreter state"
     },
     {
       "id": "capability-scoped-deictic-environment",
       "verdict": "challenge",
       "accepted": false,
-      "shape": "runtime exposes current/ancestor focus frames through an explicit capability boundary",
+      "shape": "interpreter exposes current/ancestor focus frames through an explicit capability boundary",
       "reason": "may model access restrictions while keeping semantic meaning separate from policy"
     }
   ],
@@ -63,7 +62,7 @@
     "contextSensitive": "there exist explicit contexts C1,C2 for which replay of the same formula and other inputs differs",
     "contextInvariant": "replay result is equal for the challenged contexts when all non-context inputs are fixed",
     "syntacticNoPronounImpliesGlobalInvariance": false,
-    "reason": "absence of direct pronouns is useful static evidence but indirect future constructs may still depend on context; do not promote a syntactic theorem prematurely"
+    "reason": "absence of direct pronouns is useful static evidence but indirect definition dependencies may still depend on context; do not promote a syntactic theorem prematurely"
   },
   "focusIdentityQuestion": {
     "pairOfRolesEqualsRelationIdentity": false,
@@ -77,9 +76,9 @@
     "parentLifecycleAccepted": false,
     "unresolvedSources": [
       "recursive form entry",
-      "explicit runtime focus change",
+      "explicit interpreter focus change",
       "formula invocation",
-      "host/runtime policy"
+      "interpreter/runtime policy"
     ],
     "ambientGlobalFallbackAllowed": false
   },
@@ -92,27 +91,28 @@
   "proofBoundary": {
     "mtsProofV03ModifiedByThisChallenge": false,
     "explicitContextFrameRemainsReplaySubstrate": true,
-    "hostIdentityMayAffectReplay": false,
-    "subjectIdentityMayAffectReplayWithoutExplicitFutureContract": false,
+    "hostOrInterpreterIdentityMayAffectReplay": false,
+    "separateSubjectConceptRequired": false,
     "futureFocusBindingMustBeVersionedAdditively": true
   },
   "requiredVectors": [
     "context-independent baseline example gives identical replay under distinct explicit frames",
     "pronoun-bearing example gives different replay under distinct explicit frames",
-    "same explicit frame replays identically under different test-only host labels",
+    "same explicit frame replays identically under different test-only interpreter labels",
     "virtual frame and frame constructed from a materialized relation's poles are equivalent while relation identity is unobservable",
     "single and repeated parent ascent follow only the explicit parent chain",
     "missing parent does not fall back to a hidden global frame",
-    "production interpret signature contains no subject/host/current-LinkRef semantic input",
+    "production interpret signature contains no interpreter/host/current-LinkRef semantic input beyond explicit frame",
     "replay does not mutate MemoryView"
   ],
   "vetoes": [
     "hidden arbitrary interpreter introspection",
+    "introducing a separate subject ontology for this context model",
     "treating ◁/▷ as global variables",
     "equating security policy with semantic meaning",
     "equating (start,end) with current relation identity without a new contract",
     "requiring ContextFrame materialization",
-    "injecting an ambient canonical subject or focus",
+    "injecting an ambient canonical interpreter or focus",
     "changing the ten root definitions",
     "editing v0.3/v0.4 contracts in place",
     "adding a current-link pronoun before challenge",
@@ -121,8 +121,7 @@
   "nextGate": {
     "artifact": "mts-deictic-context-decision/v0.5",
     "mustDecide": [
-      "whether subject is a formal MTS concept at all",
-      "whether Focus(subject,context) belongs to MTS or only host/runtime integration",
+      "whether Focus(interpreterLink,currentFocus) belongs to MTS or only interpreter/runtime integration",
       "whether current focus has observable identity beyond its roles",
       "the lifecycle/meaning of parent focus",
       "typed semantics for unavailable parent/context",

--- a/contracts/mts-deictic-context-challenge-v0.5.json
+++ b/contracts/mts-deictic-context-challenge-v0.5.json
@@ -1,0 +1,134 @@
+{
+  "schema": "mts-deictic-context-challenge/v0.5",
+  "status": "candidate-challenge",
+  "issue": 148,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-proof/v0.3"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionSemanticChangeAllowed": false,
+  "purpose": "Separate the already accepted explicit ContextFrame semantics from candidate subject/focus/deictic runtime bindings before introducing any new pronoun, focus identity or interpreter introspection.",
+  "currentAcceptedBaseline": {
+    "semanticInput": "explicit ContextFrame(start,end,parent?)",
+    "startPronoun": "◁ reads current ContextFrame.start",
+    "endPronoun": "▷ reads current ContextFrame.end",
+    "parentAscent": "↑ traverses the explicit parent chain one frame per prefix",
+    "contextMustBeMaterialized": false,
+    "currentRelationIdentityObservable": false,
+    "subjectIdentityObservable": false,
+    "interpreterIdentityObservable": false,
+    "ambientSessionStateObservable": false,
+    "proofReplayUsesExplicitContext": true,
+    "missingParentCurrentBehavior": "ValueError; challenged, not promoted as final v0.5 semantics"
+  },
+  "requiredDistinctions": [
+    "interpreter/runtime",
+    "subject",
+    "focus/current relation",
+    "explicit semantic ContextFrame",
+    "security/capability policy"
+  ],
+  "candidateModels": [
+    {
+      "id": "hidden-interpreter-introspection",
+      "verdict": "reject",
+      "accepted": false,
+      "shape": "formula may inspect arbitrary host/interpreter/session state",
+      "reason": "introduces hidden replay inputs and ties semantics to runtime implementation"
+    },
+    {
+      "id": "explicit-contextframe-only",
+      "verdict": "accepted-baseline",
+      "accepted": false,
+      "shape": "formula observes only explicit ContextFrame roles and ancestors",
+      "reason": "this is already the versioned v0.3/v0.4 baseline, not a new v0.5 decision"
+    },
+    {
+      "id": "subject-focus-binds-context",
+      "verdict": "challenge",
+      "accepted": false,
+      "shape": "Focus(subject, context) is a separate binding relation; formula still consumes only context",
+      "reason": "explains where runtime context comes from without changing pronoun character or adding hidden host state"
+    },
+    {
+      "id": "capability-scoped-deictic-environment",
+      "verdict": "challenge",
+      "accepted": false,
+      "shape": "runtime exposes current/ancestor focus frames through an explicit capability boundary",
+      "reason": "may model access restrictions while keeping semantic meaning separate from policy"
+    }
+  ],
+  "contextDependence": {
+    "contextSensitive": "there exist explicit contexts C1,C2 for which replay of the same formula and other inputs differs",
+    "contextInvariant": "replay result is equal for the challenged contexts when all non-context inputs are fixed",
+    "syntacticNoPronounImpliesGlobalInvariance": false,
+    "reason": "absence of direct pronouns is useful static evidence but indirect future constructs may still depend on context; do not promote a syntactic theorem prematurely"
+  },
+  "focusIdentityQuestion": {
+    "pairOfRolesEqualsRelationIdentity": false,
+    "virtualContextAllowedByBaseline": true,
+    "materializedLinkRefRequired": false,
+    "candidateCurrentLinkRefPronounAccepted": false,
+    "nextQuestion": "whether current focus needs its own observable identity in addition to start/end roles"
+  },
+  "parentFocusQuestion": {
+    "acceptedMeaning": "↑ reads an explicitly supplied parent ContextFrame",
+    "parentLifecycleAccepted": false,
+    "unresolvedSources": [
+      "recursive form entry",
+      "explicit runtime focus change",
+      "formula invocation",
+      "host/runtime policy"
+    ],
+    "ambientGlobalFallbackAllowed": false
+  },
+  "securityBoundary": {
+    "policyDefinesPronounMeaning": false,
+    "policyMayControlWhichContextFramesAreExposed": true,
+    "hiddenParentInjectionAllowed": false,
+    "semanticReplayMustContainAllObservedFrames": true
+  },
+  "proofBoundary": {
+    "mtsProofV03ModifiedByThisChallenge": false,
+    "explicitContextFrameRemainsReplaySubstrate": true,
+    "hostIdentityMayAffectReplay": false,
+    "subjectIdentityMayAffectReplayWithoutExplicitFutureContract": false,
+    "futureFocusBindingMustBeVersionedAdditively": true
+  },
+  "requiredVectors": [
+    "context-independent baseline example gives identical replay under distinct explicit frames",
+    "pronoun-bearing example gives different replay under distinct explicit frames",
+    "same explicit frame replays identically under different test-only host labels",
+    "virtual frame and frame constructed from a materialized relation's poles are equivalent while relation identity is unobservable",
+    "single and repeated parent ascent follow only the explicit parent chain",
+    "missing parent does not fall back to a hidden global frame",
+    "production interpret signature contains no subject/host/current-LinkRef semantic input",
+    "replay does not mutate MemoryView"
+  ],
+  "vetoes": [
+    "hidden arbitrary interpreter introspection",
+    "treating ◁/▷ as global variables",
+    "equating security policy with semantic meaning",
+    "equating (start,end) with current relation identity without a new contract",
+    "requiring ContextFrame materialization",
+    "injecting an ambient canonical subject or focus",
+    "changing the ten root definitions",
+    "editing v0.3/v0.4 contracts in place",
+    "adding a current-link pronoun before challenge",
+    "making proof replay depend on ambient user/session/process identity"
+  ],
+  "nextGate": {
+    "artifact": "mts-deictic-context-decision/v0.5",
+    "mustDecide": [
+      "whether subject is a formal MTS concept at all",
+      "whether Focus(subject,context) belongs to MTS or only host/runtime integration",
+      "whether current focus has observable identity beyond its roles",
+      "the lifecycle/meaning of parent focus",
+      "typed semantics for unavailable parent/context",
+      "whether a static context-invariance analysis is sound",
+      "whether any explicit focus-switch operator is needed"
+    ],
+    "mustNotChangeProductionBeforeDecision": true
+  }
+}

--- a/tests/test_mts_deictic_context_challenge.py
+++ b/tests/test_mts_deictic_context_challenge.py
@@ -1,4 +1,4 @@
-"""Executable evidence for the non-normative deictic context/focus challenge v0.5."""
+"""Executable evidence for the non-normative deictic interpreter-focus challenge v0.5."""
 
 import inspect
 import json
@@ -114,16 +114,16 @@ def test_pronoun_bearing_formula_can_depend_on_explicit_context():
     assert different.success is False
 
 
-def test_same_explicit_frame_replays_identically_under_different_test_only_host_labels():
+def test_same_explicit_frame_replays_identically_under_different_interpreter_labels():
     frame = ContextFrame(start=3, end=4)
 
-    def run_under_host(_host_id: str):
-        # Host identity is deliberately not forwarded: current production
-        # semantics has no such input.
+    def run_under_interpreter(_interpreter_id: str):
+        # Interpreter identity is deliberately not forwarded: current production
+        # semantics has only the explicit ContextFrame at this boundary.
         return replay("{◁ = a, ▷ = b}", frame, symbols={"a": 3, "b": 4})
 
-    first = run_under_host("host-A")
-    second = run_under_host("host-B")
+    first = run_under_interpreter("interpreter-A")
+    second = run_under_interpreter("interpreter-B")
 
     assert result_shape(first) == result_shape(second)
     assert first.success is True
@@ -175,25 +175,25 @@ def test_parent_ascent_uses_only_the_explicit_parent_chain():
 
 
 def test_missing_parent_fails_explicitly_instead_of_falling_back_to_hidden_global_context():
-    with pytest.raises(ValueError, match="Context ascent escapes the available parent chain"):
+    with pytest.raises(ValueError, match="выше корневого контекста"):
         replay("↑◁ = a", ContextFrame(start=1, end=2), symbols={"a": 1})
 
     baseline = read(CHALLENGE)["currentAcceptedBaseline"]
     assert baseline["missingParentCurrentBehavior"].startswith("ValueError")
 
 
-def test_current_production_interpreter_has_no_subject_host_or_current_linkref_input():
+def test_current_production_interpreter_has_only_explicit_frame_not_hidden_interpreter_identity():
     parameters = inspect.signature(interpret_constraints).parameters
 
-    assert list(parameters) == ["expression", "context", "memory", "symbols"]
-    assert "subject" not in parameters
+    assert list(parameters) == ["expression", "frame", "memory", "symbols"]
+    assert "interpreter" not in parameters
     assert "host" not in parameters
     assert "session" not in parameters
     assert "focus" not in parameters
     assert "current_link" not in parameters
 
     baseline = read(CHALLENGE)["currentAcceptedBaseline"]
-    assert baseline["subjectIdentityObservable"] is False
+    assert baseline["separateSubjectConceptIntroduced"] is False
     assert baseline["interpreterIdentityObservable"] is False
     assert baseline["currentRelationIdentityObservable"] is False
 
@@ -211,11 +211,14 @@ def test_root_program_remains_exactly_ten_definitions_and_challenge_adds_no_new_
     assert "adding a current-link pronoun before challenge" in challenge["vetoes"]
 
 
-def test_next_gate_is_a_decision_about_subject_focus_identity_and_parent_lifecycle():
+def test_next_gate_is_a_decision_about_interpreter_focus_identity_and_parent_lifecycle():
     gate = read(CHALLENGE)["nextGate"]
 
     assert gate["artifact"] == "mts-deictic-context-decision/v0.5"
     assert gate["mustNotChangeProductionBeforeDecision"] is True
-    assert "whether subject is a formal MTS concept at all" in gate["mustDecide"]
+    assert (
+        "whether Focus(interpreterLink,currentFocus) belongs to MTS or only interpreter/runtime integration"
+        in gate["mustDecide"]
+    )
     assert "whether current focus has observable identity beyond its roles" in gate["mustDecide"]
     assert "the lifecycle/meaning of parent focus" in gate["mustDecide"]

--- a/tests/test_mts_deictic_context_challenge.py
+++ b/tests/test_mts_deictic_context_challenge.py
@@ -1,0 +1,221 @@
+"""Executable evidence for the non-normative deictic context/focus challenge v0.5."""
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-deictic-context-challenge-v0.5.json"
+MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class NoReadMemory(MemoryView):
+    """Fails if a challenged formula accidentally touches L4."""
+
+    def poles(self, link: int) -> tuple[int, int]:
+        raise AssertionError(f"unexpected poles({link})")
+
+    def find_link(self, start: int, end: int) -> int | None:
+        raise AssertionError(f"unexpected find_link({start}, {end})")
+
+    def find_start_projection(self, form: int) -> int | None:
+        raise AssertionError(f"unexpected find_start_projection({form})")
+
+    def find_end_projection(self, form: int) -> int | None:
+        raise AssertionError(f"unexpected find_end_projection({form})")
+
+
+class FiniteMemory(MemoryView):
+    def __init__(self, links: dict[int, tuple[int, int]]):
+        self.links = dict(links)
+        self.by_poles = {poles: link for link, poles in links.items()}
+
+    def poles(self, link: int) -> tuple[int, int]:
+        return self.links[link]
+
+    def find_link(self, start: int, end: int) -> int | None:
+        return self.by_poles.get((start, end))
+
+    def find_start_projection(self, form: int) -> int | None:
+        for link, poles in self.links.items():
+            if poles == (link, form):
+                return link
+        return None
+
+    def find_end_projection(self, form: int) -> int | None:
+        for link, poles in self.links.items():
+            if poles == (form, link):
+                return link
+        return None
+
+
+def replay(source: str, context: ContextFrame, *, symbols: dict[str, int] | None = None):
+    return interpret_constraints(
+        parse_formula(source),
+        context,
+        NoReadMemory(),
+        symbols=symbols,
+    )
+
+
+def result_shape(result) -> tuple[bool, tuple, tuple]:
+    return result.success, result.holes, result.aliases
+
+
+def test_challenge_is_non_normative_and_does_not_change_published_context_or_proof_contracts():
+    challenge = read(CHALLENGE)
+    v04 = read(MTS_V04)
+    proof = read(PROOF_V03)
+
+    assert challenge["schema"] == "mts-deictic-context-challenge/v0.5"
+    assert challenge["status"] == "candidate-challenge"
+    assert challenge["acceptedContractLinkAllowed"] is False
+    assert challenge["productionSemanticChangeAllowed"] is False
+    assert challenge["schema"] not in MTS_V04.read_text(encoding="utf-8")
+    assert v04["contextBoundary"]["acceptedContextInput"] == "explicit ContextFrame(start,end,parent?)"
+    assert v04["contextBoundary"]["subjectIdentity"] is False
+    assert v04["contextBoundary"]["currentFocusLinkRefIdentity"] is False
+    assert proof["contextVersionBoundary"]["explicitContextFrameOnly"] is True
+    assert proof["contextVersionBoundary"]["subjectOrFocusAddedToV03Artifact"] is False
+
+
+def test_formula_without_context_pronouns_can_be_context_invariant_for_distinct_frames():
+    left = replay("[] = []", ContextFrame(start=1, end=2))
+    right = replay("[] = []", ContextFrame(start=900, end=901))
+
+    assert result_shape(left) == result_shape(right)
+    assert left.success is True
+    assert len(left.aliases) == 1
+
+    boundary = read(CHALLENGE)["contextDependence"]
+    assert boundary["syntacticNoPronounImpliesGlobalInvariance"] is False
+
+
+def test_pronoun_bearing_formula_can_depend_on_explicit_context():
+    source = "◁ = a"
+    symbols = {"a": 1}
+
+    matching = replay(source, ContextFrame(start=1, end=77), symbols=symbols)
+    different = replay(source, ContextFrame(start=2, end=77), symbols=symbols)
+
+    assert matching.success is True
+    assert different.success is False
+
+
+def test_same_explicit_frame_replays_identically_under_different_test_only_host_labels():
+    frame = ContextFrame(start=3, end=4)
+
+    def run_under_host(_host_id: str):
+        # Host identity is deliberately not forwarded: current production
+        # semantics has no such input.
+        return replay("{◁ = a, ▷ = b}", frame, symbols={"a": 3, "b": 4})
+
+    first = run_under_host("host-A")
+    second = run_under_host("host-B")
+
+    assert result_shape(first) == result_shape(second)
+    assert first.success is True
+
+
+def test_virtual_frame_and_frame_constructed_from_materialized_link_poles_are_equivalent():
+    memory = FiniteMemory({10: (3, 4)})
+    materialized_start, materialized_end = memory.poles(10)
+
+    virtual = ContextFrame(start=3, end=4)
+    from_materialized_poles = ContextFrame(
+        start=materialized_start,
+        end=materialized_end,
+    )
+
+    first = replay("{◁ = a, ▷ = b}", virtual, symbols={"a": 3, "b": 4})
+    second = replay(
+        "{◁ = a, ▷ = b}",
+        from_materialized_poles,
+        symbols={"a": 3, "b": 4},
+    )
+
+    assert result_shape(first) == result_shape(second)
+    assert first.success is True
+
+    identity = read(CHALLENGE)["focusIdentityQuestion"]
+    assert identity["pairOfRolesEqualsRelationIdentity"] is False
+    assert identity["virtualContextAllowedByBaseline"] is True
+    assert identity["materializedLinkRefRequired"] is False
+
+
+def test_parent_ascent_uses_only_the_explicit_parent_chain():
+    context = ContextFrame(
+        start=5,
+        end=6,
+        parent=ContextFrame(
+            start=2,
+            end=3,
+            parent=ContextFrame(start=1, end=4),
+        ),
+    )
+
+    parent_start = replay("↑◁ = a", context, symbols={"a": 2})
+    grandparent_end = replay("↑↑▷ = b", context, symbols={"b": 4})
+
+    assert parent_start.success is True
+    assert grandparent_end.success is True
+    assert read(CHALLENGE)["parentFocusQuestion"]["ambientGlobalFallbackAllowed"] is False
+
+
+def test_missing_parent_fails_explicitly_instead_of_falling_back_to_hidden_global_context():
+    with pytest.raises(ValueError, match="Context ascent escapes the available parent chain"):
+        replay("↑◁ = a", ContextFrame(start=1, end=2), symbols={"a": 1})
+
+    baseline = read(CHALLENGE)["currentAcceptedBaseline"]
+    assert baseline["missingParentCurrentBehavior"].startswith("ValueError")
+
+
+def test_current_production_interpreter_has_no_subject_host_or_current_linkref_input():
+    parameters = inspect.signature(interpret_constraints).parameters
+
+    assert list(parameters) == ["expression", "context", "memory", "symbols"]
+    assert "subject" not in parameters
+    assert "host" not in parameters
+    assert "session" not in parameters
+    assert "focus" not in parameters
+    assert "current_link" not in parameters
+
+    baseline = read(CHALLENGE)["currentAcceptedBaseline"]
+    assert baseline["subjectIdentityObservable"] is False
+    assert baseline["interpreterIdentityObservable"] is False
+    assert baseline["currentRelationIdentityObservable"] is False
+
+
+def test_root_program_remains_exactly_ten_definitions_and_challenge_adds_no_new_pronoun():
+    lines = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    challenge = read(CHALLENGE)
+
+    assert len(lines) == 10
+    assert challenge["focusIdentityQuestion"]["candidateCurrentLinkRefPronounAccepted"] is False
+    assert "adding a current-link pronoun before challenge" in challenge["vetoes"]
+
+
+def test_next_gate_is_a_decision_about_subject_focus_identity_and_parent_lifecycle():
+    gate = read(CHALLENGE)["nextGate"]
+
+    assert gate["artifact"] == "mts-deictic-context-decision/v0.5"
+    assert gate["mustNotChangeProductionBeforeDecision"] is True
+    assert "whether subject is a formal MTS concept at all" in gate["mustDecide"]
+    assert "whether current focus has observable identity beyond its roles" in gate["mustDecide"]
+    assert "the lifecycle/meaning of parent focus" in gate["mustDecide"]


### PR DESCRIPTION
Refs #148, #156, #120, #122.

Non-normative research gate. Production interpreter, proof contracts and 10 root definitions are unchanged.

## Model refinement

No separate `subject` concept is introduced. The interpreter/runtime itself is a link.

The challenged boundary is:

```text
interpreter-link
    ↓ current focus / explicit binding
ContextFrame(start,end,parent?)
    ↓
formula ◁ / ▷ / ↑
```

Current accepted semantics exposes only the explicit `ContextFrame`; it does not expose arbitrary interpreter state or current relation identity.

## Executable evidence

Challenge tests require:
- a no-pronoun example can replay identically under distinct frames;
- a pronoun-bearing formula can vary with explicit frame;
- same frame gives same replay under different test-only interpreter labels;
- virtual frame and a frame constructed from materialized link poles are equivalent while current relation identity is unobservable;
- `↑` and `↑↑` use only explicit parent chain;
- missing parent raises the current canonical explicit error rather than falling back to ambient/global context;
- current production `interpret_constraints(expression, frame, memory, *, symbols)` has no interpreter/host/session/focus/current-LinkRef semantic input beyond explicit frame;
- challenged examples do not read/mutate L4.

## Candidate models

Rejected:
- hidden arbitrary interpreter introspection.

Baseline only, not new v0.5 acceptance:
- explicit ContextFrame.

Still challenged:
- `Focus(interpreterLink,currentFocus)` as a separate interpreter→semantic binding;
- capability-scoped deictic environment.

## Key non-decisions

This PR does NOT decide:
- whether focus binding belongs to MTS proper or interpreter/runtime integration;
- whether current focus needs observable LinkRef identity beyond its roles;
- semantic lifecycle of parent focus;
- a new current-link pronoun/operator;
- final typed behavior for unavailable parent;
- static context-invariance theorem (#156);
- explicit arbitrary focus-switch operator.

## Veto

- no separate subject ontology;
- no new pronouns;
- no root edits;
- no v0.3/v0.4 contract rewrite;
- no proof checker ambient state;
- no `(start,end) == relation identity` assumption;
- no policy==semantics conflation.

Merge only as challenge evidence after full green CI and `behind_by=0`. Next gates are #156 context-dependency challenge and `mts-deictic-context-decision/v0.5`.