### PR TITLE
Challenge mts-proof/v0.4 lifting for DefinitionOpeningPath

### DIFF
--- a/contracts/mts-proof-opening-path-challenge-v0.4.json
+++ b/contracts/mts-proof-opening-path-challenge-v0.4.json
@@ -1,0 +1,137 @@
+{
+  "schema": "mts-proof-opening-path-challenge/v0.4",
+  "status": "candidate-challenge",
+  "issue": 165,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-proof/v0.3",
+    "mts-opening-path/v0.4"
+  ],
+  "conformanceCorpus": "contracts/mts-proof-v0.4-conformance-candidate.json",
+  "acceptedContractLinkAllowed": false,
+  "productionCheckerChangeAllowed": false,
+  "proofV03ChangeAllowed": false,
+  "candidateProof": {
+    "proofVersion": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "requiredTopLevelFields": ["proofVersion", "contractVersion", "judgments"],
+    "judgmentOrderImpliesDependency": false,
+    "emptyJudgmentArrayAllowed": true
+  },
+  "trustedRelationsCandidate": [
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget",
+    "DefinitionOpeningPath"
+  ],
+  "baseRelationReuse": {
+    "firstFiveShapesIdenticalToV03": true,
+    "firstFiveTrustedMeaningIdenticalToV03": true,
+    "mustDelegateCanonicalExistingReplay": true,
+    "mayReinterpretV03Artifacts": false,
+    "mayAddDependencyBetweenTopLevelJudgments": false
+  },
+  "openingPathJudgment": {
+    "relation": "DefinitionOpeningPath",
+    "required": ["relation", "scopes", "lookupScope", "startTarget", "edges", "finalBody"],
+    "scopes": "same strict explicit lexical snapshot as v0.3 definition relations",
+    "lookupScope": "one serialized scope path naming the environment passed to verify_opening_path",
+    "startTarget": "parseable Form source; structural identity, equivalent whitespace allowed",
+    "edges": {
+      "minimum": 1,
+      "requiredFields": ["target", "definitionId", "body"],
+      "target": "parseable Form source; structural identity, equivalent whitespace allowed",
+      "definitionId": "exact non-negative replay-local DefinitionId(scopePath,ordinal)",
+      "body": "canonical format_expression transport parsed to typed Expression"
+    },
+    "finalBody": "canonical format_expression transport parsed to typed Expression",
+    "trustedReplay": "construct OpeningPathWitness and invoke canonical verify_opening_path exactly once",
+    "autoContinue": false
+  },
+  "transportBoundary": {
+    "unexpectedTopLevelFieldsRejected": true,
+    "unexpectedJudgmentFieldsRejected": true,
+    "unexpectedEdgeFieldsRejected": true,
+    "unknownRelationsRejected": true,
+    "wrongVersionsRejected": true,
+    "noncanonicalExpectedBodyTransportRejected": true,
+    "noncanonicalFinalBodyTransportRejected": true,
+    "targetWhitespaceCanonicalizationRequired": false,
+    "sourceSpanIdentity": false
+  },
+  "compositionBoundary": {
+    "DefinitionOpeningPathInternallyComposesEdges": true,
+    "genericJudgmentCompositionAccepted": false,
+    "openingPathFeedsContextuallySatisfiesImplicitly": false,
+    "openingPathImpliesEquality": false,
+    "openingPathImpliesEquivalence": false,
+    "openingPathImpliesNormalization": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "proofDagDependencyAccepted": false
+  },
+  "searchCheckerBoundary": {
+    "searchTrusted": false,
+    "searchTraceSerializedIntoTrustedMeaning": false,
+    "checkerMustReplayWithoutSearch": true,
+    "checkerMayAutoExtendPath": false,
+    "certificateTrustedWithoutReplay": false
+  },
+  "effectsBoundary": {
+    "openingPathReadsMemory": false,
+    "openingPathReadsContextFrame": false,
+    "openingPathReadsInterpreterIdentity": false,
+    "openingPathMaterializes": false,
+    "openingPathDeletes": false
+  },
+  "v03Regression": {
+    "schemaRemains": "mts-proof/v0.3",
+    "contractVersionRemains": "mts-contract/v0.3",
+    "trustedRelationsRemainExactlyFive": true,
+    "existingPortableArtifactsRemainStrictlyReplayable": true,
+    "retroactiveReinterpretation": false
+  },
+  "requiredCoverage": [
+    "all v0.3 valid base judgments lift and replay with identical trusted meaning",
+    "all v0.3 base forgeries remain rejected when lifted",
+    "all v0.3 invalid artifacts remain rejected by the v0.3 API",
+    "all accepted opening-path valid vectors lift and replay",
+    "all opening-path invalid vectors reject",
+    "wrong proofVersion and contractVersion reject",
+    "unknown relation rejects",
+    "unexpected proof/judgment/edge fields reject",
+    "noncanonical edge body and final body transport reject",
+    "lookupScope absent from serialized scopes rejects",
+    "mixed base/opening-path judgment order does not create dependency semantics",
+    "hidden root/duplicate scope/noncanonical scope forgeries remain rejected",
+    "ten root definitions remain unchanged"
+  ],
+  "vetoes": [
+    "editing mts-proof/v0.3 in place",
+    "copying alternate base-relation semantics",
+    "opening path implies equality",
+    "opening path implies contextual satisfaction",
+    "generic top-level judgment composition",
+    "generic proof DAG",
+    "global substitution",
+    "recursive normalization",
+    "hidden root injection",
+    "ambient interpreter/focus/session state",
+    "MemoryView effects for opening path",
+    "auto extending serialized opening paths",
+    "aprover inventing additional rules before upstream acceptance"
+  ],
+  "nextGate": {
+    "directProductionAllowedIfChallengeFindsNoArtifactAmbiguity": true,
+    "artifact": "mts-proof/v0.4",
+    "mustUseSingleTrustedModule": "core/proof_checker.py",
+    "mustReuseOpeningPathVerifier": "core/mtc_opening_path.py::verify_opening_path",
+    "mustKeepV03Api": true,
+    "mustAddNoOtherCompositionRule": true
+  }
+}

