### PR TITLE
Publish additive mts-contract/v0.5 umbrella

### DIFF
--- a/contracts/mts-conformance-v0.5.json
+++ b/contracts/mts-conformance-v0.5.json
@@ -1,0 +1,66 @@
+{
+  "schema": "mts-conformance/v0.5",
+  "status": "accepted",
+  "contract": "mts-contract/v0.5",
+  "composition": "all referenced accepted corpora are required; no prior vector is copied, weakened or replaced",
+  "requiredCorpora": [
+    {
+      "role": "base-v0.4",
+      "path": "contracts/mts-conformance-v0.4.json",
+      "schema": "mts-conformance/v0.4",
+      "contract": "mts-contract/v0.4"
+    },
+    {
+      "role": "opening-path-v0.4",
+      "path": "contracts/mts-opening-path-conformance-v0.4.json",
+      "schema": "mts-opening-path-conformance/v0.4",
+      "contract": "mts-opening-path/v0.4"
+    },
+    {
+      "role": "proof-v0.4",
+      "path": "contracts/mts-proof-conformance-v0.4.json",
+      "schema": "mts-proof-conformance/v0.4",
+      "contract": "mts-proof/v0.4"
+    },
+    {
+      "role": "direct-deixis-v0.5",
+      "path": "contracts/mts-direct-deixis-conformance-v0.5.json",
+      "schema": "mts-direct-deixis-conformance/v0.5",
+      "contract": "mts-direct-deixis/v0.5"
+    }
+  ],
+  "releaseAssertions": {
+    "allRequiredCorporaMustPass": true,
+    "mtsContractV04RemainsImmutable": true,
+    "mtsProofV04IsExactDependency": true,
+    "openingPathV04IsExactDependency": true,
+    "directDeixisV05IsExactDependency": true,
+    "rootProgramRemainsTenDefinitions": true,
+    "allSixProofRelationsReplay": true,
+    "definitionOpeningPathRemainsOperationalCertificate": true,
+    "proofSearchRemainsUntrusted": true,
+    "genericCompositionAccepted": false,
+    "judgmentOrderImpliesDependency": false,
+    "openingPathImpliesEquality": false,
+    "openingPathFeedsContextuallySatisfies": false,
+    "directDeixisImpliesContextSensitive": false,
+    "noDirectDeixisImpliesContextInvariant": false,
+    "interpreterIsALink": true,
+    "interpreterIdentityUsedAsHiddenInput": false,
+    "separateSubjectOntologyRequired": false,
+    "interpreterFocusBindingAccepted": false,
+    "relativeProductionRemainsRaw": true,
+    "persistentBackendAccepted": false,
+    "pmmCanonicalDependency": false
+  },
+  "downstreamAssertions": {
+    "aproverMayPinMtsContractV05": true,
+    "aproverMustPinMtsProofV04": true,
+    "aproverMustReplayAllSixRelationsIndependently": true,
+    "aproverMaySearchDefinitionOpeningPaths": true,
+    "aproverSearchRemainsUntrusted": true,
+    "aproverMustNotInventAdditionalComposition": true,
+    "aproverMustNotPromoteDirectDeixisToSensitivity": true,
+    "aproverMustNotUseHiddenInterpreterIdentity": true
+  }
+}

