### PR TITLE
Decide Gate N explicit nesting without parent context

### DIFF
--- a/contracts/mts-nesting-continuation-foundation-decision-v0.6.json
+++ b/contracts/mts-nesting-continuation-foundation-decision-v0.6.json
@@ -1,0 +1,126 @@
+{
+  "schema": "mts-nesting-continuation-foundation-decision/v0.6",
+  "status": "candidate-decision",
+  "accepted": false,
+  "gateResolved": true,
+  "issue": 182,
+  "dependsOn": [
+    "mts-foundation-direction-decision/v0.6",
+    "mts-current-link-equality-decision/v0.6",
+    "mts-root-anum-foundation-decision/v0.6",
+    "mts-nesting-continuation-foundation-challenge/v0.6"
+  ],
+  "purpose": "Resolve Foundation Gate N at decision quality: remove host parent-chain semantics from the preferred v0.6 foundation and represent nested data flow, call/history and continuation explicitly as ordinary links while retaining exactly one current-link deictic anchor ↑.",
+  "deicticDecision": {
+    "primitiveAnchors": ["↑"],
+    "currentMeaning": "↑ -> one current semantic link",
+    "secondParentOrOuterAnchor": false,
+    "secondAnchorPermanentlyForbidden": false,
+    "secondAnchorRequiresFutureFiniteCounterexample": true,
+    "oldUpAsDepthCounter": false,
+    "primitiveCurrentPolePronouns": false,
+    "derivedCurrentStart": "♀↑",
+    "derivedCurrentEnd": "↑♂",
+    "decision": "preferred-for-v0.6-foundation-candidate"
+  },
+  "nestingDecision": {
+    "outerDataPolicy": "data required by a child is explicitly included in the child's current semantic link or reachable explicit state structure",
+    "deepNestingPolicy": "nested current structures are ordinary binary links and are navigated with the same raw pole destructors",
+    "continuationPolicy": "result and continuation inputs are explicit links in after-state/current-state structure",
+    "callPolicy": "calls are ordinary relations between explicit act/state links",
+    "historyPolicy": "history/continuation order is represented by ordinary links",
+    "hostContextFrameParent": false,
+    "hostReturnAddress": false,
+    "hiddenCallStack": false,
+    "implicitCallerSearch": false
+  },
+  "actDecision": {
+    "outerShape": "Act = S_before ⟼ S_after",
+    "commandAndActualActDistinct": true,
+    "resultIsExplicitInGraph": true,
+    "fullActOntologyImpliesFullActObservability": false,
+    "formulaAutomaticallyObservesCallerAct": false,
+    "formulaAutomaticallyObservesInterpreterIdentity": false
+  },
+  "explicitPassingDecision": {
+    "childExample": "XC=(O,L) gives ♀↑=O and ↑♂=L",
+    "grandchildExample": "XG=(XC,G) allows ♀(♀↑)=O and (♀↑)♂=L",
+    "continuationExample": "XR=(O,R) gives outer data and explicit child result",
+    "unpassedOuterDataVisible": false,
+    "arbitraryFiniteDataMayBePackedIntoBinaryLinks": true,
+    "passingDataCreatesNewPrimitive": false
+  },
+  "incomingSearchDecision": {
+    "genericIncomingSearchMayBeAmbiguous": true,
+    "genericIncomingSearchDefinesParent": false,
+    "genericIncomingSearchDefinesCaller": false,
+    "implicitAssociativeSearchMayChangeDeicticMeaning": false,
+    "futureCallerObservationRequiresExplicitAcceptedRelation": true
+  },
+  "historicalBoundary": {
+    "ContextFrameParentPreferredOntology": false,
+    "oldParentAscentForms": ["↑◁", "↑▷", "↑↑◁", "↑↑▷"],
+    "oldParentAscentAutomaticallyPreserved": false,
+    "historicalV02ThroughV05ReplayImmutable": true,
+    "migrationDirection": "replace hidden outer-frame reads with explicit link data passed into current/state structure"
+  },
+  "proofReplayBoundary": {
+    "nestedReplayInputs": "finite serialized act/state graph plus explicit current ref per replay step",
+    "serializeHostParentStack": false,
+    "readAmbientSession": false,
+    "readAmbientInterpreterIdentity": false,
+    "sameSerializedGraphAndCurrentDeterministic": true,
+    "newParentProofRuleAccepted": false
+  },
+  "counterexamplePolicy": {
+    "currentRequiredCorpusNeedsSecondAnchor": false,
+    "universalTheoremNoSecondAnchorEverNeeded": false,
+    "futureExtensionRule": "a new deictic primitive requires the smallest finite semantic counterexample that cannot be represented by explicit current/state links under the existing constructor/destructor algebra",
+    "convenienceIsSufficientJustification": false
+  },
+  "rejectedDefaults": [
+    {
+      "model": "ContextFrame.parent as fundamental context topology",
+      "reason": "required nested data can be represented explicitly as links and replayed without a host parent chain"
+    },
+    {
+      "model": "↑ simultaneously means current link and parent ascent",
+      "reason": "dual meaning breaks operator orthogonality and makes replay context-sensitive to hidden stack structure"
+    },
+    {
+      "model": "generic incoming-link search identifies caller/parent",
+      "reason": "incoming relations are non-unique without an explicit role relation"
+    },
+    {
+      "model": "second parent pronoun added preemptively",
+      "reason": "no finite required vector currently needs it"
+    }
+  ],
+  "gateOutcome": {
+    "hostParentRemovedFromPreferredFoundation": true,
+    "oneAnchorSufficientForRequiredNestedCorpus": true,
+    "explicitPassingDirectionResolved": true,
+    "continuationDirectionResolved": true,
+    "allIsolatedFoundationGatesResolved": true,
+    "foundationAccepted": false,
+    "nextRequiredGate": "integrated-v0.6-foundation-vertical-slice"
+  },
+  "veto": {
+    "acceptedContractLinkAllowed": false,
+    "productionParserChangeAllowed": false,
+    "productionInterpreterChangeAllowed": false,
+    "aproverRepinAllowed": false,
+    "hiddenParentStackAllowed": false,
+    "dualMeaningOfUpAllowed": false,
+    "secondDeicticPrimitiveAllowedWithoutCounterexample": false
+  },
+  "nextDependencies": {
+    "foundationDirectionIssue": 179,
+    "integratedSliceMustCompose": [
+      "mts-current-link-equality-decision/v0.6",
+      "mts-root-anum-foundation-decision/v0.6",
+      "mts-nesting-continuation-foundation-decision/v0.6"
+    ],
+    "productionMigrationBeforeIntegratedSlice": false
+  }
+}

