### PR TITLE
Accept production direct deictic analysis v0.5

### DIFF
--- a/contracts/mts-direct-deixis-conformance-v0.5.json
+++ b/contracts/mts-direct-deixis-conformance-v0.5.json
@@ -1,0 +1,29 @@
+{
+  "schema": "mts-direct-deixis-conformance/v0.5",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-direct-deixis/v0.5",
+  "sourceCorpus": "contracts/mts-direct-deixis-conformance-candidate-v0.5.json",
+  "selection": {
+    "vectors": "all",
+    "equivalentSpellings": "all",
+    "negativeClaims": "all"
+  },
+  "promotion": {
+    "copiesVectors": false,
+    "changesChallengeEvidence": false,
+    "reason": "the accepted conformance selects the already challenged portable vectors without duplicating them"
+  },
+  "releaseAssertions": {
+    "allPortableVectorsReplayInProductionCore": true,
+    "allEquivalentSpellingsMatch": true,
+    "directPresenceDoesNotMeanContextSensitive": true,
+    "emptyResultDoesNotMeanContextInvariant": true,
+    "noMemoryDependency": true,
+    "noDefinitionEnvironmentDependency": true,
+    "noContextFrameDependency": true,
+    "noInterpreterIdentityDependency": true,
+    "noProofSemanticChange": true,
+    "tenRootDefinitionsUnchanged": true
+  }
+}

--- a/contracts/mts-direct-deixis-v0.5.json
+++ b/contracts/mts-direct-deixis-v0.5.json
@@ -1,0 +1,99 @@
+{
+  "schema": "mts-direct-deixis/v0.5",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 156,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-deictic-context-challenge/v0.5",
+    "mts-context-dependency-challenge/v0.5",
+    "mts-context-dependency-decision/v0.5",
+    "mts-direct-deixis-challenge/v0.5"
+  ],
+  "conformanceCorpus": "contracts/mts-direct-deixis-conformance-v0.5.json",
+  "scope": "normative read-only structural detection of explicit ContextPronoun occurrences in one typed L2 Expression; no evaluation, dependency closure, sensitivity or invariance theorem",
+  "operation": {
+    "name": "analyze_direct_deixis",
+    "input": "typed L2 Expression",
+    "result": "ordered DeicticOccurrence[]",
+    "occurrence": {
+      "path": "structural typed-AST path of non-negative integers",
+      "up": "exact ContextPronoun.up",
+      "pole": "exact ContextPronoun.pole (◁ or ▷)"
+    },
+    "ordering": "deterministic preorder, equivalent to lexicographic structural path order for this tree traversal",
+    "readsMemory": false,
+    "readsDefinitionEnvironment": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "readsSecurityPolicy": false,
+    "writesAnything": false
+  },
+  "pathSemantics": {
+    "roundOrSquareContent": [0],
+    "unaryOperand": [0],
+    "binaryLeft": [0],
+    "binaryRight": [1],
+    "bundleOrSequenceItem": "append zero-based item index",
+    "definitionTarget": [0],
+    "definitionBody": [1],
+    "groupingTransparent": false,
+    "sourceSpanIncluded": false,
+    "displayTextIncluded": false
+  },
+  "meaningBoundary": {
+    "positiveResultMeans": "the typed AST directly contains the reported explicit context-pronoun occurrences",
+    "positiveResultImpliesContextSensitivity": false,
+    "emptyResultMeans": "the typed AST contains no direct ContextPronoun occurrence",
+    "emptyResultImpliesContextInvariance": false,
+    "opensDefinitions": false,
+    "followsTransitiveDependencies": false,
+    "evaluatesExpression": false,
+    "changesInterpretSemantics": false
+  },
+  "interpreterBoundary": {
+    "interpreterIsALink": true,
+    "interpreterIdentityIsInputToThisOperation": false,
+    "focusOrContextFrameIsInputToThisOperation": false,
+    "reason": "direct deixis is a property of the typed expression structure, not of one interpreter instance or one runtime context"
+  },
+  "proofBoundary": {
+    "trustedProofRelationAdded": false,
+    "ContextInvariantAccepted": false,
+    "ContextSensitiveAccepted": false,
+    "mtsProofV03Modified": false,
+    "futureProofUseRequiresExplicitAcceptedLift": true
+  },
+  "productionIntegration": {
+    "referenceCore": "core/mtc_context_analysis.py",
+    "operation": "analyze_direct_deixis",
+    "productionConformance": "tests/test_mts_direct_deixis_reference.py",
+    "singleCanonicalImplementation": true,
+    "candidateWalkerRetainedInProduction": false
+  },
+  "rootProgram": {
+    "path": "tests/mtc_formulas.mtc",
+    "definitionCount": 10,
+    "mustRemainUnchanged": true,
+    "analysisMayInspectWithoutMutation": true
+  },
+  "acceptanceEvidence": {
+    "deicticContextChallenge": "contracts/mts-deictic-context-challenge-v0.5.json",
+    "dependencyChallenge": "contracts/mts-context-dependency-challenge-v0.5.json",
+    "dependencyDecision": "contracts/mts-context-dependency-decision-v0.5.json",
+    "directChallenge": "contracts/mts-direct-deixis-challenge-v0.5.json",
+    "challengeCorpus": "contracts/mts-direct-deixis-conformance-candidate-v0.5.json",
+    "acceptedConformance": "contracts/mts-direct-deixis-conformance-v0.5.json"
+  },
+  "versioning": {
+    "mtsContractV04Modified": false,
+    "publishedThroughUmbrella": false,
+    "futureUmbrellaMustBeAdditive": true
+  },
+  "nextBoundary": {
+    "indirectDefinitionDependencyAccepted": false,
+    "universalContextInvarianceAccepted": false,
+    "coordinationIssueForComposition": 122,
+    "interpreterFocusResearchIssue": 148
+  }
+}