--- a/contracts/mts-contract-v0.5.json
+++ b/contracts/mts-contract-v0.5.json
@@ -1,0 +1,142 @@
+{
+  "schema": "mts-contract/v0.5",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 168,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-opening-path/v0.4",
+    "mts-proof/v0.4",
+    "mts-direct-deixis/v0.5"
+  ],
+  "extends": "mts-contract/v0.4",
+  "baseContract": "contracts/mts-contract-v0.4.json",
+  "conformanceCorpus": "contracts/mts-conformance-v0.5.json",
+  "releaseModel": "additive publication umbrella over immutable v0.4; publishes already accepted opening-path, proof-v0.4 and direct-deixis surfaces without semantic promotion",
+  "rootProgram": "tests/mtc_formulas.mtc",
+  "rootDefinitionCount": 10,
+  "preservedSurface": {
+    "allV04SemanticsUnchanged": true,
+    "definitionOpeningV03Unchanged": true,
+    "valueBundlesV02Unchanged": true,
+    "rootAndQuoteAnumV02Unchanged": true,
+    "relativeAnumProductionRaw": true,
+    "persistentL4Accepted": false,
+    "interpretMayRealize": false,
+    "openingPathMayRealize": false,
+    "globalRewrite": false,
+    "displayLabelIsIdentity": false
+  },
+  "l5": {
+    "proofContract": "contracts/mts-proof-v0.4.json",
+    "proofSchema": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "trustedCheckerModule": "core/proof_checker.py",
+    "trustedRelations": [
+      "ContextuallySatisfies",
+      "Opens",
+      "NoVisibleDefinition",
+      "DefinitionConflict",
+      "NonAddressableDefinitionTarget",
+      "DefinitionOpeningPath"
+    ],
+    "definitionOpeningPathContract": "contracts/mts-opening-path-v0.4.json",
+    "definitionOpeningPathClassification": "operational-composite-certificate",
+    "searchTrusted": false,
+    "checkerTrusted": true,
+    "genericCompositionAccepted": false,
+    "judgmentOrderImpliesDependency": false,
+    "openingPathImpliesEquality": false,
+    "openingPathImpliesEquivalence": false,
+    "openingPathImpliesNormalization": false,
+    "openingPathFeedsContextuallySatisfiesImplicitly": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "proofDagDependencyAccepted": false
+  },
+  "contextAnalysis": {
+    "directDeixisContract": "contracts/mts-direct-deixis-v0.5.json",
+    "operation": "analyze_direct_deixis",
+    "meaning": "reports explicit ContextPronoun occurrences in one typed L2 Expression",
+    "positiveImpliesContextSensitive": false,
+    "emptyImpliesContextInvariant": false,
+    "opensDefinitions": false,
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "readsSecurityPolicy": false,
+    "trustedProofRelationAdded": false
+  },
+  "interpreterBoundary": {
+    "interpreterIsALink": true,
+    "separateSubjectOntologyRequired": false,
+    "acceptedEvaluationContext": "explicit ContextFrame(start,end,parent?)",
+    "interpreterLinkIdentityIsHiddenEvalInput": false,
+    "currentFocusBindingSemanticsAccepted": false,
+    "currentFocusLinkRefObservable": false,
+    "contextMayBeVirtual": true,
+    "securityPolicyChangesPronounMeaning": false,
+    "researchIssue": 148
+  },
+  "versionBoundaries": {
+    "v02ModifiedInPlace": false,
+    "v03ModifiedInPlace": false,
+    "v04ModifiedInPlace": false,
+    "proofV03ModifiedInPlace": false,
+    "proofV04ModifiedToFitUmbrella": false,
+    "openingPathV04ModifiedToFitUmbrella": false,
+    "directDeixisV05ModifiedToFitUmbrella": false,
+    "compatibilitySemanticLayerAllowed": false
+  },
+  "excludedFromThisRelease": [
+    "generic proof DAG or top-level judgment dependency semantics",
+    "opening-path to equality/equivalence/normalization/contextual-satisfaction bridge",
+    "unrestricted equality transitivity, symmetry or congruence",
+    "modus ponens or global substitution",
+    "universal ContextInvariant theorem",
+    "indirect definition dependency as current interpret semantics",
+    "interpreter-focus identity/lifecycle semantics",
+    "observable current-focus LinkRef primitive",
+    "relative Anum candidate semantics",
+    "persistent L4 backend acceptance",
+    "PMM as canonical dependency",
+    "implicit realization"
+  ],
+  "downstream": {
+    "genericConsumerMayPinV05": true,
+    "aproverProofRepinAllowed": true,
+    "requiredProofSchema": "mts-proof/v0.4",
+    "requiredProofContractVersion": "mts-contract/v0.4",
+    "consumerMustReplayIndependently": true,
+    "consumerMaySearchDefinitionOpeningPaths": true,
+    "consumerSearchTrusted": false,
+    "consumerMayInventAdditionalCompositionRules": false,
+    "consumerMayInferContextSensitivityFromDirectDeixis": false,
+    "consumerMayUseHiddenInterpreterIdentity": false
+  },
+  "nextGates": {
+    "proofComposition": {
+      "issue": 122,
+      "status": "DefinitionOpeningPath accepted; broader calculus remains open"
+    },
+    "interpreterFocus": {
+      "issue": 148,
+      "status": "research; explicit ContextFrame remains accepted boundary"
+    },
+    "contextInvariance": {
+      "issue": 156,
+      "status": "direct deixis accepted; universal/indirect claims remain deferred"
+    },
+    "relativeAnum": {
+      "issue": 123,
+      "status": "candidate research only"
+    },
+    "persistentL4": {
+      "issue": 124,
+      "status": "persistent backend conformance required"
+    }
+  }
+}

