### PR TITLE
Challenge link-only interpretation act topology

### DIFF
--- a/contracts/mts-interpretation-act-network-challenge-v0.6.json
+++ b/contracts/mts-interpretation-act-network-challenge-v0.6.json
@@ -1,0 +1,114 @@
+{
+  "schema": "mts-interpretation-act-network-challenge/v0.6",
+  "status": "candidate-challenge",
+  "accepted": false,
+  "issue": 173,
+  "dependsOn": [
+    "mts-current-link-foundation-challenge/v0.6"
+  ],
+  "purpose": "Compare finite binary-link-only topologies for representing an interpretation act before choosing a revised L2 deictic basis.",
+  "principles": {
+    "allOntologyNodesAreBinaryLinks": true,
+    "formalNotationIsInterpreterCommandSurface": true,
+    "commandAndActualActMustRemainDistinct": true,
+    "hostDataclassFieldsAreNotSemanticJustification": true,
+    "linkRefIsRepresentationIdentityOnly": true,
+    "productionSemanticsChangeAllowed": false
+  },
+  "researchDistinction": {
+    "possibleTransition": "command/rule structure describing an admissible transformation",
+    "actualAct": "a specifically represented transition between before and after link-network states",
+    "representationOfActualActExplainsPhysicalActuality": false
+  },
+  "candidateTopologies": [
+    {
+      "id": "A-positional-spine",
+      "accepted": false,
+      "status": "likely-reject",
+      "shape": "((((I,F),X),M),R)",
+      "strength": "finite and binary-only",
+      "failure": "semantic roles are known only through an external positional schema"
+    },
+    {
+      "id": "B-role-labelled-association-network",
+      "accepted": false,
+      "status": "challenge",
+      "shape": "role links + role/value assertion links + act/state attachment links",
+      "strength": "roles can be made structurally explicit",
+      "failure": "role-link meanings themselves still require internal definitions; labels cannot be magic host constants"
+    },
+    {
+      "id": "C-state-transition",
+      "accepted": false,
+      "status": "preferred-outer-shape-candidate",
+      "shape": "A = S_before -> S_after",
+      "strengths": [
+        "actual act has a natural binary outer form",
+        "command and act are distinct",
+        "result/next state is not a hidden return value",
+        "execution history can be represented as links between transitions/states"
+      ],
+      "unresolved": "the internal state role schema still must be made self-describing"
+    },
+    {
+      "id": "D-interpreter-focus-binding-only",
+      "accepted": false,
+      "status": "insufficient-as-full-act",
+      "shape": "I -> X",
+      "strength": "can explain a local focus binding",
+      "failure": "does not represent command, result, before/after transition or continuation"
+    }
+  ],
+  "deicticBoundaryHypothesis": {
+    "localAnchor": "↑ -> current focus X",
+    "accepted": false,
+    "reasonToPreferMinimality": "local formulas normally need the currently distinguished relation, not arbitrary act/interpreter introspection",
+    "focusOnlyMustNotImplyActIntrospection": true,
+    "additionalAnchorRequiresCounterexample": true
+  },
+  "reachabilityQuestions": [
+    "What is reachable by ordered pole traversal from focus X alone?",
+    "What is reachable from current act A?",
+    "Can incoming-link search from X identify a unique current act without role constraints?",
+    "Does exposing A to every formula reveal strictly more than local focus semantics requires?"
+  ],
+  "expectedChallengeFindings": {
+    "positionalSpineRolesNotIntrinsic": true,
+    "stateTransitionSeparatesCommandFromAct": true,
+    "focusForwardClosureMayBeStrictlyLocal": true,
+    "incomingLinksMayBeAmbiguous": true,
+    "currentActAnchorHasBroaderReachabilityThanFocusAnchor": true,
+    "thereforeFullActOntologyDoesNotImplyFullActObservability": true
+  },
+  "parentAndNesting": {
+    "hostParentFieldFundamental": false,
+    "candidate": "continuation/nesting/history is represented by ordinary links among act/state links",
+    "oldAscentSyntaxPreservedAutomatically": false,
+    "newParentPronounAccepted": false
+  },
+  "projectionAxis": {
+    "directStructuralPole": "raw start/end of a link in the finite carrier",
+    "semanticProjectionForm": "separately distinguished link representing ♀F/F♂ under current v0.5 runtime",
+    "actChallengeChoosesBetweenThem": false,
+    "reason": "outer act topology and pole-vs-projection semantics are orthogonal decisions that must not be collapsed"
+  },
+  "effectsVeto": {
+    "usesProductionL4": false,
+    "materializes": false,
+    "deletes": false,
+    "mutatesHistoricalContracts": false,
+    "mutatesRootFixture": false
+  },
+  "nextGate": {
+    "mustDecide": [
+      "preferred outer act topology",
+      "how semantic roles inside interpreter state become internally distinguishable",
+      "whether ↑ anchors focus X, current act A, or another structurally justified position",
+      "whether any second deictic anchor is required by a finite counterexample",
+      "how nesting/continuation replaces host parent",
+      "separately, how ♀/♂ relate to direct poles and projection forms"
+    ],
+    "productionChangeBeforeDecision": false,
+    "acceptedContractLinkAllowed": false
+  }
+}