--- a/core/mtc_context_analysis.py
+++ b/core/mtc_context_analysis.py
@@ -1,0 +1,87 @@
+"""Read-only structural context analysis for typed MTS L2 expressions.
+
+This module answers one deliberately narrow question: where does the typed AST
+contain explicit ``ContextPronoun`` nodes?  It does not evaluate the expression,
+open definitions, inspect associative memory, infer context sensitivity, or
+claim context invariance when no pronoun is present.
+"""
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from core.mtc_ast import (
+    BundleForm,
+    ContextPole,
+    ContextPronoun,
+    Definition,
+    EndProjection,
+    Equality,
+    Expression,
+    Inequality,
+    Inversion,
+    LinkForm,
+    Literal,
+    RoundForm,
+    Sequence,
+    SquareForm,
+    StartProjection,
+    Symbol,
+)
+
+
+AstPath: TypeAlias = tuple[int, ...]
+
+
+@dataclass(frozen=True, order=True)
+class DeicticOccurrence:
+    """One explicit context-pronoun occurrence in structural typed-AST space."""
+
+    path: AstPath
+    up: int
+    pole: ContextPole
+
+
+def analyze_direct_deixis(expression: Expression) -> tuple[DeicticOccurrence, ...]:
+    """Return all explicit deictic occurrences in deterministic preorder.
+
+    Paths describe the typed AST itself:
+
+    * round/square content and unary operands append ``0``;
+    * binary left/right append ``0``/``1``;
+    * bundle/sequence items append their item index;
+    * definition target/body append ``0``/``1``.
+
+    Grouping is therefore visible in a path.  Source spans, whitespace and
+    canonical display formatting are not part of occurrence identity.
+    """
+
+    return _analyze(expression, ())
+
+
+def _analyze(
+    expression: Expression,
+    path: AstPath,
+) -> tuple[DeicticOccurrence, ...]:
+    if isinstance(expression, ContextPronoun):
+        return (DeicticOccurrence(path, expression.up, expression.pole),)
+
+    found: list[DeicticOccurrence] = []
+    for index, child in enumerate(_children(expression)):
+        found.extend(_analyze(child, path + (index,)))
+    return tuple(found)
+
+
+def _children(expression: Expression) -> tuple[Expression, ...]:
+    if isinstance(expression, (Symbol, Literal, ContextPronoun)):
+        return ()
+    if isinstance(expression, (RoundForm, SquareForm)):
+        return () if expression.content is None else (expression.content,)
+    if isinstance(expression, (BundleForm, Sequence)):
+        return expression.items
+    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
+        return (expression.value,)
+    if isinstance(expression, (LinkForm, Equality, Inequality)):
+        return (expression.left, expression.right)
+    if isinstance(expression, Definition):
+        return (expression.target, expression.value)
+    raise TypeError(f"unsupported typed AST node: {type(expression).__name__}")

