### PR TITLE
Accept trusted mts-proof/v0.4 with DefinitionOpeningPath

### DIFF
--- a/contracts/mts-proof-conformance-v0.4.json
+++ b/contracts/mts-proof-conformance-v0.4.json
@@ -1,0 +1,47 @@
+{
+  "schema": "mts-proof-conformance/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-proof/v0.4",
+  "sourceCorpus": "contracts/mts-proof-v0.4-conformance-candidate.json",
+  "baseCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "openingPathCorpus": "contracts/mts-opening-path-conformance-candidate-v0.4.json",
+  "selection": {
+    "baseValidJudgments": "all",
+    "baseForgeries": "all",
+    "baseInvalidArtifactsForV03Regression": "all",
+    "openingPathValidPaths": "all",
+    "openingPathInvalidPaths": "all",
+    "v04InvalidArtifacts": "all",
+    "mixedArtifact": "required"
+  },
+  "releaseAssertions": {
+    "trustedRelationsExactlySix": true,
+    "fiveBaseRelationsReuseV03TrustedMeaning": true,
+    "allV03ValidBaseJudgmentsLift": true,
+    "allV03BaseForgeriesRemainRejected": true,
+    "allV03InvalidArtifactsRemainRejectedByV03Api": true,
+    "allOpeningPathValidVectorsLift": true,
+    "allOpeningPathInvalidVectorsReject": true,
+    "allV04TransportForgeriesReject": true,
+    "openingPathUsesCanonicalVerifier": true,
+    "mixedJudgmentOrderDoesNotCreateDependency": true,
+    "canonicalRoundTripRequired": true,
+    "mtsProofV03Unchanged": true,
+    "genericCompositionAccepted": false,
+    "tenRootDefinitionsUnchanged": true
+  },
+  "effectsAssertions": {
+    "openingPathReadsMemory": false,
+    "openingPathReadsContextFrame": false,
+    "openingPathReadsInterpreterIdentity": false,
+    "materializes": false,
+    "deletes": false
+  },
+  "versioningAssertions": {
+    "proofVersion": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "publishedThroughUmbrella": false,
+    "futureUmbrella": "mts-contract/v0.5"
+  }
+}