--- a/tests/test_mts_interpretation_act_network_challenge.py
+++ b/tests/test_mts_interpretation_act_network_challenge.py
@@ -1,0 +1,255 @@
+"""Non-normative executable challenge for issue #173.
+
+The model intentionally contains only finite binary links. Human role names are
+kept outside the carrier so tests can expose when a topology depends on an
+external positional schema rather than making roles internally distinguishable.
+"""
+
+from dataclasses import dataclass, fields
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHALLENGE = ROOT / "contracts/mts-interpretation-act-network-challenge-v0.6.json"
+CURRENT_LINK_CHALLENGE = ROOT / "contracts/mts-current-link-foundation-challenge-v0.6.json"
+MTS_V05 = ROOT / "contracts/mts-contract-v0.5.json"
+
+
+@dataclass(frozen=True)
+class Link:
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class FiniteLinkGraph:
+    links: dict[int, Link]
+
+    def validate_closed(self) -> None:
+        refs = set(self.links)
+        for ref, link in self.links.items():
+            assert link.start in refs, (ref, "start", link.start)
+            assert link.end in refs, (ref, "end", link.end)
+
+    def forward_closure(self, root: int) -> frozenset[int]:
+        assert root in self.links
+        seen: set[int] = set()
+        pending = [root]
+        while pending:
+            ref = pending.pop()
+            if ref in seen:
+                continue
+            seen.add(ref)
+            link = self.links[ref]
+            pending.extend((link.start, link.end))
+        return frozenset(seen)
+
+    def incoming(self, target: int) -> frozenset[int]:
+        return frozenset(
+            ref
+            for ref, link in self.links.items()
+            if link.start == target or link.end == target
+        )
+
+
+def atom(ref: int) -> tuple[int, Link]:
+    """A self-closed link used only as a finite challenge anchor."""
+
+    return ref, Link(ref, ref)
+
+
+def read_contract() -> dict:
+    return json.loads(CHALLENGE.read_text(encoding="utf-8"))
+
+
+def positional_spine_graph() -> tuple[FiniteLinkGraph, int, dict[str, int]]:
+    # External role names are deliberately outside the graph.
+    roles = {"I": 1, "F": 2, "X": 3, "M": 4, "R": 5}
+    graph = FiniteLinkGraph(
+        {
+            **dict(atom(ref) for ref in roles.values()),
+            10: Link(roles["I"], roles["F"]),
+            11: Link(10, roles["X"]),
+            12: Link(11, roles["M"]),
+            13: Link(12, roles["R"]),
+        }
+    )
+    return graph, 13, roles
+
+
+def transition_graph() -> tuple[FiniteLinkGraph, dict[str, int]]:
+    # Atomic challenge anchors. Their human names are fixture metadata, not
+    # ontology; this is precisely what candidate C still has to solve later.
+    role = {
+        "I": 1,
+        "F": 2,
+        "X": 3,
+        "M": 4,
+        "R": 5,
+        "R2": 6,
+    }
+    graph = FiniteLinkGraph(
+        {
+            **dict(atom(ref) for ref in role.values()),
+            # before-state: ((I,M),(F,X))
+            10: Link(role["I"], role["M"]),
+            11: Link(role["F"], role["X"]),
+            12: Link(10, 11),  # S_before
+            # after-state: ((I,M),(R,X))
+            13: Link(role["I"], role["M"]),
+            14: Link(role["R"], role["X"]),
+            15: Link(13, 14),  # S_after
+            16: Link(12, 15),  # Act A = S_before -> S_after
+            # A second transition and an explicit history/continuation relation.
+            17: Link(role["I"], role["M"]),
+            18: Link(role["R2"], role["X"]),
+            19: Link(17, 18),  # S_after2
+            20: Link(15, 19),  # Act A2
+            21: Link(16, 20),  # continuation/history link A -> A2
+        }
+    )
+    refs = {
+        **role,
+        "S_before": 12,
+        "S_after": 15,
+        "A": 16,
+        "S_after2": 19,
+        "A2": 20,
+        "history": 21,
+    }
+    return graph, refs
+
+
+def test_challenge_is_non_normative_and_composes_first_foundation_evidence():
+    contract = read_contract()
+    first = json.loads(CURRENT_LINK_CHALLENGE.read_text(encoding="utf-8"))
+    accepted = MTS_V05.read_text(encoding="utf-8")
+
+    assert contract["schema"] == "mts-interpretation-act-network-challenge/v0.6"
+    assert contract["status"] == "candidate-challenge"
+    assert contract["accepted"] is False
+    assert first["schema"] in contract["dependsOn"]
+    assert contract["schema"] not in accepted
+    assert contract["nextGate"]["productionChangeBeforeDecision"] is False
+    assert contract["nextGate"]["acceptedContractLinkAllowed"] is False
+
+
+def test_carrier_node_type_contains_only_two_link_poles():
+    assert [field.name for field in fields(Link)] == ["start", "end"]
+
+    for graph, _root in ((positional_spine_graph()[0], positional_spine_graph()[1]),):
+        graph.validate_closed()
+        assert all(isinstance(link, Link) for link in graph.links.values())
+
+    graph, _refs = transition_graph()
+    graph.validate_closed()
+    assert all(isinstance(link, Link) for link in graph.links.values())
+
+
+def test_positional_spine_is_binary_but_role_meaning_is_external():
+    graph, act, roles = positional_spine_graph()
+    graph.validate_closed()
+
+    assert graph.forward_closure(act) == frozenset(graph.links)
+
+    # The exact same carrier admits a different external interpretation of two
+    # structurally atomic refs. Nothing inside the graph says that ref 1 is
+    # "interpreter" and ref 2 is "form".
+    alternative_roles = dict(roles)
+    alternative_roles["I"], alternative_roles["F"] = roles["F"], roles["I"]
+
+    assert alternative_roles != roles
+    assert graph.links == positional_spine_graph()[0].links
+    assert read_contract()["candidateTopologies"][0]["status"] == "likely-reject"
+
+
+def test_transition_candidate_makes_actual_act_a_binary_before_after_link():
+    graph, ref = transition_graph()
+    graph.validate_closed()
+
+    act = graph.links[ref["A"]]
+    assert act == Link(ref["S_before"], ref["S_after"])
+    assert ref["F"] != ref["A"]
+    assert ref["R"] != ref["A"]
+
+    before = graph.forward_closure(ref["S_before"])
+    after = graph.forward_closure(ref["S_after"])
+    assert ref["F"] in before
+    assert ref["X"] in before
+    assert ref["M"] in before
+    assert ref["R"] not in before
+    assert ref["R"] in after
+
+
+def test_result_and_next_state_are_not_hidden_return_values():
+    graph, ref = transition_graph()
+    act_closure = graph.forward_closure(ref["A"])
+
+    assert ref["S_after"] in act_closure
+    assert ref["R"] in act_closure
+    assert ref["A"] in graph.links
+    assert ref["R"] in graph.links
+
+
+def test_continuation_is_an_ordinary_link_not_a_host_parent_field():
+    graph, ref = transition_graph()
+
+    assert graph.links[ref["A2"]] == Link(ref["S_after"], ref["S_after2"])
+    assert graph.links[ref["history"]] == Link(ref["A"], ref["A2"])
+    assert [field.name for field in fields(Link)] == ["start", "end"]
+    assert "parent" not in {field.name for field in fields(Link)}
+
+
+def test_focus_anchor_has_strictly_local_forward_closure():
+    graph, ref = transition_graph()
+
+    focus_closure = graph.forward_closure(ref["X"])
+    act_closure = graph.forward_closure(ref["A"])
+
+    assert focus_closure == frozenset({ref["X"]})
+    assert ref["A"] not in focus_closure
+    assert ref["I"] not in focus_closure
+    assert ref["F"] not in focus_closure
+    assert ref["M"] not in focus_closure
+    assert ref["R"] not in focus_closure
+
+    assert focus_closure < act_closure
+    assert {ref["I"], ref["F"], ref["X"], ref["M"], ref["R"]} <= act_closure
+
+
+def test_incoming_search_from_focus_does_not_identify_one_unique_act():
+    graph, ref = transition_graph()
+    incoming = graph.incoming(ref["X"])
+
+    # X participates in before, after and later state payloads. Associative
+    # incoming search is useful, but without additional role/act constraints it
+    # cannot be treated as a magic "go to my current act" operation.
+    assert {11, 14, 18} <= incoming
+    assert len(incoming) >= 3
+    assert ref["A"] not in incoming
+
+
+def test_full_act_ontology_does_not_imply_full_act_observability():
+    contract = read_contract()
+    expected = contract["expectedChallengeFindings"]
+
+    assert expected["focusForwardClosureMayBeStrictlyLocal"] is True
+    assert expected["currentActAnchorHasBroaderReachabilityThanFocusAnchor"] is True
+    assert expected["thereforeFullActOntologyDoesNotImplyFullActObservability"] is True
+    assert contract["deicticBoundaryHypothesis"]["focusOnlyMustNotImplyActIntrospection"] is True
+    assert contract["deicticBoundaryHypothesis"]["additionalAnchorRequiresCounterexample"] is True
+
+
+def test_no_candidate_topology_is_promoted_by_the_challenge():
+    models = read_contract()["candidateTopologies"]
+
+    assert {model["id"] for model in models} == {
+        "A-positional-spine",
+        "B-role-labelled-association-network",
+        "C-state-transition",
+        "D-interpreter-focus-binding-only",
+    }
+    assert all(model["accepted"] is False for model in models)
+    preferred = next(model for model in models if model["id"] == "C-state-transition")
+    assert preferred["status"] == "preferred-outer-shape-candidate"