--- a/contracts/mts-proof-v0.4-conformance-candidate.json
+++ b/contracts/mts-proof-v0.4-conformance-candidate.json
@@ -1,0 +1,130 @@
+{
+  "schema": "mts-proof-conformance-candidate/v0.4",
+  "status": "candidate-challenge-corpus",
+  "contract": "mts-proof-opening-path-challenge/v0.4",
+  "baseCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "openingPathCorpus": "contracts/mts-opening-path-conformance-candidate-v0.4.json",
+  "selection": {
+    "baseValidJudgments": "all",
+    "baseForgeries": "all",
+    "baseInvalidArtifactsForV03Regression": "all",
+    "openingPathValidPaths": "all",
+    "openingPathInvalidPaths": "all"
+  },
+  "candidateVersions": {
+    "proofVersion": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4"
+  },
+  "invalidArtifacts": [
+    {
+      "id": "wrong-proof-version",
+      "artifact": {"proofVersion": "mts-proof/v0.3", "contractVersion": "mts-contract/v0.4", "judgments": []}
+    },
+    {
+      "id": "wrong-contract-version",
+      "artifact": {"proofVersion": "mts-proof/v0.4", "contractVersion": "mts-contract/v0.3", "judgments": []}
+    },
+    {
+      "id": "unexpected-proof-field",
+      "artifact": {"proofVersion": "mts-proof/v0.4", "contractVersion": "mts-contract/v0.4", "judgments": [], "searchTrace": []}
+    },
+    {
+      "id": "unknown-relation",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{"relation": "Equality", "left": "a", "right": "b"}]
+      }
+    },
+    {
+      "id": "opening-unexpected-field",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}],
+          "finalBody": "b",
+          "searchTrace": []
+        }]
+      }
+    },
+    {
+      "id": "edge-unexpected-field",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b", "trusted": true}],
+          "finalBody": "b"
+        }]
+      }
+    },
+    {
+      "id": "noncanonical-edge-body",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : (b)"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "( b )"}],
+          "finalBody": "(b)"
+        }]
+      }
+    },
+    {
+      "id": "noncanonical-final-body",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : {◁ = x}"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "{◁ = x}"}],
+          "finalBody": "{ ◁ = x }"
+        }]
+      }
+    },
+    {
+      "id": "lookup-scope-not-serialized",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+          "lookupScope": [0],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}],
+          "finalBody": "b"
+        }]
+      }
+    }
+  ],
+  "mixedArtifact": {
+    "baseJudgmentId": "opens-direct",
+    "openingPathId": "two-edge",
+    "requiredBothOrdersAccepted": true,
+    "orderImpliesDependency": false
+  },
+  "releaseAssertions": {
+    "trustedRelationsExactlySix": true,
+    "baseMeaningReusedFromV03": true,
+    "openingPathMeaningReusedFromAcceptedVerifier": true,
+    "judgmentOrderHasNoGenericDependencyMeaning": true,
+    "proofV03RegressionRequired": true,
+    "genericCompositionAccepted": false
+  }
+}