--- a/contracts/mts-proof-v0.4.json
+++ b/contracts/mts-proof-v0.4.json
@@ -1,0 +1,136 @@
+{
+  "schema": "mts-proof/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 165,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-proof/v0.3",
+    "mts-opening-path/v0.4",
+    "mts-proof-opening-path-challenge/v0.4"
+  ],
+  "conformanceCorpus": "contracts/mts-proof-conformance-v0.4.json",
+  "purpose": "Trusted independent replay of the five accepted v0.3 base relations plus the accepted finite DefinitionOpeningPath operational composite certificate; no other composition or inference rule is accepted.",
+  "proofObject": {
+    "required": ["proofVersion", "contractVersion", "judgments"],
+    "proofVersion": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "judgments": "ordered V04Judgment[]; array order is artifact order only and has no generic premise/dependency meaning"
+  },
+  "trustedRelations": [
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget",
+    "DefinitionOpeningPath"
+  ],
+  "baseRelations": {
+    "shapesIdenticalToV03": true,
+    "trustedMeaningIdenticalToV03": true,
+    "checkerPath": "core/proof_checker.py::check_v03_judgment",
+    "reimplementedForV04": false,
+    "proofV03ArtifactsReinterpretedAsV04": false
+  },
+  "definitionOpeningPath": {
+    "required": ["relation", "scopes", "lookupScope", "startTarget", "edges", "finalBody"],
+    "relation": "DefinitionOpeningPath",
+    "scopes": "same explicit canonical lexical snapshot semantics as v0.3 definition judgments",
+    "lookupScope": "one exact serialized scope path used for every opening edge",
+    "startTarget": "parseable Form source; structural identity after parsing; equivalent whitespace permitted",
+    "edges": {
+      "minimum": 1,
+      "required": ["target", "definitionId", "body"],
+      "target": "parseable Form source; structural identity after parsing; equivalent whitespace permitted",
+      "definitionId": "exact non-negative replay-local DefinitionId(scopePath,ordinal)",
+      "body": "exact canonical format_expression transport parsed into typed Expression"
+    },
+    "finalBody": "exact canonical format_expression transport parsed into typed Expression",
+    "typedWitness": "OpeningPathWitness",
+    "trustedReplay": "core/mtc_opening_path.py::verify_opening_path",
+    "autoContinues": false,
+    "searchTraceTrusted": false
+  },
+  "transportBoundary": {
+    "wrongOrMissingVersionsRejected": true,
+    "unexpectedProofFieldsRejected": true,
+    "unexpectedJudgmentFieldsRejected": true,
+    "unexpectedOpeningEdgeFieldsRejected": true,
+    "unknownRelationsRejected": true,
+    "noncanonicalExpectedBodyTransportRejected": true,
+    "noncanonicalFinalBodyTransportRejected": true,
+    "targetWhitespaceCanonicalizationRequired": false,
+    "sourceSpanIdentity": false
+  },
+  "checker": {
+    "module": "core/proof_checker.py",
+    "singleTrustedModuleForV02V03V04": true,
+    "baseRelationsDelegateExistingV03Replay": true,
+    "openingPathDelegatesCanonicalVerifier": true,
+    "trustsSerializedOpeningBodyWithoutReplay": false,
+    "trustsSerializedDefinitionIdWithoutReplay": false,
+    "trustsSearchTrace": false,
+    "mayAutoExtendOpeningPath": false,
+    "mayReadAmbientInterpreterState": false,
+    "mayInjectCanonicalRootDefinitions": false,
+    "mayMaterialize": false,
+    "mayDelete": false
+  },
+  "compositionBoundary": {
+    "DefinitionOpeningPathInternallyComposesOpeningEdges": true,
+    "judgmentOrderImpliesDependency": false,
+    "genericCompositionAccepted": false,
+    "openingPathFeedsContextuallySatisfiesImplicitly": false,
+    "openingPathImpliesEquality": false,
+    "openingPathImpliesEquivalence": false,
+    "openingPathImpliesNormalization": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "proofDagDependencyAccepted": false
+  },
+  "effectsBoundary": {
+    "openingPathReadsMemory": false,
+    "openingPathReadsContextFrame": false,
+    "openingPathReadsInterpreterIdentity": false,
+    "openingPathMaterializes": false,
+    "openingPathDeletes": false
+  },
+  "v03Compatibility": {
+    "mtsProofV03Modified": false,
+    "mtsProofV03Schema": "mts-proof/v0.3",
+    "mtsProofV03ContractVersion": "mts-contract/v0.3",
+    "trustedRelationsRemainExactlyFive": true,
+    "existingV03ArtifactsReplayByExistingApi": true,
+    "retroactiveReinterpretation": false
+  },
+  "serialization": {
+    "typedApi": [
+      "proof_v04_from_data",
+      "check_proof_v04",
+      "check_proof_v04_data",
+      "proof_v04_to_data",
+      "canonical_proof_v04_json"
+    ],
+    "canonicalTargetSerialization": "format_expression; decoder additionally accepts structurally equivalent target whitespace",
+    "canonicalBodySerialization": "format_expression",
+    "roundTripRequired": true
+  },
+  "rootProgram": {
+    "definitionCount": 10,
+    "mustRemainUnchanged": true
+  },
+  "versioning": {
+    "mtsContractV04Modified": false,
+    "publishedThroughUmbrella": false,
+    "futureUmbrella": "mts-contract/v0.5",
+    "futureUmbrellaMustBeAdditive": true
+  },
+  "downstream": {
+    "directAproverRepinAllowedBeforeUmbrella": false,
+    "reason": "publish the full new context/proof surface through additive mts-contract/v0.5 before downstream exact pin",
+    "aproverMayInventAdditionalRules": false
+  }
+}

--- a/core/proof_checker.py
+++ b/core/proof_checker.py
@@ -13,14 +13,16 @@ from dataclasses import dataclass
 import json
 from typing import TypeAlias
 
-from core.mtc_ast import Definition, Form, format_expression
+from core.mtc_ast import Definition, Expression, Form, format_expression
 from core.mtc_definitions import (
     DefinitionEnvironment,
+    DefinitionId,
     DefinitionLookupKind,
     DefinitionRegistrationKind,
     open_definition,
 )
 from core.mtc_interpreter import ContextFrame, MemoryView, interpret_constraints
