### PR TITLE
Challenge finite DefinitionOpeningPath composition v0.4

### DIFF
--- a/contracts/mts-opening-path-challenge-v0.4.json
+++ b/contracts/mts-opening-path-challenge-v0.4.json
@@ -1,0 +1,124 @@
+{
+  "schema": "mts-opening-path-challenge/v0.4",
+  "status": "candidate-challenge",
+  "issue": 161,
+  "dependsOn": [
+    "mts-definition-opening/v0.3",
+    "mts-derivation-base/v0.3",
+    "mts-proof/v0.3"
+  ],
+  "conformanceCorpus": "contracts/mts-opening-path-conformance-candidate-v0.4.json",
+  "acceptedContractLinkAllowed": false,
+  "productionProofChangeAllowed": false,
+  "trustedRuleChangeAllowed": false,
+  "purpose": "Challenge a finite self-contained DefinitionOpeningPath witness composed only from independently replayable successful open_definition edges, without equality, normalization or implicit recursive evaluation.",
+  "candidateRelation": {
+    "name": "DefinitionOpeningPath",
+    "artifactInputs": [
+      "one explicit lexical DefinitionEnvironment snapshot",
+      "one explicit lookupScope",
+      "one startTarget",
+      "one or more ordered successful opening edges",
+      "one finalBody"
+    ],
+    "sharedEnvironment": true,
+    "sharedLookupScope": true,
+    "environmentSwitchPerEdgeRepresentable": false,
+    "zeroEdgePathAllowed": false
+  },
+  "edge": {
+    "required": ["target", "definitionId", "body"],
+    "target": "canonical typed Form source used for this edge's open_definition replay",
+    "definitionId": "exact replay-local DefinitionId(scopePath,ordinal)",
+    "body": "exact canonical format_expression of replayed Definition.value",
+    "mustReplayKind": "match",
+    "negativeOpeningKindsAllowedAsEdges": false
+  },
+  "adjacency": {
+    "firstEdgeTargetMustMatchStartTargetStructurally": true,
+    "nextEdgeTargetMustMatchPreviousReplayedBodyStructurally": true,
+    "intermediateBodyMustBeForm": true,
+    "nextTargetMustReplaySuccessfully": true,
+    "canonicalDisplayTextIsIdentity": false,
+    "sourceSpanIsIdentity": false,
+    "textualSubstitution": false
+  },
+  "finalBody": {
+    "mustEqualLastReplayedBodyCanonicalFormat": true,
+    "mayBeNonFormExpression": true,
+    "automaticallyEvaluated": false,
+    "automaticallyContextuallySatisfied": false,
+    "normalFormClaimed": false
+  },
+  "cycleBoundary": {
+    "definitionIdMayAppearAtMostOnce": true,
+    "selfDefinition": "a:a is represented by one edge and may end again at a",
+    "mutualDefinition": "a:b,b:a is represented by two distinct DefinitionIds and may end again at a",
+    "repeatedDefinitionIdRejected": true,
+    "reason": "finite canonical witness boundary; rejection of repetition is not rejection of the semantic cycle"
+  },
+  "meaningBoundary": {
+    "impliesEquality": false,
+    "impliesEquivalence": false,
+    "impliesTransitiveEquality": false,
+    "impliesGlobalRewrite": false,
+    "impliesNormalization": false,
+    "evaluatesAnyBody": false,
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "materializes": false,
+    "deletes": false
+  },
+  "checkerBoundary": {
+    "replaysExactlySerializedEdgeCount": true,
+    "autoContinuesUntilTerminal": false,
+    "trustsSerializedDefinitionId": false,
+    "trustsSerializedBody": false,
+    "trustsSearchTrace": false,
+    "replaysEveryEdgeWithCanonicalOpenDefinition": true,
+    "checksTypedStructuralAdjacency": true
+  },
+  "requiredCoverage": [
+    "one-edge path",
+    "two-edge finite chain",
+    "chain ending in non-Form constraint bundle",
+    "child-scope shadowing",
+    "self cycle in one edge",
+    "mutual cycle in two edges",
+    "repeated DefinitionId rejected",
+    "zero-edge path rejected",
+    "forged body rejected",
+    "forged DefinitionId rejected",
+    "next-target mismatch rejected",
+    "intermediate non-Form continuation rejected",
+    "no-match/conflict/non-addressable cannot be successful edges",
+    "whitespace/source-span differences do not break structural adjacency",
+    "no MemoryView/ContextFrame/L4 effects"
+  ],
+  "vetoes": [
+    "opening path implies equality",
+    "opening path implies normal form",
+    "unrestricted transitivity",
+    "global textual substitution",
+    "recursive textual normalization",
+    "hidden root injection",
+    "per-edge environment switching",
+    "per-edge lookupScope switching",
+    "repeated DefinitionId unfolding",
+    "MemoryView or L4 effects",
+    "ContextFrame dependence",
+    "editing mts-proof/v0.3 in place",
+    "aprover inventing the rule before upstream acceptance"
+  ],
+  "nextGate": {
+    "artifact": "mts-opening-path-decision/v0.4",
+    "mustNotChangeProductionProofBeforeDecision": true,
+    "mustDecide": [
+      "whether DefinitionOpeningPath is admitted as a derivation relation or only an operational composite certificate",
+      "whether proof-v0.4 stores self-contained edges or references prior Opens judgments",
+      "whether duplicate DefinitionId rejection is normative canonicality",
+      "whether an opening path may later compose with ContextuallySatisfies without asserting equality",
+      "exact checker serialization and forgery boundary"
+    ]
+  }
+}