### PR DESCRIPTION
Refs #173, #171, #148, #156.

Non-normative foundation challenge. No production parser/interpreter/root change.

## What this tests

It replaces the vague research tuple `Act(I,F,X,M,R)` with finite carriers containing **only binary `Link(start,end)` nodes**, then compares four topology families.

Key findings encoded as challenge expectations:

- a positional binary spine is link-only but not self-describing: semantic role names remain an external schema;
- `A = S_before ⟼ S_after` is the preferred outer-shape candidate because command and actual act are distinct and result/next state is explicit in the graph;
- the internal state schema is still unresolved and therefore the transition candidate is not accepted;
- a focus-only binding is insufficient as the full act, but may still be the right local deictic boundary;
- forward pole traversal from focus `X` can remain strictly local, while current-act anchor `A` exposes a much larger closure;
- incoming associative search from `X` can be ambiguous, so it must not become a magic implicit "find my current act" operation;
- continuation/history is represented as ordinary links between acts/states, not a host `parent` field.

## Important separation

```text
full act exists in ontology
!=
formula may introspect full act
```

This supports a minimal local candidate `↑ -> current focus X` without denying that interpreter/form/environment/result are themselves links elsewhere in the act network.

The PR deliberately does **not** decide whether `♀/♂` mean direct structural poles or semantic projection forms; that axis remains separate after #172.

No topology and no new pronoun is promoted. Next gate is decision-quality work on internal state role distinguishability + the exact deictic anchor.