+from core.mtc_opening_path import OpeningPathEdge, OpeningPathWitness, verify_opening_path
 from core.mtc_parser import parse_formula
 
 
@@ -477,7 +479,6 @@ def _memory_from_data(data: object) -> tuple[DistinguishedLink, ...]:
                 end=_int_from_data(item["end"], "memory.end"),
             )
         )
-    # ProofMemory performs the semantic duplicate/ambiguity validation.
     ProofMemory(tuple(result))
     return tuple(result)
 
@@ -705,10 +706,7 @@ def _symbols_to_data(symbols: tuple[tuple[str, int], ...]) -> list[list[object]]
 def _substitutions_to_data(
     substitutions: tuple[ExpectedSubstitution, ...],
 ) -> list[dict]:
-    return [
-        {"path": list(item.path), "link": item.link}
-        for item in substitutions
-    ]
+    return [{"path": list(item.path), "link": item.link} for item in substitutions]
 
 
 def _aliases_to_data(aliases: tuple[ExpectedAlias, ...]) -> list[dict]:
@@ -799,11 +797,6 @@ def canonical_proof_v03_json(proof: ProofObjectV03) -> str:
 # v0.4 extends the same trusted module with exactly one accepted composite
 # certificate relation.  Existing v0.2/v0.3 APIs and semantics above remain
 # independent and unchanged.
-from core.mtc_ast import Expression
-from core.mtc_definitions import DefinitionId
-from core.mtc_opening_path import OpeningPathEdge, OpeningPathWitness, verify_opening_path
-
-
 CONTRACT_VERSION_V04 = "mts-contract/v0.4"
 PROOF_SCHEMA_V04 = "mts-proof/v0.4"
 

--- a/core/proof_checker.py
+++ b/core/proof_checker.py
@@ -794,3 +794,216 @@ def canonical_proof_v03_json(proof: ProofObjectV03) -> str:
         sort_keys=True,
         separators=(",", ":"),
     )
