### PR TITLE
Accept production DefinitionOpeningPath verifier v0.4

### DIFF
--- a/contracts/mts-opening-path-conformance-v0.4.json
+++ b/contracts/mts-opening-path-conformance-v0.4.json
@@ -1,0 +1,52 @@
+{
+  "schema": "mts-opening-path-conformance/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-opening-path/v0.4",
+  "sourceCorpus": "contracts/mts-opening-path-conformance-candidate-v0.4.json",
+  "selection": {
+    "validPaths": "all",
+    "invalidPaths": "all"
+  },
+  "transportAssertions": {
+    "targetSourcesParsedBeforeStructuralComparison": true,
+    "equivalentTargetWhitespaceAllowed": true,
+    "edgeBodyMustBeCanonicalFormatExpression": true,
+    "finalBodyMustBeCanonicalFormatExpression": true,
+    "definitionIdMustReplayExactly": true,
+    "sharedEnvironmentAndLookupScope": true
+  },
+  "coreAssertions": {
+    "allValidPathsAcceptedByCanonicalVerifier": true,
+    "allInvalidPathsRejectedByCanonicalVerifierOrStrictTransportAdapter": true,
+    "emptyPathRejected": true,
+    "startAndAdjacencyCheckedStructurally": true,
+    "everyEdgeIndependentlyOpened": true,
+    "repeatedDefinitionIdRejected": true,
+    "nonFormAndNonAddressableTerminalBodiesAllowed": true,
+    "continuationAcrossNonFormOrNonAddressableBodyRejected": true,
+    "noAutoContinuation": true
+  },
+  "meaningAssertions": {
+    "impliesEquality": false,
+    "impliesEquivalence": false,
+    "impliesNormalization": false,
+    "impliesContextualSatisfaction": false,
+    "genericCompositionAccepted": false
+  },
+  "effectsAssertions": {
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "materializes": false,
+    "deletes": false,
+    "mutatesDefinitionEnvironment": false
+  },
+  "releaseAssertions": {
+    "mtsProofV03Unchanged": true,
+    "mtsContractV04Unchanged": true,
+    "tenRootDefinitionsUnchanged": true,
+    "standaloneRelationOnly": true,
+    "proofV04StillRequiresSeparateAcceptance": true
+  }
+}

--- a/contracts/mts-opening-path-v0.4.json
+++ b/contracts/mts-opening-path-v0.4.json
@@ -1,0 +1,141 @@
+{
+  "schema": "mts-opening-path/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 161,
+  "dependsOn": [
+    "mts-opening-path-decision/v0.4",
+    "mts-opening-path-challenge/v0.4",
+    "mts-definition-opening/v0.3",
+    "mts-derivation-base/v0.3",
+    "mts-proof/v0.3"
+  ],
+  "conformanceCorpus": "contracts/mts-opening-path-conformance-v0.4.json",
+  "scope": "normative read-only verification of one finite self-contained DefinitionOpeningPath operational composite certificate; no equality, normalization, evaluation, generic composition, memory or context effects",
+  "relation": {
+    "name": "DefinitionOpeningPath",
+    "classification": "operational-composite-certificate",
+    "minimumEdges": 1,
+    "sharedDefinitionEnvironment": true,
+    "sharedLookupScope": true,
+    "replaysExactlyWitnessEdges": true,
+    "autoContinues": false
+  },
+  "typedCore": {
+    "module": "core/mtc_opening_path.py",
+    "verifier": "verify_opening_path",
+    "environmentArgument": "DefinitionEnvironment already representing the explicit lookup scope",
+    "witness": {
+      "startTarget": "Form",
+      "edges": "ordered non-empty tuple[OpeningPathEdge,...]",
+      "finalBody": "Expression"
+    },
+    "edge": {
+      "target": "Form",
+      "definitionId": "DefinitionId(scopePath,ordinal)",
+      "body": "Expression"
+    },
+    "comparison": "typed structural_key equality; SourceSpan/display text are not semantic identity",
+    "singleCanonicalImplementation": true
+  },
+  "portableCertificate": {
+    "sharedFields": ["scopes", "lookupScope", "startTarget", "edges", "finalBody"],
+    "scopes": "same explicit lexical snapshot semantics as mts-proof/v0.3 definition relations",
+    "lookupScope": "one exact serialized scope path used for every edge",
+    "startTarget": "parseable Form source; structural identity after parsing",
+    "edges": {
+      "target": "parseable Form source; structural identity after parsing; equivalent whitespace allowed",
+      "definitionId": "exact replay-local DefinitionId",
+      "body": "canonical format_expression transport of the expected replay body"
+    },
+    "finalBody": "canonical format_expression transport of the final expected replay body",
+    "transportDecoderOwnedByCoreVerifier": false,
+    "reason": "transport/version validation belongs to the consuming artifact layer; every consumer must construct the same typed witness and invoke the one canonical verifier"
+  },
+  "verificationOrder": [
+    "reject empty path",
+    "check first edge target structurally matches startTarget",
+    "for each later edge require previous replay body is Form and structurally equals next target",
+    "replay open_definition(target, environment)",
+    "require kind=match",
+    "require exact replay-local DefinitionId",
+    "reject repeated replayed DefinitionId",
+    "require replay body structurally equals expected typed edge body",
+    "after exact serialized edge count require last replay body structurally equals finalBody"
+  ],
+  "failureCodes": [
+    "empty-path",
+    "start-target-mismatch",
+    "previous-body-not-form",
+    "adjacency-mismatch",
+    "opening-not-match",
+    "definition-id-mismatch",
+    "repeated-definition-id",
+    "body-mismatch",
+    "final-body-mismatch"
+  ],
+  "cycleCanonicality": {
+    "definitionIdMayAppearAtMostOnce": true,
+    "selfCycleCanonicalWitness": "one edge",
+    "mutualCycleCanonicalWitness": "one edge per distinct DefinitionId until repetition",
+    "repeatedDefinitionIdMeansSemanticFalse": false,
+    "repeatedDefinitionIdMeansInvalidCertificate": true
+  },
+  "terminalBoundary": {
+    "finalBodyMayBeAnyExpression": true,
+    "nonFormFinalBodyAllowed": true,
+    "nonAddressableFormFinalBodyAllowed": true,
+    "continuationRequiresPreviousBodyIsForm": true,
+    "continuationRequiresNextOpenDefinitionMatch": true,
+    "finalBodyEvaluated": false
+  },
+  "meaningBoundary": {
+    "impliesEquality": false,
+    "impliesEquivalence": false,
+    "impliesNormalization": false,
+    "impliesContextualSatisfaction": false,
+    "impliesGenericTransitivity": false,
+    "opensOnlySerializedEdges": true,
+    "evaluatesBodies": false,
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "materializes": false,
+    "deletes": false
+  },
+  "searchCheckerBoundary": {
+    "searchTrusted": false,
+    "searchMayExploreDefinitionGraph": true,
+    "searchMayUseVisitedDefinitionIds": true,
+    "certificateTrustedWithoutReplay": false,
+    "checkerMustInvokeCanonicalVerifier": true,
+    "searchTracePartOfTrustedMeaning": false
+  },
+  "proofBoundary": {
+    "trustedProofRelationAddedByThisContract": false,
+    "eligibleForFutureProofRelation": true,
+    "futureRelationName": "DefinitionOpeningPath",
+    "futureTrustedMeaningMustEqualThisVerifier": true,
+    "mtsProofV03Modified": false,
+    "genericCompositionAccepted": false,
+    "openingPathPlusContextuallySatisfiesAccepted": false
+  },
+  "productionIntegration": {
+    "referenceCore": "core/mtc_opening_path.py",
+    "productionConformance": "tests/test_mts_opening_path_reference.py",
+    "challengeCorpus": "contracts/mts-opening-path-conformance-candidate-v0.4.json",
+    "acceptedConformance": "contracts/mts-opening-path-conformance-v0.4.json"
+  },
+  "versioning": {
+    "mtsContractV04Modified": false,
+    "mtsProofV03Modified": false,
+    "publishedThroughUmbrella": false,
+    "futureUmbrellaMustBeAdditive": true
+  },
+  "nextBoundary": {
+    "proofV04MayConsumeThisRelationAfterSeparateAcceptance": true,
+    "otherCompositionRulesAccepted": false,
+    "compositionIssue": 122,
+    "aproverMayInventAdditionalRules": false
+  }
+}