--- a/tests/test_mts_contract_v05.py
+++ b/tests/test_mts_contract_v05.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+from core.validate_root import validate_root_library
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts/mts-contract-v0.5.json"
+CONFORMANCE = ROOT / "contracts/mts-conformance-v0.5.json"
+ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_v05_release_composes_only_accepted_surfaces():
+    contract = _load(CONTRACT)
+    conformance = _load(CONFORMANCE)
+
+    assert contract["schema"] == "mts-contract/v0.5"
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert contract["extends"] == "mts-contract/v0.4"
+    assert contract["baseContract"] == "contracts/mts-contract-v0.4.json"
+    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.5.json"
+    assert contract["dependsOn"] == [
+        "mts-contract/v0.4",
+        "mts-opening-path/v0.4",
+        "mts-proof/v0.4",
+        "mts-direct-deixis/v0.5",
+    ]
+
+    required = {item["role"]: item for item in conformance["requiredCorpora"]}
+    assert set(required) == {
+        "base-v0.4",
+        "opening-path-v0.4",
+        "proof-v0.4",
+        "direct-deixis-v0.5",
+    }
+    assert required["base-v0.4"]["schema"] == "mts-conformance/v0.4"
+    assert required["opening-path-v0.4"]["schema"] == "mts-opening-path-conformance/v0.4"
+    assert required["proof-v0.4"]["schema"] == "mts-proof-conformance/v0.4"
+    assert required["direct-deixis-v0.5"]["schema"] == "mts-direct-deixis-conformance/v0.5"
+
+
+def test_v05_publishes_exact_proof_surface_without_generic_composition():
+    contract = _load(CONTRACT)
+    l5 = contract["l5"]
+
+    assert l5["proofSchema"] == "mts-proof/v0.4"
+    assert l5["contractVersion"] == "mts-contract/v0.4"
+    assert l5["trustedRelations"] == [
+        "ContextuallySatisfies",
+        "Opens",
+        "NoVisibleDefinition",
+        "DefinitionConflict",
+        "NonAddressableDefinitionTarget",
+        "DefinitionOpeningPath",
+    ]
+    assert l5["definitionOpeningPathClassification"] == "operational-composite-certificate"
+    assert l5["genericCompositionAccepted"] is False
+    assert l5["judgmentOrderImpliesDependency"] is False
+    assert l5["openingPathImpliesEquality"] is False
+    assert l5["openingPathFeedsContextuallySatisfiesImplicitly"] is False
+    assert l5["transitivityAccepted"] is False
+    assert l5["proofDagDependencyAccepted"] is False
+
+
+def test_v05_keeps_direct_deixis_structural_only():
+    analysis = _load(CONTRACT)["contextAnalysis"]
+
+    assert analysis["operation"] == "analyze_direct_deixis"
+    assert analysis["positiveImpliesContextSensitive"] is False
+    assert analysis["emptyImpliesContextInvariant"] is False
+    assert analysis["opensDefinitions"] is False
+    assert analysis["readsMemory"] is False
+    assert analysis["readsContextFrame"] is False
+    assert analysis["readsInterpreterIdentity"] is False
+    assert analysis["trustedProofRelationAdded"] is False
+
+
+def test_v05_models_interpreter_as_link_without_hidden_identity():
+    boundary = _load(CONTRACT)["interpreterBoundary"]
+
+    assert boundary["interpreterIsALink"] is True
+    assert boundary["separateSubjectOntologyRequired"] is False
+    assert boundary["acceptedEvaluationContext"] == "explicit ContextFrame(start,end,parent?)"
+    assert boundary["interpreterLinkIdentityIsHiddenEvalInput"] is False
+    assert boundary["currentFocusBindingSemanticsAccepted"] is False
+    assert boundary["currentFocusLinkRefObservable"] is False
+    assert boundary["contextMayBeVirtual"] is True
+    assert boundary["securityPolicyChangesPronounMeaning"] is False
+
+
+def test_v05_downstream_boundary_allows_search_but_not_new_rules():
+    downstream = _load(CONTRACT)["downstream"]
+
+    assert downstream["aproverProofRepinAllowed"] is True
+    assert downstream["requiredProofSchema"] == "mts-proof/v0.4"
+    assert downstream["consumerMaySearchDefinitionOpeningPaths"] is True
+    assert downstream["consumerSearchTrusted"] is False
+    assert downstream["consumerMayInventAdditionalCompositionRules"] is False
+    assert downstream["consumerMayInferContextSensitivityFromDirectDeixis"] is False
+    assert downstream["consumerMayUseHiddenInterpreterIdentity"] is False
+
+
+def test_v05_preserves_root_program():
+    contract = _load(CONTRACT)
+    result = validate_root_library(ROOT_FIXTURE)
+
+    assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
+    assert contract["rootDefinitionCount"] == 10
+    assert result.is_valid, result.messages
+    formulas = [
+        line
+        for line in ROOT_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert len(formulas) == 10

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -17,6 +17,8 @@ MTS_CONTRACT_V03 = ROOT / "contracts/mts-contract-v0.3.json"
 MTS_CONFORMANCE_V03 = ROOT / "contracts/mts-conformance-v0.3.json"
 MTS_CONTRACT_V04 = ROOT / "contracts/mts-contract-v0.4.json"
 MTS_CONFORMANCE_V04 = ROOT / "contracts/mts-conformance-v0.4.json"
+MTS_CONTRACT_V05 = ROOT / "contracts/mts-contract-v0.5.json"
+MTS_CONFORMANCE_V05 = ROOT / "contracts/mts-conformance-v0.5.json"
 ACTIVE_THEORY = {"Основания МТС.md", "Система аксиом МТС.md", "Пучки связей МТС.md"}
 ACTIVE_SPECS = {
     "Reference model МТС v0.2.md",
@@ -103,6 +105,8 @@ def test_versioned_machine_contract_and_conformance_chain_is_exact():
         MTS_CONFORMANCE_V03,
         MTS_CONTRACT_V04,
         MTS_CONFORMANCE_V04,
+        MTS_CONTRACT_V05,
+        MTS_CONFORMANCE_V05,
     ):
         assert path.is_file()
 
@@ -112,6 +116,8 @@ def test_versioned_machine_contract_and_conformance_chain_is_exact():
     v03_corpus = json.loads(MTS_CONFORMANCE_V03.read_text(encoding="utf-8"))
     v04 = json.loads(MTS_CONTRACT_V04.read_text(encoding="utf-8"))
     v04_corpus = json.loads(MTS_CONFORMANCE_V04.read_text(encoding="utf-8"))
+    v05 = json.loads(MTS_CONTRACT_V05.read_text(encoding="utf-8"))
+    v05_corpus = json.loads(MTS_CONFORMANCE_V05.read_text(encoding="utf-8"))
 
     assert v02["schema"] == "mts-contract/v0.2"
     assert v02["status"] == "accepted"
@@ -151,13 +157,47 @@ def test_versioned_machine_contract_and_conformance_chain_is_exact():
     assert required_v04["proof-v0.3"]["schema"] == "mts-proof-conformance/v0.3"
     assert required_v04["proof-v0.3"]["contract"] == "mts-proof/v0.3"
 
+    assert v05["schema"] == "mts-contract/v0.5"
+    assert v05["status"] == "accepted"
+    assert v05["extends"] == v04["schema"]
+    assert v05["baseContract"] == "contracts/mts-contract-v0.4.json"
+    assert v05["rootProgram"] == v04["rootProgram"]
+    assert v05["conformanceCorpus"] == "contracts/mts-conformance-v0.5.json"
+    assert v05["dependsOn"] == [
+        v04["schema"],
+        "mts-opening-path/v0.4",
+        "mts-proof/v0.4",
+        "mts-direct-deixis/v0.5",
+    ]
+    assert v05_corpus["schema"] == "mts-conformance/v0.5"
+    assert v05_corpus["contract"] == v05["schema"]
+    assert v05_corpus["status"] == "accepted"
+    required_v05 = {item["role"]: item for item in v05_corpus["requiredCorpora"]}
+    assert set(required_v05) == {
+        "base-v0.4",
+        "opening-path-v0.4",
+        "proof-v0.4",
+        "direct-deixis-v0.5",
+    }
+    assert required_v05["base-v0.4"]["schema"] == v04_corpus["schema"]
+    assert required_v05["base-v0.4"]["contract"] == v04_corpus["contract"]
+    assert required_v05["opening-path-v0.4"]["contract"] == "mts-opening-path/v0.4"
+    assert required_v05["proof-v0.4"]["contract"] == "mts-proof/v0.4"
+    assert required_v05["direct-deixis-v0.5"]["contract"] == "mts-direct-deixis/v0.5"
+
     contract_files = sorted((ROOT / "contracts").glob("mts-contract-*.json"))
     conformance_files = sorted((ROOT / "contracts").glob("mts-conformance-*.json"))
-    assert contract_files == [MTS_CONTRACT_V02, MTS_CONTRACT_V03, MTS_CONTRACT_V04]
+    assert contract_files == [
+        MTS_CONTRACT_V02,
+        MTS_CONTRACT_V03,
+        MTS_CONTRACT_V04,
+        MTS_CONTRACT_V05,
+    ]
     assert conformance_files == [
         MTS_CONFORMANCE_V02,
         MTS_CONFORMANCE_V03,
         MTS_CONFORMANCE_V04,
+        MTS_CONFORMANCE_V05,
     ]
 
 


### PR DESCRIPTION
Closes #168. Refs #120, #122, #148, #156.

Publishes an additive `mts-contract/v0.5` umbrella over immutable v0.4, composing only already accepted standalone surfaces:

- `mts-opening-path/v0.4`;
- `mts-proof/v0.4`;
- `mts-direct-deixis/v0.5`.

## L5

Requires `mts-proof/v0.4` and exactly six trusted relations. `DefinitionOpeningPath` remains an operational composite certificate only; top-level judgment order has no dependency semantics and there is no equality/equivalence/normalization/ContextuallySatisfies bridge or generic proof DAG.

## Context / interpreter

The interpreter is a link. No separate `subject` ontology is introduced. Current evaluation/replay boundary remains explicit `ContextFrame(start,end,parent?)`; interpreter identity is not a hidden semantic input. `mts-direct-deixis/v0.5` is published as structural analysis only: direct presence does not imply ContextSensitive and empty result does not imply ContextInvariant.

Unresolved interpreter-focus identity/lifecycle from #148 is explicitly excluded.

## Conformance

`mts-conformance/v0.5` composes, without copying vectors:

- `mts-conformance/v0.4`;
- `mts-opening-path-conformance/v0.4`;
- `mts-proof-conformance/v0.4`;
- `mts-direct-deixis-conformance/v0.5`.

Dedicated release tests verify semantic non-promotion, downstream boundaries and unchanged ten-root program. Repository contract guard is extended through the exact v0.2→v0.3→v0.4→v0.5 chain.

## Downstream

After merge, aprover may exact-pin `mts-contract/v0.5` + `mts-proof/v0.4` and implement untrusted `DefinitionOpeningPath` search with independent replay. It may not invent any additional composition rule.

Merge only after full CI green and `behind_by=0`.