### PR TITLE
Decide context dependency boundary v0.5

### DIFF
--- a/contracts/mts-context-dependency-decision-v0.5.json
+++ b/contracts/mts-context-dependency-decision-v0.5.json
@@ -1,0 +1,150 @@
+{
+  "schema": "mts-context-dependency-decision/v0.5",
+  "status": "candidate-decision",
+  "issue": 156,
+  "dependsOn": [
+    "mts-context-dependency-challenge/v0.5",
+    "mts-deictic-context-challenge/v0.5",
+    "mts-definition-opening/v0.3",
+    "mts-contract/v0.4"
+  ],
+  "acceptedContractLinkAllowed": false,
+  "productionSemanticChangeAllowed": false,
+  "trustedProofChangeAllowed": false,
+  "question": "Which context-dependency claims are justified now without turning direct syntax, finite replay samples, or definition opening into a stronger semantics than MTS currently accepts?",
+  "evidence": {
+    "directDeixis": "#157 shows ContextPronoun occurrence is a source-span-independent typed-AST fact",
+    "finiteReplay": "#157 shows one explicit context pair can witness sensitivity while equal results on finitely many frames establish only finite-domain observational invariance",
+    "definitionClosure": "#157 builds a terminating DefinitionId graph only by explicit open_definition calls; current interpret_constraints never performs that traversal automatically",
+    "interpreterBoundary": "the interpreter is a link but only its explicit ContextFrame projection enters current evaluation semantics"
+  },
+  "models": [
+    {
+      "id": "A",
+      "name": "no-direct-pronoun-means-universal-context-invariance",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Absence of ContextPronoun is a local typed-AST fact. Future accepted composition or explicitly opened definitions may carry context dependence, and no universal quantification over contexts has been justified."
+    },
+    {
+      "id": "B",
+      "name": "finite-replay-sampling-proves-universal-context-invariance",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "Equal replay on a finite serialized context set proves only observational invariance on that declared set."
+    },
+    {
+      "id": "C",
+      "name": "typed-direct-deixis-plus-scoped-observational-evidence",
+      "verdict": "preferred-candidate",
+      "accepted": false,
+      "reason": "Expose direct typed-AST deixis as a precise static fact; keep replay sensitivity/invariance explicitly scoped to its context domain; never silently promote either to universal theoremhood."
+    },
+    {
+      "id": "D",
+      "name": "definition-opening-closure-is-current-evaluation-semantics",
+      "verdict": "reject",
+      "accepted": false,
+      "reason": "open_definition is an accepted separate one-step operation and interpret_constraints does not automatically open or recursively evaluate definitions."
+    },
+    {
+      "id": "E",
+      "name": "definition-dependency-is-separate-static-relation",
+      "verdict": "defer",
+      "accepted": false,
+      "reason": "A finite DefinitionId dependency graph is technically viable, but its normative meaning must be coordinated with accepted composition/dependency semantics rather than masquerading as current evaluation."
+    }
+  ],
+  "preferredCandidate": {
+    "directAnalysis": {
+      "relation": "DirectDeictic(expression)",
+      "meaning": "the typed AST contains at least one ContextPronoun occurrence",
+      "resultMayInclude": [
+        "occurrence path",
+        "parent ascent depth",
+        "context pole"
+      ],
+      "sourceSpanPartOfIdentity": false,
+      "displayTextPartOfIdentity": false,
+      "readsMemory": false,
+      "readsInterpreterIdentity": false,
+      "impliesContextSensitivity": false,
+      "negationImpliesUniversalInvariance": false
+    },
+    "replayEvidence": {
+      "sensitivity": "different canonical replay result for the same non-context inputs on an explicitly named pair/domain of ContextFrames",
+      "finiteDomainInvariance": "equal canonical replay result for all explicitly named frames in one finite domain",
+      "universalInvarianceAccepted": false,
+      "resultEquality": "success + grounded holes + aliases; trace remains diagnostic"
+    },
+    "unknown": {
+      "requiredWhen": [
+        "a claimed dependency requires unaccepted composition semantics",
+        "a referenced definition/dependency cannot be resolved under the declared analysis substrate",
+        "finite replay evidence is being asked to justify an unbounded invariance claim"
+      ],
+      "mustNotBeCollapsedIntoInvariant": true,
+      "mustNotBeCollapsedIntoSensitive": true
+    }
+  },
+  "definitionBoundary": {
+    "candidateDependencyGraphUsesCanonicalOpening": true,
+    "graphIdentity": "DefinitionId(scopePath,ordinal)",
+    "cyclesRemainFinite": true,
+    "graphTraversalIsCurrentInterpretSemantics": false,
+    "openingImpliesEvaluation": false,
+    "openingImpliesEquality": false,
+    "normativeIndirectDependencyAcceptedHere": false,
+    "coordinationIssue": 122
+  },
+  "interpreterBoundary": {
+    "interpreterIsALink": true,
+    "interpreterLinkIdentityIsImplicitEvalInput": false,
+    "explicitContextFrameIsCurrentSemanticBoundary": true,
+    "securityPolicyDefinesEffect": false,
+    "separateSubjectConceptRequired": false
+  },
+  "proofBoundary": {
+    "ContextInvariantTrustedRelationAccepted": false,
+    "DirectDeicticTrustedRelationAccepted": false,
+    "finiteReplayEvidenceAutomaticallyTheorem": false,
+    "proofV03Modified": false,
+    "futureProofUseRequiresSeparateLiftingOrRuleAcceptance": true
+  },
+  "productionCandidateForNextGate": {
+    "scope": "read-only direct typed-AST deictic analysis only",
+    "mayReturnNoDirectDeictic": true,
+    "mayReturnUniversalContextInvariant": false,
+    "mayTraverseDefinitionEnvironment": false,
+    "mayReadMemory": false,
+    "mayReadInterpreterIdentity": false,
+    "mustHaveLanguageNeutralConformance": true
+  },
+  "stillRejectedOrDeferred": [
+    "no pronoun => universal context invariance",
+    "finite sampling => universal context invariance",
+    "implicit definition unfolding during interpret",
+    "definition opening => equality",
+    "definition opening => evaluation",
+    "hidden interpreter/session/policy dependency",
+    "global textual substitution",
+    "recursive textual normalization",
+    "trusted ContextInvariant proof relation",
+    "trusted generic dependency composition"
+  ],
+  "nextGate": {
+    "artifact": "mts-direct-deixis-challenge/v0.5",
+    "status": "candidate-challenge",
+    "mustNotChangeInterpretSemantics": true,
+    "mustNotChangeProofSemantics": true,
+    "requiredQuestions": [
+      "exact typed traversal over every current AST node",
+      "stable occurrence paths independent of SourceSpan/whitespace",
+      "whether Definition target and RHS are both traversed when analyzing a Definition AST itself",
+      "deterministic ordering of multiple pronouns",
+      "round/grouping path behavior",
+      "proof that the operation reads no MemoryView, DefinitionEnvironment, interpreter identity or policy",
+      "portable conformance vectors for zero/one/multiple/current/parent pronouns"
+    ]
+  }
+}

