### PR TITLE
Challenge revised root and Anum boundary v0.6

### DIFF
--- a/contracts/anum-boundary-conformance-candidate-v0.6.json
+++ b/contracts/anum-boundary-conformance-candidate-v0.6.json
@@ -1,0 +1,141 @@
+{
+  "schema": "anum-boundary-conformance-candidate/v0.6",
+  "status": "candidate-challenge-corpus",
+  "accepted": false,
+  "issue": 181,
+  "dependsOn": [
+    "mts-foundation-direction-decision/v0.6",
+    "mts-current-link-equality-decision/v0.6",
+    "anum-boundary-projection/v0.2",
+    "anum-recursive-denotation/v0.2"
+  ],
+  "candidateRootRefs": {
+    "R": 0,
+    "O": 1,
+    "C": 2,
+    "L": 3,
+    "U": 4,
+    "OO": 5,
+    "CC": 6
+  },
+  "candidatePairs": {
+    "R": [0, 0],
+    "O": [1, 0],
+    "C": [0, 2],
+    "L": [1, 2],
+    "U": [2, 1],
+    "OO": [1, 1],
+    "CC": [2, 2]
+  },
+  "rootMeanings": {
+    "∞": "R",
+    "([)": "O",
+    "(])": "C",
+    "(⟼)": "L",
+    "(↛)": "U"
+  },
+  "protocolProjection": [
+    {
+      "raw": "[",
+      "meaning": "O",
+      "kind": "boundary-anchor",
+      "protocolValue": null
+    },
+    {
+      "raw": "]",
+      "meaning": "C",
+      "kind": "boundary-anchor",
+      "protocolValue": null
+    },
+    {
+      "raw": "1",
+      "meaning": "L",
+      "kind": "protocol-value",
+      "protocolValue": "1",
+      "denotationAnchor": "protocol:1"
+    },
+    {
+      "raw": "0",
+      "meaning": "U",
+      "kind": "protocol-value",
+      "protocolValue": "0",
+      "denotationAnchor": "protocol:0"
+    }
+  ],
+  "specialBoundaryVectors": [
+    {
+      "raw": "[[",
+      "meaning": "OO",
+      "pair": ["O", "O"],
+      "protocolValue": null,
+      "recursiveDenotation": "raw"
+    },
+    {
+      "raw": "[]",
+      "meaning": "L",
+      "pair": ["O", "C"],
+      "protocolValue": "1",
+      "recursiveDenotation": "protocol:1"
+    },
+    {
+      "raw": "][",
+      "meaning": "U",
+      "pair": ["C", "O"],
+      "protocolValue": "0",
+      "recursiveDenotation": "protocol:0"
+    },
+    {
+      "raw": "]]",
+      "meaning": "CC",
+      "pair": ["C", "C"],
+      "protocolValue": null,
+      "recursiveDenotation": "raw"
+    }
+  ],
+  "protocolAnchorBindings": {
+    "protocol:1": "L",
+    "protocol:0": "U"
+  },
+  "historicalBridge": {
+    "oldOpenForm": "♀∞",
+    "oldCloseForm": "∞♂",
+    "candidateOpenForm": "([)",
+    "candidateCloseForm": "(])",
+    "individualOpenCarrierTopologyPreserved": true,
+    "individualCloseCarrierTopologyPreserved": true,
+    "compoundSharingTopologyPreserved": false,
+    "compoundSharingDifference": "historical engineering link_carrier copies operand carriers into disjoint occurrence spaces; candidate exact-pair root uses one shared R substrate",
+    "compoundSharingDifferenceIsL2EqualityDecision": false,
+    "reason": "carrier_isomorphic is explicitly an engineering topology check, not accepted L2 equality"
+  },
+  "recursiveCompatibility": {
+    "historicalCorpus": "contracts/anum-recursive-denotation-conformance-v0.2.json",
+    "rawGrammarChanged": false,
+    "specialBoundaryPrecedenceChanged": false,
+    "protocolAnchorNamesChanged": false,
+    "rootOpeningCollapseChanged": false,
+    "canonicalInverseChanged": false,
+    "occurrencePreservingNodePolicyChanged": false,
+    "quoteContextChanged": false,
+    "relativeContextChanged": false,
+    "memoryDependencyAdded": false,
+    "claim": "candidate changes how protocol anchors are derived from the root network, not the recursive occurrence-tree grammar"
+  },
+  "roundRootA2": {
+    "requiredForThisAnumBoundaryCorpus": false,
+    "removingA2ChangesROCLU": false,
+    "foundationNeedStillOpen": true
+  },
+  "expected": {
+    "candidatePairsAllExactUnique": true,
+    "candidateGraphFiniteClosed": true,
+    "openCloseDistinct": true,
+    "oneZeroDistinct": true,
+    "emptySquareAliasesOne": true,
+    "closeOpenAliasesZero": true,
+    "openOpenStaysRaw": true,
+    "closeCloseStaysRaw": true,
+    "allAcceptedRecursiveV02VectorsReplayUnchanged": true,
+    "allCanonicalRecursiveInversesReplayUnchanged": true
+  }
+}