--- a/contracts/mts-opening-path-challenge-v0.4.json
+++ b/contracts/mts-opening-path-challenge-v0.4.json
@@ -28,7 +28,7 @@
   },
   "edge": {
     "required": ["target", "definitionId", "body"],
-    "target": "canonical typed Form source used for this edge's open_definition replay",
+    "target": "parseable typed Form source; replay/adjacency identity is structural and does not require canonical whitespace",
     "definitionId": "exact replay-local DefinitionId(scopePath,ordinal)",
     "body": "exact canonical format_expression of replayed Definition.value",
     "mustReplayKind": "match",
@@ -42,6 +42,11 @@
     "canonicalDisplayTextIsIdentity": false,
     "sourceSpanIsIdentity": false,
     "textualSubstitution": false
+  },
+  "transportBoundary": {
+    "targetSourceMayUseEquivalentWhitespace": true,
+    "bodyMustUseCanonicalFormatExpression": true,
+    "reason": "targets are parsed before structural comparison; bodies are replay results serialized deterministically, not lookup identity strings"
   },
   "finalBody": {
     "mustEqualLastReplayedBodyCanonicalFormat": true,

--- a/contracts/mts-opening-path-conformance-candidate-v0.4.json
+++ b/contracts/mts-opening-path-conformance-candidate-v0.4.json
@@ -14,6 +14,16 @@
       "finalBody": "b"
     },
     {
+      "id": "ends-in-non-form-judgment",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b = c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b = c"}
+      ],
+      "finalBody": "b = c"
+    },
+    {
       "id": "two-edge",
       "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : c"]}],
       "lookupScope": [],