--- a/tests/test_mts_context_dependency_decision.py
+++ b/tests/test_mts_context_dependency_decision.py
@@ -1,0 +1,219 @@
+"""Executable checks for the non-normative context-dependency decision v0.5."""
+
+import inspect
+import json
+from pathlib import Path
+
+from core.mtc_ast import ContextPronoun, Expression, Form, structural_key
+from core.mtc_definitions import DefinitionEnvironment, open_definition
+from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+DECISION = ROOT / "contracts" / "mts-context-dependency-decision-v0.5.json"
+CHALLENGE = ROOT / "contracts" / "mts-context-dependency-challenge-v0.5.json"
+MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class NoReadMemory(MemoryView):
+    def poles(self, link: int) -> tuple[int, int]:
+        raise AssertionError(f"unexpected poles({link})")
+
+    def find_link(self, start: int, end: int) -> int | None:
+        raise AssertionError(f"unexpected find_link({start}, {end})")
+
+    def find_start_projection(self, form: int) -> int | None:
+        raise AssertionError(f"unexpected find_start_projection({form})")
+
+    def find_end_projection(self, form: int) -> int | None:
+        raise AssertionError(f"unexpected find_end_projection({form})")
+
+
+def direct_pronouns(expression: Expression, path: tuple[int, ...] = ()):
+    """Decision-local structural walker; not a production operation yet."""
+
+    if isinstance(expression, ContextPronoun):
+        return ((path, expression.up, expression.pole.value),)
+
+    children: tuple[Expression, ...]
+    if hasattr(expression, "content"):
+        content = getattr(expression, "content")
+        children = () if content is None else (content,)
+    elif hasattr(expression, "items"):
+        children = tuple(getattr(expression, "items"))
+    elif hasattr(expression, "value") and not hasattr(expression, "target"):
+        children = (getattr(expression, "value"),)
+    elif hasattr(expression, "left") and hasattr(expression, "right"):
+        children = (getattr(expression, "left"), getattr(expression, "right"))
+    elif hasattr(expression, "target") and hasattr(expression, "value"):
+        children = (getattr(expression, "target"), getattr(expression, "value"))
+    else:
+        children = ()
+
+    found = []
+    for index, child in enumerate(children):
+        if isinstance(child, Expression):
+            found.extend(direct_pronouns(child, path + (index,)))
+    return tuple(found)
+
+
+def replay(source: str, frame: ContextFrame, *, symbols: dict[str, int] | None = None):
+    return interpret_constraints(
+        parse_formula(source),
+        frame,
+        NoReadMemory(),
+        symbols=symbols,
+    )
+
+
+def result_shape(result):
+    return result.success, result.holes, result.aliases
+
+
+def test_decision_is_non_normative_and_depends_on_green_challenge():
+    decision = read(DECISION)
+    challenge = read(CHALLENGE)
+
+    assert decision["schema"] == "mts-context-dependency-decision/v0.5"
+    assert decision["status"] == "candidate-decision"
+    assert decision["acceptedContractLinkAllowed"] is False
+    assert decision["productionSemanticChangeAllowed"] is False
+    assert decision["trustedProofChangeAllowed"] is False
+    assert challenge["schema"] in decision["dependsOn"]
+    assert decision["schema"] not in MTS_V04.read_text(encoding="utf-8")
+    assert decision["schema"] not in PROOF_V03.read_text(encoding="utf-8")
+
+
+def test_only_typed_direct_deixis_is_selected_as_next_production_candidate():
+    decision = read(DECISION)
+    models = {model["id"]: model for model in decision["models"]}
+
+    assert models["A"]["verdict"] == "reject"
+    assert models["B"]["verdict"] == "reject"
+    assert models["C"]["verdict"] == "preferred-candidate"
+    assert models["D"]["verdict"] == "reject"
+    assert models["E"]["verdict"] == "defer"
+    assert all(model["accepted"] is False for model in models.values())
+
+    candidate = decision["productionCandidateForNextGate"]
+    assert candidate["scope"] == "read-only direct typed-AST deictic analysis only"
+    assert candidate["mayReturnUniversalContextInvariant"] is False
+    assert candidate["mayTraverseDefinitionEnvironment"] is False
+    assert candidate["mayReadMemory"] is False
+    assert candidate["mayReadInterpreterIdentity"] is False
+
+
+def test_no_direct_pronoun_is_not_promoted_to_context_invariant():
+    expression = parse_formula("[] = []")
+    assert direct_pronouns(expression) == ()
+
+    direct = read(DECISION)["preferredCandidate"]["directAnalysis"]
+    assert direct["negationImpliesUniversalInvariance"] is False
+    assert direct["impliesContextSensitivity"] is False
+
+    replay_a = replay("[] = []", ContextFrame(start=1, end=2))
+    replay_b = replay("[] = []", ContextFrame(start=9, end=10))
+    assert result_shape(replay_a) == result_shape(replay_b)
+
+    evidence = read(DECISION)["preferredCandidate"]["replayEvidence"]
+    assert evidence["universalInvarianceAccepted"] is False
+
+
+def test_direct_pronoun_fact_is_structural_and_does_not_itself_prove_sensitivity():
+    compact = parse_formula("◁=a")
+    spaced = parse_formula("  ◁ = a  ")
+
+    assert structural_key(compact) == structural_key(spaced)
+    assert direct_pronouns(compact) == (((0,), 0, "◁"),)
+    assert direct_pronouns(compact) == direct_pronouns(spaced)
+
+    direct = read(DECISION)["preferredCandidate"]["directAnalysis"]
+    assert direct["sourceSpanPartOfIdentity"] is False
+    assert direct["displayTextPartOfIdentity"] is False
+    assert direct["impliesContextSensitivity"] is False
+
+
+def test_context_sensitivity_requires_explicit_semantic_counterexample():
+    matching = replay("◁ = a", ContextFrame(start=1, end=7), symbols={"a": 1})
+    different = replay("◁ = a", ContextFrame(start=2, end=7), symbols={"a": 1})
+
+    assert matching.success is True
+    assert different.success is False
+
+    evidence = read(DECISION)["preferredCandidate"]["replayEvidence"]
+    assert "different canonical replay result" in evidence["sensitivity"]
+
+
+def test_definition_opening_remains_separate_from_current_eval_dependency():
+    environment = DefinitionEnvironment()
+    definition = parse_formula("a : ◁")
+    assert hasattr(definition, "target")
+    registration = environment.register(definition)
+    assert registration.entry is not None
+
+    target = parse_formula("a")
+    assert isinstance(target, Form)
+    opened = open_definition(target, environment)
+    assert opened.body is not None
+    assert direct_pronouns(opened.body) == (((), 0, "◁"),)
+
+    boundary = read(DECISION)["definitionBoundary"]
+    assert boundary["candidateDependencyGraphUsesCanonicalOpening"] is True
+    assert boundary["graphTraversalIsCurrentInterpretSemantics"] is False
+    assert boundary["openingImpliesEvaluation"] is False
+    assert boundary["openingImpliesEquality"] is False
+    assert boundary["normativeIndirectDependencyAcceptedHere"] is False
+
+
+def test_unknown_is_required_instead_of_optimistic_classification():
+    unknown = read(DECISION)["preferredCandidate"]["unknown"]
+
+    assert unknown["mustNotBeCollapsedIntoInvariant"] is True
+    assert unknown["mustNotBeCollapsedIntoSensitive"] is True
+    assert len(unknown["requiredWhen"]) >= 3
+
+
+def test_interpreter_is_a_link_but_not_a_hidden_eval_parameter():
+    boundary = read(DECISION)["interpreterBoundary"]
+    parameters = inspect.signature(interpret_constraints).parameters
+
+    assert boundary["interpreterIsALink"] is True
+    assert boundary["interpreterLinkIdentityIsImplicitEvalInput"] is False
+    assert boundary["explicitContextFrameIsCurrentSemanticBoundary"] is True
+    assert boundary["separateSubjectConceptRequired"] is False
+    assert list(parameters) == ["expression", "frame", "memory", "symbols"]
+    assert "interpreter" not in parameters
+
+
+def test_proof_surface_and_root_program_stay_unchanged():
+    decision = read(DECISION)
+    proof = read(PROOF_V03)
+    lines = [
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    assert len(lines) == 10
+    assert "ContextInvariant" not in proof["trustedRelations"]
+    assert "DirectDeictic" not in proof["trustedRelations"]
+    assert decision["proofBoundary"]["ContextInvariantTrustedRelationAccepted"] is False
+    assert decision["proofBoundary"]["DirectDeicticTrustedRelationAccepted"] is False
+    assert decision["proofBoundary"]["proofV03Modified"] is False
+
+
+def test_next_gate_is_direct_deixis_challenge_not_generic_dependency_production():
+    gate = read(DECISION)["nextGate"]
+
+    assert gate["artifact"] == "mts-direct-deixis-challenge/v0.5"
+    assert gate["mustNotChangeInterpretSemantics"] is True
+    assert gate["mustNotChangeProofSemantics"] is True
+    assert "deterministic ordering of multiple pronouns" in gate["requiredQuestions"]
+    assert "portable conformance vectors for zero/one/multiple/current/parent pronouns" in gate["requiredQuestions"]


### PR DESCRIPTION
Refs #156, #148, #122, #120. Depends on merged challenge #157.

Non-normative decision gate; no production interpreter/proof changes.

## Decision

Preferred next production candidate is deliberately narrow:

```text
DirectDeictic(expression)
```

meaning only that the typed AST contains one or more `ContextPronoun` occurrences. This fact may expose stable occurrence path, ascent depth and pole.

It does **not** imply context sensitivity, and its negation does **not** imply universal context invariance.

## Rejected/deferred

Rejected:
- no direct pronoun => universal context invariance;
- finite replay sample => universal context invariance;
- definition-opening closure == current `interpret_constraints` semantics.

Deferred:
- normative transitive definition-dependency graph, until its relation to accepted composition/dependency semantics is settled (notably #122).

## Replay evidence

A concrete context pair may witness sensitivity when canonical replay results differ. Equal replay over a finite explicit context domain establishes only invariance over that declared domain.

`Unknown` remains mandatory when current accepted operations/evidence do not justify a stronger claim.

## Interpreter boundary

The interpreter itself is a link, but its identity is not a hidden evaluation parameter. Current semantic boundary remains explicit `ContextFrame(start,end,parent?)`. No separate subject concept.

## Proof boundary

No `DirectDeictic` or `ContextInvariant` trusted proof relation is accepted. `mts-proof/v0.3` remains unchanged.

## Next gate

A separate `mts-direct-deixis-challenge/v0.5` must challenge exact typed traversal, stable occurrence paths, deterministic ordering and proof of no MemoryView/DefinitionEnvironment/interpreter-policy dependencies before any production analysis is added.