--- a/core/mtc_opening_path.py
+++ b/core/mtc_opening_path.py
@@ -64,8 +64,8 @@ def verify_opening_path(
     """Independently replay exactly one finite definition-opening path.
 
     ``environment`` is already the explicit lexical lookup scope chosen by the
-    caller.  The verifier never walks beyond the serialized edge count, never
-    evaluates an RHS, and never touches ContextFrame or associative memory.
+    caller.  The verifier never walks beyond the serialized edge count and
+    never evaluates an RHS or reads any runtime evaluation substrate.
     """
 
     if not witness.edges:

--- a/core/mtc_opening_path.py
+++ b/core/mtc_opening_path.py
@@ -1,0 +1,122 @@
+"""Canonical read-only verifier for finite MTS definition-opening paths.
+
+``DefinitionOpeningPath`` is deliberately an operational composite certificate,
+not equality, rewriting, normalization, or evaluation.  The verifier replays
+exactly the serialized/typed edges supplied by the caller against one explicit
+``DefinitionEnvironment`` and stops after the last edge.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+from core.mtc_ast import Expression, Form, structural_key
+from core.mtc_definitions import (
+    DefinitionEnvironment,
+    DefinitionId,
+    DefinitionLookupKind,
+    open_definition,
+)
+
+
+@dataclass(frozen=True)
+class OpeningPathEdge:
+    """One expected successful ``open_definition`` edge."""
+
+    target: Form
+    definition_id: DefinitionId
+    body: Expression
+
+
+@dataclass(frozen=True)
+class OpeningPathWitness:
+    """Self-contained typed path substrate apart from its explicit environment."""
+
+    start_target: Form
+    edges: tuple[OpeningPathEdge, ...]
+    final_body: Expression
+
+
+class OpeningPathFailure(str, Enum):
+    EMPTY_PATH = "empty-path"
+    START_TARGET_MISMATCH = "start-target-mismatch"
+    PREVIOUS_BODY_NOT_FORM = "previous-body-not-form"
+    ADJACENCY_MISMATCH = "adjacency-mismatch"
+    OPENING_NOT_MATCH = "opening-not-match"
+    DEFINITION_ID_MISMATCH = "definition-id-mismatch"
+    REPEATED_DEFINITION_ID = "repeated-definition-id"
+    BODY_MISMATCH = "body-mismatch"
+    FINAL_BODY_MISMATCH = "final-body-mismatch"
+
+
+@dataclass(frozen=True)
+class OpeningPathReplayResult:
+    """Fail-closed replay result with deterministic diagnostic coordinates."""
+
+    accepted: bool
+    failure: OpeningPathFailure | None = None
+    failed_edge: int | None = None
+
+
+def verify_opening_path(
+    witness: OpeningPathWitness,
+    environment: DefinitionEnvironment,
+) -> OpeningPathReplayResult:
+    """Independently replay exactly one finite definition-opening path.
+
+    ``environment`` is already the explicit lexical lookup scope chosen by the
+    caller.  The verifier never walks beyond the serialized edge count, never
+    evaluates an RHS, and never touches ContextFrame or associative memory.
+    """
+
+    if not witness.edges:
+        return _failure(OpeningPathFailure.EMPTY_PATH)
+
+    used_ids: set[DefinitionId] = set()
+    previous_body: Expression | None = None
+
+    for index, edge in enumerate(witness.edges):
+        if index == 0:
+            if not _same_expression(edge.target, witness.start_target):
+                return _failure(OpeningPathFailure.START_TARGET_MISMATCH, index)
+        else:
+            if not isinstance(previous_body, Form):
+                return _failure(OpeningPathFailure.PREVIOUS_BODY_NOT_FORM, index)
+            if not _same_expression(edge.target, previous_body):
+                return _failure(OpeningPathFailure.ADJACENCY_MISMATCH, index)
+
+        opening = open_definition(edge.target, environment)
+        if opening.kind is not DefinitionLookupKind.MATCH:
+            return _failure(OpeningPathFailure.OPENING_NOT_MATCH, index)
+        if opening.definition_id is None or opening.body is None:
+            return _failure(OpeningPathFailure.OPENING_NOT_MATCH, index)
+
+        if opening.definition_id != edge.definition_id:
+            return _failure(OpeningPathFailure.DEFINITION_ID_MISMATCH, index)
+        if opening.definition_id in used_ids:
+            return _failure(OpeningPathFailure.REPEATED_DEFINITION_ID, index)
+        used_ids.add(opening.definition_id)
+
+        if not _same_expression(opening.body, edge.body):
+            return _failure(OpeningPathFailure.BODY_MISMATCH, index)
+        previous_body = opening.body
+
+    assert previous_body is not None
+    if not _same_expression(previous_body, witness.final_body):
+        return _failure(OpeningPathFailure.FINAL_BODY_MISMATCH)
+
+    return OpeningPathReplayResult(accepted=True)
+
+
+def _same_expression(left: Expression, right: Expression) -> bool:
+    return structural_key(left) == structural_key(right)
+
+
+def _failure(
+    failure: OpeningPathFailure,
+    failed_edge: int | None = None,
+) -> OpeningPathReplayResult:
+    return OpeningPathReplayResult(
+        accepted=False,
+        failure=failure,
+        failed_edge=failed_edge,
+    )

--- a/tests/test_mts_opening_path_reference.py
+++ b/tests/test_mts_opening_path_reference.py
@@ -5,8 +5,6 @@ import json
 from copy import deepcopy
 from pathlib import Path
 
-import pytest
-
 from core.mtc_ast import Definition, Expression, Form, format_expression
 from core.mtc_definitions import DefinitionEnvironment, DefinitionId
 from core.mtc_opening_path import (
@@ -75,39 +73,35 @@ def build_environments(scopes: list[dict]) -> dict[tuple[int, ...], DefinitionEn
     return environments
 
 
-def decode_portable_vector(vector: dict) -> tuple[OpeningPathWitness, DefinitionEnvironment]:
-    """Strict conformance adapter; the core verifier remains transport-agnostic."""
-
+def decode_portable(vector: dict) -> tuple[OpeningPathWitness, DefinitionEnvironment]:
     environments = build_environments(vector["scopes"])
     environment = environments[tuple(vector["lookupScope"])]
     edges: list[OpeningPathEdge] = []
 
     for index, edge in enumerate(vector["edges"]):
-        expected_id = edge["definitionId"]
+        definition_id = edge["definitionId"]
         edges.append(
             OpeningPathEdge(
                 target=parse_form(edge["target"]),
                 definition_id=DefinitionId(
-                    tuple(expected_id["scopePath"]),
-                    expected_id["ordinal"],
+                    tuple(definition_id["scopePath"]),
+                    definition_id["ordinal"],
                 ),
                 body=parse_canonical_expression(edge["body"], f"edge[{index}].body"),
             )
         )
 
-    return (
-        OpeningPathWitness(
-            start_target=parse_form(vector["startTarget"]),
-            edges=tuple(edges),
-            final_body=parse_canonical_expression(vector["finalBody"], "finalBody"),
-        ),
-        environment,
+    witness = OpeningPathWitness(
+        start_target=parse_form(vector["startTarget"]),
+        edges=tuple(edges),
+        final_body=parse_canonical_expression(vector["finalBody"], "finalBody"),
     )
+    return witness, environment
 
 
 def verify_portable(vector: dict) -> bool:
     try:
-        witness, environment = decode_portable_vector(vector)
+        witness, environment = decode_portable(vector)
     except (KeyError, TypeError, ValueError):
         return False
     return verify_opening_path(witness, environment).accepted
@@ -121,7 +115,7 @@ def root_sources() -> tuple[str, ...]:
     )
 
 
-def test_contract_is_accepted_standalone_without_rewriting_v04_or_proof_v03():
+def test_contract_is_accepted_standalone_and_old_releases_are_immutable():
     contract = read(CONTRACT)
     conformance = read(CONFORMANCE)
 
@@ -138,7 +132,7 @@ def test_contract_is_accepted_standalone_without_rewriting_v04_or_proof_v03():
     assert contract["schema"] not in PROOF_V03.read_text(encoding="utf-8")
 
 
-def test_accepted_conformance_selects_all_green_challenge_vectors_without_copying():
+def test_conformance_selects_all_green_challenge_vectors_without_copying():
     conformance = read(CONFORMANCE)
     corpus = read(CHALLENGE_CORPUS)
 
@@ -151,77 +145,66 @@ def test_accepted_conformance_selects_all_green_challenge_vectors_without_copyin
     assert corpus["status"] == "candidate-challenge-corpus"
 
 
-def test_every_challenged_valid_path_replays_in_canonical_production_verifier():
-    for vector in read(CHALLENGE_CORPUS)["validPaths"]:
+def test_every_challenge_vector_replays_fail_closed_in_production():
+    corpus = read(CHALLENGE_CORPUS)
+
+    for vector in corpus["validPaths"]:
         assert verify_portable(vector), vector["id"]
-
-
-def test_every_challenged_invalid_path_fails_closed():
-    for vector in read(CHALLENGE_CORPUS)["invalidPaths"]:
+    for vector in corpus["invalidPaths"]:
         assert not verify_portable(vector), vector["id"]
 
 
-def test_transport_requires_canonical_body_but_target_identity_remains_structural():
+def test_transport_is_canonical_for_bodies_but_structural_for_targets():
     vector = next(
         deepcopy(item)
         for item in read(CHALLENGE_CORPUS)["validPaths"]
         if item["id"] == "structural-adjacency-whitespace"
     )
 
-    # Non-canonical whitespace in a target is explicitly allowed.
     assert vector["edges"][1]["target"] == "( b )"
     assert verify_portable(vector)
 
-    # The expected body is deterministic replay output, so transport is canonical.
+    witness, environment = decode_portable(vector)
+    edges = list(witness.edges)
+    edges[1] = OpeningPathEdge(
+        target=parse_form("(    b    )"),
+        definition_id=edges[1].definition_id,
+        body=edges[1].body,
+    )
+    structural_variant = OpeningPathWitness(
+        start_target=witness.start_target,
+        edges=tuple(edges),
+        final_body=witness.final_body,
+    )
+    assert verify_opening_path(structural_variant, environment).accepted is True
+
     vector["edges"][0]["body"] = "( b )"
     assert not verify_portable(vector)
+
+    bundle = next(
+        deepcopy(item)
+        for item in read(CHALLENGE_CORPUS)["validPaths"]
+        if item["id"] == "ends-in-constraint-bundle"
+    )
+    bundle["finalBody"] = "{ ◁ = x, ▷ = y }"
+    assert not verify_portable(bundle)
 
     transport = read(CONTRACT)["portableCertificate"]
     assert "equivalent whitespace allowed" in transport["edges"]["target"]
     assert "canonical format_expression" in transport["edges"]["body"]
 
 
-def test_typed_core_verifier_uses_structural_identity_not_display_text():
-    vector = next(
-        item
-        for item in read(CHALLENGE_CORPUS)["validPaths"]
-        if item["id"] == "structural-adjacency-whitespace"
-    )
-    witness, environment = decode_portable_vector(vector)
+def test_failure_surface_and_representative_core_failures_are_deterministic():
+    expected_codes = set(read(CONTRACT)["failureCodes"])
+    assert {item.value for item in OpeningPathFailure} == expected_codes
 
-    # Rebuild the second target from equivalent source spelling; typed replay stays valid.
-    rebuilt_edges = list(witness.edges)
-    rebuilt_edges[1] = OpeningPathEdge(
-        target=parse_form("(    b    )"),
-        definition_id=rebuilt_edges[1].definition_id,
-        body=rebuilt_edges[1].body,
-    )
-    rebuilt = OpeningPathWitness(
-        start_target=witness.start_target,
-        edges=tuple(rebuilt_edges),
-        final_body=witness.final_body,
-    )
-
-    assert verify_opening_path(rebuilt, environment).accepted is True
-    assert read(CONTRACT)["typedCore"]["comparison"].startswith("typed structural_key")
-
-
-def test_failure_codes_are_deterministic_for_core_forgery_classes():
     environment = DefinitionEnvironment()
-    registration_a = environment.register(parse_formula("a : b"))
-    registration_b = environment.register(parse_formula("b : a"))
-    assert registration_a.entry is not None
-    assert registration_b.entry is not None
-
-    edge_a = OpeningPathEdge(
+    registered = environment.register(parse_formula("a : b"))
+    assert registered.entry is not None
+    edge = OpeningPathEdge(
         target=parse_form("a"),
-        definition_id=registration_a.entry.identity,
+        definition_id=registered.entry.identity,
         body=parse_formula("b"),
-    )
-    edge_b = OpeningPathEdge(
-        target=parse_form("b"),
-        definition_id=registration_b.entry.identity,
-        body=parse_formula("a"),
     )
 
     cases = [
@@ -230,46 +213,17 @@ def test_failure_codes_are_deterministic_for_core_forgery_classes():
             OpeningPathFailure.EMPTY_PATH,
         ),
         (
-            OpeningPathWitness(parse_form("x"), (edge_a,), parse_formula("b")),
+            OpeningPathWitness(parse_form("x"), (edge,), parse_formula("b")),
             OpeningPathFailure.START_TARGET_MISMATCH,
         ),
         (
             OpeningPathWitness(
                 parse_form("a"),
                 (
-                    edge_a,
                     OpeningPathEdge(
-                        target=parse_form("x"),
-                        definition_id=registration_b.entry.identity,
-                        body=parse_formula("a"),
-                    ),
-                ),
-                parse_formula("a"),
-            ),
-            OpeningPathFailure.ADJACENCY_MISMATCH,
-        ),
-        (
-            OpeningPathWitness(
-                parse_form("missing"),
-                (
-                    OpeningPathEdge(
-                        target=parse_form("missing"),
-                        definition_id=DefinitionId((), 0),
-                        body=parse_formula("x"),
-                    ),
-                ),
-                parse_formula("x"),
-            ),
-            OpeningPathFailure.OPENING_NOT_MATCH,
-        ),
-        (
-            OpeningPathWitness(
-                parse_form("a"),
-                (
-                    OpeningPathEdge(
-                        target=parse_form("a"),
-                        definition_id=DefinitionId((), 99),
-                        body=parse_formula("b"),
+                        parse_form("a"),
+                        DefinitionId((), 99),
+                        parse_formula("b"),
                     ),
                 ),
                 parse_formula("b"),
@@ -281,9 +235,9 @@ def test_failure_codes_are_deterministic_for_core_forgery_classes():
                 parse_form("a"),
                 (
                     OpeningPathEdge(
-                        target=parse_form("a"),
-                        definition_id=registration_a.entry.identity,
-                        body=parse_formula("wrong"),
+                        parse_form("a"),
+                        registered.entry.identity,
+                        parse_formula("wrong"),
                     ),
                 ),
                 parse_formula("wrong"),
@@ -291,77 +245,84 @@ def test_failure_codes_are_deterministic_for_core_forgery_classes():
             OpeningPathFailure.BODY_MISMATCH,
         ),
         (
-            OpeningPathWitness(parse_form("a"), (edge_a,), parse_formula("wrong")),
+            OpeningPathWitness(parse_form("a"), (edge,), parse_formula("wrong")),
             OpeningPathFailure.FINAL_BODY_MISMATCH,
         ),
     ]
 
-    for witness, expected in cases:
+    for witness, failure in cases:
         result = verify_opening_path(witness, environment)
         assert result.accepted is False
-        assert result.failure is expected
+        assert result.failure is failure
 
-    # A repeated DefinitionId is caught after both replayed edges have matched.
-    recursive_environment = DefinitionEnvironment()
-    recursive = recursive_environment.register(parse_formula("a : a"))
-    assert recursive.entry is not None
-    repeated_edge = OpeningPathEdge(
+
+def test_repeated_definition_id_is_invalid_certificate_not_false_cycle():
+    environment = DefinitionEnvironment()
+    registered = environment.register(parse_formula("a : a"))
+    assert registered.entry is not None
+    edge = OpeningPathEdge(
         target=parse_form("a"),
-        definition_id=recursive.entry.identity,
+        definition_id=registered.entry.identity,
         body=parse_formula("a"),
     )
-    repeated = verify_opening_path(
-        OpeningPathWitness(
-            start_target=parse_form("a"),
-            edges=(repeated_edge, repeated_edge),
-            final_body=parse_formula("a"),
-        ),
-        recursive_environment,
+
+    one_edge = verify_opening_path(
+        OpeningPathWitness(parse_form("a"), (edge,), parse_formula("a")),
+        environment,
     )
+    repeated = verify_opening_path(
+        OpeningPathWitness(parse_form("a"), (edge, edge), parse_formula("a")),
+        environment,
+    )
+
+    assert one_edge.accepted is True
     assert repeated.accepted is False
     assert repeated.failure is OpeningPathFailure.REPEATED_DEFINITION_ID
     assert repeated.failed_edge == 1
+    assert read(CONTRACT)["cycleCanonicality"]["repeatedDefinitionIdMeansSemanticFalse"] is False
 
 
-def test_non_form_terminal_is_valid_but_cannot_have_a_following_edge():
+def test_non_form_terminal_is_valid_but_cannot_continue():
     environment = DefinitionEnvironment()
-    registration = environment.register(parse_formula("a : b = c"))
-    assert registration.entry is not None
-
+    registered = environment.register(parse_formula("a : b = c"))
+    assert registered.entry is not None
     terminal_edge = OpeningPathEdge(
         target=parse_form("a"),
-        definition_id=registration.entry.identity,
+        definition_id=registered.entry.identity,
         body=parse_formula("b = c"),
     )
+
     terminal = verify_opening_path(
         OpeningPathWitness(
-            start_target=parse_form("a"),
-            edges=(terminal_edge,),
-            final_body=parse_formula("b = c"),
+            parse_form("a"),
+            (terminal_edge,),
+            parse_formula("b = c"),
         ),
         environment,
-    )
-    assert terminal.accepted is True
-
-    extra = OpeningPathEdge(
-        target=parse_form("x"),
-        definition_id=DefinitionId((), 99),
-        body=parse_formula("y"),
     )
     continued = verify_opening_path(
         OpeningPathWitness(
-            start_target=parse_form("a"),
-            edges=(terminal_edge, extra),
-            final_body=parse_formula("y"),
+            parse_form("a"),
+            (
+                terminal_edge,
+                OpeningPathEdge(
+                    parse_form("x"),
+                    DefinitionId((), 99),
+                    parse_formula("y"),
+                ),
+            ),
+            parse_formula("y"),
         ),
         environment,
     )
+
+    assert terminal.accepted is True
     assert continued.accepted is False
     assert continued.failure is OpeningPathFailure.PREVIOUS_BODY_NOT_FORM
     assert continued.failed_edge == 1
 
 
-def test_verifier_is_read_only_and_has_no_context_memory_or_interpreter_input():
+def test_verifier_is_read_only_and_has_no_runtime_evaluation_inputs():
     environment = DefinitionEnvironment()
     first = environment.register(parse_formula("a : b"))
     second = environment.register(parse_formula("b : c"))
@@ -382,15 +343,15 @@ def test_verifier_is_read_only_and_has_no_context_memory_or_interpreter_input():
     assert verify_opening_path(witness, environment).accepted is True
     assert environment.entries() == before_entries
     assert environment.conflicts() == before_conflicts
+    assert list(inspect.signature(verify_opening_path).parameters) == ["witness", "environment"]
 
-    signature = inspect.signature(verify_opening_path)
-    assert list(signature.parameters) == ["witness", "environment"]
     core_source = CORE.read_text(encoding="utf-8")
-    for forbidden in ("MemoryView", "ContextFrame", "interpret_constraints", "realize", "delete"):
-        assert forbidden not in core_source
+    assert "from core.mtc_interpreter" not in core_source
+    assert "MemoryView" not in core_source
+    assert "interpret_constraints" not in core_source
 
 
-def test_relation_never_claims_equality_normalization_or_generic_composition():
+def test_relation_does_not_claim_logical_or_evaluation_semantics():
     meaning = read(CONTRACT)["meaningBoundary"]
     proof = read(CONTRACT)["proofBoundary"]
 
@@ -400,32 +361,38 @@ def test_relation_never_claims_equality_normalization_or_generic_composition():
     assert meaning["impliesContextualSatisfaction"] is False
     assert meaning["impliesGenericTransitivity"] is False
     assert meaning["evaluatesBodies"] is False
+    assert meaning["readsMemory"] is False
+    assert meaning["readsContextFrame"] is False
+    assert meaning["readsInterpreterIdentity"] is False
+    assert meaning["materializes"] is False
+    assert meaning["deletes"] is False
     assert proof["trustedProofRelationAddedByThisContract"] is False
     assert proof["genericCompositionAccepted"] is False
     assert proof["openingPathPlusContextuallySatisfiesAccepted"] is False
 
 
-def test_root_program_remains_exactly_ten_and_replay_does_not_mutate_it():
+def test_all_ten_root_definitions_are_unchanged_one_edge_certificates():
     before = root_sources()
     assert len(before) == 10
 
     environment = DefinitionEnvironment()
     entries = []
     for source in before:
-        registration = environment.register(parse_formula(source))
+        definition = parse_formula(source)
+        assert isinstance(definition, Definition)
+        registration = environment.register(definition)
         assert registration.entry is not None
         entries.append(registration.entry)
 
-    # Each canonical root definition remains a valid one-edge certificate.
     for entry in entries:
         result = verify_opening_path(
             OpeningPathWitness(
                 start_target=entry.definition.target,
                 edges=(
                     OpeningPathEdge(
-                        target=entry.definition.target,
-                        definition_id=entry.identity,
-                        body=entry.definition.value,
+                        entry.definition.target,
+                        entry.identity,
+                        entry.definition.value,
                     ),
                 ),
                 final_body=entry.definition.value,
@@ -436,40 +403,3 @@ def test_root_program_remains_exactly_ten_and_replay_does_not_mutate_it():
 
     assert root_sources() == before
     assert len(environment.entries()) == 10
-
-
-def test_public_failure_code_surface_matches_contract_exactly():
-    expected = set(read(CONTRACT)["failureCodes"])
-    actual = {item.value for item in OpeningPathFailure}
-    assert actual == expected
-
-
-def test_transport_adapter_rejects_noncanonical_final_body_even_when_structurally_equal():
-    vector = next(
-        deepcopy(item)
-        for item in read(CHALLENGE_CORPUS)["validPaths"]
-        if item["id"] == "structural-adjacency-whitespace"
-    )
-    assert vector["finalBody"] == "c"
-
-    # Parentheses change structure, so instead use canonical-whitespace variance on a bundle.
-    bundle = next(
-        deepcopy(item)
-        for item in read(CHALLENGE_CORPUS)["validPaths"]
-        if item["id"] == "ends-in-constraint-bundle"
-    )
-    bundle["finalBody"] = "{ ◁ = x, ▷ = y }"
-    assert not verify_portable(bundle)
-
-
-@pytest.mark.parametrize(
-    "source",
-    ["a : b", "a : b = c", "a : {◁ = x}"],
-)
-def test_definition_registration_substrate_is_not_reinterpreted(source: str):
-    environment = DefinitionEnvironment()
-    definition = parse_formula(source)
-    assert isinstance(definition, Definition)
-    result = environment.register(definition)
-    assert result.entry is not None
-    assert environment.entries() == (result.entry,)

--- a/tests/test_mts_opening_path_reference.py
+++ b/tests/test_mts_opening_path_reference.py
@@ -1,0 +1,475 @@
+"""Production conformance for accepted mts-opening-path/v0.4."""
+
+import inspect
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from core.mtc_ast import Definition, Expression, Form, format_expression
+from core.mtc_definitions import DefinitionEnvironment, DefinitionId
+from core.mtc_opening_path import (
+    OpeningPathEdge,
+    OpeningPathFailure,
+    OpeningPathWitness,
+    verify_opening_path,
+)
+from core.mtc_parser import parse_formula
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-opening-path-v0.4.json"
+CONFORMANCE = ROOT / "contracts" / "mts-opening-path-conformance-v0.4.json"
+CHALLENGE_CORPUS = ROOT / "contracts" / "mts-opening-path-conformance-candidate-v0.4.json"
+MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+CORE = ROOT / "core" / "mtc_opening_path.py"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_form(source: str) -> Form:
+    expression = parse_formula(source)
+    if not isinstance(expression, Form):
+        raise ValueError("expected Form")
+    return expression
+
+
+def parse_canonical_expression(source: str, label: str) -> Expression:
+    expression = parse_formula(source)
+    if format_expression(expression) != source:
+        raise ValueError(f"{label} must use canonical format_expression transport")
+    return expression
+
+
+def build_environments(scopes: list[dict]) -> dict[tuple[int, ...], DefinitionEnvironment]:
+    environments: dict[tuple[int, ...], DefinitionEnvironment] = {}
+
+    for index, spec in enumerate(scopes):
+        path = tuple(spec["path"])
+        parent_path = None if spec["parent"] is None else tuple(spec["parent"])
+        if parent_path is None:
+            if index != 0 or path != ():
+                raise ValueError("root scope must be first")
+            environment = DefinitionEnvironment()
+        else:
+            parent = environments[parent_path]
+            if not path or path[:-1] != parent_path:
+                raise ValueError("scope must extend parent")
+            environment = parent.child(path[-1])
+
+        if path in environments:
+            raise ValueError("duplicate scope")
+        environments[path] = environment
+
+        for source in spec["definitions"]:
+            definition = parse_formula(source)
+            if not isinstance(definition, Definition):
+                raise ValueError("scope entry must be Definition")
+            environment.register(definition)
+
+    return environments
+
+
+def decode_portable_vector(vector: dict) -> tuple[OpeningPathWitness, DefinitionEnvironment]:
+    """Strict conformance adapter; the core verifier remains transport-agnostic."""
+
+    environments = build_environments(vector["scopes"])
+    environment = environments[tuple(vector["lookupScope"])]
+    edges: list[OpeningPathEdge] = []
+
+    for index, edge in enumerate(vector["edges"]):
+        expected_id = edge["definitionId"]
+        edges.append(
+            OpeningPathEdge(
+                target=parse_form(edge["target"]),
+                definition_id=DefinitionId(
+                    tuple(expected_id["scopePath"]),
+                    expected_id["ordinal"],
+                ),
+                body=parse_canonical_expression(edge["body"], f"edge[{index}].body"),
+            )
+        )
+
+    return (
+        OpeningPathWitness(
+            start_target=parse_form(vector["startTarget"]),
+            edges=tuple(edges),
+            final_body=parse_canonical_expression(vector["finalBody"], "finalBody"),
+        ),
+        environment,
+    )
+
+
+def verify_portable(vector: dict) -> bool:
+    try:
+        witness, environment = decode_portable_vector(vector)
+    except (KeyError, TypeError, ValueError):
+        return False
+    return verify_opening_path(witness, environment).accepted
+
+
+def root_sources() -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def test_contract_is_accepted_standalone_without_rewriting_v04_or_proof_v03():
+    contract = read(CONTRACT)
+    conformance = read(CONFORMANCE)
+
+    assert contract["schema"] == "mts-opening-path/v0.4"
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert conformance["schema"] == "mts-opening-path-conformance/v0.4"
+    assert conformance["accepted"] is True
+    assert conformance["contract"] == contract["schema"]
+    assert contract["versioning"]["mtsContractV04Modified"] is False
+    assert contract["versioning"]["mtsProofV03Modified"] is False
+    assert contract["versioning"]["publishedThroughUmbrella"] is False
+    assert contract["schema"] not in MTS_V04.read_text(encoding="utf-8")
+    assert contract["schema"] not in PROOF_V03.read_text(encoding="utf-8")
+
+
+def test_accepted_conformance_selects_all_green_challenge_vectors_without_copying():
+    conformance = read(CONFORMANCE)
+    corpus = read(CHALLENGE_CORPUS)
+
+    assert conformance["sourceCorpus"] == (
+        "contracts/mts-opening-path-conformance-candidate-v0.4.json"
+    )
+    assert conformance["selection"] == {"validPaths": "all", "invalidPaths": "all"}
+    assert "validPaths" not in conformance
+    assert "invalidPaths" not in conformance
+    assert corpus["status"] == "candidate-challenge-corpus"
+
+
+def test_every_challenged_valid_path_replays_in_canonical_production_verifier():
+    for vector in read(CHALLENGE_CORPUS)["validPaths"]:
+        assert verify_portable(vector), vector["id"]
+
+
+def test_every_challenged_invalid_path_fails_closed():
+    for vector in read(CHALLENGE_CORPUS)["invalidPaths"]:
+        assert not verify_portable(vector), vector["id"]
+
+
+def test_transport_requires_canonical_body_but_target_identity_remains_structural():
+    vector = next(
+        deepcopy(item)
+        for item in read(CHALLENGE_CORPUS)["validPaths"]
+        if item["id"] == "structural-adjacency-whitespace"
+    )
+
+    # Non-canonical whitespace in a target is explicitly allowed.
+    assert vector["edges"][1]["target"] == "( b )"
+    assert verify_portable(vector)
+
+    # The expected body is deterministic replay output, so transport is canonical.
+    vector["edges"][0]["body"] = "( b )"
+    assert not verify_portable(vector)
+
+    transport = read(CONTRACT)["portableCertificate"]
+    assert "equivalent whitespace allowed" in transport["edges"]["target"]
+    assert "canonical format_expression" in transport["edges"]["body"]
+
+
+def test_typed_core_verifier_uses_structural_identity_not_display_text():
+    vector = next(
+        item
+        for item in read(CHALLENGE_CORPUS)["validPaths"]
+        if item["id"] == "structural-adjacency-whitespace"
+    )
+    witness, environment = decode_portable_vector(vector)
+
+    # Rebuild the second target from equivalent source spelling; typed replay stays valid.
+    rebuilt_edges = list(witness.edges)
+    rebuilt_edges[1] = OpeningPathEdge(
+        target=parse_form("(    b    )"),
+        definition_id=rebuilt_edges[1].definition_id,
+        body=rebuilt_edges[1].body,
+    )
+    rebuilt = OpeningPathWitness(
+        start_target=witness.start_target,
+        edges=tuple(rebuilt_edges),
+        final_body=witness.final_body,
+    )
+
+    assert verify_opening_path(rebuilt, environment).accepted is True
+    assert read(CONTRACT)["typedCore"]["comparison"].startswith("typed structural_key")
+
+
+def test_failure_codes_are_deterministic_for_core_forgery_classes():
+    environment = DefinitionEnvironment()
+    registration_a = environment.register(parse_formula("a : b"))
+    registration_b = environment.register(parse_formula("b : a"))
+    assert registration_a.entry is not None
+    assert registration_b.entry is not None
+
+    edge_a = OpeningPathEdge(
+        target=parse_form("a"),
+        definition_id=registration_a.entry.identity,
+        body=parse_formula("b"),
+    )
+    edge_b = OpeningPathEdge(
+        target=parse_form("b"),
+        definition_id=registration_b.entry.identity,
+        body=parse_formula("a"),
+    )
+
+    cases = [
+        (
+            OpeningPathWitness(parse_form("a"), (), parse_formula("a")),
+            OpeningPathFailure.EMPTY_PATH,
+        ),
+        (
+            OpeningPathWitness(parse_form("x"), (edge_a,), parse_formula("b")),
+            OpeningPathFailure.START_TARGET_MISMATCH,
+        ),
+        (
+            OpeningPathWitness(
+                parse_form("a"),
+                (
+                    edge_a,
+                    OpeningPathEdge(
+                        target=parse_form("x"),
+                        definition_id=registration_b.entry.identity,
+                        body=parse_formula("a"),
+                    ),
+                ),
+                parse_formula("a"),
+            ),
+            OpeningPathFailure.ADJACENCY_MISMATCH,
+        ),
+        (
+            OpeningPathWitness(
+                parse_form("missing"),
+                (
+                    OpeningPathEdge(
+                        target=parse_form("missing"),
+                        definition_id=DefinitionId((), 0),
+                        body=parse_formula("x"),
+                    ),
+                ),
+                parse_formula("x"),
+            ),
+            OpeningPathFailure.OPENING_NOT_MATCH,
+        ),
+        (
+            OpeningPathWitness(
+                parse_form("a"),
+                (
+                    OpeningPathEdge(
+                        target=parse_form("a"),
+                        definition_id=DefinitionId((), 99),
+                        body=parse_formula("b"),
+                    ),
+                ),
+                parse_formula("b"),
+            ),
+            OpeningPathFailure.DEFINITION_ID_MISMATCH,
+        ),
+        (
+            OpeningPathWitness(
+                parse_form("a"),
+                (
+                    OpeningPathEdge(
+                        target=parse_form("a"),
+                        definition_id=registration_a.entry.identity,
+                        body=parse_formula("wrong"),
+                    ),
+                ),
+                parse_formula("wrong"),
+            ),
+            OpeningPathFailure.BODY_MISMATCH,
+        ),
+        (
+            OpeningPathWitness(parse_form("a"), (edge_a,), parse_formula("wrong")),
+            OpeningPathFailure.FINAL_BODY_MISMATCH,
+        ),
+    ]
+
+    for witness, expected in cases:
+        result = verify_opening_path(witness, environment)
+        assert result.accepted is False
+        assert result.failure is expected
+
+    # A repeated DefinitionId is caught after both replayed edges have matched.
+    recursive_environment = DefinitionEnvironment()
+    recursive = recursive_environment.register(parse_formula("a : a"))
+    assert recursive.entry is not None
+    repeated_edge = OpeningPathEdge(
+        target=parse_form("a"),
+        definition_id=recursive.entry.identity,
+        body=parse_formula("a"),
+    )
+    repeated = verify_opening_path(
+        OpeningPathWitness(
+            start_target=parse_form("a"),
+            edges=(repeated_edge, repeated_edge),
+            final_body=parse_formula("a"),
+        ),
+        recursive_environment,
+    )
+    assert repeated.accepted is False
+    assert repeated.failure is OpeningPathFailure.REPEATED_DEFINITION_ID
+    assert repeated.failed_edge == 1
+
+
+def test_non_form_terminal_is_valid_but_cannot_have_a_following_edge():
+    environment = DefinitionEnvironment()
+    registration = environment.register(parse_formula("a : b = c"))
+    assert registration.entry is not None
+
+    terminal_edge = OpeningPathEdge(
+        target=parse_form("a"),
+        definition_id=registration.entry.identity,
+        body=parse_formula("b = c"),
+    )
+    terminal = verify_opening_path(
+        OpeningPathWitness(
+            start_target=parse_form("a"),
+            edges=(terminal_edge,),
+            final_body=parse_formula("b = c"),
+        ),
+        environment,
+    )
+    assert terminal.accepted is True
+
+    extra = OpeningPathEdge(
+        target=parse_form("x"),
+        definition_id=DefinitionId((), 99),
+        body=parse_formula("y"),
+    )
+    continued = verify_opening_path(
+        OpeningPathWitness(
+            start_target=parse_form("a"),
+            edges=(terminal_edge, extra),
+            final_body=parse_formula("y"),
+        ),
+        environment,
+    )
+    assert continued.accepted is False
+    assert continued.failure is OpeningPathFailure.PREVIOUS_BODY_NOT_FORM
+    assert continued.failed_edge == 1
+
+
+def test_verifier_is_read_only_and_has_no_context_memory_or_interpreter_input():
+    environment = DefinitionEnvironment()
+    first = environment.register(parse_formula("a : b"))
+    second = environment.register(parse_formula("b : c"))
+    assert first.entry is not None
+    assert second.entry is not None
+
+    before_entries = environment.entries()
+    before_conflicts = environment.conflicts()
+    witness = OpeningPathWitness(
+        start_target=parse_form("a"),
+        edges=(
+            OpeningPathEdge(parse_form("a"), first.entry.identity, parse_formula("b")),
+            OpeningPathEdge(parse_form("b"), second.entry.identity, parse_formula("c")),
+        ),
+        final_body=parse_formula("c"),
+    )
+
+    assert verify_opening_path(witness, environment).accepted is True
+    assert environment.entries() == before_entries
+    assert environment.conflicts() == before_conflicts
+
+    signature = inspect.signature(verify_opening_path)
+    assert list(signature.parameters) == ["witness", "environment"]
+    core_source = CORE.read_text(encoding="utf-8")
+    for forbidden in ("MemoryView", "ContextFrame", "interpret_constraints", "realize", "delete"):
+        assert forbidden not in core_source
+
+
+def test_relation_never_claims_equality_normalization_or_generic_composition():
+    meaning = read(CONTRACT)["meaningBoundary"]
+    proof = read(CONTRACT)["proofBoundary"]
+
+    assert meaning["impliesEquality"] is False
+    assert meaning["impliesEquivalence"] is False
+    assert meaning["impliesNormalization"] is False
+    assert meaning["impliesContextualSatisfaction"] is False
+    assert meaning["impliesGenericTransitivity"] is False
+    assert meaning["evaluatesBodies"] is False
+    assert proof["trustedProofRelationAddedByThisContract"] is False
+    assert proof["genericCompositionAccepted"] is False
+    assert proof["openingPathPlusContextuallySatisfiesAccepted"] is False
+
+
+def test_root_program_remains_exactly_ten_and_replay_does_not_mutate_it():
+    before = root_sources()
+    assert len(before) == 10
+
+    environment = DefinitionEnvironment()
+    entries = []
+    for source in before:
+        registration = environment.register(parse_formula(source))
+        assert registration.entry is not None
+        entries.append(registration.entry)
+
+    # Each canonical root definition remains a valid one-edge certificate.
+    for entry in entries:
+        result = verify_opening_path(
+            OpeningPathWitness(
+                start_target=entry.definition.target,
+                edges=(
+                    OpeningPathEdge(
+                        target=entry.definition.target,
+                        definition_id=entry.identity,
+                        body=entry.definition.value,
+                    ),
+                ),
+                final_body=entry.definition.value,
+            ),
+            environment,
+        )
+        assert result.accepted is True
+
+    assert root_sources() == before
+    assert len(environment.entries()) == 10
+
+
+def test_public_failure_code_surface_matches_contract_exactly():
+    expected = set(read(CONTRACT)["failureCodes"])
+    actual = {item.value for item in OpeningPathFailure}
+    assert actual == expected
+
+
+def test_transport_adapter_rejects_noncanonical_final_body_even_when_structurally_equal():
+    vector = next(
+        deepcopy(item)
+        for item in read(CHALLENGE_CORPUS)["validPaths"]
+        if item["id"] == "structural-adjacency-whitespace"
+    )
+    assert vector["finalBody"] == "c"
+
+    # Parentheses change structure, so instead use canonical-whitespace variance on a bundle.
+    bundle = next(
+        deepcopy(item)
+        for item in read(CHALLENGE_CORPUS)["validPaths"]
+        if item["id"] == "ends-in-constraint-bundle"
+    )
+    bundle["finalBody"] = "{ ◁ = x, ▷ = y }"
+    assert not verify_portable(bundle)
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["a : b", "a : b = c", "a : {◁ = x}"],
+)
+def test_definition_registration_substrate_is_not_reinterpreted(source: str):
+    environment = DefinitionEnvironment()
+    definition = parse_formula(source)
+    assert isinstance(definition, Definition)
+    result = environment.register(definition)
+    assert result.entry is not None
+    assert environment.entries() == (result.entry,)


### PR DESCRIPTION
Refs #161, #122, #120. Depends on merged decision #163 and challenge #162.

Publishes standalone accepted `mts-opening-path/v0.4` plus one canonical typed production verifier. `mts-proof/v0.3` and `mts-contract/v0.4` remain immutable.

## Typed core

`core/mtc_opening_path.py` defines:
- `OpeningPathEdge(target: Form, definition_id: DefinitionId, body: Expression)`;
- `OpeningPathWitness(start_target, edges, final_body)`;
- deterministic `OpeningPathFailure` codes;
- `verify_opening_path(witness, environment)`.

The verifier independently replays exactly the supplied edges with canonical `open_definition`, checks structural start/adjacency/body/final identity, exact DefinitionId, unique DefinitionId cycle canonicality, and never auto-continues.

## Transport boundary

Core remains transport-agnostic. Portable artifacts keep shared scopes/lookupScope/startTarget/edges/finalBody; artifact decoders must parse targets structurally and require canonical `format_expression` transport for expected bodies/finalBody before constructing the typed witness.

## Meaning boundary

`DefinitionOpeningPath` is only an operational composite certificate. It does NOT imply equality, equivalence, normalization, contextual satisfaction, generic transitivity, or evaluation.

## Effects

No MemoryView, ContextFrame, interpreter identity, realize/delete, or DefinitionEnvironment mutation.

## Conformance

Accepted conformance selects all green #162 challenge vectors without copying them. Production tests require all valid vectors accepted, all invalid vectors rejected, exact failure-code surface, transport canonicality, terminal non-Form behavior, read-only replay, and unchanged ten roots.

## Versioning

Standalone relation only. No proof relation is added here; proof-v0.4 requires a separate acceptance step and must reuse this verifier exactly.