--- a/contracts/mts-opening-path-conformance-candidate-v0.4.json
+++ b/contracts/mts-opening-path-conformance-candidate-v0.4.json
@@ -1,0 +1,199 @@
+{
+  "schema": "mts-opening-path-conformance-candidate/v0.4",
+  "status": "candidate-challenge-corpus",
+  "contract": "mts-opening-path-challenge/v0.4",
+  "validPaths": [
+    {
+      "id": "one-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "two-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "c"}
+      ],
+      "finalBody": "c"
+    },
+    {
+      "id": "ends-in-constraint-bundle",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : {◁ = x, ▷ = y}"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "{◁ = x, ▷ = y}"}
+      ],
+      "finalBody": "{◁ = x, ▷ = y}"
+    },
+    {
+      "id": "child-shadowing",
+      "scopes": [
+        {"path": [], "parent": null, "definitions": ["a : root", "b : rootEnd"]},
+        {"path": [0], "parent": [], "definitions": ["a : b", "b : childEnd"]}
+      ],
+      "lookupScope": [0],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [0], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [0], "ordinal": 1}, "body": "childEnd"}
+      ],
+      "finalBody": "childEnd"
+    },
+    {
+      "id": "self-cycle-one-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : a"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "a"}
+      ],
+      "finalBody": "a"
+    },
+    {
+      "id": "mutual-cycle-two-edges",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : a"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "a"}
+      ],
+      "finalBody": "a"
+    },
+    {
+      "id": "structural-adjacency-whitespace",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : (b)", "b : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "(b)"},
+        {"target": "( b )", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "c"}
+      ],
+      "finalBody": "c"
+    }
+  ],
+  "invalidPaths": [
+    {
+      "id": "zero-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [],
+      "finalBody": "a"
+    },
+    {
+      "id": "repeated-definition-id",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : a"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "a"},
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "forged-body",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "c"}
+      ],
+      "finalBody": "c"
+    },
+    {
+      "id": "forged-definition-id",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 9}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "next-target-mismatch",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "c : d"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "c", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "d"}
+      ],
+      "finalBody": "d"
+    },
+    {
+      "id": "start-target-mismatch",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "x : y"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "x", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "y"}
+      ],
+      "finalBody": "y"
+    },
+    {
+      "id": "continue-after-non-form",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : {◁ = x}", "b : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "{◁ = x}"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "c"}
+      ],
+      "finalBody": "c"
+    },
+    {
+      "id": "no-match-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": []}],
+      "lookupScope": [],
+      "startTarget": "missing",
+      "edges": [
+        {"target": "missing", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "x"}
+      ],
+      "finalBody": "x"
+    },
+    {
+      "id": "conflict-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "a : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "non-addressable-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": []}],
+      "lookupScope": [],
+      "startTarget": "[]",
+      "edges": [
+        {"target": "[]", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "x"}
+      ],
+      "finalBody": "x"
+    },
+    {
+      "id": "forged-final-body",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "c"
+    }
+  ]
+}

--- a/contracts/mts-opening-path-conformance-candidate-v0.4.json
+++ b/contracts/mts-opening-path-conformance-candidate-v0.4.json
@@ -72,7 +72,7 @@
     },
     {
       "id": "structural-adjacency-whitespace",
-      "scopes": [{"path": [], "parent": null, "definitions": ["a : (b)", "b : c"]}],
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : (b)", "(b) : c"]}],
       "lookupScope": [],
       "startTarget": "a",
       "edges": [

--- a/contracts/mts-opening-path-conformance-candidate-v0.4.json
+++ b/contracts/mts-opening-path-conformance-candidate-v0.4.json
@@ -146,14 +146,25 @@
     },
     {
       "id": "continue-after-non-form",
-      "scopes": [{"path": [], "parent": null, "definitions": ["a : {◁ = x}", "b : c"]}],
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b = c", "x : y"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b = c"},
+        {"target": "x", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "y"}
+      ],
+      "finalBody": "y"
+    },
+    {
+      "id": "continue-after-non-addressable-form",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : {◁ = x}"]}],
       "lookupScope": [],
       "startTarget": "a",
       "edges": [
         {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "{◁ = x}"},
-        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "c"}
+        {"target": "{ ◁ = x }", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "z"}
       ],
