### PR TITLE
Select preferred MTS v0.6 foundation direction

### DIFF
--- a/contracts/mts-foundation-direction-decision-v0.6.json
+++ b/contracts/mts-foundation-direction-decision-v0.6.json
@@ -1,0 +1,180 @@
+{
+  "schema": "mts-foundation-direction-decision/v0.6",
+  "status": "candidate-decision",
+  "accepted": false,
+  "issue": 179,
+  "dependsOn": [
+    "mts-current-link-foundation-challenge/v0.6",
+    "mts-interpretation-act-network-challenge/v0.6",
+    "mts-pole-projection-foundation-challenge/v0.6",
+    "mts-constructor-destructor-foundation-challenge/v0.6"
+  ],
+  "purpose": "Select one preferred research direction after the foundation reset without accepting or migrating production semantics yet.",
+  "historicalBoundary": {
+    "publishedContractsV02ThroughV05RemainImmutable": true,
+    "historicalReplayRemainsValid": true,
+    "historicalRootFixtureRemainsUnchanged": true,
+    "historicalRootDefinitionCount": 10,
+    "historicalContextModel": "ContextFrame(start,end,parent?) + primitive ◁/▷ + ↑ ascent",
+    "historicalContextModelStillPreferredFoundation": false,
+    "historicalProjectionMeaning": "♀/♂ resolve semantic self-closed projection-form links rather than raw poles",
+    "historicalProjectionMeaningStillPreferredFoundation": false
+  },
+  "preferredDirection": {
+    "ontology": "everything is a link",
+    "linkConstructor": {
+      "symbol": "⟼",
+      "meaning": "construct/describe one ordered binary link with raw start and end poles"
+    },
+    "rawStartDestructor": {
+      "symbol": "♀",
+      "meaning": "read the raw start pole of one already distinguished link"
+    },
+    "rawEndDestructor": {
+      "symbol": "♂",
+      "meaning": "read the raw end pole of one already distinguished link"
+    },
+    "currentLinkDeixis": {
+      "symbol": "↑",
+      "meaning": "the one currently distinguished semantic link/value",
+      "mayBeVirtual": true,
+      "requiresL4LinkRef": false
+    },
+    "derivedCurrentStart": "♀↑",
+    "derivedCurrentEnd": "↑♂",
+    "primitiveCurrentPolePronouns": false,
+    "parentAscentPrimitive": false,
+    "genericConstructiveProjectionWrapper": false,
+    "contextFrameOntology": false,
+    "separateSubjectOntology": false
+  },
+  "operatorOrthogonality": {
+    "constructor": "⟼",
+    "destructors": ["♀", "♂"],
+    "deixis": "↑",
+    "inversion": "¬",
+    "definitionIntroduction": ":",
+    "judgments": ["=", "!="],
+    "sameOperatorMustNotCarryBothRawDestructorAndWrapperConstructorSemantics": true
+  },
+  "selfClosedWrapperPolicy": {
+    "genericOperatorSemanticsRequired": false,
+    "ifNeededUseOrdinaryRecursiveLinks": [
+      "S : S ⟼ F",
+      "E : F ⟼ E"
+    ],
+    "realNeedStillRequiresGateEvidence": true
+  },
+  "preferredCandidateRoot": [
+    "∞ : ∞ ⟼ ∞",
+    "() : ♀() ⟼ ()♂",
+    "([) : ([) ⟼ ∞",
+    "(]) : ∞ ⟼ (])",
+    "(⟼) : ([) ⟼ (])",
+    "(↛) : (]) ⟼ ([)",
+    "[1] : (⟼)",
+    "[0] : (↛)",
+    "(=) : {♀(♀↑) = ♀(↑♂), (♀↑)♂ = (↑♂)♂}",
+    "(!=) : ¬(=)"
+  ],
+  "rootBoundary": {
+    "candidateAroot": "∞ : ∞ ⟼ ∞",
+    "arootUsesDeixis": false,
+    "rootCountIsFundamentalVeto": false,
+    "roundFormA2StillRequired": "challenged",
+    "candidateRootAccepted": false
+  },
+  "candidateRootCarrier": {
+    "R": "(R,R)",
+    "O": "(O,R)",
+    "C": "(R,C)",
+    "L": "(O,C)",
+    "U": "(C,O)",
+    "finite": true,
+    "closed": true,
+    "exactPairUnique": true,
+    "acceptedAsProductionRoot": false
+  },
+  "anumDirection": {
+    "candidateOpen": "([)",
+    "candidateClose": "(])",
+    "candidateOne": "(⟼)",
+    "candidateZero": "(↛)",
+    "productionBoundaryChanged": false,
+    "requiresGate": 181
+  },
+  "contextAdapterBoundary": {
+    "legacyContextFrameMayTemporarilyAdaptCurrentLink": true,
+    "legacyAdapterShape": "VirtualCurrentLink(start,end) <-> ContextFrame(start,end)",
+    "legacyParentFieldPreferredOntology": false,
+    "adapterMayDefineNewSemantics": false,
+    "adapterIsNotFoundation": true
+  },
+  "fullActBoundary": {
+    "preferredOuterResearchShape": "Act = S_before ⟼ S_after",
+    "fullActOntologyImpliesFullActObservability": false,
+    "currentLinkAnchorMayStayLocal": true,
+    "genericIncomingSearchMeansCurrentAct": false,
+    "nestingMustStartFromOrdinaryActStateLinks": true,
+    "requiresGate": 182
+  },
+  "equalityBoundary": {
+    "candidateForCurrentXEqualAB": "{♀(♀↑) = ♀(↑♂), (♀↑)♂ = (↑♂)♂}",
+    "materializedExactPairObservationAvailable": true,
+    "virtualRecursiveEqualityAccepted": false,
+    "genericGraphIsomorphismAcceptedAsEquality": false,
+    "requiresGate": 180
+  },
+  "demotedFromPreferredFoundation": [
+    "ContextFrame as an ontological primitive",
+    "primitive ContextPronoun START/END forms",
+    "↑ as a host parent-depth counter",
+    "♀/♂ as generic constructive self-closed projection-wrapper operators",
+    "ten root definitions as a fundamental veto"
+  ],
+  "nextGates": {
+    "E": {
+      "issue": 180,
+      "goal": "storage-neutral virtual current-link and finite equality semantics"
+    },
+    "A": {
+      "issue": 181,
+      "goal": "revised root carrier and Anum boundary conformance"
+    },
+    "N": {
+      "issue": 182,
+      "goal": "nesting and continuation without host ContextFrame.parent"
+    }
+  },
+  "effectsBoundary": {
+    "interpretMayRealize": false,
+    "findMayRealize": false,
+    "foundationDecisionMutatesL4": false
+  },
+  "migrationBoundary": {
+    "productionMigrationAllowed": false,
+    "acceptedContractLinkAllowed": false,
+    "aproverRepinAllowed": false,
+    "dualProjectionSemanticCompatibilityLayerAllowed": false,
+    "dualMeaningOfUpAllowed": false,
+    "ifLaterAcceptedUseOneCanonicalParserInterpreterPath": true,
+    "deleteSupersededSemanticPathAfterConsumerMigration": true
+  },
+  "acceptanceGate": {
+    "directionChosen": true,
+    "foundationAccepted": false,
+    "requiresAllGates": [180, 181, 182],
+    "requiresExecutableVerticalSlice": true,
+    "requiredVerticalSlice": [
+      "finite link carrier",
+      "link constructor and raw pole destructors",
+      "storage-neutral current-link ↑",
+      "revised root",
+      "finite equality",
+      "revised Anum orientation",
+      "read-only interpretation",
+      "optional explicit L4 realization",
+      "deterministic proof replay boundary"
+    ]
+  }
+}