--- a/tests/test_mts_nesting_continuation_foundation_decision.py
+++ b/tests/test_mts_nesting_continuation_foundation_decision.py
@@ -1,0 +1,167 @@
+"""Decision guards for Foundation v0.6 Gate N / issue #182."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DECISION = ROOT / "contracts/mts-nesting-continuation-foundation-decision-v0.6.json"
+DIRECTION = ROOT / "contracts/mts-foundation-direction-decision-v0.6.json"
+EQUALITY = ROOT / "contracts/mts-current-link-equality-decision-v0.6.json"
+ANUM = ROOT / "contracts/mts-root-anum-foundation-decision-v0.6.json"
+CHALLENGE = ROOT / "contracts/mts-nesting-continuation-foundation-challenge-v0.6.json"
+MTS_V05 = ROOT / "contracts/mts-contract-v0.5.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_gate_n_is_resolved_without_overall_foundation_acceptance():
+    decision = read(DECISION)
+
+    assert decision["schema"] == "mts-nesting-continuation-foundation-decision/v0.6"
+    assert decision["status"] == "candidate-decision"
+    assert decision["accepted"] is False
+    assert decision["gateResolved"] is True
+    assert decision["issue"] == 182
+    assert decision["gateOutcome"]["foundationAccepted"] is False
+    assert decision["veto"]["acceptedContractLinkAllowed"] is False
+    assert decision["veto"]["productionInterpreterChangeAllowed"] is False
+
+
+def test_gate_n_depends_on_all_prior_foundation_decisions_and_its_challenge():
+    decision = read(DECISION)
+
+    assert decision["dependsOn"] == [
+        read(DIRECTION)["schema"],
+        read(EQUALITY)["schema"],
+        read(ANUM)["schema"],
+        read(CHALLENGE)["schema"],
+    ]
+    assert read(CHALLENGE)["status"] == "candidate-challenge"
+    assert read(CHALLENGE)["accepted"] is False
+    assert decision["schema"] not in MTS_V05.read_text(encoding="utf-8")
+
+
+def test_only_one_current_link_deictic_anchor_is_selected():
+    deictic = read(DECISION)["deicticDecision"]
+
+    assert deictic["primitiveAnchors"] == ["↑"]
+    assert deictic["currentMeaning"] == "↑ -> one current semantic link"
+    assert deictic["secondParentOrOuterAnchor"] is False
+    assert deictic["secondAnchorPermanentlyForbidden"] is False
+    assert deictic["secondAnchorRequiresFutureFiniteCounterexample"] is True
+    assert deictic["oldUpAsDepthCounter"] is False
+    assert deictic["primitiveCurrentPolePronouns"] is False
+    assert deictic["derivedCurrentStart"] == "♀↑"
+    assert deictic["derivedCurrentEnd"] == "↑♂"
+
+
+def test_nested_data_and_continuation_are_explicit_link_structure():
+    nesting = read(DECISION)["nestingDecision"]
+
+    assert nesting["outerDataPolicy"].startswith("data required by a child is explicitly included")
+    assert nesting["deepNestingPolicy"].startswith("nested current structures are ordinary binary links")
+    assert nesting["continuationPolicy"].startswith("result and continuation inputs are explicit links")
+    assert nesting["callPolicy"].startswith("calls are ordinary relations")
+    assert nesting["historyPolicy"].startswith("history/continuation order is represented by ordinary links")
+    assert nesting["hostContextFrameParent"] is False
+    assert nesting["hostReturnAddress"] is False
+    assert nesting["hiddenCallStack"] is False
+    assert nesting["implicitCallerSearch"] is False
+
+
+def test_full_act_exists_without_becoming_implicitly_observable():
+    act = read(DECISION)["actDecision"]
+
+    assert act["outerShape"] == "Act = S_before ⟼ S_after"
+    assert act["commandAndActualActDistinct"] is True
+    assert act["resultIsExplicitInGraph"] is True
+    assert act["fullActOntologyImpliesFullActObservability"] is False
+    assert act["formulaAutomaticallyObservesCallerAct"] is False
+    assert act["formulaAutomaticallyObservesInterpreterIdentity"] is False
+
+
+def test_explicit_passing_examples_are_the_selected_nesting_mechanism():
+    passing = read(DECISION)["explicitPassingDecision"]
+
+    assert passing["childExample"] == "XC=(O,L) gives ♀↑=O and ↑♂=L"
+    assert passing["grandchildExample"] == (
+        "XG=(XC,G) allows ♀(♀↑)=O and (♀↑)♂=L"
+    )
+    assert passing["continuationExample"] == "XR=(O,R) gives outer data and explicit child result"
+    assert passing["unpassedOuterDataVisible"] is False
+    assert passing["arbitraryFiniteDataMayBePackedIntoBinaryLinks"] is True
+    assert passing["passingDataCreatesNewPrimitive"] is False
+
+
+def test_generic_incoming_search_is_not_promoted_to_parent_or_caller_semantics():
+    incoming = read(DECISION)["incomingSearchDecision"]
+
+    assert incoming["genericIncomingSearchMayBeAmbiguous"] is True
+    assert incoming["genericIncomingSearchDefinesParent"] is False
+    assert incoming["genericIncomingSearchDefinesCaller"] is False
+    assert incoming["implicitAssociativeSearchMayChangeDeicticMeaning"] is False
+    assert incoming["futureCallerObservationRequiresExplicitAcceptedRelation"] is True
+
+
+def test_historical_parent_ascent_is_demoted_not_reinterpreted_in_place():
+    historical = read(DECISION)["historicalBoundary"]
+
+    assert historical["ContextFrameParentPreferredOntology"] is False
+    assert historical["oldParentAscentForms"] == ["↑◁", "↑▷", "↑↑◁", "↑↑▷"]
+    assert historical["oldParentAscentAutomaticallyPreserved"] is False
+    assert historical["historicalV02ThroughV05ReplayImmutable"] is True
+    assert historical["migrationDirection"].startswith(
+        "replace hidden outer-frame reads with explicit link data"
+    )
+
+
+def test_nested_replay_boundary_contains_no_hidden_stack_or_ambient_identity():
+    replay = read(DECISION)["proofReplayBoundary"]
+
+    assert replay["nestedReplayInputs"].startswith("finite serialized act/state graph")
+    assert replay["serializeHostParentStack"] is False
+    assert replay["readAmbientSession"] is False
+    assert replay["readAmbientInterpreterIdentity"] is False
+    assert replay["sameSerializedGraphAndCurrentDeterministic"] is True
+    assert replay["newParentProofRuleAccepted"] is False
+
+
+def test_second_deictic_anchor_requires_future_counterexample_not_convenience():
+    policy = read(DECISION)["counterexamplePolicy"]
+
+    assert policy["currentRequiredCorpusNeedsSecondAnchor"] is False
+    assert policy["universalTheoremNoSecondAnchorEverNeeded"] is False
+    assert "smallest finite semantic counterexample" in policy["futureExtensionRule"]
+    assert policy["convenienceIsSufficientJustification"] is False
+
+
+def test_all_isolated_foundation_gates_are_resolved_but_integrated_slice_is_next():
+    decision = read(DECISION)
+
+    assert decision["gateOutcome"]["hostParentRemovedFromPreferredFoundation"] is True
+    assert decision["gateOutcome"]["oneAnchorSufficientForRequiredNestedCorpus"] is True
+    assert decision["gateOutcome"]["explicitPassingDirectionResolved"] is True
+    assert decision["gateOutcome"]["continuationDirectionResolved"] is True
+    assert decision["gateOutcome"]["allIsolatedFoundationGatesResolved"] is True
+    assert decision["gateOutcome"]["foundationAccepted"] is False
+    assert decision["gateOutcome"]["nextRequiredGate"] == (
+        "integrated-v0.6-foundation-vertical-slice"
+    )
+
+
+def test_production_and_aprover_remain_blocked_until_integrated_slice():
+    decision = read(DECISION)
+    veto = decision["veto"]
+
+    assert veto["productionParserChangeAllowed"] is False
+    assert veto["productionInterpreterChangeAllowed"] is False
+    assert veto["aproverRepinAllowed"] is False
+    assert veto["hiddenParentStackAllowed"] is False
+    assert veto["dualMeaningOfUpAllowed"] is False
+    assert veto["secondDeicticPrimitiveAllowedWithoutCounterexample"] is False
+    assert decision["nextDependencies"]["productionMigrationBeforeIntegratedSlice"] is False


### PR DESCRIPTION
Closes #182. Refs #179, #188, #180, #181.

Candidate Gate N decision, not overall foundation acceptance.

Based on green challenge #188, it removes host `ContextFrame.parent` and parent-ascent semantics from the preferred v0.6 foundation.

## Deictic decision

```text
primitive anchors = [↑]
↑ -> one current semantic link
♀↑ / ↑♂ -> its raw poles
```

No second parent/outer anchor is justified by the required corpus. This is not a permanent ban: a future primitive requires the smallest finite semantic counterexample that cannot be represented by explicit current/state links.

## Nesting/continuation decision

- child-required outer/local data are explicit components of the child's current/state links;
- deep nesting uses nested binary link structures and the same raw destructors;
- continuation/result data are explicit after-state/current links;
- calls and history are ordinary relations among act/state links;
- no hidden call stack, parent field or host return address;
- generic incoming-link search does not define parent/caller semantics.

The full act may still exist as `Act=S_before ⟼ S_after`, but its existence does not grant arbitrary act/interpreter introspection to the formula.

Historical `↑◁/↑▷/↑↑...` remain replayable only in immutable old contracts; they are not silently reinterpreted.

## Gate boundary

```text
gateResolved = true
allIsolatedFoundationGatesResolved = true
foundationAccepted = false
```

The next mandatory step is one integrated v0.6 foundation vertical-slice challenge composing Gate E + Gate A + Gate N. Production parser/interpreter migration and aprover repin remain blocked until that integrated slice and a later acceptance decision.