-      "finalBody": "c"
+      "finalBody": "z"
     },
     {
       "id": "no-match-edge",

--- a/tests/test_mts_opening_path_challenge.py
+++ b/tests/test_mts_opening_path_challenge.py
@@ -1,0 +1,280 @@
+"""Executable evidence for the non-normative DefinitionOpeningPath challenge v0.4."""
+
+import inspect
+import json
+from pathlib import Path
+
+from core.mtc_ast import Definition, Expression, Form, format_expression, structural_key
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionId,
+    DefinitionLookupKind,
+    open_definition,
+)
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-opening-path-challenge-v0.4.json"
+CORPUS = ROOT / "contracts" / "mts-opening-path-conformance-candidate-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_form(source: str) -> Form:
+    expression = parse_formula(source)
+    if not isinstance(expression, Form):
+        raise ValueError("expected Form")
+    return expression
+
+
+def build_environments(scopes: list[dict]) -> dict[tuple[int, ...], DefinitionEnvironment]:
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+
+    for index, spec in enumerate(scopes):
+        path = tuple(spec["path"])
+        parent_path = None if spec["parent"] is None else tuple(spec["parent"])
+        if parent_path is None:
+            if index != 0 or path != ():
+                raise ValueError("root scope must be first")
+            environment = DefinitionEnvironment()
+        else:
+            parent = environments[parent_path]
+            if not path or path[:-1] != parent_path:
+                raise ValueError("scope must extend parent")
+            environment = parent.child(path[-1])
+
+        if path in environments:
+            raise ValueError("duplicate scope")
+        environments[path] = environment
+
+        for source in spec["definitions"]:
+            definition = parse_formula(source)
+            if not isinstance(definition, Definition):
+                raise ValueError("scope entry must be Definition")
+            environment.register(definition)
+
+    return environments
+
+
+def same_form(left: Form, right: Form) -> bool:
+    return structural_key(left) == structural_key(right)
+
+
+def verify_candidate_path(vector: dict) -> bool:
+    """Challenge-only verifier; production proof semantics is intentionally untouched."""
+
+    try:
+        environments = build_environments(vector["scopes"])
+        lookup = environments[tuple(vector["lookupScope"])]
+        start = parse_form(vector["startTarget"])
+        edges = vector["edges"]
+        if not edges:
+            return False
+
+        previous_body: Expression | None = None
+        used_ids: set[DefinitionId] = set()
+
+        for index, edge in enumerate(edges):
+            target = parse_form(edge["target"])
+            if index == 0:
+                if not same_form(target, start):
+                    return False
+            else:
+                if not isinstance(previous_body, Form):
+                    return False
+                if not same_form(target, previous_body):
+                    return False
+
+            opened = open_definition(target, lookup)
+            if opened.kind is not DefinitionLookupKind.MATCH:
+                return False
+            if opened.definition_id is None or opened.body is None:
+                return False
+
+            expected_id = edge["definitionId"]
+            if opened.definition_id.scope_path != tuple(expected_id["scopePath"]):
+                return False
+            if opened.definition_id.ordinal != expected_id["ordinal"]:
+                return False
+            if opened.definition_id in used_ids:
+                return False
+            used_ids.add(opened.definition_id)
+
+            if format_expression(opened.body) != edge["body"]:
+                return False
+            previous_body = opened.body
+
+        assert previous_body is not None
+        return format_expression(previous_body) == vector["finalBody"]
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def root_sources() -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def test_challenge_is_non_normative_and_proof_v03_is_unchanged():
+    challenge = read(CHALLENGE)
+    proof = read(PROOF_V03)
+
+    assert challenge["schema"] == "mts-opening-path-challenge/v0.4"
+    assert challenge["status"] == "candidate-challenge"
+    assert challenge["acceptedContractLinkAllowed"] is False
+    assert challenge["productionProofChangeAllowed"] is False
+    assert challenge["trustedRuleChangeAllowed"] is False
+    assert challenge["schema"] not in PROOF_V03.read_text(encoding="utf-8")
+    assert proof["compositionBoundary"]["genericCompositionAccepted"] is False
+
+
+def test_all_valid_portable_paths_verify_by_independent_one_step_replay():
+    for vector in read(CORPUS)["validPaths"]:
+        assert verify_candidate_path(vector), vector["id"]
+
+
+def test_all_invalid_portable_paths_fail_closed():
+    for vector in read(CORPUS)["invalidPaths"]:
+        assert not verify_candidate_path(vector), vector["id"]
+
+
+def test_self_and_mutual_cycles_are_finite_without_reusing_definition_id():
+    vectors = {item["id"]: item for item in read(CORPUS)["validPaths"]}
+
+    self_path = vectors["self-cycle-one-edge"]
+    mutual = vectors["mutual-cycle-two-edges"]
+
+    assert verify_candidate_path(self_path)
+    assert len(self_path["edges"]) == 1
+    assert self_path["startTarget"] == self_path["finalBody"] == "a"
+
+    assert verify_candidate_path(mutual)
+    assert len(mutual["edges"]) == 2
+    ids = [
+        (tuple(edge["definitionId"]["scopePath"]), edge["definitionId"]["ordinal"])
+        for edge in mutual["edges"]
+    ]
+    assert len(ids) == len(set(ids)) == 2
+    assert mutual["startTarget"] == mutual["finalBody"] == "a"
+
+    boundary = read(CHALLENGE)["cycleBoundary"]
+    assert boundary["definitionIdMayAppearAtMostOnce"] is True
+    assert boundary["repeatedDefinitionIdRejected"] is True
+
+
+def test_checker_replays_exactly_serialized_edges_and_never_auto_normalizes():
+    challenge = read(CHALLENGE)
+    boundary = challenge["checkerBoundary"]
+
+    assert boundary["replaysExactlySerializedEdgeCount"] is True
+    assert boundary["autoContinuesUntilTerminal"] is False
+    assert boundary["trustsSerializedDefinitionId"] is False
+    assert boundary["trustsSerializedBody"] is False
+    assert boundary["replaysEveryEdgeWithCanonicalOpenDefinition"] is True
+
+    one_edge = next(
+        item for item in read(CORPUS)["validPaths"] if item["id"] == "one-edge"
+    )
+    assert verify_candidate_path(one_edge)
+    assert len(one_edge["edges"]) == 1
+
+
+def test_structural_adjacency_ignores_whitespace_but_preserves_grouping_identity():
+    vector = next(
+        item
+        for item in read(CORPUS)["validPaths"]
+        if item["id"] == "structural-adjacency-whitespace"
+    )
+
+    assert verify_candidate_path(vector)
+    first_body = parse_formula(vector["edges"][0]["body"])
+    second_target = parse_formula(vector["edges"][1]["target"])
+    assert structural_key(first_body) == structural_key(second_target)
+    assert format_expression(second_target) == "(b)"
+
+    challenge = read(CHALLENGE)
+    assert challenge["adjacency"]["canonicalDisplayTextIsIdentity"] is False
+    assert challenge["transportBoundary"]["targetSourceMayUseEquivalentWhitespace"] is True
+
+
+def test_child_scope_is_shared_for_every_edge():
+    vector = next(
+        item for item in read(CORPUS)["validPaths"] if item["id"] == "child-shadowing"
+    )
+
+    assert verify_candidate_path(vector)
+    assert vector["lookupScope"] == [0]
+    assert [edge["definitionId"]["scopePath"] for edge in vector["edges"]] == [[0], [0]]
+
+    relation = read(CHALLENGE)["candidateRelation"]
+    assert relation["sharedEnvironment"] is True
+    assert relation["sharedLookupScope"] is True
+    assert relation["environmentSwitchPerEdgeRepresentable"] is False
+
+
+def test_chain_may_end_in_bundle_without_evaluating_it():
+    vector = next(
+        item
+        for item in read(CORPUS)["validPaths"]
+        if item["id"] == "ends-in-constraint-bundle"
+    )
+
+    assert verify_candidate_path(vector)
+    assert vector["finalBody"] == "{◁ = x, ▷ = y}"
+
+    final = read(CHALLENGE)["finalBody"]
+    assert final["mayBeNonFormExpression"] is True
+    assert final["automaticallyEvaluated"] is False
+    assert final["automaticallyContextuallySatisfied"] is False
+
+
+def test_candidate_verifier_has_no_memory_context_or_effect_input():
+    signature = inspect.signature(verify_candidate_path)
+    opening_signature = inspect.signature(open_definition)
+
+    assert list(signature.parameters) == ["vector"]
+    assert list(opening_signature.parameters) == ["target", "environment"]
+
+    meaning = read(CHALLENGE)["meaningBoundary"]
+    assert meaning["readsMemory"] is False
+    assert meaning["readsContextFrame"] is False
+    assert meaning["materializes"] is False
+    assert meaning["deletes"] is False
+
+
+def test_path_never_claims_equality_equivalence_or_normal_form():
+    meaning = read(CHALLENGE)["meaningBoundary"]
+
+    assert meaning["impliesEquality"] is False
+    assert meaning["impliesEquivalence"] is False
+    assert meaning["impliesTransitiveEquality"] is False
+    assert meaning["impliesGlobalRewrite"] is False
+    assert meaning["impliesNormalization"] is False
+    assert meaning["evaluatesAnyBody"] is False
+
+
+def test_root_program_and_canonical_opening_api_remain_unchanged():
+    before = root_sources()
+    assert len(before) == 10
+
+    environments = build_environments(
+        [{"path": [], "parent": None, "definitions": list(before)}]
+    )
+    root = environments[()]
+    entries_before = root.entries()
+
+    # Read-only challenge activity must not mutate the environment.
+    for entry in entries_before:
+        result = open_definition(entry.definition.target, root)
+        assert result.kind is DefinitionLookupKind.MATCH
+
+    assert root.entries() == entries_before
+    assert root_sources() == before