--- a/tests/test_mts_proof_v04_opening_path_challenge.py
+++ b/tests/test_mts_proof_v04_opening_path_challenge.py
@@ -1,0 +1,355 @@
+"""Executable evidence for the non-normative mts-proof/v0.4 lifting challenge."""
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from core.mtc_ast import format_expression
+from core.mtc_definitions import DefinitionId
+from core.mtc_opening_path import OpeningPathEdge, OpeningPathWitness, verify_opening_path
+from core.mtc_parser import parse_formula
+from core.proof_checker import (
+    _build_definition_environments,
+    _definition_id_from_data,
+    _parse_definition_target,
+    _path_from_data,
+    _require_exact_keys,
+    _scopes_from_data,
+    check_proof_v03,
+    proof_v03_from_data,
+)
+
+
+ROOT = Path(__file__).parents[1]
+CHALLENGE = ROOT / "contracts" / "mts-proof-opening-path-challenge-v0.4.json"
+CORPUS = ROOT / "contracts" / "mts-proof-v0.4-conformance-candidate.json"
+BASE_CORPUS = ROOT / "contracts" / "mts-proof-conformance-v0.3.json"
+OPENING_CORPUS = ROOT / "contracts" / "mts-opening-path-conformance-candidate-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+OPENING_CONTRACT = ROOT / "contracts" / "mts-opening-path-v0.4.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+PROOF_VERSION = "mts-proof/v0.4"
+CONTRACT_VERSION = "mts-contract/v0.4"
+BASE_RELATIONS = {
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget",
+}
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def root_sources() -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def candidate_artifact(judgments: list[dict]) -> dict:
+    return {
+        "proofVersion": PROOF_VERSION,
+        "contractVersion": CONTRACT_VERSION,
+        "judgments": judgments,
+    }
+
+
+def base_judgment_replays(judgment: dict) -> bool:
+    artifact = {
+        "proofVersion": "mts-proof/v0.3",
+        "contractVersion": "mts-contract/v0.3",
+        "judgments": [judgment],
+    }
+    try:
+        proof = proof_v03_from_data(artifact)
+    except (KeyError, TypeError, ValueError):
+        return False
+    return check_proof_v03(proof)
+
+
+def v03_artifact_replays(artifact: dict) -> bool:
+    try:
+        proof = proof_v03_from_data(artifact)
+    except (KeyError, TypeError, ValueError):
+        return False
+    return check_proof_v03(proof)
+
+
+def opening_path_judgment(vector: dict) -> dict:
+    return {"relation": "DefinitionOpeningPath", **deepcopy(vector)}
+
+
+def check_opening_path_judgment(data: dict) -> bool:
+    try:
+        _require_exact_keys(
+            data,
+            {"relation", "scopes", "lookupScope", "startTarget", "edges", "finalBody"},
+            "DefinitionOpeningPath",
+        )
+        if data["relation"] != "DefinitionOpeningPath":
+            return False
+        if not isinstance(data["startTarget"], str):
+            raise ValueError("startTarget must be a string")
+        if not isinstance(data["edges"], list):
+            raise ValueError("edges must be an array")
+        if not isinstance(data["finalBody"], str):
+            raise ValueError("finalBody must be a string")
+
+        scopes = _scopes_from_data(data["scopes"])
+        environments = _build_definition_environments(scopes)
+        lookup_scope = _path_from_data(data["lookupScope"], "lookupScope")
+        environment = environments.get(lookup_scope)
+        if environment is None:
+            raise ValueError("lookupScope must name a serialized scope")
+
+        start_target = _parse_definition_target(data["startTarget"])
+        edges: list[OpeningPathEdge] = []
+        for index, edge_data in enumerate(data["edges"]):
+            if not isinstance(edge_data, dict):
+                raise ValueError("opening path edge must be an object")
+            _require_exact_keys(
+                edge_data,
+                {"target", "definitionId", "body"},
+                "opening path edge",
+            )
+            if not isinstance(edge_data["target"], str):
+                raise ValueError("edge target must be a string")
+            if not isinstance(edge_data["body"], str):
+                raise ValueError("edge body must be a string")
+
+            target = _parse_definition_target(edge_data["target"])
+            expected_id = _definition_id_from_data(edge_data["definitionId"])
+            body = parse_formula(edge_data["body"])
+            if format_expression(body) != edge_data["body"]:
+                raise ValueError(f"edge[{index}].body must be canonical")
+            edges.append(
+                OpeningPathEdge(
+                    target=target,
+                    definition_id=DefinitionId(
+                        expected_id.scope_path,
+                        expected_id.ordinal,
+                    ),
+                    body=body,
+                )
+            )
+
+        final_body = parse_formula(data["finalBody"])
+        if format_expression(final_body) != data["finalBody"]:
+            raise ValueError("finalBody must be canonical")
+
+        witness = OpeningPathWitness(
+            start_target=start_target,
+            edges=tuple(edges),
+            final_body=final_body,
+        )
+        return verify_opening_path(witness, environment).accepted
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def check_candidate_proof(data: object) -> bool:
+    try:
+        if not isinstance(data, dict):
+            raise ValueError("proof must be an object")
+        _require_exact_keys(
+            data,
+            {"proofVersion", "contractVersion", "judgments"},
+            "proof",
+        )
+        if data["proofVersion"] != PROOF_VERSION:
+            raise ValueError("unsupported proofVersion")
+        if data["contractVersion"] != CONTRACT_VERSION:
+            raise ValueError("unsupported contractVersion")
+        if not isinstance(data["judgments"], list):
+            raise ValueError("judgments must be an array")
+
+        for judgment in data["judgments"]:
+            if not isinstance(judgment, dict):
+                return False
+            relation = judgment.get("relation")
+            if relation == "DefinitionOpeningPath":
+                if not check_opening_path_judgment(judgment):
+                    return False
+            elif relation in BASE_RELATIONS:
+                if not base_judgment_replays(judgment):
+                    return False
+            else:
+                return False
+        return True
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def patch_dotted(source: dict, patch: dict) -> dict:
+    result = deepcopy(source)
+    for dotted, replacement in patch.items():
+        parts = dotted.split(".")
+        current = result
+        for part in parts[:-1]:
+            current = current[part]
+        current[parts[-1]] = deepcopy(replacement)
+    return result
+
+
+def base_by_id() -> dict[str, dict]:
+    return {
+        item["id"]: item["judgment"]
+        for item in read(BASE_CORPUS)["validJudgments"]
+    }
+
+
+def forge_base(vector: dict) -> dict:
+    if "judgment" in vector:
+        return deepcopy(vector["judgment"])
+
+    source = base_by_id()[vector["sourceJudgment"]]
+    result = patch_dotted(source, vector.get("patch", {}))
+    if "replaceRelation" in vector:
+        result["relation"] = vector["replaceRelation"]
+    for key in vector.get("remove", []):
+        result.pop(key, None)
+    return result
+
+
+def test_challenge_is_non_normative_and_does_not_modify_proof_v03():
+    challenge = read(CHALLENGE)
+    v03 = read(PROOF_V03)
+
+    assert challenge["schema"] == "mts-proof-opening-path-challenge/v0.4"
+    assert challenge["status"] == "candidate-challenge"
+    assert challenge["acceptedContractLinkAllowed"] is False
+    assert challenge["productionCheckerChangeAllowed"] is False
+    assert challenge["proofV03ChangeAllowed"] is False
+    assert challenge["schema"] not in PROOF_V03.read_text(encoding="utf-8")
+    assert v03["proofObject"]["proofVersion"] == "mts-proof/v0.3"
+    assert v03["compositionBoundary"]["genericCompositionAccepted"] is False
+
+
+def test_candidate_versions_and_exact_six_relation_surface_are_fixed():
+    challenge = read(CHALLENGE)
+    candidate = challenge["candidateProof"]
+
+    assert candidate["proofVersion"] == PROOF_VERSION
+    assert candidate["contractVersion"] == CONTRACT_VERSION
+    assert candidate["judgmentOrderImpliesDependency"] is False
+    assert candidate["emptyJudgmentArrayAllowed"] is True
+    assert set(challenge["trustedRelationsCandidate"]) == BASE_RELATIONS | {
+        "DefinitionOpeningPath"
+    }
+    assert len(challenge["trustedRelationsCandidate"]) == 6
+
+
+def test_all_v03_valid_base_judgments_lift_without_new_base_semantics():
+    for vector in read(BASE_CORPUS)["validJudgments"]:
+        judgment = vector["judgment"]
+        assert base_judgment_replays(judgment), vector["id"]
+        assert check_candidate_proof(candidate_artifact([judgment])), vector["id"]
+
+    reuse = read(CHALLENGE)["baseRelationReuse"]
+    assert reuse["firstFiveShapesIdenticalToV03"] is True
+    assert reuse["firstFiveTrustedMeaningIdenticalToV03"] is True
+    assert reuse["mustDelegateCanonicalExistingReplay"] is True
+
+
+def test_all_v03_base_forgeries_remain_rejected_when_lifted():
+    for vector in read(BASE_CORPUS)["forgeries"]:
+        forged = forge_base(vector)
+        assert vector["mustReject"] is True
+        assert not base_judgment_replays(forged), vector["id"]
+        assert not check_candidate_proof(candidate_artifact([forged])), vector["id"]
+
+
+def test_existing_v03_invalid_artifacts_remain_rejected_by_existing_api():
+    for vector in read(BASE_CORPUS)["invalidArtifacts"]:
+        assert not v03_artifact_replays(vector["artifact"]), vector["id"]
+
+    regression = read(CHALLENGE)["v03Regression"]
+    assert regression["existingPortableArtifactsRemainStrictlyReplayable"] is True
+    assert regression["retroactiveReinterpretation"] is False
+
+
+def test_all_opening_path_valid_vectors_lift_through_canonical_verifier():
+    for vector in read(OPENING_CORPUS)["validPaths"]:
+        judgment = opening_path_judgment(vector)
+        assert check_opening_path_judgment(judgment), vector["id"]
+        assert check_candidate_proof(candidate_artifact([judgment])), vector["id"]
+
+
+def test_all_opening_path_invalid_vectors_reject_when_lifted():
+    for vector in read(OPENING_CORPUS)["invalidPaths"]:
+        judgment = opening_path_judgment(vector)
+        assert not check_opening_path_judgment(judgment), vector["id"]
+        assert not check_candidate_proof(candidate_artifact([judgment])), vector["id"]
+
+
+def test_v04_specific_transport_forgeries_fail_closed():
+    for vector in read(CORPUS)["invalidArtifacts"]:
+        assert not check_candidate_proof(vector["artifact"]), vector["id"]
+
+
+def test_mixed_base_and_opening_judgments_are_independent_of_array_order():
+    mixed = read(CORPUS)["mixedArtifact"]
+    base = base_by_id()[mixed["baseJudgmentId"]]
+    opening_vector = next(
+        item
+        for item in read(OPENING_CORPUS)["validPaths"]
+        if item["id"] == mixed["openingPathId"]
+    )
+    opening = opening_path_judgment(opening_vector)
+
+    assert check_candidate_proof(candidate_artifact([base, opening]))
+    assert check_candidate_proof(candidate_artifact([opening, base]))
+    assert mixed["requiredBothOrdersAccepted"] is True
+    assert mixed["orderImpliesDependency"] is False
+
+
+def test_opening_path_transport_delegates_to_accepted_relation_not_search_trace():
+    challenge = read(CHALLENGE)
+    opening = read(OPENING_CONTRACT)
+
+    assert challenge["openingPathJudgment"]["trustedReplay"].endswith(
+        "canonical verify_opening_path exactly once"
+    )
+    assert opening["typedCore"]["verifier"] == "verify_opening_path"
+    assert challenge["searchCheckerBoundary"]["searchTrusted"] is False
+    assert challenge["searchCheckerBoundary"]["checkerMustReplayWithoutSearch"] is True
+    assert challenge["searchCheckerBoundary"]["checkerMayAutoExtendPath"] is False
+
+
+def test_no_generic_composition_or_equality_bridge_is_introduced():
+    boundary = read(CHALLENGE)["compositionBoundary"]
+
+    assert boundary["DefinitionOpeningPathInternallyComposesEdges"] is True
+    assert boundary["genericJudgmentCompositionAccepted"] is False
+    assert boundary["openingPathFeedsContextuallySatisfiesImplicitly"] is False
+    assert boundary["openingPathImpliesEquality"] is False
+    assert boundary["openingPathImpliesEquivalence"] is False
+    assert boundary["openingPathImpliesNormalization"] is False
+    assert boundary["transitivityAccepted"] is False
+    assert boundary["symmetryAccepted"] is False
+    assert boundary["congruenceAccepted"] is False
+    assert boundary["modusPonensAccepted"] is False
+    assert boundary["globalSubstitutionAccepted"] is False
+    assert boundary["proofDagDependencyAccepted"] is False
+
+
+def test_candidate_checker_reads_no_hidden_runtime_state_for_opening_paths():
+    effects = read(CHALLENGE)["effectsBoundary"]
+
+    assert effects["openingPathReadsMemory"] is False
+    assert effects["openingPathReadsContextFrame"] is False
+    assert effects["openingPathReadsInterpreterIdentity"] is False
+    assert effects["openingPathMaterializes"] is False
+    assert effects["openingPathDeletes"] is False
+
+
+def test_root_program_remains_exactly_ten_and_unchanged():
+    before = root_sources()
+    assert len(before) == 10
+    assert root_sources() == before

