### PR TITLE
Challenge Anum as root-relative structural meaning description

### DIFF
--- a/contracts/anum-root-relative-meaning-challenge-v0.7.json
+++ b/contracts/anum-root-relative-meaning-challenge-v0.7.json
@@ -1,0 +1,79 @@
+{
+  "schema": "anum-root-relative-meaning-challenge/v0.7",
+  "status": "candidate-challenge",
+  "accepted": false,
+  "issue": 206,
+  "dependsOn": [
+    "mts-semantic-root-kernel-challenge/v0.7",
+    "anum-streaming-interpreter-challenge/v0.7"
+  ],
+  "purpose": "Challenge whether recursive Anum is best understood as a root-relative structural meaning description, while exposing the exact boundaries where occurrence identity, sharing and cycles are not preserved.",
+  "rootVocabulary": {
+    "R": "∞",
+    "O": "[",
+    "C": "]",
+    "L": "1",
+    "U": "0"
+  },
+  "candidateReading": {
+    "sourceUsesFourAbits": true,
+    "semanticLeavesUseProtocolLAndU": true,
+    "bracketsCarryNestedContextStructure": true,
+    "rootIsImplicit": true,
+    "meaningPrimitiveRequired": false,
+    "claim": "within the accepted recursive occurrence-tree domain, canonical Anum is a finite root-relative structural description built from the root-derived vocabulary"
+  },
+  "criticalBoundary": {
+    "sourceStringEqualsSemanticLink": false,
+    "canonicalAnumPreservesOccurrenceTree": true,
+    "canonicalAnumPreservesExplicitSharingIdentity": false,
+    "canonicalAnumRepresentsGeneralCyclesDirectly": false,
+    "rootSelfCycleIsUnfoldedInfinitely": false,
+    "generalArbitraryLinkMeaningSolved": false
+  },
+  "sharing": {
+    "explicitSharedNodeInverseMustReject": true,
+    "occurrenceExpandedCopyCanEncode": true,
+    "reason": "the same recursive spelling can describe repeated equal-shaped occurrences but does not carry a node-sharing identity relation"
+  },
+  "cycles": {
+    "structuralDenotationNodesAreTopologicallyOrdered": true,
+    "nodeSelfReferenceAllowed": false,
+    "mutualNodeCycleAllowed": false,
+    "cycleSupportWouldRequireAnotherFiniteReferenceOrSelfClosureMechanism": true
+  },
+  "semanticLayeringCandidate": {
+    "rootStructuralMeaning": "root-relative recursive structure reconstructed from the four-abit protocol",
+    "sharingAndReferenceMeaning": "additional explicit link identity/reference relations outside the recursive occurrence-tree code",
+    "theoryContextMeaning": "future explicit dictionary/theory relations from issue 202",
+    "separateOntologiesRequired": false
+  },
+  "requiredAssertions": [
+    "all accepted recursive structural root vectors round-trip through canonical Anum",
+    "decoded structural leaves are only protocol:0/protocol:1 and can be interpreted as root-kernel U/L",
+    "canonical raw carriers use only 0/1/[ ]",
+    "brackets determine occurrence nesting but are not emitted as denotation leaf nodes",
+    "an explicit shared structural node is rejected by the canonical recursive inverse",
+    "an occurrence-expanded copy of the shared shape is encodable",
+    "StructuralDenotation rejects direct self-cycle node references",
+    "StructuralDenotation cannot encode a mutual node cycle because node refs may target only earlier nodes",
+    "root self-closure remains a finite external/root semantic fixed point, not an infinitely unfolded recursive tree",
+    "no Meaning metadata is added to denotation nodes"
+  ],
+  "notDecided": [
+    "whether to call canonical Anum the meaning of a link or only its root-relative structural description",
+    "the finite representation of arbitrary cyclic/shared asets",
+    "how self-closure signs integrate with general cycle serialization",
+    "how dictionaries/theories contribute higher contextual meaning",
+    "production serialization changes"
+  ],
+  "veto": {
+    "meaningTagAllowed": false,
+    "sharingLossMayBeHidden": false,
+    "infiniteCycleUnfoldingAllowed": false,
+    "newRecursiveGrammarAllowed": false,
+    "productionChangeAllowed": false,
+    "historicalContractMutationAllowed": false,
+    "aproverRepinAllowed": false
+  }
+}