--- a/tests/test_mts_opening_path_challenge.py
+++ b/tests/test_mts_opening_path_challenge.py
@@ -231,9 +231,24 @@ def test_chain_may_end_in_bundle_without_evaluating_it():
     assert vector["finalBody"] == "{◁ = x, ▷ = y}"
 
     final = read(CHALLENGE)["finalBody"]
-    assert final["mayBeNonFormExpression"] is True
     assert final["automaticallyEvaluated"] is False
     assert final["automaticallyContextuallySatisfied"] is False
+
+
+def test_chain_may_end_in_non_form_expression_but_cannot_continue_through_it():
+    vectors = {item["id"]: item for item in read(CORPUS)["validPaths"]}
+    invalid = {item["id"]: item for item in read(CORPUS)["invalidPaths"]}
+
+    terminal = vectors["ends-in-non-form-judgment"]
+    continuation = invalid["continue-after-non-form"]
+
+    assert verify_candidate_path(terminal)
+    assert not isinstance(parse_formula(terminal["finalBody"]), Form)
+    assert not verify_candidate_path(continuation)
+
+    final = read(CHALLENGE)["finalBody"]
+    assert final["mayBeNonFormExpression"] is True
+    assert final["automaticallyEvaluated"] is False
 
 
 def test_candidate_verifier_has_no_memory_context_or_effect_input():