+
+
+# v0.4 extends the same trusted module with exactly one accepted composite
+# certificate relation.  Existing v0.2/v0.3 APIs and semantics above remain
+# independent and unchanged.
+from core.mtc_ast import Expression
+from core.mtc_definitions import DefinitionId
+from core.mtc_opening_path import OpeningPathEdge, OpeningPathWitness, verify_opening_path
+
+
+CONTRACT_VERSION_V04 = "mts-contract/v0.4"
+PROOF_SCHEMA_V04 = "mts-proof/v0.4"
+
+
+@dataclass(frozen=True)
+class DefinitionOpeningPathJudgment:
+    scopes: tuple[DefinitionScopeSnapshot, ...]
+    lookup_scope: tuple[int, ...]
+    start_target: Form
+    edges: tuple[OpeningPathEdge, ...]
+    final_body: Expression
+    relation: str = "DefinitionOpeningPath"
+
+
+V04Judgment: TypeAlias = V03Judgment | DefinitionOpeningPathJudgment
+
+
+@dataclass(frozen=True)
+class ProofObjectV04:
+    judgments: tuple[V04Judgment, ...]
+    contract_version: str = CONTRACT_VERSION_V04
+    proof_version: str = PROOF_SCHEMA_V04
+
+
+def _canonical_expression_from_data(value: object, label: str) -> Expression:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    expression = parse_formula(value)
+    if format_expression(expression) != value:
+        raise ValueError(f"{label} must use canonical format_expression transport")
+    return expression
+
+
+def _opening_path_judgment_from_data(data: object) -> DefinitionOpeningPathJudgment:
+    if not isinstance(data, dict):
+        raise ValueError("DefinitionOpeningPath judgment must be an object")
+    _require_exact_keys(
+        data,
+        {"relation", "scopes", "lookupScope", "startTarget", "edges", "finalBody"},
+        "DefinitionOpeningPath",
+    )
+    if data["relation"] != "DefinitionOpeningPath":
+        raise ValueError("invalid DefinitionOpeningPath relation")
+    if not isinstance(data["startTarget"], str):
+        raise ValueError("startTarget must be a string")
+    if not isinstance(data["edges"], list) or not data["edges"]:
+        raise ValueError("edges must be a non-empty array")
+
+    edges: list[OpeningPathEdge] = []
+    for index, edge_data in enumerate(data["edges"]):
+        if not isinstance(edge_data, dict):
+            raise ValueError("opening path edge must be an object")
+        _require_exact_keys(
+            edge_data,
+            {"target", "definitionId", "body"},
+            "opening path edge",
+        )
+        if not isinstance(edge_data["target"], str):
+            raise ValueError("opening path edge target must be a string")
+        expected_id = _definition_id_from_data(edge_data["definitionId"])
+        edges.append(
+            OpeningPathEdge(
+                target=_parse_definition_target(edge_data["target"]),
+                definition_id=DefinitionId(
+                    expected_id.scope_path,
+                    expected_id.ordinal,
+                ),
+                body=_canonical_expression_from_data(
+                    edge_data["body"],
+                    f"opening path edge[{index}].body",
+                ),
+            )
+        )
+
+    return DefinitionOpeningPathJudgment(
+        scopes=_scopes_from_data(data["scopes"]),
+        lookup_scope=_path_from_data(data["lookupScope"], "lookupScope"),
+        start_target=_parse_definition_target(data["startTarget"]),
+        edges=tuple(edges),
+        final_body=_canonical_expression_from_data(data["finalBody"], "finalBody"),
+    )
+
+
+def check_definition_opening_path(judgment: DefinitionOpeningPathJudgment) -> bool:
+    """Replay one accepted finite opening-path certificate exactly once."""
+
+    if judgment.relation != "DefinitionOpeningPath":
+        return False
+    try:
+        _validate_path(judgment.lookup_scope)
+        environments = _build_definition_environments(judgment.scopes)
+        environment = environments.get(judgment.lookup_scope)
+        if environment is None:
+            return False
+        witness = OpeningPathWitness(
+            start_target=judgment.start_target,
+            edges=judgment.edges,
+            final_body=judgment.final_body,
+        )
+        return verify_opening_path(witness, environment).accepted
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def check_v04_judgment(judgment: V04Judgment) -> bool:
+    if isinstance(judgment, DefinitionOpeningPathJudgment):
+        return check_definition_opening_path(judgment)
+    return check_v03_judgment(judgment)
+
+
+def check_proof_v04(proof: ProofObjectV04) -> bool:
+    """Replay six accepted v0.4 relations; array order has no dependency meaning."""
+
+    if (
+        proof.proof_version != PROOF_SCHEMA_V04
+        or proof.contract_version != CONTRACT_VERSION_V04
+    ):
+        return False
+    return all(check_v04_judgment(judgment) for judgment in proof.judgments)
+
+
+def _v04_judgment_from_data(data: object) -> V04Judgment:
+    if isinstance(data, dict) and data.get("relation") == "DefinitionOpeningPath":
+        return _opening_path_judgment_from_data(data)
+    return _judgment_from_data(data)
+
+
+def proof_v04_from_data(data: object) -> ProofObjectV04:
+    """Strictly parse one portable mts-proof/v0.4 JSON-shaped artifact."""
+
+    if not isinstance(data, dict):
+        raise ValueError("proof must be an object")
+    _require_exact_keys(
+        data,
+        {"proofVersion", "contractVersion", "judgments"},
+        "proof",
+    )
+    if data["proofVersion"] != PROOF_SCHEMA_V04:
+        raise ValueError("unsupported proofVersion")
+    if data["contractVersion"] != CONTRACT_VERSION_V04:
+        raise ValueError("unsupported contractVersion")
+    if not isinstance(data["judgments"], list):
+        raise ValueError("judgments must be an array")
+    return ProofObjectV04(
+        judgments=tuple(_v04_judgment_from_data(item) for item in data["judgments"]),
+    )
+
+
+def check_proof_v04_data(data: object) -> bool:
+    """Strictly parse then independently replay one portable v0.4 artifact."""
+
+    try:
+        return check_proof_v04(proof_v04_from_data(data))
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def _opening_path_judgment_to_data(judgment: DefinitionOpeningPathJudgment) -> dict:
+    return {
+        "relation": judgment.relation,
+        "scopes": _scopes_to_data(judgment.scopes),
+        "lookupScope": list(judgment.lookup_scope),
+        "startTarget": format_expression(judgment.start_target),
+        "edges": [
+            {
+                "target": format_expression(edge.target),
+                "definitionId": {
+                    "scopePath": list(edge.definition_id.scope_path),
+                    "ordinal": edge.definition_id.ordinal,
+                },
+                "body": format_expression(edge.body),
+            }
+            for edge in judgment.edges
+        ],
+        "finalBody": format_expression(judgment.final_body),
+    }
+
+
+def _v04_judgment_to_data(judgment: V04Judgment) -> dict:
+    if isinstance(judgment, DefinitionOpeningPathJudgment):
+        return _opening_path_judgment_to_data(judgment)
+    return _judgment_to_data(judgment)
+
+
+def proof_v04_to_data(proof: ProofObjectV04) -> dict:
+    """Serialize one valid typed v0.4 proof object to canonical portable data."""
+
+    if not check_proof_v04(proof):
+        raise ValueError("cannot serialize invalid v0.4 proof object")
+    return {
+        "proofVersion": proof.proof_version,
+        "contractVersion": proof.contract_version,
+        "judgments": [_v04_judgment_to_data(item) for item in proof.judgments],
+    }
+
+
+def canonical_proof_v04_json(proof: ProofObjectV04) -> str:
+    return json.dumps(
+        proof_v04_to_data(proof),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )

--- a/tests/test_mts_proof_v04.py
+++ b/tests/test_mts_proof_v04.py
@@ -1,0 +1,330 @@
+"""Production acceptance for mts-proof/v0.4 with DefinitionOpeningPath."""
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from core.proof_checker import (
+    CONTRACT_VERSION_V04,
+    PROOF_SCHEMA_V04,
+    DefinitionOpeningPathJudgment,
+    ProofObjectV04,
+    canonical_proof_v04_json,
+    check_proof_v03_data,
+    check_proof_v04,
+    check_proof_v04_data,
+    proof_v04_from_data,
+    proof_v04_to_data,
+)
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACT = ROOT / "contracts" / "mts-proof-v0.4.json"
+CONFORMANCE = ROOT / "contracts" / "mts-proof-conformance-v0.4.json"
+CANDIDATE = ROOT / "contracts" / "mts-proof-v0.4-conformance-candidate.json"
+BASE_CORPUS = ROOT / "contracts" / "mts-proof-conformance-v0.3.json"
+OPENING_CORPUS = ROOT / "contracts" / "mts-opening-path-conformance-candidate-v0.4.json"
+PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
+MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
+
+BASE_RELATIONS = {
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget",
+}
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def root_sources() -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+
+
+def v04_artifact(judgments: list[dict]) -> dict:
+    return {
+        "proofVersion": PROOF_SCHEMA_V04,
+        "contractVersion": CONTRACT_VERSION_V04,
+        "judgments": judgments,
+    }
+
+
+def v03_artifact(judgments: list[dict]) -> dict:
+    return {
+        "proofVersion": "mts-proof/v0.3",
+        "contractVersion": "mts-contract/v0.3",
+        "judgments": judgments,
+    }
+
+
+def opening_judgment(vector: dict) -> dict:
+    return {
+        "relation": "DefinitionOpeningPath",
+        "scopes": deepcopy(vector["scopes"]),
+        "lookupScope": deepcopy(vector["lookupScope"]),
+        "startTarget": vector["startTarget"],
+        "edges": deepcopy(vector["edges"]),
+        "finalBody": vector["finalBody"],
+    }
+
+
+def patch_dotted(source: dict, patch: dict) -> dict:
+    result = deepcopy(source)
+    for dotted, replacement in patch.items():
+        parts = dotted.split(".")
+        current = result
+        for part in parts[:-1]:
+            current = current[part]
+        current[parts[-1]] = deepcopy(replacement)
+    return result
+
+
+def base_by_id() -> dict[str, dict]:
+    return {
+        item["id"]: item["judgment"]
+        for item in read(BASE_CORPUS)["validJudgments"]
+    }
+
+
+def forged_base(vector: dict) -> dict:
+    if "sourceJudgment" in vector:
+        source = base_by_id()[vector["sourceJudgment"]]
+    elif "judgment" in vector:
+        source = vector["judgment"]
+    else:
+        raise ValueError("forgery vector must provide sourceJudgment or judgment")
+
+    result = patch_dotted(source, vector.get("patch", {}))
+    if "replaceRelation" in vector:
+        result["relation"] = vector["replaceRelation"]
+    for key in vector.get("remove", []):
+        result.pop(key, None)
+    return result
+
+
+def test_contract_is_accepted_with_exact_six_relation_surface():
+    contract = read(CONTRACT)
+    conformance = read(CONFORMANCE)
+
+    assert contract["schema"] == "mts-proof/v0.4"
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert contract["proofObject"]["proofVersion"] == PROOF_SCHEMA_V04
+    assert contract["proofObject"]["contractVersion"] == CONTRACT_VERSION_V04
+    assert set(contract["trustedRelations"]) == BASE_RELATIONS | {"DefinitionOpeningPath"}
+    assert len(contract["trustedRelations"]) == 6
+    assert conformance["schema"] == "mts-proof-conformance/v0.4"
+    assert conformance["accepted"] is True
+    assert conformance["contract"] == contract["schema"]
+
+
+def test_conformance_selects_green_source_corpora_without_semantic_vector_copy():
+    conformance = read(CONFORMANCE)
+
+    assert conformance["sourceCorpus"] == (
+        "contracts/mts-proof-v0.4-conformance-candidate.json"
+    )
+    assert conformance["baseCorpus"] == "contracts/mts-proof-conformance-v0.3.json"
+    assert conformance["openingPathCorpus"] == (
+        "contracts/mts-opening-path-conformance-candidate-v0.4.json"
+    )
+    assert "validJudgments" not in conformance
+    assert "validPaths" not in conformance
+    assert "invalidPaths" not in conformance
+
+
+def test_every_v03_valid_base_judgment_replays_identically_when_lifted():
+    for vector in read(BASE_CORPUS)["validJudgments"]:
+        judgment = vector["judgment"]
+        assert check_proof_v03_data(v03_artifact([judgment])), vector["id"]
+        assert check_proof_v04_data(v04_artifact([judgment])), vector["id"]
+
+    base = read(CONTRACT)["baseRelations"]
+    assert base["shapesIdenticalToV03"] is True
+    assert base["trustedMeaningIdenticalToV03"] is True
+    assert base["reimplementedForV04"] is False
+
+
+def test_every_v03_base_forgery_remains_rejected_by_both_versioned_paths():
+    for vector in read(BASE_CORPUS)["forgeries"]:
+        forged = forged_base(vector)
+        assert vector["mustReject"] is True
+        assert not check_proof_v03_data(v03_artifact([forged])), vector["id"]
+        assert not check_proof_v04_data(v04_artifact([forged])), vector["id"]
+
+
+def test_every_existing_v03_invalid_artifact_remains_rejected_by_v03_api():
+    for vector in read(BASE_CORPUS)["invalidArtifacts"]:
+        assert not check_proof_v03_data(vector["artifact"]), vector["id"]
+
+    compatibility = read(CONTRACT)["v03Compatibility"]
+    assert compatibility["mtsProofV03Modified"] is False
+    assert compatibility["trustedRelationsRemainExactlyFive"] is True
+    assert compatibility["existingV03ArtifactsReplayByExistingApi"] is True
+    assert compatibility["retroactiveReinterpretation"] is False
+
+
+def test_every_opening_path_valid_vector_lifts_to_trusted_v04_relation():
+    for vector in read(OPENING_CORPUS)["validPaths"]:
+        artifact = v04_artifact([opening_judgment(vector)])
+        assert check_proof_v04_data(artifact), vector["id"]
+        typed = proof_v04_from_data(artifact)
+        assert len(typed.judgments) == 1
+        assert isinstance(typed.judgments[0], DefinitionOpeningPathJudgment)
+        assert check_proof_v04(typed), vector["id"]
+
+
+def test_every_opening_path_invalid_vector_rejects_when_lifted():
+    for vector in read(OPENING_CORPUS)["invalidPaths"]:
+        assert not check_proof_v04_data(v04_artifact([opening_judgment(vector)])), vector["id"]
+
+
+def test_every_v04_specific_transport_forgery_rejects():
+    for vector in read(CANDIDATE)["invalidArtifacts"]:
+        assert not check_proof_v04_data(vector["artifact"]), vector["id"]
+
+
+def test_mixed_base_and_opening_path_judgment_order_has_no_dependency_meaning():
+    mixed = read(CANDIDATE)["mixedArtifact"]
+    base = base_by_id()[mixed["baseJudgmentId"]]
+    opening_vector = next(
+        item
+        for item in read(OPENING_CORPUS)["validPaths"]
+        if item["id"] == mixed["openingPathId"]
+    )
+    opening = opening_judgment(opening_vector)
+
+    assert check_proof_v04_data(v04_artifact([base, opening]))
+    assert check_proof_v04_data(v04_artifact([opening, base]))
+    assert mixed["requiredBothOrdersAccepted"] is True
+    assert mixed["orderImpliesDependency"] is False
+
+    boundary = read(CONTRACT)["compositionBoundary"]
+    assert boundary["judgmentOrderImpliesDependency"] is False
+    assert boundary["genericCompositionAccepted"] is False
+    assert boundary["proofDagDependencyAccepted"] is False
+
+
+def test_v04_canonical_round_trip_is_deterministic_for_mixed_proof():
+    base = base_by_id()["opens-direct"]
+    opening_vector = next(
+        item for item in read(OPENING_CORPUS)["validPaths"] if item["id"] == "two-edge"
+    )
+    source = v04_artifact([base, opening_judgment(opening_vector)])
+
+    proof = proof_v04_from_data(source)
+    assert check_proof_v04(proof)
+    canonical_data = proof_v04_to_data(proof)
+    canonical_json = canonical_proof_v04_json(proof)
+
+    assert canonical_data["proofVersion"] == PROOF_SCHEMA_V04
+    assert canonical_data["contractVersion"] == CONTRACT_VERSION_V04
+    assert check_proof_v04_data(canonical_data)
+    assert json.loads(canonical_json) == canonical_data
+    assert canonical_proof_v04_json(proof_v04_from_data(canonical_data)) == canonical_json
+
+
+def test_target_transport_may_normalize_whitespace_on_serialization_without_changing_identity():
+    vector = next(
+        deepcopy(item)
+        for item in read(OPENING_CORPUS)["validPaths"]
+        if item["id"] == "structural-adjacency-whitespace"
+    )
+    artifact = v04_artifact([opening_judgment(vector)])
+
+    assert artifact["judgments"][0]["edges"][1]["target"] == "( b )"
+    proof = proof_v04_from_data(artifact)
+    canonical = proof_v04_to_data(proof)
+
+    assert canonical["judgments"][0]["edges"][1]["target"] == "(b)"
+    assert check_proof_v04_data(canonical)
+
+
+def test_noncanonical_expected_body_and_final_body_are_transport_errors():
+    vector = next(
+        deepcopy(item)
+        for item in read(OPENING_CORPUS)["validPaths"]
+        if item["id"] == "structural-adjacency-whitespace"
+    )
+    judgment = opening_judgment(vector)
+    judgment["edges"][0]["body"] = "( b )"
+    assert not check_proof_v04_data(v04_artifact([judgment]))
+
+    bundle = next(
+        deepcopy(item)
+        for item in read(OPENING_CORPUS)["validPaths"]
+        if item["id"] == "ends-in-constraint-bundle"
+    )
+    judgment = opening_judgment(bundle)
+    judgment["finalBody"] = "{ ◁ = x, ▷ = y }"
+    assert not check_proof_v04_data(v04_artifact([judgment]))
+
+
+def test_opening_path_relation_uses_no_equality_or_other_generic_rule():
+    boundary = read(CONTRACT)["compositionBoundary"]
+
+    assert boundary["DefinitionOpeningPathInternallyComposesOpeningEdges"] is True
+    assert boundary["openingPathFeedsContextuallySatisfiesImplicitly"] is False
+    assert boundary["openingPathImpliesEquality"] is False
+    assert boundary["openingPathImpliesEquivalence"] is False
+    assert boundary["openingPathImpliesNormalization"] is False
+    assert boundary["transitivityAccepted"] is False
+    assert boundary["symmetryAccepted"] is False
+    assert boundary["congruenceAccepted"] is False
+    assert boundary["modusPonensAccepted"] is False
+    assert boundary["globalSubstitutionAccepted"] is False
+
+
+def test_checker_and_effect_boundaries_remain_explicit():
+    checker = read(CONTRACT)["checker"]
+    effects = read(CONTRACT)["effectsBoundary"]
+
+    assert checker["module"] == "core/proof_checker.py"
+    assert checker["singleTrustedModuleForV02V03V04"] is True
+    assert checker["baseRelationsDelegateExistingV03Replay"] is True
+    assert checker["openingPathDelegatesCanonicalVerifier"] is True
+    assert checker["trustsSearchTrace"] is False
+    assert checker["mayAutoExtendOpeningPath"] is False
+    assert checker["mayReadAmbientInterpreterState"] is False
+    assert checker["mayInjectCanonicalRootDefinitions"] is False
+    assert checker["mayMaterialize"] is False
+    assert checker["mayDelete"] is False
+
+    assert effects["openingPathReadsMemory"] is False
+    assert effects["openingPathReadsContextFrame"] is False
+    assert effects["openingPathReadsInterpreterIdentity"] is False
+    assert effects["openingPathMaterializes"] is False
+    assert effects["openingPathDeletes"] is False
+
+
+def test_standalone_proof_release_waits_for_additive_v05_umbrella_before_aprover_repin():
+    versioning = read(CONTRACT)["versioning"]
+    downstream = read(CONTRACT)["downstream"]
+
+    assert versioning["mtsContractV04Modified"] is False
+    assert versioning["publishedThroughUmbrella"] is False
+    assert versioning["futureUmbrella"] == "mts-contract/v0.5"
+    assert downstream["directAproverRepinAllowedBeforeUmbrella"] is False
+    assert downstream["aproverMayInventAdditionalRules"] is False
+    assert "mts-proof/v0.4" not in MTS_V04.read_text(encoding="utf-8")
+
+
+def test_root_program_remains_exactly_ten_and_unchanged():
+    before = root_sources()
+    assert len(before) == 10
+    assert root_sources() == before
+
+
+def test_v03_contract_artifact_is_still_the_original_five_relation_release():
+    v03 = read(PROOF_V03)
+    assert v03["schema"] == "mts-proof/v0.3"
+    assert len(v03["trustedRelations"]) == 5
+    assert "DefinitionOpeningPath" not in v03["trustedRelations"]