--- a/tests/test_anum_root_relative_meaning_challenge.py
+++ b/tests/test_anum_root_relative_meaning_challenge.py
@@ -1,0 +1,292 @@
+"""Non-normative root-relative Anum meaning challenge for issue #206.
+
+This challenge asks what accepted recursive Anum actually preserves.  It treats
+root-relative structural description as a candidate meaning layer, while making
+sharing, cycle and source-spelling losses explicit rather than hiding them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_denotation import (
+    AnumDenotation,
+    DenotationNode,
+    DenotationRef,
+    StructuralDenotation,
+    canonical_denotation_json,
+)
+from core.anum_model import ProjectionContext
+from core.anum_pair_denotation import PROTOCOL_ONE_ANCHOR, PROTOCOL_ZERO_ANCHOR
+from core.anum_parser import parse_raw_quaternary
+from core.anum_recursive_denotation import canonical_recursive_anum, denotate_recursive_anum
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHALLENGE = ROOT / "contracts/anum-root-relative-meaning-challenge-v0.7.json"
+CORPUS = ROOT / "contracts/anum-recursive-denotation-conformance-v0.2.json"
+
+ROOT_REF = 0
+OPEN_REF = 1
+CLOSE_REF = 2
+LINK_REF = 3
+UNLINK_REF = 4
+
+
+@dataclass(frozen=True)
+class Link:
+    start: int
+    end: int
+
+
+class RootRelativeGraph:
+    """Replace protocol anchors by the five-link root kernel for inspection."""
+
+    def __init__(self) -> None:
+        self.links: dict[int, Link] = {
+            ROOT_REF: Link(ROOT_REF, ROOT_REF),
+            OPEN_REF: Link(OPEN_REF, ROOT_REF),
+            CLOSE_REF: Link(ROOT_REF, CLOSE_REF),
+            LINK_REF: Link(OPEN_REF, CLOSE_REF),
+            UNLINK_REF: Link(CLOSE_REF, OPEN_REF),
+        }
+        self._next_ref = 5
+
+    def add_occurrence(self, start: int, end: int) -> int:
+        ref = self._next_ref
+        self._next_ref += 1
+        self.links[ref] = Link(start, end)
+        return ref
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def root_relative_occurrence_graph(value) -> tuple[RootRelativeGraph, int]:
+    structural = value.structural
+    assert structural is not None
+    graph = RootRelativeGraph()
+    node_refs: dict[int, int] = {}
+
+    def map_ref(ref: DenotationRef) -> int:
+        if ref.anchor is not None:
+            if ref.anchor == PROTOCOL_ONE_ANCHOR:
+                return LINK_REF
+            if ref.anchor == PROTOCOL_ZERO_ANCHOR:
+                return UNLINK_REF
+            raise ValueError(f"unexpected protocol anchor: {ref.anchor}")
+        assert ref.node is not None
+        return node_refs[ref.node]
+
+    for node in structural.nodes:
+        node_refs[node.id] = graph.add_occurrence(map_ref(node.start), map_ref(node.end))
+
+    return graph, map_ref(structural.root)
+
+
+def test_contract_is_non_normative_and_does_not_equate_source_with_semantic_link():
+    contract = read(CHALLENGE)
+
+    assert contract["schema"] == "anum-root-relative-meaning-challenge/v0.7"
+    assert contract["status"] == "candidate-challenge"
+    assert contract["accepted"] is False
+    assert contract["issue"] == 206
+    assert contract["criticalBoundary"]["sourceStringEqualsSemanticLink"] is False
+    assert contract["criticalBoundary"]["generalArbitraryLinkMeaningSolved"] is False
+    assert contract["veto"]["meaningTagAllowed"] is False
+    assert contract["veto"]["productionChangeAllowed"] is False
+
+
+def test_all_accepted_root_structural_vectors_round_trip_to_their_canonical_anum():
+    corpus = read(CORPUS)
+    tested = 0
+
+    for case in corpus["cases"]:
+        if case["context"] != "root" or case["expected"]["kind"] != "structural":
+            continue
+        value = denotate_recursive_anum(
+            parse_raw_quaternary(case["raw"]), ProjectionContext.ROOT
+        )
+        assert value.structural is not None
+        assert canonical_recursive_anum(value) == case["canonicalRaw"]
+        tested += 1
+
+    assert tested == 8
+
+
+def test_distinct_source_spellings_can_have_identical_structural_denotation():
+    pairs = [("[]", "1"), ("][", "0")]
+
+    for first_raw, second_raw in pairs:
+        first = denotate_recursive_anum(
+            parse_raw_quaternary(first_raw), ProjectionContext.ROOT
+        )
+        second = denotate_recursive_anum(
+            parse_raw_quaternary(second_raw), ProjectionContext.ROOT
+        )
+        assert canonical_denotation_json(first) == canonical_denotation_json(second)
+        assert first_raw != second_raw
+        assert canonical_recursive_anum(first) == second_raw
+
+
+def test_recursive_raw_uses_only_four_abits_but_denotation_leaves_use_only_link_unlink_protocols():
+    corpus = read(CORPUS)
+    allowed_source = set("01[]")
+
+    for case in corpus["cases"]:
+        assert set(case["raw"]) <= allowed_source
+        if case["expected"]["kind"] != "structural":
+            continue
+        value = denotate_recursive_anum(
+            parse_raw_quaternary(case["raw"]), ProjectionContext(case["context"])
+        )
+        if value.structural is None:
+            continue
+        assert set(value.structural.anchors) <= {
+            PROTOCOL_ZERO_ANCHOR,
+            PROTOCOL_ONE_ANCHOR,
+        }
+
+
+def test_brackets_encode_occurrence_nesting_but_are_not_semantic_leaf_anchors():
+    value = denotate_recursive_anum(
+        parse_raw_quaternary("[01][10]"), ProjectionContext.ROOT
+    )
+    structural = value.structural
+    assert structural is not None
+
+    assert structural.anchors == (PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR)
+    assert len(structural.nodes) == 3
+    assert all("[" not in anchor and "]" not in anchor for anchor in structural.anchors)
+
+
+def test_protocol_leaves_can_be_rebased_onto_root_kernel_link_unlink_meanings():
+    value = denotate_recursive_anum(
+        parse_raw_quaternary("[01]1"), ProjectionContext.ROOT
+    )
+    graph, root = root_relative_occurrence_graph(value)
+
+    assert graph.links[ROOT_REF] == Link(ROOT_REF, ROOT_REF)
+    assert graph.links[LINK_REF] == Link(OPEN_REF, CLOSE_REF)
+    assert graph.links[UNLINK_REF] == Link(CLOSE_REF, OPEN_REF)
+    assert graph.links[root].end == LINK_REF
+    nested = graph.links[root].start
+    assert graph.links[nested] == Link(UNLINK_REF, LINK_REF)
+
+
+def test_denotation_nodes_have_no_embedded_meaning_metadata():
+    assert [field.name for field in fields(DenotationNode)] == ["id", "start", "end"]
+
+
+def test_explicit_shared_node_identity_is_rejected_by_recursive_inverse():
+    zero = DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR)
+    one = DenotationRef.anchor_ref(PROTOCOL_ONE_ANCHOR)
+    shared = DenotationRef.node_ref(0)
+    value = StructuralDenotation(
+        anchors=(PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR),
+        nodes=(
+            DenotationNode(id=0, start=zero, end=one),
+            DenotationNode(id=1, start=shared, end=shared),
+        ),
+        root=DenotationRef.node_ref(1),
+    )
+
+    with pytest.raises(ValueError, match="shared node"):
+        canonical_recursive_anum(AnumDenotation.structural_result(value))
+
+
+def test_occurrence_expanded_equal_copies_are_encodable():
+    zero = DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR)
+    one = DenotationRef.anchor_ref(PROTOCOL_ONE_ANCHOR)
+    value = StructuralDenotation(
+        anchors=(PROTOCOL_ZERO_ANCHOR, PROTOCOL_ONE_ANCHOR),
+        nodes=(
+            DenotationNode(id=0, start=zero, end=one),
+            DenotationNode(id=1, start=zero, end=one),
+            DenotationNode(
+                id=2,
+                start=DenotationRef.node_ref(0),
+                end=DenotationRef.node_ref(1),
+            ),
+        ),
+        root=DenotationRef.node_ref(2),
+    )
+
+    encoded = canonical_recursive_anum(AnumDenotation.structural_result(value))
+    assert encoded == "[01][01]"
+
+
+def test_structural_denotation_rejects_direct_node_self_cycle():
+    zero = DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR)
+
+    with pytest.raises(ValueError, match="earlier node"):
+        StructuralDenotation(
+            anchors=(PROTOCOL_ZERO_ANCHOR,),
+            nodes=(
+                DenotationNode(
+                    id=0,
+                    start=DenotationRef.node_ref(0),
+                    end=zero,
+                ),
+            ),
+            root=DenotationRef.node_ref(0),
+        )
+
+
+def test_structural_denotation_rejects_forward_reference_needed_for_mutual_cycle():
+    zero = DenotationRef.anchor_ref(PROTOCOL_ZERO_ANCHOR)
+
+    with pytest.raises(ValueError, match="earlier node"):
+        StructuralDenotation(
+            anchors=(PROTOCOL_ZERO_ANCHOR,),
+            nodes=(
+                DenotationNode(
+                    id=0,
+                    start=DenotationRef.node_ref(1),
+                    end=zero,
+                ),
+                DenotationNode(
+                    id=1,
+                    start=DenotationRef.node_ref(0),
+                    end=zero,
+                ),
+            ),
+            root=DenotationRef.node_ref(1),
+        )
+
+
+def test_root_self_cycle_is_finite_kernel_fixed_point_not_recursive_tree_unfolding():
+    graph = RootRelativeGraph()
+
+    assert graph.links[ROOT_REF] == Link(ROOT_REF, ROOT_REF)
+    assert ROOT_REF not in {LINK_REF, UNLINK_REF}
+    contract = read(CHALLENGE)
+    assert contract["criticalBoundary"]["rootSelfCycleIsUnfoldedInfinitely"] is False
+    assert contract["cycles"]["cycleSupportWouldRequireAnotherFiniteReferenceOrSelfClosureMechanism"] is True
+
+
+def test_challenge_states_occurrence_tree_boundary_instead_of_hiding_sharing_loss():
+    contract = read(CHALLENGE)
+
+    assert contract["criticalBoundary"]["canonicalAnumPreservesOccurrenceTree"] is True
+    assert contract["criticalBoundary"]["canonicalAnumPreservesExplicitSharingIdentity"] is False
+    assert contract["sharing"]["explicitSharedNodeInverseMustReject"] is True
+    assert contract["sharing"]["occurrenceExpandedCopyCanEncode"] is True
+    assert contract["veto"]["sharingLossMayBeHidden"] is False
+
+
+def test_general_cycle_and_higher_theory_meaning_remain_open():
+    contract = read(CHALLENGE)
+
+    assert contract["notDecided"] == [
+        "whether to call canonical Anum the meaning of a link or only its root-relative structural description",
+        "the finite representation of arbitrary cyclic/shared asets",
+        "how self-closure signs integrate with general cycle serialization",
+        "how dictionaries/theories contribute higher contextual meaning",
+        "production serialization changes",
+    ]


### PR DESCRIPTION
Advances #206 with a non-normative boundary challenge.

## Positive candidate

Within the accepted recursive occurrence-tree domain, canonical Anum is challenged as a finite root-relative structural description:
- raw source uses only `0 1 [ ]`;
- structural leaves are only `protocol:0/protocol:1`, mapped in this challenge to root-kernel U/L;
- brackets carry nested occurrence/context structure but are not emitted as semantic leaf anchors;
- accepted structural root vectors round-trip to their canonical Anum.

## Critical source/meaning distinction

Accepted aliases already prove source spelling is not semantic identity:

```text
[]  and  1  -> same protocol:1 denotation
][  and  0  -> same protocol:0 denotation
```

The canonical inverse chooses `1/0`.

## Sharing boundary

The existing recursive inverse deliberately rejects explicit shared node references. An occurrence-expanded pair of equal-shaped copies is encodable (`[01][01]`), but the sharing identity itself is not carried by recursive Anum.

## Cycle boundary

`StructuralDenotation` node refs are topologically ordered and may only reference earlier nodes, so direct self-node and mutual-node cycles are outside this representation. The root self-cycle remains a finite semantic kernel fixed point, not an infinitely unfolded recursive tree.

## Non-claim

This PR does not decide whether the term "meaning" should be identified with canonical Anum. It explicitly leaves open whether Anum is best called root-relative structural meaning or only root-relative structural description, and leaves arbitrary shared/cyclic asets to a richer reference/self-closure mechanism.

No production or historical contract changes.