### PR DESCRIPTION
Refs #161, #122, #120.

Non-normative challenge for the first genuinely multi-step MTS composition candidate. No production proof/checker changes.

## Candidate relation

`DefinitionOpeningPath` is one finite witness over one explicit lexical environment snapshot and one lookup scope. It contains one or more ordered successful `open_definition` edges.

The checker candidate independently replays every serialized edge, verifies exact replay-local `DefinitionId`, exact canonical body, and structural adjacency to the next target.

## Critical semantic boundary

The path does **not** mean equality, equivalence, global rewrite or normal form. No RHS is evaluated. The checker replays exactly the serialized number of edges and never auto-continues until a terminal form.

## Cycles

Each `DefinitionId` may occur at most once in one path. Therefore:
- `a:a` is a finite one-edge self-cycle witness;
- `a:b, b:a` is a finite two-edge mutual-cycle witness;
- a third edge reusing an already seen DefinitionId is rejected as non-canonical repetition, not because the semantic cycle is denied.

## Artifact safety

Environment and lookupScope exist once at path level, so per-edge environment switching is not representable. Negative opening results are not valid path edges.

## Portable corpus

Includes positive one/two-edge paths, bundle terminal, child shadowing, self/mutual cycles, structural whitespace; and fail-closed vectors for zero edge, repeated id, forged body/id/final body, target mismatch, no-match/conflict/non-addressable, and invalid continuation.

## Explicit veto

No opening→equality, unrestricted transitivity, textual substitution, recursive normalization, MemoryView/ContextFrame/L4 effects, proof-v0.3 mutation, or aprover-local rule invention.

Next gate after green evidence is `mts-opening-path-decision/v0.4`; this PR does not accept the relation.