--- a/contracts/mts-root-anum-foundation-challenge-v0.6.json
+++ b/contracts/mts-root-anum-foundation-challenge-v0.6.json
@@ -1,0 +1,136 @@
+{
+  "schema": "mts-root-anum-foundation-challenge/v0.6",
+  "status": "candidate-challenge",
+  "accepted": false,
+  "issue": 181,
+  "dependsOn": [
+    "mts-foundation-direction-decision/v0.6",
+    "mts-current-link-equality-decision/v0.6",
+    "mts-constructor-destructor-foundation-challenge/v0.6",
+    "anum-boundary-projection/v0.2",
+    "anum-recursive-denotation/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-boundary-conformance-candidate-v0.6.json",
+  "purpose": "Challenge a revised explicit root and Anum boundary under raw-pole destructor semantics while replaying all accepted recursive Anum v0.2 syntax/canonicality properties unchanged and explicitly classifying the root-sharing topology delta.",
+  "candidateRootSubset": [
+    "∞ : ∞ ⟼ ∞",
+    "([) : ([) ⟼ ∞",
+    "(]) : ∞ ⟼ (])",
+    "(⟼) : ([) ⟼ (])",
+    "(↛) : (]) ⟼ ([)",
+    "[1] : (⟼)",
+    "[0] : (↛)"
+  ],
+  "candidateCarrier": {
+    "R": "(R,R)",
+    "O": "(O,R)",
+    "C": "(R,C)",
+    "L": "(O,C)",
+    "U": "(C,O)",
+    "finite": true,
+    "closed": true,
+    "exactPairUnique": true
+  },
+  "boundaryDecisionUnderChallenge": {
+    "open": "([)",
+    "close": "(])",
+    "one": "(⟼)",
+    "zero": "(↛)",
+    "openPair": "O=(O,R)",
+    "closePair": "C=(R,C)",
+    "onePair": "L=(O,C)",
+    "zeroPair": "U=(C,O)",
+    "accepted": false
+  },
+  "specialBoundary": {
+    "[[": "Link(O,O), stays outside recursive grammar",
+    "[]": "Link(O,C)=L, aliases protocol:1",
+    "][": "Link(C,O)=U, aliases protocol:0",
+    "]]": "Link(C,C), stays outside recursive grammar"
+  },
+  "historicalCarrierComparison": {
+    "open": {
+      "historical": "start_carrier(root)",
+      "candidate": "O=(O,R)",
+      "exactRootedTopologyIsomorphic": true
+    },
+    "close": {
+      "historical": "end_carrier(root)",
+      "candidate": "C=(R,C)",
+      "exactRootedTopologyIsomorphic": true
+    },
+    "one": {
+      "historical": "link_carrier(start_carrier(root), end_carrier(root))",
+      "candidate": "L=(O,C) over one shared R",
+      "exactRootedTopologyIsomorphic": false,
+      "difference": "historical engineering helper preserves operand occurrences by copying them into disjoint spaces; candidate root gives O and C one shared semantic R"
+    },
+    "zero": {
+      "historical": "link_carrier(end_carrier(root), start_carrier(root))",
+      "candidate": "U=(C,O) over one shared R",
+      "exactRootedTopologyIsomorphic": false,
+      "difference": "same occurrence-copy versus shared-root distinction with reversed ordered poles"
+    },
+    "carrierIsomorphicIsL2Equality": false,
+    "sharingDeltaAutomaticallyRejected": false,
+    "sharingDeltaAutomaticallyAccepted": false,
+    "classification": "intentional foundation candidate delta; L3 recursive denotation is occurrence-preserving above opaque protocol anchors and does not inspect anchor-internal sharing"
+  },
+  "protocolAnchorBoundary": {
+    "protocol:1": "L",
+    "protocol:0": "U",
+    "anchorNamesChanged": false,
+    "anchorDerivationChanged": true,
+    "recursiveDenotationReadsAnchorInternalCarrier": false
+  },
+  "preservedRecursiveSemantics": {
+    "rawAlphabet": ["[", "]", "1", "0"],
+    "rootGrammarChanged": false,
+    "rootOpeningCollapseChanged": false,
+    "canonicalInverseChanged": false,
+    "specialBoundaryPrecedenceChanged": false,
+    "occurrencePreservingPostorderNodesChanged": false,
+    "explicitSharedNodeReferencesAccepted": false,
+    "quoteContextChanged": false,
+    "relativeContextChanged": false,
+    "memoryReadAdded": false,
+    "memoryMutationAdded": false,
+    "realizationAdded": false
+  },
+  "candidateInterpretation": {
+    "summary": "L3 raw syntax and recursive occurrence-tree denotation remain stable; only the root-level semantic construction of open/close/one/zero anchors is replaced by explicit ordinary links",
+    "acceptedAsFoundation": false,
+    "requiresNoNewRawAbit": true,
+    "requiresNoRecursiveGrammarFork": true
+  },
+  "roundFormA2": {
+    "requiredForCandidateAnumBoundary": false,
+    "removalWouldChangeROCLUCarrier": false,
+    "minimalRootDecisionDeferred": true
+  },
+  "effectsBoundary": {
+    "challengeReadsProductionL4ForExactPairParity": true,
+    "recursiveDenotationReadsL4": false,
+    "interpretMayRealize": false,
+    "implicitRealization": false,
+    "historicalContractsMutated": false,
+    "historicalRootFixtureMutated": false
+  },
+  "challengeQuestions": [
+    "Does the explicit R/O/C/L/U graph preserve the intended ordered open/close/link/unlink roles?",
+    "Do O and C reproduce the exact historical individual boundary carrier topologies?",
+    "Is the L/U shared-root topology delta explicit rather than silently treated as old carrier isomorphism?",
+    "Can every accepted recursive v0.2 corpus vector replay byte-for-byte at the raw/canonical boundary with protocol:0/1 anchor names unchanged?",
+    "Do [] and ][ retain protocol aliases while [[ and ]] remain outside recursive grammar?",
+    "Does any accepted recursive property require constructive ♀/♂ wrappers rather than opaque protocol anchors?",
+    "Is A2 () required by Anum after the explicit boundary roots exist?"
+  ],
+  "releaseVeto": {
+    "productionRootChangeAllowed": false,
+    "productionAnumChangeAllowed": false,
+    "acceptedContractLinkAllowed": false,
+    "aproverRepinAllowed": false,
+    "sharingDeltaMayBeHidden": false,
+    "nextGateAfterChallenge": "Gate A decision classifying preserved recursive semantics and the explicit shared-root boundary model"
+  }
+}

--- a/tests/test_mts_root_anum_foundation_challenge.py
+++ b/tests/test_mts_root_anum_foundation_challenge.py
@@ -124,7 +124,7 @@ def test_candidate_boundary_graph_is_finite_closed_exact_pair_unique_and_oriente
     assert pairs["OO"] == (ref["O"], ref["O"])
     assert pairs["CC"] == (ref["C"], ref["C"])
     assert len(set(pairs.values())) == len(pairs)
-    assert memory.all_links() == frozenset(ref.values())
+    assert memory.all_links() == tuple(sorted(ref.values()))
     assert ref["O"] != ref["C"]
     assert ref["L"] != ref["U"]
 

--- a/tests/test_mts_root_anum_foundation_challenge.py
+++ b/tests/test_mts_root_anum_foundation_challenge.py
@@ -1,0 +1,299 @@
+"""Executable non-normative challenge for Foundation Gate A / issue #181.
+
+The test separates two questions that the historical implementation mixed:
+
+* how root-level protocol anchors are constructed from links; and
+* the already accepted recursive Anum occurrence-tree grammar over opaque
+  ``protocol:0`` / ``protocol:1`` anchors.
+
+No production root or Anum contract is modified here.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+import json
+from pathlib import Path
+
+from core.anum_denotation import canonical_denotation_json, denotation_from_data
+from core.anum_memory import AnumMemory
+from core.anum_model import ProjectionContext
+from core.anum_parser import parse_raw_quaternary
+from core.anum_recursive_denotation import canonical_recursive_anum, denotate_recursive_anum
+from core.semantic_carrier import (
+    CarrierGraph,
+    LinkNode,
+    associative_root_carrier,
+    carrier_isomorphic,
+    end_carrier,
+    link_carrier,
+    start_carrier,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHALLENGE = ROOT / "contracts/mts-root-anum-foundation-challenge-v0.6.json"
+CORPUS = ROOT / "contracts/anum-boundary-conformance-candidate-v0.6.json"
+DIRECTION = ROOT / "contracts/mts-foundation-direction-decision-v0.6.json"
+EQUALITY_DECISION = ROOT / "contracts/mts-current-link-equality-decision-v0.6.json"
+HISTORICAL_BOUNDARY = ROOT / "contracts/anum-boundary-projection-v0.2.json"
+RECURSIVE_CONTRACT = ROOT / "contracts/anum-recursive-denotation-v0.2.json"
+RECURSIVE_CORPUS = ROOT / "contracts/anum-recursive-denotation-conformance-v0.2.json"
+MTS_V05 = ROOT / "contracts/mts-contract-v0.5.json"
+ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def context(name: str) -> ProjectionContext:
+    return ProjectionContext(name)
+
+
+def candidate_memory() -> tuple[AnumMemory, dict[str, int]]:
+    corpus = read(CORPUS)
+    refs = {name: int(ref) for name, ref in corpus["candidateRootRefs"].items()}
+    pairs = {
+        refs[name]: (int(pair[0]), int(pair[1]))
+        for name, pair in corpus["candidatePairs"].items()
+    }
+    return AnumMemory(pairs), refs
+
+
+def carrier_from_memory(memory: AnumMemory, root: int) -> CarrierGraph:
+    """Project one reachable exact-pair L4 subgraph into the L1 engineering IR."""
+
+    order: list[int] = []
+    seen: set[int] = set()
+    pending = deque([root])
+    while pending:
+        ref = pending.popleft()
+        if ref in seen:
+            continue
+        seen.add(ref)
+        order.append(ref)
+        start, end = memory.poles(ref)
+        pending.extend((start, end))
+
+    remap = {ref: index for index, ref in enumerate(order)}
+    nodes = tuple(
+        LinkNode(start=remap[memory.poles(ref)[0]], end=remap[memory.poles(ref)[1]])
+        for ref in order
+    )
+    return CarrierGraph(nodes=nodes, root=remap[root])
+
+
+def historical_root_lines() -> list[str]:
+    return [
+        line.strip()
+        for line in ROOT_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_gate_a_challenge_is_non_normative_and_composes_gate_e():
+    challenge = read(CHALLENGE)
+    direction = read(DIRECTION)
+    equality = read(EQUALITY_DECISION)
+    corpus = read(CORPUS)
+
+    assert challenge["schema"] == "mts-root-anum-foundation-challenge/v0.6"
+    assert challenge["status"] == "candidate-challenge"
+    assert challenge["accepted"] is False
+    assert challenge["issue"] == 181
+    assert direction["schema"] in challenge["dependsOn"]
+    assert equality["schema"] in challenge["dependsOn"]
+    assert challenge["conformanceCorpus"] == "contracts/anum-boundary-conformance-candidate-v0.6.json"
+    assert corpus["status"] == "candidate-challenge-corpus"
+    assert corpus["accepted"] is False
+    assert challenge["schema"] not in MTS_V05.read_text(encoding="utf-8")
+    assert challenge["releaseVeto"]["productionRootChangeAllowed"] is False
+    assert challenge["releaseVeto"]["productionAnumChangeAllowed"] is False
+
+
+def test_candidate_boundary_graph_is_finite_closed_exact_pair_unique_and_oriented():
+    memory, ref = candidate_memory()
+    pairs = {name: memory.poles(value) for name, value in ref.items()}
+
+    assert pairs["R"] == (ref["R"], ref["R"])
+    assert pairs["O"] == (ref["O"], ref["R"])
+    assert pairs["C"] == (ref["R"], ref["C"])
+    assert pairs["L"] == (ref["O"], ref["C"])
+    assert pairs["U"] == (ref["C"], ref["O"])
+    assert pairs["OO"] == (ref["O"], ref["O"])
+    assert pairs["CC"] == (ref["C"], ref["C"])
+    assert len(set(pairs.values())) == len(pairs)
+    assert memory.all_links() == frozenset(ref.values())
+    assert ref["O"] != ref["C"]
+    assert ref["L"] != ref["U"]
+
+
+def test_special_boundary_pairs_are_directly_expressed_by_candidate_root_links():
+    memory, ref = candidate_memory()
+
+    assert memory.find_link(ref["O"], ref["O"]) == ref["OO"]
+    assert memory.find_link(ref["O"], ref["C"]) == ref["L"]
+    assert memory.find_link(ref["C"], ref["O"]) == ref["U"]
+    assert memory.find_link(ref["C"], ref["C"]) == ref["CC"]
+
+    vectors = {item["raw"]: item for item in read(CORPUS)["specialBoundaryVectors"]}
+    assert vectors["[]"]["meaning"] == "L"
+    assert vectors["[]"]["protocolValue"] == "1"
+    assert vectors["]["]["meaning"] == "U"
+    assert vectors["]["]["protocolValue"] == "0"
+    assert vectors["[["]["recursiveDenotation"] == "raw"
+    assert vectors["]]"]["recursiveDenotation"] == "raw"
+
+
+def test_individual_open_close_topologies_match_historical_boundary_carriers():
+    memory, ref = candidate_memory()
+    historical_root = associative_root_carrier()
+    historical_open = start_carrier(historical_root)
+    historical_close = end_carrier(historical_root)
+    candidate_open = carrier_from_memory(memory, ref["O"])
+    candidate_close = carrier_from_memory(memory, ref["C"])
+
+    assert carrier_isomorphic(candidate_open, historical_open)
+    assert carrier_isomorphic(candidate_close, historical_close)
+
+    bridge = read(CORPUS)["historicalBridge"]
+    assert bridge["individualOpenCarrierTopologyPreserved"] is True
+    assert bridge["individualCloseCarrierTopologyPreserved"] is True
+
+
+def test_candidate_one_zero_make_shared_root_delta_explicit_instead_of_claiming_old_isomorphism():
+    memory, ref = candidate_memory()
+    historical_root = associative_root_carrier()
+    historical_open = start_carrier(historical_root)
+    historical_close = end_carrier(historical_root)
+    historical_one = link_carrier(historical_open, historical_close)
+    historical_zero = link_carrier(historical_close, historical_open)
+    candidate_one = carrier_from_memory(memory, ref["L"])
+    candidate_zero = carrier_from_memory(memory, ref["U"])
+
+    assert not carrier_isomorphic(candidate_one, historical_one)
+    assert not carrier_isomorphic(candidate_zero, historical_zero)
+
+    # The ordered local root roles are nevertheless exactly the intended O/C
+    # and C/O links in one shared semantic root network.
+    assert memory.poles(ref["L"]) == (ref["O"], ref["C"])
+    assert memory.poles(ref["U"]) == (ref["C"], ref["O"])
+
+    comparison = read(CHALLENGE)["historicalCarrierComparison"]
+    assert comparison["one"]["exactRootedTopologyIsomorphic"] is False
+    assert comparison["zero"]["exactRootedTopologyIsomorphic"] is False
+    assert comparison["carrierIsomorphicIsL2Equality"] is False
+    assert comparison["sharingDeltaAutomaticallyRejected"] is False
+    assert comparison["sharingDeltaAutomaticallyAccepted"] is False
+
+
+def test_candidate_protocol_anchor_binding_is_total_for_recursive_v02_denotations():
+    bindings = read(CORPUS)["protocolAnchorBindings"]
+    accepted = read(RECURSIVE_CORPUS)
+
+    assert bindings == {"protocol:1": "L", "protocol:0": "U"}
+    allowed = set(bindings)
+
+    for case in accepted["cases"]:
+        result = denotate_recursive_anum(
+            parse_raw_quaternary(case["raw"]),
+            context(case["context"]),
+        )
+        if result.structural is not None:
+            assert set(result.structural.anchors) <= allowed
+
+
+def test_every_accepted_recursive_v02_vector_replays_unchanged_under_candidate_anchor_derivation():
+    accepted = read(RECURSIVE_CORPUS)
+
+    assert accepted["status"] == "accepted"
+    for case in accepted["cases"]:
+        result = denotate_recursive_anum(
+            parse_raw_quaternary(case["raw"]),
+            context(case["context"]),
+        )
+        expected = denotation_from_data(case["expected"])
+        assert canonical_denotation_json(result) == canonical_denotation_json(expected)
+
+        canonical = case["canonicalRaw"]
+        if canonical is not None:
+            assert result.structural is not None
+            assert canonical_recursive_anum(result) == canonical
+
+
+def test_recursive_grammar_and_inverse_are_independent_of_root_anchor_internal_topology():
+    recursive = read(RECURSIVE_CONTRACT)
+    challenge = read(CHALLENGE)["preservedRecursiveSemantics"]
+    corpus = read(CORPUS)["recursiveCompatibility"]
+
+    assert recursive["semantics"]["0"] == "Anchor(protocol:0)"
+    assert recursive["semantics"]["1"] == "Anchor(protocol:1)"
+    assert challenge["rawAlphabet"] == ["[", "]", "1", "0"]
+    assert challenge["rootGrammarChanged"] is False
+    assert challenge["rootOpeningCollapseChanged"] is False
+    assert challenge["canonicalInverseChanged"] is False
+    assert challenge["occurrencePreservingPostorderNodesChanged"] is False
+    assert challenge["quoteContextChanged"] is False
+    assert challenge["relativeContextChanged"] is False
+    assert challenge["memoryReadAdded"] is False
+    assert corpus["protocolAnchorNamesChanged"] is False
+    assert corpus["rawGrammarChanged"] is False
+    assert corpus["canonicalInverseChanged"] is False
+
+
+def test_special_boundary_precedence_matches_historical_raw_behavior_without_old_projection_construction():
+    expected = {
+        "[]": ("protocol:1", "1"),
+        "][": ("protocol:0", "0"),
+    }
+    for raw, (anchor, canonical) in expected.items():
+        result = denotate_recursive_anum(parse_raw_quaternary(raw), ProjectionContext.ROOT)
+        assert result.structural is not None
+        assert result.structural.anchors == (anchor,)
+        assert canonical_recursive_anum(result) == canonical
+
+    for raw in ("[[", "]]"):
+        result = denotate_recursive_anum(parse_raw_quaternary(raw), ProjectionContext.ROOT)
+        assert result.structural is None
+        assert result.raw == raw
+
+
+def test_candidate_boundary_keeps_historical_protocol_orientation_but_changes_derivation_names():
+    historical = read(HISTORICAL_BOUNDARY)
+    candidate = read(CORPUS)
+
+    assert historical["orientation"] == {"open": "♀∞", "close": "∞♂"}
+    meanings = {item["raw"]: item["meaning"] for item in candidate["protocolProjection"]}
+    assert meanings == {"[": "O", "]": "C", "1": "L", "0": "U"}
+    assert candidate["rootMeanings"] == {
+        "∞": "R",
+        "([)": "O",
+        "(])": "C",
+        "(⟼)": "L",
+        "(↛)": "U",
+    }
+    assert candidate["recursiveCompatibility"]["specialBoundaryPrecedenceChanged"] is False
+
+
+def test_round_form_a2_is_not_required_by_the_candidate_anum_boundary():
+    corpus = read(CORPUS)["roundRootA2"]
+    root_meanings = read(CORPUS)["rootMeanings"]
+
+    assert "()" not in root_meanings
+    assert corpus["requiredForThisAnumBoundaryCorpus"] is False
+    assert corpus["removingA2ChangesROCLU"] is False
+    assert corpus["foundationNeedStillOpen"] is True
+
+
+def test_historical_root_and_anum_contracts_remain_unchanged():
+    lines = historical_root_lines()
+    challenge = read(CHALLENGE)
+
+    assert len(lines) == 10
+    assert lines[0] == "∞ : {◁ = ∞, ▷ = ∞}"
+    assert read(HISTORICAL_BOUNDARY)["status"] == "accepted-subset"
+    assert read(RECURSIVE_CONTRACT)["status"] == "accepted"
+    assert challenge["effectsBoundary"]["historicalContractsMutated"] is False
+    assert challenge["effectsBoundary"]["historicalRootFixtureMutated"] is False
+    assert challenge["releaseVeto"]["acceptedContractLinkAllowed"] is False


### PR DESCRIPTION
Refs #181, #179, #180, #175, #177.

Non-normative Gate A challenge. No production root/Anum/parser/interpreter changes.

## Candidate root boundary

```text
R = ∞    = (R,R)
O = ([)  = (O,R)
C = (])  = (R,C)
L = (⟼)  = (O,C)
U = (↛)  = (C,O)
```

Candidate protocol projection:

```text
[ -> O
] -> C
1 -> L -> protocol:1
0 -> U -> protocol:0
```

Special boundary:

```text
[[ -> Link(O,O), raw
[] -> Link(O,C)=L -> 1
][ -> Link(C,O)=U -> 0
]] -> Link(C,C), raw
```

## What is preserved

The challenge directly replays every accepted `anum-recursive-denotation/v0.2` corpus vector with unchanged raw grammar, `protocol:0/1` anchor names, special-boundary precedence, root-opening collapse, canonical inverse, occurrence-preserving node policy, quote behavior and relative behavior.

This is possible because recursive L3 treats protocol anchors as opaque: the candidate changes how `protocol:0/1` are derived from the root network, not the recursive occurrence-tree grammar.

## Important sharing-topology delta

This PR does **not** make a false historical-isomorphism claim.

- candidate O is exactly topology-isomorphic to historical `start_carrier(root)`;
- candidate C is exactly topology-isomorphic to historical `end_carrier(root)`;
- candidate L/U use one shared semantic R;
- historical engineering `link_carrier` copies operand carriers into disjoint occurrence spaces, so its compound carriers are not topology-isomorphic to candidate L/U.

That difference is explicit in the contract/corpus. `carrier_isomorphic` is an engineering topology check and is not L2 equality; therefore the delta is neither silently accepted nor silently rejected here.

## A2

The corpus also proves that `()` is not required to construct the R/O/C/L/U Anum boundary. Its broader L2 need remains open; root count is not protected for its own sake.

If green, the next step is a Gate A decision classifying the shared-root boundary model and preserved L3 semantics. Production migration remains blocked.