### PR TITLE
Challenge current-link deixis and projection foundation

### DIFF
--- a/contracts/mts-current-link-foundation-challenge-v0.6.json
+++ b/contracts/mts-current-link-foundation-challenge-v0.6.json
@@ -1,0 +1,125 @@
+{
+  "schema": "mts-current-link-foundation-challenge/v0.6",
+  "status": "candidate-challenge",
+  "accepted": false,
+  "issue": 171,
+  "trigger": "issue #148 observation: ◁ ?= ♀↑ and ▷ ?= ↑♂",
+  "dependsOnHistoricalSnapshots": [
+    "mts-contract/v0.5",
+    "mts-direct-deixis/v0.5"
+  ],
+  "purpose": "Challenge whether the current ContextFrame + two atomic pole pronouns + parent-ascent model is a minimal/fundamental L2 basis once L0 all-is-link is applied to the interpretation context itself.",
+  "currentSnapshot": {
+    "contextCarrier": "ContextFrame(start,end,parent?)",
+    "astPrimitive": "ContextPronoun(up,pole)",
+    "currentStart": "◁",
+    "currentEnd": "▷",
+    "parentAccess": "↑◁ / ↑▷ / repeated ↑",
+    "standaloneUpIsForm": false,
+    "contextMayBeVirtual": true,
+    "productionParserChangeAllowedByThisChallenge": false,
+    "productionInterpreterChangeAllowedByThisChallenge": false
+  },
+  "foundationObservation": {
+    "l0": "everything is a link",
+    "candidateCurrentAnchor": "↑ denotes the current relation/focus itself",
+    "candidateDerivedStart": "♀↑",
+    "candidateDerivedEnd": "↑♂",
+    "claimAccepted": false,
+    "reason": "the claim is not valid under the current operational projection implementation without first deciding what ♀/♂ mean relative to direct link poles"
+  },
+  "criticalDistinction": {
+    "directPole": {
+      "operation": "MemoryView.poles(F)",
+      "meaningUnderTest": "the structural start/end links of F"
+    },
+    "projectionForm": {
+      "startOperation": "MemoryView.find_start_projection(F)",
+      "endOperation": "MemoryView.find_end_projection(F)",
+      "meaningUnderCurrentInterpreter": "a separately distinguished projection-form link associated with F"
+    },
+    "mustNotConflate": true,
+    "theoryRuntimeAlignmentRequired": true
+  },
+  "candidateModels": [
+    {
+      "id": "A-context-frame-three-glyph",
+      "description": "Historical accepted computational snapshot: ContextFrame(start,end,parent?) with atomic ◁/▷ and ↑ ascent.",
+      "accepted": false,
+      "challengeStatus": "historical-baseline",
+      "foundationalMinimalityProven": false
+    },
+    {
+      "id": "B-current-link-plus-direct-poles",
+      "description": "One deictic Form ↑ denotes current relation X; ordinary pole operations derive X.start and X.end.",
+      "accepted": false,
+      "challengeStatus": "preferred-research-candidate",
+      "requires": [
+        "standalone ↑ becomes a Form",
+        "exact semantics of ♀/♂ as direct pole access or an equivalent derivation",
+        "parent/nesting derived from link-only act structure instead of hidden host field"
+      ]
+    },
+    {
+      "id": "C-current-link-plus-current-projection-form-runtime",
+      "description": "One deictic Form ↑ denotes current relation X while existing find_start_projection/find_end_projection semantics are used unchanged.",
+      "accepted": false,
+      "challengeStatus": "counterexample-required",
+      "expectedProblem": "for finite graphs projection-form refs can differ from X.start/X.end, so old ◁/▷ are not automatically equal to ♀↑/↑♂"
+    },
+    {
+      "id": "D-full-act-link-network",
+      "description": "Current anchor is a position in a finite self-contained link-only interpretation-act network; other observations are ordinary structural traversals/projections.",
+      "accepted": false,
+      "challengeStatus": "next-gate",
+      "requires": "finite link-only reconstruction of interpreter, command/form, current focus, available environment/memory, result/next state and nesting/continuation"
+    }
+  ],
+  "executableQuestions": [
+    "Does production parser reject standalone ↑ while accepting ◁, ▷, ↑◁ and ↑▷?",
+    "For a finite focus X=(A,B), do current ◁/▷ resolve exactly to A/B?",
+    "Can find_start_projection(X) and find_end_projection(X) be different from A/B?",
+    "Does that counterexample invalidate a silent equation ◁=♀↑ and ▷=↑♂ under current runtime semantics?",
+    "Can a test-local virtual current-link value reproduce current-pole access with one anchor and direct structural poles without L4 mutation?"
+  ],
+  "rootBoundary": {
+    "historicalRootDefinitionCount": 10,
+    "historicalFixtureImmutable": true,
+    "historicalFixtureIsFundamentalVeto": false,
+    "candidateRewriteMayBeStudied": true,
+    "candidateAroot": "∞ : {♀↑ = ∞, ↑♂ = ∞}",
+    "candidateArootAccepted": false,
+    "equalityRootRewriteDeferred": true,
+    "reason": "operator precedence and the exact semantics of nested pole projections must be decided first"
+  },
+  "parentBoundary": {
+    "currentParentFieldAcceptedAsFundamental": false,
+    "oldAscentSyntaxAutomaticallyPreserved": false,
+    "reason": "if ↑ becomes current-link deixis, host-side parent ascent collides with its new role and must be reconstructed from the link-only interpretation act"
+  },
+  "fullActGate": {
+    "researchMetanotationOnly": "Act(I,F,X,M,R,...)",
+    "nAryActIsOntology": false,
+    "requiredOutcome": "finite network containing only links, from which the minimal deictic anchors are derived rather than postulated",
+    "mustAnswer": [
+      "whether current focus alone is a sufficient anchor",
+      "whether interpreter-link must ever be directly observable",
+      "whether current-act reference is required",
+      "how nesting/continuation/parent is represented as links",
+      "which context glyphs are primitive, derived, or display sugar"
+    ]
+  },
+  "effectsVeto": {
+    "readsMayInspectFiniteMemory": true,
+    "materializes": false,
+    "deletes": false,
+    "mutatesHistoricalContracts": false,
+    "mutatesRootFixture": false
+  },
+  "releaseVeto": {
+    "acceptedContractLinkAllowed": false,
+    "productionSemanticPromotionAllowed": false,
+    "aproverSemanticRepinAllowedFromThisChallenge": false,
+    "nextGate": "finite link-only interpretation-act model and decision on direct pole vs projection-form semantics"
+  }
+}