--- a/tests/test_mts_foundation_direction_decision.py
+++ b/tests/test_mts_foundation_direction_decision.py
@@ -1,0 +1,202 @@
+"""Non-normative decision guards for the MTS v0.6 foundation reset.
+
+The decision selects one preferred research direction after executable challenges,
+but deliberately keeps every production semantic migration blocked until Gates
+E/A/N provide the remaining evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DECISION = ROOT / "contracts/mts-foundation-direction-decision-v0.6.json"
+MTS_V05 = ROOT / "contracts/mts-contract-v0.5.json"
+ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
+
+EVIDENCE = {
+    "mts-current-link-foundation-challenge/v0.6": ROOT
+    / "contracts/mts-current-link-foundation-challenge-v0.6.json",
+    "mts-interpretation-act-network-challenge/v0.6": ROOT
+    / "contracts/mts-interpretation-act-network-challenge-v0.6.json",
+    "mts-pole-projection-foundation-challenge/v0.6": ROOT
+    / "contracts/mts-pole-projection-foundation-challenge-v0.6.json",
+    "mts-constructor-destructor-foundation-challenge/v0.6": ROOT
+    / "contracts/mts-constructor-destructor-foundation-challenge-v0.6.json",
+}
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def historical_root() -> list[str]:
+    return [
+        line.strip()
+        for line in ROOT_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_decision_is_candidate_only_and_not_published_through_v05():
+    decision = read(DECISION)
+    accepted = MTS_V05.read_text(encoding="utf-8")
+
+    assert decision["schema"] == "mts-foundation-direction-decision/v0.6"
+    assert decision["status"] == "candidate-decision"
+    assert decision["accepted"] is False
+    assert decision["issue"] == 179
+    assert decision["schema"] not in accepted
+    assert decision["migrationBoundary"]["productionMigrationAllowed"] is False
+    assert decision["migrationBoundary"]["acceptedContractLinkAllowed"] is False
+    assert decision["migrationBoundary"]["aproverRepinAllowed"] is False
+
+
+def test_all_four_executable_foundation_challenges_are_exact_dependencies():
+    decision = read(DECISION)
+
+    assert decision["dependsOn"] == list(EVIDENCE)
+    for schema, path in EVIDENCE.items():
+        evidence = read(path)
+        assert evidence["schema"] == schema
+        assert evidence["accepted"] is False
+        assert evidence["status"] == "candidate-challenge"
+
+
+def test_preferred_direction_has_one_constructor_two_destructors_and_one_deictic_anchor():
+    preferred = read(DECISION)["preferredDirection"]
+
+    assert preferred["ontology"] == "everything is a link"
+    assert preferred["linkConstructor"]["symbol"] == "⟼"
+    assert preferred["rawStartDestructor"]["symbol"] == "♀"
+    assert preferred["rawEndDestructor"]["symbol"] == "♂"
+    assert preferred["currentLinkDeixis"]["symbol"] == "↑"
+    assert preferred["currentLinkDeixis"]["mayBeVirtual"] is True
+    assert preferred["currentLinkDeixis"]["requiresL4LinkRef"] is False
+    assert preferred["derivedCurrentStart"] == "♀↑"
+    assert preferred["derivedCurrentEnd"] == "↑♂"
+    assert preferred["primitiveCurrentPolePronouns"] is False
+    assert preferred["parentAscentPrimitive"] is False
+    assert preferred["genericConstructiveProjectionWrapper"] is False
+    assert preferred["contextFrameOntology"] is False
+    assert preferred["separateSubjectOntology"] is False
+
+
+def test_operator_roles_are_not_overloaded_in_the_preferred_direction():
+    roles = read(DECISION)["operatorOrthogonality"]
+
+    assert roles["constructor"] == "⟼"
+    assert roles["destructors"] == ["♀", "♂"]
+    assert roles["deixis"] == "↑"
+    assert roles["inversion"] == "¬"
+    assert roles["definitionIntroduction"] == ":"
+    assert roles["judgments"] == ["=", "!="]
+    assert roles[
+        "sameOperatorMustNotCarryBothRawDestructorAndWrapperConstructorSemantics"
+    ] is True
+
+
+def test_historical_root_remains_immutable_but_is_not_a_foundation_veto():
+    decision = read(DECISION)
+    historical = historical_root()
+    candidate = decision["preferredCandidateRoot"]
+
+    assert len(historical) == decision["historicalBoundary"]["historicalRootDefinitionCount"] == 10
+    assert historical[0] == "∞ : {◁ = ∞, ▷ = ∞}"
+    assert candidate[0] == "∞ : ∞ ⟼ ∞"
+    assert historical != candidate
+    assert decision["historicalBoundary"]["historicalRootFixtureRemainsUnchanged"] is True
+    assert decision["rootBoundary"]["rootCountIsFundamentalVeto"] is False
+    assert decision["rootBoundary"]["candidateRootAccepted"] is False
+
+
+def test_candidate_root_carrier_and_anum_direction_remain_unaccepted():
+    decision = read(DECISION)
+    carrier = decision["candidateRootCarrier"]
+    anum = decision["anumDirection"]
+
+    assert carrier == {
+        "R": "(R,R)",
+        "O": "(O,R)",
+        "C": "(R,C)",
+        "L": "(O,C)",
+        "U": "(C,O)",
+        "finite": True,
+        "closed": True,
+        "exactPairUnique": True,
+        "acceptedAsProductionRoot": False,
+    }
+    assert anum["candidateOpen"] == "([)"
+    assert anum["candidateClose"] == "(])"
+    assert anum["candidateOne"] == "(⟼)"
+    assert anum["candidateZero"] == "(↛)"
+    assert anum["productionBoundaryChanged"] is False
+    assert anum["requiresGate"] == 181
+
+
+def test_context_frame_is_demoted_to_adapter_not_ontology():
+    decision = read(DECISION)
+    adapter = decision["contextAdapterBoundary"]
+
+    assert adapter["legacyContextFrameMayTemporarilyAdaptCurrentLink"] is True
+    assert adapter["legacyAdapterShape"] == (
+        "VirtualCurrentLink(start,end) <-> ContextFrame(start,end)"
+    )
+    assert adapter["legacyParentFieldPreferredOntology"] is False
+    assert adapter["adapterMayDefineNewSemantics"] is False
+    assert adapter["adapterIsNotFoundation"] is True
+    assert "ContextFrame as an ontological primitive" in decision[
+        "demotedFromPreferredFoundation"
+    ]
+
+
+def test_full_act_and_local_observability_are_kept_distinct():
+    boundary = read(DECISION)["fullActBoundary"]
+
+    assert boundary["preferredOuterResearchShape"] == "Act = S_before ⟼ S_after"
+    assert boundary["fullActOntologyImpliesFullActObservability"] is False
+    assert boundary["currentLinkAnchorMayStayLocal"] is True
+    assert boundary["genericIncomingSearchMeansCurrentAct"] is False
+    assert boundary["nestingMustStartFromOrdinaryActStateLinks"] is True
+    assert boundary["requiresGate"] == 182
+
+
+def test_equality_stays_blocked_until_virtual_recursive_semantics_are_challenged():
+    equality = read(DECISION)["equalityBoundary"]
+
+    assert equality["candidateForCurrentXEqualAB"] == (
+        "{♀(♀↑) = ♀(↑♂), (♀↑)♂ = (↑♂)♂}"
+    )
+    assert equality["materializedExactPairObservationAvailable"] is True
+    assert equality["virtualRecursiveEqualityAccepted"] is False
+    assert equality["genericGraphIsomorphismAcceptedAsEquality"] is False
+    assert equality["requiresGate"] == 180
+
+
+def test_all_three_falsification_gates_are_required_before_acceptance():
+    decision = read(DECISION)
+    gates = decision["nextGates"]
+
+    assert gates["E"]["issue"] == 180
+    assert gates["A"]["issue"] == 181
+    assert gates["N"]["issue"] == 182
+    assert decision["acceptanceGate"]["directionChosen"] is True
+    assert decision["acceptanceGate"]["foundationAccepted"] is False
+    assert decision["acceptanceGate"]["requiresAllGates"] == [180, 181, 182]
+    assert decision["acceptanceGate"]["requiresExecutableVerticalSlice"] is True
+
+
+def test_effect_and_migration_vetoes_preserve_existing_architecture_boundaries():
+    decision = read(DECISION)
+    effects = decision["effectsBoundary"]
+    migration = decision["migrationBoundary"]
+
+    assert effects["interpretMayRealize"] is False
+    assert effects["findMayRealize"] is False
+    assert effects["foundationDecisionMutatesL4"] is False
+    assert migration["dualProjectionSemanticCompatibilityLayerAllowed"] is False
+    assert migration["dualMeaningOfUpAllowed"] is False
+    assert migration["ifLaterAcceptedUseOneCanonicalParserInterpreterPath"] is True
+    assert migration["deleteSupersededSemanticPathAfterConsumerMigration"] is True


### PR DESCRIPTION
Refs #179, #171, #173, #175, #177, #180, #181, #182.

This PR records a **candidate direction decision**, not production acceptance.

After executable evidence from #172/#174/#176/#178, it selects one preferred research architecture:

```text
A ⟼ B  — link constructor
♀F     — raw start destructor
F♂     — raw end destructor
↑      — one current-link deictic anchor

◁ := ♀↑
▷ := ↑♂
```

The decision explicitly demotes from the preferred foundation:

- `ContextFrame` as ontology;
- primitive `◁/▷` AST forms;
- `↑` as host parent-depth counter;
- `♀/♂` as generic constructive projection-wrapper operators;
- root count 10 as a fundamental veto.

All v0.2–v0.5 contracts and the historical root fixture remain immutable/replayable.

## Candidate root direction

The contract records the currently preferred research root beginning with:

```text
∞   : ∞ ⟼ ∞
([) : ([) ⟼ ∞
(]) : ∞ ⟼ (])
(⟼) : ([) ⟼ (])
(↛) : (]) ⟼ ([)
```

but keeps it explicitly unaccepted.

## Remaining falsification gates

The decision requires all three before any acceptance/migration:

- #180 Gate E — storage-neutral virtual current link + finite equality;
- #181 Gate A — revised root + Anum boundary conformance;
- #182 Gate N — nesting/continuation without host `ContextFrame.parent`.

`ContextFrame(start,end)` may exist only as a temporary historical adapter for a virtual current link; it may not define new semantics. `parent` is not preferred ontology.

## Migration veto

```text
productionMigrationAllowed = false
acceptedContractLinkAllowed = false
aproverRepinAllowed = false
```

If the foundation is accepted later, migrate one canonical parser/interpreter path and delete the superseded semantic path after consumers move. No dual projection semantics and no dual meaning of `↑` compatibility mode.

Diff is intentionally only the candidate-decision contract and its guards.