--- a/tests/test_mts_proof_v04_opening_path_challenge.py
+++ b/tests/test_mts_proof_v04_opening_path_challenge.py
@@ -205,10 +205,13 @@ def base_by_id() -> dict[str, dict]:
 
 
 def forge_base(vector: dict) -> dict:
-    if "judgment" in vector:
-        return deepcopy(vector["judgment"])
+    if "sourceJudgment" in vector:
+        source = base_by_id()[vector["sourceJudgment"]]
+    elif "judgment" in vector:
+        source = vector["judgment"]
+    else:
+        raise ValueError("forgery vector must provide sourceJudgment or judgment")
 
-    source = base_by_id()[vector["sourceJudgment"]]
     result = patch_dotted(source, vector.get("patch", {}))
     if "replaceRelation" in vector:
         result["relation"] = vector["replaceRelation"]
@@ -313,8 +316,8 @@ def test_opening_path_transport_delegates_to_accepted_relation_not_search_trace(
     challenge = read(CHALLENGE)
     opening = read(OPENING_CONTRACT)
 
-    assert challenge["openingPathJudgment"]["trustedReplay"].endswith(
-        "canonical verify_opening_path exactly once"
+    assert challenge["openingPathJudgment"]["trustedReplay"] == (
+        "construct OpeningPathWitness and invoke canonical verify_opening_path exactly once"
     )
     assert opening["typedCore"]["verifier"] == "verify_opening_path"
     assert challenge["searchCheckerBoundary"]["searchTrusted"] is False

--- a/tests/test_mts_proof_v04_opening_path_challenge.py
+++ b/tests/test_mts_proof_v04_opening_path_challenge.py
@@ -82,7 +82,14 @@ def v03_artifact_replays(artifact: dict) -> bool:
 
 
 def opening_path_judgment(vector: dict) -> dict:
-    return {"relation": "DefinitionOpeningPath", **deepcopy(vector)}
+    return {
+        "relation": "DefinitionOpeningPath",
+        "scopes": deepcopy(vector["scopes"]),
+        "lookupScope": deepcopy(vector["lookupScope"]),
+        "startTarget": vector["startTarget"],
+        "edges": deepcopy(vector["edges"]),
+        "finalBody": vector["finalBody"],
+    }
 
 
 def check_opening_path_judgment(data: dict) -> bool:


### PR DESCRIPTION
Refs #165, #122, #120.

Non-normative proof-version challenge. Production checker and `mts-proof/v0.3` are untouched.

## Candidate proof surface

```text
proofVersion = mts-proof/v0.4
contractVersion = mts-contract/v0.4
```

Exactly six candidate trusted relations: the five accepted v0.3 base relations plus `DefinitionOpeningPath`.

## Base reuse

The challenge does not implement alternate base semantics. Every lifted base judgment is wrapped into the existing strict v0.3 artifact shape and replayed by the existing v0.3 decoder/checker. All v0.3 valid vectors must pass and all v0.3 base forgeries must remain rejected.

## Opening-path lift

`DefinitionOpeningPath` uses a self-contained scopes/lookupScope/startTarget/edges/finalBody substrate. Test-kernel strictly decodes it, reconstructs the exact lexical environment, constructs `OpeningPathWitness`, and invokes accepted `verify_opening_path`.

Targets use structural typed identity; expected edge bodies and finalBody require canonical `format_expression` transport.

## Corpus composition

No copied semantic vectors. The challenge consumes:
- all `mts-proof-conformance/v0.3` valid judgments/forgeries/invalid-artifact regression;
- all `mts-opening-path` valid/invalid challenge vectors;
- v0.4-specific version/unknown-field/noncanonical-transport/lookup-scope attacks.

## Composition boundary

Top-level judgment order still has no generic dependency meaning. An opening-path judgment is internally multi-edge, but it does not imply equality, normalization, ContextuallySatisfies, transitivity, proof-DAG semantics or any other rule.

If this challenge is fully green and exposes no artifact ambiguity, next step is direct production `mts-proof/v0.4` in the existing single `core/proof_checker.py`, reusing `verify_opening_path` exactly.