--- a/tests/test_mts_direct_deixis_reference.py
+++ b/tests/test_mts_direct_deixis_reference.py
@@ -1,0 +1,198 @@
+"""Production conformance for accepted mts-direct-deixis/v0.5."""
+
+import inspect
+import json
+from pathlib import Path
+
+from core.mtc_context_analysis import DeicticOccurrence, analyze_direct_deixis
+from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-direct-deixis-v0.5.json"
+CONFORMANCE = ROOT / "contracts" / "mts-direct-deixis-conformance-v0.5.json"
+CHALLENGE_CORPUS = ROOT / "contracts" / "mts-direct-deixis-conformance-candidate-v0.5.json"
+MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+CORE = ROOT / "core" / "mtc_context_analysis.py"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def portable(occurrences: tuple[DeicticOccurrence, ...]) -> list[dict]:
+    return [
+        {"path": list(item.path), "up": item.up, "pole": item.pole.value}
+        for item in occurrences
+    ]
+
+
+class NoReadMemory(MemoryView):
+    def poles(self, link: int) -> tuple[int, int]:
+        raise AssertionError(f"unexpected poles({link})")
+
+    def find_link(self, start: int, end: int) -> int | None:
+        raise AssertionError(f"unexpected find_link({start}, {end})")
+
+    def find_start_projection(self, form: int) -> int | None:
+        raise AssertionError(f"unexpected find_start_projection({form})")
+
+    def find_end_projection(self, form: int) -> int | None:
+        raise AssertionError(f"unexpected find_end_projection({form})")
+
+
+def root_sources() -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def test_contract_is_accepted_but_not_retroactively_added_to_v04_umbrella():
+    contract = read(CONTRACT)
+    conformance = read(CONFORMANCE)
+
+    assert contract["schema"] == "mts-direct-deixis/v0.5"
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert conformance["schema"] == "mts-direct-deixis-conformance/v0.5"
+    assert conformance["accepted"] is True
+    assert conformance["contract"] == contract["schema"]
+    assert contract["versioning"]["mtsContractV04Modified"] is False
+    assert contract["versioning"]["publishedThroughUmbrella"] is False
+    assert contract["schema"] not in MTS_V04.read_text(encoding="utf-8")
+
+
+def test_accepted_conformance_selects_challenge_corpus_without_copying_vectors():
+    conformance = read(CONFORMANCE)
+    corpus = read(CHALLENGE_CORPUS)
+
+    assert conformance["sourceCorpus"] == (
+        "contracts/mts-direct-deixis-conformance-candidate-v0.5.json"
+    )
+    assert conformance["selection"] == {
+        "vectors": "all",
+        "equivalentSpellings": "all",
+        "negativeClaims": "all",
+    }
+    assert conformance["promotion"]["copiesVectors"] is False
+    assert "vectors" not in conformance
+    assert corpus["status"] == "candidate-challenge-corpus"
+
+
+def test_every_challenged_portable_vector_replays_exactly_in_production_core():
+    for vector in read(CHALLENGE_CORPUS)["vectors"]:
+        result = analyze_direct_deixis(parse_formula(vector["source"]))
+        assert portable(result) == vector["expected"], vector["id"]
+
+
+def test_every_equivalent_spelling_has_same_production_result():
+    for vector in read(CHALLENGE_CORPUS)["equivalentSpellings"]:
+        observed = [
+            portable(analyze_direct_deixis(parse_formula(source)))
+            for source in vector["sources"]
+        ]
+        assert all(result == vector["expected"] for result in observed), vector["id"]
+
+
+def test_production_result_is_typed_ordered_and_structural():
+    result = analyze_direct_deixis(parse_formula("{◁ = a, ↑▷ = b, ▷ = c}"))
+
+    assert result == tuple(sorted(result))
+    assert all(isinstance(item, DeicticOccurrence) for item in result)
+    assert [item.path for item in result] == [(0, 0), (1, 0), (2, 0)]
+    assert [item.up for item in result] == [0, 1, 0]
+    assert [item.pole.value for item in result] == ["◁", "▷", "▷"]
+
+
+def test_grouping_and_definition_target_body_paths_match_normative_contract():
+    grouped = analyze_direct_deixis(parse_formula("((↑↑◁)) = a"))
+    definition = analyze_direct_deixis(parse_formula("◁ : {▷ = a, ↑◁ = b}"))
+
+    assert portable(grouped) == [{"path": [0, 0, 0], "up": 2, "pole": "◁"}]
+    assert portable(definition) == [
+        {"path": [0], "up": 0, "pole": "◁"},
+        {"path": [1, 0, 0], "up": 0, "pole": "▷"},
+        {"path": [1, 1, 0], "up": 1, "pole": "◁"},
+    ]
+    assert read(CONTRACT)["pathSemantics"]["groupingTransparent"] is False
+
+
+def test_operation_has_no_runtime_definition_memory_or_interpreter_dependency():
+    signature = inspect.signature(analyze_direct_deixis)
+    core_source = CORE.read_text(encoding="utf-8")
+
+    assert list(signature.parameters) == ["expression"]
+    for forbidden in (
+        "MemoryView",
+        "DefinitionEnvironment",
+        "open_definition",
+        "interpret_constraints",
+        "ContextFrame",
+        "interpreter",
+        "security",
+        "policy",
+    ):
+        assert forbidden not in core_source
+
+    operation = read(CONTRACT)["operation"]
+    assert operation["readsMemory"] is False
+    assert operation["readsDefinitionEnvironment"] is False
+    assert operation["readsContextFrame"] is False
+    assert operation["readsInterpreterIdentity"] is False
+    assert operation["readsSecurityPolicy"] is False
+
+
+def test_positive_direct_deixis_does_not_imply_semantic_context_sensitivity():
+    source = "◁ = ◁"
+    assert len(analyze_direct_deixis(parse_formula(source))) == 2
+
+    first = interpret_constraints(
+        parse_formula(source),
+        ContextFrame(start=1, end=2),
+        NoReadMemory(),
+    )
+    second = interpret_constraints(
+        parse_formula(source),
+        ContextFrame(start=999, end=1000),
+        NoReadMemory(),
+    )
+
+    assert (first.success, first.holes, first.aliases) == (
+        second.success,
+        second.holes,
+        second.aliases,
+    )
+    assert first.success is True
+    assert read(CONTRACT)["meaningBoundary"]["positiveResultImpliesContextSensitivity"] is False
+
+
+def test_empty_direct_deixis_result_does_not_claim_context_invariance():
+    assert analyze_direct_deixis(parse_formula("[] = []")) == ()
+    assert read(CONTRACT)["meaningBoundary"]["emptyResultImpliesContextInvariance"] is False
+
+
+def test_proof_surface_is_unchanged_and_no_new_trusted_relation_exists():
+    contract = read(CONTRACT)
+    proof = read(PROOF_V03)
+
+    assert "DirectDeictic" not in proof["trustedRelations"]
+    assert "ContextInvariant" not in proof["trustedRelations"]
+    assert contract["proofBoundary"]["trustedProofRelationAdded"] is False
+    assert contract["proofBoundary"]["mtsProofV03Modified"] is False
+
+
+def test_root_program_is_still_exactly_ten_and_analysis_is_repeatable():
+    before = root_sources()
+    first = tuple(analyze_direct_deixis(parse_formula(source)) for source in before)
+    second = tuple(analyze_direct_deixis(parse_formula(source)) for source in before)
+    after = root_sources()
+
+    assert len(before) == 10
+    assert before == after
+    assert first == second
+    assert any(result for result in first)


### PR DESCRIPTION
Refs #156, #148. Depends on merged challenge #159 and decision #158.

Adds the first production context-analysis operation without changing interpretation or proof semantics.

## Accepted operation

```text
analyze_direct_deixis(Expression) -> tuple[DeicticOccurrence, ...]
```

`DeicticOccurrence` contains structural typed-AST `path`, exact ascent `up`, and pole `◁/▷`.

The operation is read-only and imports only typed AST definitions. It does not read MemoryView, DefinitionEnvironment, ContextFrame, interpreter identity or security policy; it does not evaluate or open definitions.

## Meaning boundary

- positive result: explicit ContextPronoun nodes exist at those structural paths;
- positive result does NOT imply `ContextSensitive`;
- empty result does NOT imply `ContextInvariant`;
- no transitive definition dependency is inferred.

## Conformance

`mts-direct-deixis-conformance/v0.5` selects all vectors from the already-green challenge corpus without copying them. Production tests replay all vectors/equivalent spellings and preserve the two negative claims.

## Versioning

This accepts standalone `mts-direct-deixis/v0.5` only. `mts-contract/v0.4` remains immutable and no umbrella v0.5 is published in this PR. `mts-proof/v0.3` and the ten root definitions are unchanged.