### PR DESCRIPTION
Closes #165. Refs #122, #120. Depends on merged challenge #166 and accepted `mts-opening-path/v0.4`.

Publishes standalone trusted `mts-proof/v0.4` with exactly one new relation: `DefinitionOpeningPath`.

## Single trusted kernel

`core/proof_checker.py` remains the one trusted module for v0.2/v0.3/v0.4.

- v0.2/v0.3 APIs remain independent and unchanged;
- v0.4 first five relations delegate `check_v03_judgment`;
- `DefinitionOpeningPath` constructs typed `OpeningPathWitness` and delegates accepted `verify_opening_path`;
- no search trace or auto-extension is trusted.

## Strict transport

Proof version is `mts-proof/v0.4`, contract version `mts-contract/v0.4`.

Opening-path judgment is self-contained: scopes, lookupScope, startTarget, non-empty edges, finalBody. Targets are structural after parsing; expected bodies/final body require canonical `format_expression` transport. Unexpected fields/versions/relations reject.

## Composition boundary

The new judgment internally certifies multiple opening edges only. Top-level judgment ordering still has no premise/dependency semantics. No equality/equivalence/normalization/ContextuallySatisfies bridge, transitivity, symmetry, congruence, modus ponens, global substitution or generic proof DAG.

## Regression/conformance

Production tests consume the same green source corpora used by #166:
- every v0.3 valid base judgment replays through v0.3 and lifted v0.4;
- every v0.3 base forgery rejects through both paths;
- every v0.3 invalid artifact remains rejected by the existing v0.3 API;
- every opening-path valid vector lifts;
- every opening-path invalid vector rejects;
- all v0.4-specific transport forgeries reject;
- mixed base/opening order has no dependency meaning;
- canonical typed/data/JSON round-trip is deterministic.

## Versioning

Standalone proof release only. `mts-contract/v0.4` and `mts-proof/v0.3` remain immutable. Downstream aprover repin stays blocked until additive `mts-contract/v0.5` umbrella publishes the new surface.