--- a/tests/test_mts_current_link_foundation_challenge.py
+++ b/tests/test_mts_current_link_foundation_challenge.py
@@ -1,0 +1,220 @@
+"""Executable non-normative challenge for the foundation reset in issue #171.
+
+This file intentionally does not change production parsing or interpretation.
+It exposes the distinction between:
+
+* the two roles currently supplied by ``ContextFrame``;
+* the structural poles of a concrete focus link; and
+* the separate projection-form links used by the current ``♀`` / ``♂`` runtime.
+
+The challenge therefore prevents us from silently treating ``◁ == ♀↑`` and
+``▷ == ↑♂`` as already true under the v0.5 implementation.
+"""
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+import pytest
+
+from core.mtc_ast import ContextPole, ContextPronoun
+from core.mtc_interpreter import ContextFrame, MemoryView, resolve_context_pronoun
+from core.mtc_parser import MTCParseError, parse_formula
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHALLENGE = ROOT / "contracts/mts-current-link-foundation-challenge-v0.6.json"
+MTS_CONTRACT_V05 = ROOT / "contracts/mts-contract-v0.5.json"
+ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
+
+
+@dataclass
+class FiniteProjectionMemory(MemoryView):
+    """Finite read-only graph in which direct poles and projection forms differ."""
+
+    links: dict[int, tuple[int, int]]
+    reads: int = 0
+
+    def poles(self, link: int) -> tuple[int, int]:
+        self.reads += 1
+        return self.links[link]
+
+    def find_link(self, start: int, end: int) -> int | None:
+        self.reads += 1
+        for link, poles in self.links.items():
+            if poles == (start, end):
+                return link
+        return None
+
+    def find_start_projection(self, form: int) -> int | None:
+        self.reads += 1
+        for link, poles in self.links.items():
+            if poles == (link, form):
+                return link
+        return None
+
+    def find_end_projection(self, form: int) -> int | None:
+        self.reads += 1
+        for link, poles in self.links.items():
+            if poles == (form, link):
+                return link
+        return None
+
+
+@dataclass(frozen=True)
+class CandidateCurrentLink:
+    """Test-local storage-neutral semantic link value for candidate B."""
+
+    start: int
+    end: int
+
+
+def challenge_contract() -> dict:
+    return json.loads(CHALLENGE.read_text(encoding="utf-8"))
+
+
+def current_root_formulas() -> list[str]:
+    return [
+        line.strip()
+        for line in ROOT_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def projection_counterexample_memory() -> FiniteProjectionMemory:
+    # X=10 has direct structural poles A=1 and B=2.
+    # 110 and 210 are distinct projection-form links for X under the existing
+    # MemoryView protocol: (110, X) and (X, 210).
+    return FiniteProjectionMemory(
+        {
+            1: (1, 1),
+            2: (2, 2),
+            10: (1, 2),
+            110: (110, 10),
+            210: (10, 210),
+        }
+    )
+
+
+def test_challenge_is_non_normative_and_not_published_through_v05():
+    contract = challenge_contract()
+    assert contract["schema"] == "mts-current-link-foundation-challenge/v0.6"
+    assert contract["status"] == "candidate-challenge"
+    assert contract["accepted"] is False
+    assert contract["releaseVeto"]["acceptedContractLinkAllowed"] is False
+    assert contract["releaseVeto"]["productionSemanticPromotionAllowed"] is False
+
+    accepted = json.loads(MTS_CONTRACT_V05.read_text(encoding="utf-8"))
+    assert contract["schema"] not in accepted.get("dependsOn", [])
+    assert contract["schema"] not in MTS_CONTRACT_V05.read_text(encoding="utf-8")
+
+
+def test_current_parser_exposes_two_pole_pronouns_but_not_standalone_current_link():
+    start = parse_formula("◁")
+    end = parse_formula("▷")
+    parent_start = parse_formula("↑◁")
+
+    assert isinstance(start, ContextPronoun)
+    assert start.up == 0 and start.pole is ContextPole.START
+    assert isinstance(end, ContextPronoun)
+    assert end.up == 0 and end.pole is ContextPole.END
+    assert isinstance(parent_start, ContextPronoun)
+    assert parent_start.up == 1 and parent_start.pole is ContextPole.START
+
+    with pytest.raises(MTCParseError, match="После `↑` ожидается"):
+        parse_formula("↑")
+
+
+def test_old_pronouns_equal_direct_focus_poles_when_frame_is_projection_of_focus():
+    memory = projection_counterexample_memory()
+    focus = 10
+    direct_start, direct_end = memory.poles(focus)
+    frame = ContextFrame(start=direct_start, end=direct_end)
+
+    old_start = resolve_context_pronoun(parse_formula("◁"), frame)
+    old_end = resolve_context_pronoun(parse_formula("▷"), frame)
+
+    assert old_start == direct_start == 1
+    assert old_end == direct_end == 2
+
+
+def test_current_projection_form_runtime_is_not_direct_pole_access():
+    memory = projection_counterexample_memory()
+    focus = 10
+    direct_start, direct_end = memory.poles(focus)
+
+    projection_start = memory.find_start_projection(focus)
+    projection_end = memory.find_end_projection(focus)
+
+    assert (direct_start, direct_end) == (1, 2)
+    assert (projection_start, projection_end) == (110, 210)
+    assert projection_start != direct_start
+    assert projection_end != direct_end
+
+
+def test_naive_current_link_equation_is_not_valid_under_existing_projection_runtime():
+    memory = projection_counterexample_memory()
+    focus = 10
+    direct_start, direct_end = memory.poles(focus)
+    frame = ContextFrame(start=direct_start, end=direct_end)
+
+    old_start = resolve_context_pronoun(parse_formula("◁"), frame)
+    old_end = resolve_context_pronoun(parse_formula("▷"), frame)
+
+    # If candidate ↑ simply denoted focus=10 while current ♀/♂ implementation
+    # stayed unchanged, ♀↑/↑♂ would resolve through projection-form links.
+    naive_female_up = memory.find_start_projection(focus)
+    naive_up_male = memory.find_end_projection(focus)
+
+    assert old_start == 1
+    assert old_end == 2
+    assert naive_female_up == 110
+    assert naive_up_male == 210
+    assert old_start != naive_female_up
+    assert old_end != naive_up_male
+
+
+def test_one_current_link_anchor_is_sufficient_for_direct_pole_access_candidate():
+    current = CandidateCurrentLink(start=1, end=2)
+
+    # Candidate B deliberately models pole access structurally, without L4
+    # materialization and without introducing separate start/end pronouns.
+    candidate_female_up = current.start
+    candidate_up_male = current.end
+
+    frame = ContextFrame(start=current.start, end=current.end)
+    old_start = resolve_context_pronoun(parse_formula("◁"), frame)
+    old_end = resolve_context_pronoun(parse_formula("▷"), frame)
+
+    assert candidate_female_up == old_start == 1
+    assert candidate_up_male == old_end == 2
+
+
+def test_historical_roots_are_preserved_but_no_longer_a_foundation_veto():
+    contract = challenge_contract()
+    formulas = current_root_formulas()
+
+    assert len(formulas) == contract["rootBoundary"]["historicalRootDefinitionCount"] == 10
+    assert "∞ : {◁ = ∞, ▷ = ∞}" in formulas
+    assert contract["rootBoundary"]["historicalFixtureImmutable"] is True
+    assert contract["rootBoundary"]["historicalFixtureIsFundamentalVeto"] is False
+    assert contract["rootBoundary"]["candidateAroot"] == "∞ : {♀↑ = ∞, ↑♂ = ∞}"
+    assert contract["rootBoundary"]["candidateArootAccepted"] is False
+
+
+def test_all_candidate_models_remain_unaccepted_until_full_act_gate():
+    contract = challenge_contract()
+    models = {item["id"]: item for item in contract["candidateModels"]}
+
+    assert set(models) == {
+        "A-context-frame-three-glyph",
+        "B-current-link-plus-direct-poles",
+        "C-current-link-plus-current-projection-form-runtime",
+        "D-full-act-link-network",
+    }
+    assert all(item["accepted"] is False for item in models.values())
+    assert models["B-current-link-plus-direct-poles"]["challengeStatus"] == (
+        "preferred-research-candidate"
+    )
+    assert models["D-full-act-link-network"]["challengeStatus"] == "next-gate"
+    assert contract["fullActGate"]["nAryActIsOntology"] is False


### PR DESCRIPTION
Refs #171, #148, #156, #120.

This is a **non-normative foundation challenge**. It does not change production parser/interpreter/root semantics.

The challenge was triggered by the observation:

```text
◁ ?= ♀↑
▷ ?= ↑♂
```

and tests why that cannot be silently accepted under the current v0.5 runtime.

## What it establishes

Current production has three distinct notions that were easy to conflate:

1. `ContextFrame.start/end` used by atomic `◁/▷`;
2. structural poles returned by `MemoryView.poles(F)`;
3. projection-form links returned by `find_start_projection(F)` / `find_end_projection(F)` and used by current `♀/♂` interpretation.

A finite graph counterexample has a focus `X=(A,B)` where:

```text
old ◁ = A
old ▷ = B

find_start_projection(X) != A
find_end_projection(X) != B
```

Therefore `↑ -> X` plus the existing projection-form runtime does **not** automatically prove `◁=♀↑` / `▷=↑♂`.

## Preferred research candidate

The challenge keeps unaccepted but makes explicit:

```text
↑ = one deictic Form denoting current relation X
♀↑ = direct structural start of X
↑♂ = direct structural end of X
```

This candidate can reproduce current-pole access in a test-local storage-neutral model, but only if we decide what `♀/♂` fundamentally mean.

## Foundation reset consequences

- standalone `↑` is currently rejected by the production parser; current `↑` is only ascent before `◁/▷`;
- current `ContextFrame(start,end,parent?)` remains an historical computational snapshot, not assumed minimal foundation;
- `parent`/nesting must be reconstructed from a finite link-only interpretation-act model if `↑` becomes current-link deixis;
- the 10 v0.2 roots remain immutable historical artifacts, but no longer veto a new root candidate;
- no accepted contract is linked or changed;
- no aprover semantic repin is allowed from this PR.

Next gate after this PR: construct a finite link-only model of the complete interpretation act (`interpreter / form / current focus / environment-memory / result-next-state / nesting`) and derive the minimal deictic anchors from that graph rather than postulating them.