### PR TITLE
Challenge colon effects as persistent link-only lexical dictionary changes

### DIFF
--- a/contracts/mts-colon-definition-effects-challenge-v0.7.json
+++ b/contracts/mts-colon-definition-effects-challenge-v0.7.json
@@ -1,0 +1,121 @@
+{
+  "schema": "mts-colon-definition-effects-challenge/v0.7",
+  "status": "candidate-challenge",
+  "accepted": false,
+  "issue": 225,
+  "dependsOn": [
+    "mts-foundation-v2-integrated-direction-decision/v0.7",
+    "mts-scoped-link-dictionary-challenge/v0.7",
+    "mts-integrated-interpreter-act-challenge/v0.7"
+  ],
+  "purpose": "Re-derive colon-definition effects as explicit persistent link-network changes instead of inheriting the historical host DefinitionEnvironment by compatibility.",
+  "candidateA": {
+    "name": "same-dictionary-monotonic-membership",
+    "effect": "add D ⟼ (S ⟼ F) directly to the same D",
+    "problem": "persistent before/after state and lexical-scope identity are not explicit",
+    "preferred": false,
+    "accepted": false
+  },
+  "candidateB": {
+    "name": "one-child-dictionary-per-definition",
+    "effect": "D' has parent D and one local S ⟼ F",
+    "problem": "sequential definitions become nested shadowing and cannot represent same lexical scope conflicts",
+    "preferred": false,
+    "accepted": false
+  },
+  "candidateC": {
+    "name": "persistent-lexical-scope-snapshot",
+    "scope": "D = D ⟼ (parentScope ⟼ localHistory)",
+    "history": "H' = H ⟼ Entry; Entry = S ⟼ F",
+    "definitionEffect": "D' = D' ⟼ (sameParentScope ⟼ H')",
+    "enterChildScope": "Child = Child ⟼ (D ⟼ R)",
+    "lookup": "search local history; if no local match recurse to explicit parent scope",
+    "sameLocalDistinctForms": "conflict",
+    "sameLocalRepeatedIdenticalForm": "idempotent mapping with distinct definition-act occurrence history",
+    "childLocalMatchShadowsParent": true,
+    "parentImmutable": true,
+    "rhsEvaluation": false,
+    "preferredAfterChallenge": false,
+    "accepted": false
+  },
+  "definitionOccurrence": {
+    "entryIdentity": "Entry=S⟼F may be exact-pair reused",
+    "occurrenceIdentity": "history cell H'=H⟼Entry",
+    "sameDefinitionMayHaveMultipleActualOccurrences": true,
+    "occurrenceMultiplicityImpliesConflict": false
+  },
+  "historicalParityClassificationCandidate": {
+    "preserve": [
+      "child local definition shadows parent",
+      "different local forms for one source conflict",
+      "no hidden root definitions are injected",
+      "one-step lookup/opening does not evaluate RHS",
+      "definition/opening does not imply equality",
+      "self and mutual references terminate because stored form is not recursively normalized"
+    ],
+    "rederiveOrSupersede": [
+      "same-scope repeated identical definition automatically conflicts",
+      "DefinitionId(scopePath, ordinal) as the semantic identity model",
+      "AST-specific addressability of empty () and [] targets",
+      "host lexical scope tree as ontology"
+    ]
+  },
+  "effectReplay": {
+    "fields": [
+      "beforeScopeRef",
+      "sourceCarrier",
+      "sourceRef",
+      "formRef",
+      "entryRef",
+      "occurrenceRef",
+      "afterScopeRef"
+    ],
+    "checkerReadOnly": true,
+    "mustVerifySameLexicalParent": true,
+    "mustVerifyHistoryAppend": true,
+    "mustVerifyExactEntry": true,
+    "mustVerifyLookupAfterEffect": true,
+    "mustRejectForgedBefore": true,
+    "mustRejectForgedSource": true,
+    "mustRejectForgedForm": true,
+    "mustRejectForgedOccurrence": true,
+    "mustRejectForgedAfter": true
+  },
+  "requiredAssertions": [
+    "root lexical scope is a start-self-closed relation with parent R and empty local history R",
+    "definition execution creates a new persistent scope snapshot and does not mutate the prior scope",
+    "local history stores actual definition occurrences in order",
+    "repeating identical S:F creates a new occurrence but leaves unique lookup result F",
+    "adding S:F1 and S:F2 to the same lexical scope produces conflict",
+    "entering a child scope and defining S:F2 shadows parent S:F1 without mutating parent",
+    "missing child-local source falls through to explicit parent scope",
+    "one-step lookup returns exact stored F and does not evaluate it",
+    "self/mutual form refs may be stored and resolved without recursive normalization",
+    "no root definitions are implicitly injected into an empty root scope",
+    "definition effect does not create an equality/theorem relation",
+    "occurrence identity is the history cell, not the globally reusable Entry pair",
+    "read-only effect replay rejects forged evidence",
+    "old same-identical-definition conflict is recorded as a candidate semantic change rather than silently preserved",
+    "AST-specific empty-target addressability remains outside this gate"
+  ],
+  "notDecided": [
+    "whether candidate C is accepted as canonical lexical dictionary topology",
+    "whether repeated identical definitions should be semantically idempotent or conflict in final MTS",
+    "canonical source/form syntax for colon definitions after grammar reset",
+    "whether a definition effect also changes active interpreter context K",
+    "interaction with theory admission T",
+    "production migration"
+  ],
+  "veto": {
+    "parseAutomaticallyMutatesDictionary": false,
+    "mutableHostLexicalMapAccepted": false,
+    "globalDictionaryAllowed": false,
+    "lastWriteWinsAllowed": false,
+    "definitionImpliesEquality": false,
+    "rhsRecursiveEvaluationByDefault": false,
+    "oldEnvironmentCompatibilityLayerAllowed": false,
+    "productionChangeAllowed": false,
+    "historicalContractMutationAllowed": false,
+    "aproverRepinAllowed": false
+  }
+}

--- a/contracts/mts-colon-definition-effects-challenge-v0.7.json
+++ b/contracts/mts-colon-definition-effects-challenge-v0.7.json
@@ -2,7 +2,7 @@
   "schema": "mts-colon-definition-effects-challenge/v0.7",
   "status": "candidate-challenge",
   "accepted": false,
-  "issue": 225,
+  "issue": 224,
   "dependsOn": [
     "mts-foundation-v2-integrated-direction-decision/v0.7",
     "mts-scoped-link-dictionary-challenge/v0.7",
@@ -26,7 +26,7 @@
   "candidateC": {
     "name": "persistent-lexical-scope-snapshot",
     "scope": "D = D ⟼ (parentScope ⟼ localHistory)",
-    "history": "H' = H ⟼ Entry; Entry = S ⟼ F",
+    "history": "Occ = D_before ⟼ Entry; H' = H ⟼ Occ; Entry = S ⟼ F",
     "definitionEffect": "D' = D' ⟼ (sameParentScope ⟼ H')",
     "enterChildScope": "Child = Child ⟼ (D ⟼ R)",
     "lookup": "search local history; if no local match recurse to explicit parent scope",
@@ -40,7 +40,7 @@
   },
   "definitionOccurrence": {
     "entryIdentity": "Entry=S⟼F may be exact-pair reused",
-    "occurrenceIdentity": "history cell H'=H⟼Entry",
+    "occurrenceIdentity": "Occ=D_before⟼Entry binds the exact before-scope occurrence; history cell H'=H⟼Occ preserves order",
     "sameDefinitionMayHaveMultipleActualOccurrences": true,
     "occurrenceMultiplicityImpliesConflict": false
   },
@@ -93,7 +93,7 @@
     "self/mutual form refs may be stored and resolved without recursive normalization",
     "no root definitions are implicitly injected into an empty root scope",
     "definition effect does not create an equality/theorem relation",
-    "occurrence identity is the history cell, not the globally reusable Entry pair",
+    "occurrence identity binds the exact before-scope snapshot to the reusable Entry pair, while a separate history cell preserves order",
     "read-only effect replay rejects forged evidence",
     "old same-identical-definition conflict is recorded as a candidate semantic change rather than silently preserved",
     "AST-specific empty-target addressability remains outside this gate"

--- a/tests/test_mts_colon_definition_effects_challenge.py
+++ b/tests/test_mts_colon_definition_effects_challenge.py
@@ -1,0 +1,483 @@
+"""Non-normative colon-definition effect challenge for issue #225.
+
+Candidate C models a persistent lexical scope snapshot entirely with links:
+D = D -> (parentScope -> localHistory), where local history records actual
+S->F definition occurrences without evaluating F.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, replace
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHALLENGE = ROOT / "contracts/mts-colon-definition-effects-challenge-v0.7.json"
+
+ROOT_REF = 0
+OPEN_REF = 1
+CLOSE_REF = 2
+LINK_REF = 3
+UNLINK_REF = 4
+
+
+@dataclass(frozen=True)
+class Link:
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ScopeView:
+    parent_ref: int
+    history_ref: int
+
+
+@dataclass(frozen=True)
+class DefinitionEvidence:
+    before_scope_ref: int
+    source_carrier: str
+    source_ref: int
+    form_ref: int
+    entry_ref: int
+    occurrence_ref: int
+    after_scope_ref: int
+
+
+class UnknownDefinition(ValueError):
+    pass
+
+
+class DefinitionConflict(ValueError):
+    pass
+
+
+class LinkGraph:
+    def __init__(self) -> None:
+        self.links: dict[int, Link] = {
+            ROOT_REF: Link(ROOT_REF, ROOT_REF),
+            OPEN_REF: Link(OPEN_REF, ROOT_REF),
+            CLOSE_REF: Link(ROOT_REF, CLOSE_REF),
+            LINK_REF: Link(OPEN_REF, CLOSE_REF),
+            UNLINK_REF: Link(CLOSE_REF, OPEN_REF),
+        }
+        self._pairs = {link: ref for ref, link in self.links.items()}
+        self._next_ref = 5
+
+    def intern(self, start: int, end: int) -> int:
+        pair = Link(start, end)
+        existing = self._pairs.get(pair)
+        if existing is not None:
+            return existing
+        ref = self._next_ref
+        self._next_ref += 1
+        self.links[ref] = pair
+        self._pairs[pair] = ref
+        return ref
+
+    def find_pair(self, start: int, end: int) -> int | None:
+        return self._pairs.get(Link(start, end))
+
+    def self_closed_start(self, end: int) -> int:
+        ref = self._next_ref
+        self._next_ref += 1
+        pair = Link(ref, end)
+        assert pair not in self._pairs
+        self.links[ref] = pair
+        self._pairs[pair] = ref
+        return ref
+
+    def self_closed_end(self, start: int) -> int:
+        ref = self._next_ref
+        self._next_ref += 1
+        pair = Link(start, ref)
+        assert pair not in self._pairs
+        self.links[ref] = pair
+        self._pairs[pair] = ref
+        return ref
+
+
+def challenge() -> dict:
+    return json.loads(CHALLENGE.read_text(encoding="utf-8"))
+
+
+def encode_text(text: str) -> str:
+    return "".join(f"[{byte:08b}]" for byte in text.encode("utf-8"))
+
+
+def abit_meaning(token: str) -> int:
+    return {"[": OPEN_REF, "]": CLOSE_REF, "1": LINK_REF, "0": UNLINK_REF}[token]
+
+
+def add_source(graph: LinkGraph, carrier: str) -> int:
+    current = ROOT_REF
+    for token in carrier:
+        current = graph.intern(current, abit_meaning(token))
+    return current
+
+
+def find_source(graph: LinkGraph, carrier: str) -> int:
+    current = ROOT_REF
+    for token in carrier:
+        next_ref = graph.find_pair(current, abit_meaning(token))
+        if next_ref is None:
+            raise UnknownDefinition(carrier)
+        current = next_ref
+    return current
+
+
+def make_scope(graph: LinkGraph, parent_ref: int, history_ref: int) -> int:
+    payload_ref = graph.intern(parent_ref, history_ref)
+    return graph.self_closed_start(payload_ref)
+
+
+def root_scope(graph: LinkGraph) -> int:
+    return make_scope(graph, ROOT_REF, ROOT_REF)
+
+
+def read_scope(graph: LinkGraph, scope_ref: int) -> ScopeView:
+    scope = graph.links[scope_ref]
+    if scope.start != scope_ref:
+        raise ValueError("scope must be start-self-closed")
+    payload = graph.links[scope.end]
+    return ScopeView(parent_ref=payload.start, history_ref=payload.end)
+
+
+def enter_child_scope(graph: LinkGraph, parent_scope_ref: int) -> int:
+    return make_scope(graph, parent_scope_ref, ROOT_REF)
+
+
+def define(
+    graph: LinkGraph,
+    before_scope_ref: int,
+    source_carrier: str,
+    form_ref: int,
+) -> DefinitionEvidence:
+    before = read_scope(graph, before_scope_ref)
+    source_ref = add_source(graph, source_carrier)
+    entry_ref = graph.intern(source_ref, form_ref)
+    occurrence_ref = graph.intern(before.history_ref, entry_ref)
+    after_scope_ref = make_scope(graph, before.parent_ref, occurrence_ref)
+    return DefinitionEvidence(
+        before_scope_ref=before_scope_ref,
+        source_carrier=source_carrier,
+        source_ref=source_ref,
+        form_ref=form_ref,
+        entry_ref=entry_ref,
+        occurrence_ref=occurrence_ref,
+        after_scope_ref=after_scope_ref,
+    )
+
+
+def local_entries(graph: LinkGraph, history_ref: int) -> tuple[int, ...]:
+    if history_ref == ROOT_REF:
+        return ()
+    reverse_entries: list[int] = []
+    current = history_ref
+    seen: set[int] = set()
+    while current != ROOT_REF:
+        if current in seen:
+            raise ValueError("local history cycle")
+        seen.add(current)
+        cell = graph.links[current]
+        reverse_entries.append(cell.end)
+        current = cell.start
+    return tuple(reversed(reverse_entries))
+
+
+def lookup(graph: LinkGraph, scope_ref: int, source_carrier: str) -> int:
+    source_ref = find_source(graph, source_carrier)
+    current_scope = scope_ref
+    while True:
+        scope = read_scope(graph, current_scope)
+        local_forms = {
+            graph.links[entry_ref].end
+            for entry_ref in local_entries(graph, scope.history_ref)
+            if graph.links[entry_ref].start == source_ref
+        }
+        if len(local_forms) > 1:
+            raise DefinitionConflict(source_carrier)
+        if len(local_forms) == 1:
+            return next(iter(local_forms))
+        if scope.parent_ref == ROOT_REF:
+            raise UnknownDefinition(source_carrier)
+        current_scope = scope.parent_ref
+
+
+def count_local_occurrences(
+    graph: LinkGraph,
+    scope_ref: int,
+    source_carrier: str,
+) -> int:
+    source_ref = find_source(graph, source_carrier)
+    scope = read_scope(graph, scope_ref)
+    return sum(
+        1
+        for entry_ref in local_entries(graph, scope.history_ref)
+        if graph.links[entry_ref].start == source_ref
+    )
+
+
+def check_definition_effect(graph: LinkGraph, evidence: DefinitionEvidence) -> bool:
+    before_snapshot = dict(graph.links)
+    try:
+        try:
+            before = read_scope(graph, evidence.before_scope_ref)
+            after = read_scope(graph, evidence.after_scope_ref)
+            source_ref = find_source(graph, evidence.source_carrier)
+        except (KeyError, ValueError, UnknownDefinition):
+            return False
+        if source_ref != evidence.source_ref:
+            return False
+        if graph.links.get(evidence.entry_ref) != Link(
+            evidence.source_ref, evidence.form_ref
+        ):
+            return False
+        if graph.links.get(evidence.occurrence_ref) != Link(
+            before.history_ref, evidence.entry_ref
+        ):
+            return False
+        if after.parent_ref != before.parent_ref:
+            return False
+        if after.history_ref != evidence.occurrence_ref:
+            return False
+        try:
+            resolved = lookup(
+                graph, evidence.after_scope_ref, evidence.source_carrier
+            )
+        except (UnknownDefinition, DefinitionConflict):
+            return False
+        return resolved == evidence.form_ref
+    finally:
+        assert graph.links == before_snapshot
+
+
+def test_contract_is_non_normative_and_rederives_old_environment():
+    value = challenge()
+
+    assert value["schema"] == "mts-colon-definition-effects-challenge/v0.7"
+    assert value["status"] == "candidate-challenge"
+    assert value["accepted"] is False
+    assert value["issue"] == 225
+    assert value["candidateC"]["preferredAfterChallenge"] is False
+    assert value["veto"]["mutableHostLexicalMapAccepted"] is False
+    assert value["veto"]["definitionImpliesEquality"] is False
+    assert value["veto"]["productionChangeAllowed"] is False
+
+
+def test_links_have_no_scope_or_definition_metadata_fields():
+    assert [field.name for field in fields(Link)] == ["start", "end"]
+
+
+def test_root_scope_is_self_closed_with_root_parent_and_empty_history():
+    graph = LinkGraph()
+    scope_ref = root_scope(graph)
+    view = read_scope(graph, scope_ref)
+
+    assert view == ScopeView(parent_ref=ROOT_REF, history_ref=ROOT_REF)
+    assert graph.links[scope_ref].start == scope_ref
+
+
+def test_definition_creates_persistent_scope_snapshot_without_mutating_before():
+    graph = LinkGraph()
+    before = root_scope(graph)
+    before_link = graph.links[before]
+    carrier = encode_text("x")
+    form_ref = graph.self_closed_end(LINK_REF)
+
+    evidence = define(graph, before, carrier, form_ref)
+
+    assert evidence.after_scope_ref != before
+    assert graph.links[before] == before_link
+    assert lookup(graph, evidence.after_scope_ref, carrier) == form_ref
+    with pytest.raises(UnknownDefinition):
+        lookup(graph, before, carrier)
+    assert check_definition_effect(graph, evidence)
+
+
+def test_local_history_preserves_definition_occurrence_order():
+    graph = LinkGraph()
+    scope = root_scope(graph)
+    first = define(graph, scope, encode_text("x"), LINK_REF)
+    second = define(
+        graph, first.after_scope_ref, encode_text("y"), UNLINK_REF
+    )
+    history = read_scope(graph, second.after_scope_ref).history_ref
+
+    assert local_entries(graph, history) == (first.entry_ref, second.entry_ref)
+    assert first.occurrence_ref != second.occurrence_ref
+
+
+def test_repeated_identical_definition_keeps_unique_mapping_but_distinct_occurrences():
+    graph = LinkGraph()
+    carrier = encode_text("x")
+    scope = root_scope(graph)
+    first = define(graph, scope, carrier, LINK_REF)
+    second = define(graph, first.after_scope_ref, carrier, LINK_REF)
+
+    assert first.entry_ref == second.entry_ref
+    assert first.occurrence_ref != second.occurrence_ref
+    assert lookup(graph, second.after_scope_ref, carrier) == LINK_REF
+    assert count_local_occurrences(graph, second.after_scope_ref, carrier) == 2
+    assert challenge()["candidateC"]["sameLocalRepeatedIdenticalForm"].startswith(
+        "idempotent mapping"
+    )
+
+
+def test_distinct_forms_for_same_source_in_same_lexical_scope_conflict():
+    graph = LinkGraph()
+    carrier = encode_text("x")
+    scope = root_scope(graph)
+    first = define(graph, scope, carrier, LINK_REF)
+    second = define(
+        graph, first.after_scope_ref, carrier, UNLINK_REF
+    )
+
+    with pytest.raises(DefinitionConflict):
+        lookup(graph, second.after_scope_ref, carrier)
+
+
+def test_child_local_definition_shadows_parent_without_mutating_parent():
+    graph = LinkGraph()
+    carrier = encode_text("x")
+    parent0 = root_scope(graph)
+    parent_definition = define(graph, parent0, carrier, LINK_REF)
+    parent = parent_definition.after_scope_ref
+    parent_link = graph.links[parent]
+    child = enter_child_scope(graph, parent)
+    child_definition = define(graph, child, carrier, UNLINK_REF)
+
+    assert lookup(graph, parent, carrier) == LINK_REF
+    assert lookup(graph, child_definition.after_scope_ref, carrier) == UNLINK_REF
+    assert graph.links[parent] == parent_link
+
+
+def test_missing_child_local_definition_falls_through_explicit_parent_chain():
+    graph = LinkGraph()
+    carrier = encode_text("x")
+    root0 = root_scope(graph)
+    parent_definition = define(graph, root0, carrier, LINK_REF)
+    child = enter_child_scope(graph, parent_definition.after_scope_ref)
+
+    assert lookup(graph, child, carrier) == LINK_REF
+
+
+def test_lookup_is_one_step_and_does_not_evaluate_stored_form():
+    graph = LinkGraph()
+    carrier = encode_text("self")
+    scope = root_scope(graph)
+    opaque_recursive_form = graph.self_closed_start(ROOT_REF)
+    evidence = define(graph, scope, carrier, opaque_recursive_form)
+
+    assert lookup(graph, evidence.after_scope_ref, carrier) == opaque_recursive_form
+    assert graph.links[opaque_recursive_form].start == opaque_recursive_form
+
+
+def test_self_and_mutual_reference_forms_store_without_recursive_normalization():
+    graph = LinkGraph()
+    scope = root_scope(graph)
+    self_form = graph.self_closed_start(LINK_REF)
+    mutual_left = graph.self_closed_start(UNLINK_REF)
+    mutual_right = graph.self_closed_end(mutual_left)
+    first = define(graph, scope, encode_text("self"), self_form)
+    second = define(
+        graph, first.after_scope_ref, encode_text("left"), mutual_left
+    )
+    third = define(
+        graph, second.after_scope_ref, encode_text("right"), mutual_right
+    )
+
+    assert lookup(graph, third.after_scope_ref, encode_text("self")) == self_form
+    assert lookup(graph, third.after_scope_ref, encode_text("left")) == mutual_left
+    assert lookup(graph, third.after_scope_ref, encode_text("right")) == mutual_right
+
+
+def test_empty_root_scope_injects_no_hidden_definitions():
+    graph = LinkGraph()
+    scope = root_scope(graph)
+    for name in ("∞", "1", "0", "[", "]"):
+        with pytest.raises(UnknownDefinition):
+            lookup(graph, scope, encode_text(name))
+
+
+def test_definition_effect_creates_no_equality_or_theorem_relation():
+    graph = LinkGraph()
+    scope = root_scope(graph)
+    carrier = encode_text("x")
+    form_ref = graph.self_closed_end(LINK_REF)
+    evidence = define(graph, scope, carrier, form_ref)
+
+    assert graph.links[evidence.entry_ref] == Link(evidence.source_ref, form_ref)
+    assert graph.find_pair(form_ref, evidence.source_ref) is None
+    assert challenge()["veto"]["definitionImpliesEquality"] is False
+
+
+def test_occurrence_identity_is_history_cell_not_globally_reused_entry_pair():
+    graph = LinkGraph()
+    scope = root_scope(graph)
+    carrier = encode_text("x")
+    first = define(graph, scope, carrier, LINK_REF)
+    second = define(graph, first.after_scope_ref, carrier, LINK_REF)
+
+    assert first.entry_ref == second.entry_ref
+    assert first.occurrence_ref != second.occurrence_ref
+    assert graph.links[first.occurrence_ref].end == first.entry_ref
+    assert graph.links[second.occurrence_ref].end == second.entry_ref
+
+
+def test_effect_replay_is_read_only_and_rejects_forged_evidence():
+    graph = LinkGraph()
+    before = root_scope(graph)
+    carrier = encode_text("x")
+    form_ref = graph.self_closed_end(LINK_REF)
+    evidence = define(graph, before, carrier, form_ref)
+    other_scope = root_scope(graph)
+    other_form = graph.self_closed_start(UNLINK_REF)
+    before_snapshot = dict(graph.links)
+
+    assert check_definition_effect(graph, evidence)
+    forged = [
+        replace(evidence, before_scope_ref=other_scope),
+        replace(evidence, source_carrier=encode_text("y")),
+        replace(evidence, source_ref=ROOT_REF),
+        replace(evidence, form_ref=other_form),
+        replace(evidence, entry_ref=ROOT_REF),
+        replace(evidence, occurrence_ref=ROOT_REF),
+        replace(evidence, after_scope_ref=other_scope),
+    ]
+    assert all(not check_definition_effect(graph, item) for item in forged)
+    assert graph.links == before_snapshot
+
+
+def test_historical_same_identical_definition_conflict_is_not_silently_preserved():
+    parity = challenge()["historicalParityClassificationCandidate"]
+
+    assert "same-scope repeated identical definition automatically conflicts" in parity[
+        "rederiveOrSupersede"
+    ]
+    assert "different local forms for one source conflict" in parity["preserve"]
+    assert "child local definition shadows parent" in parity["preserve"]
+
+
+def test_ast_specific_empty_target_addressability_is_explicitly_outside_gate():
+    parity = challenge()["historicalParityClassificationCandidate"]
+
+    assert "AST-specific addressability of empty () and [] targets" in parity[
+        "rederiveOrSupersede"
+    ]
+
+
+def test_definition_candidate_remains_noncanonical_and_production_blocked():
+    value = challenge()
+
+    assert value["notDecided"] == [
+        "whether candidate C is accepted as canonical lexical dictionary topology",
+        "whether repeated identical definitions should be semantically idempotent or conflict in final MTS",
+        "canonical source/form syntax for colon definitions after grammar reset",
+        "whether a definition effect also changes active interpreter context K",
+        "interaction with theory admission T",
+        "production migration",
+    ]

--- a/tests/test_mts_colon_definition_effects_challenge.py
+++ b/tests/test_mts_colon_definition_effects_challenge.py
@@ -1,4 +1,4 @@
-"""Non-normative colon-definition effect challenge for issue #225.
+"""Non-normative colon-definition effect challenge for issue #224.
 
 Candidate C models a persistent lexical scope snapshot entirely with links:
 D = D -> (parentScope -> localHistory), where local history records actual
@@ -159,8 +159,9 @@ def define(
     before = read_scope(graph, before_scope_ref)
     source_ref = add_source(graph, source_carrier)
     entry_ref = graph.intern(source_ref, form_ref)
-    occurrence_ref = graph.intern(before.history_ref, entry_ref)
-    after_scope_ref = make_scope(graph, before.parent_ref, occurrence_ref)
+    occurrence_ref = graph.intern(before_scope_ref, entry_ref)
+    history_ref = graph.intern(before.history_ref, occurrence_ref)
+    after_scope_ref = make_scope(graph, before.parent_ref, history_ref)
     return DefinitionEvidence(
         before_scope_ref=before_scope_ref,
         source_carrier=source_carrier,
@@ -183,7 +184,8 @@ def local_entries(graph: LinkGraph, history_ref: int) -> tuple[int, ...]:
             raise ValueError("local history cycle")
         seen.add(current)
         cell = graph.links[current]
-        reverse_entries.append(cell.end)
+        occurrence = graph.links[cell.end]
+        reverse_entries.append(occurrence.end)
         current = cell.start
     return tuple(reversed(reverse_entries))
 
@@ -237,12 +239,14 @@ def check_definition_effect(graph: LinkGraph, evidence: DefinitionEvidence) -> b
         ):
             return False
         if graph.links.get(evidence.occurrence_ref) != Link(
-            before.history_ref, evidence.entry_ref
+            evidence.before_scope_ref, evidence.entry_ref
         ):
             return False
         if after.parent_ref != before.parent_ref:
             return False
-        if after.history_ref != evidence.occurrence_ref:
+        if graph.links.get(after.history_ref) != Link(
+            before.history_ref, evidence.occurrence_ref
+        ):
             return False
         try:
             resolved = lookup(
@@ -261,7 +265,7 @@ def test_contract_is_non_normative_and_rederives_old_environment():
     assert value["schema"] == "mts-colon-definition-effects-challenge/v0.7"
     assert value["status"] == "candidate-challenge"
     assert value["accepted"] is False
-    assert value["issue"] == 225
+    assert value["issue"] == 224
     assert value["candidateC"]["preferredAfterChallenge"] is False
     assert value["veto"]["mutableHostLexicalMapAccepted"] is False
     assert value["veto"]["definitionImpliesEquality"] is False
@@ -415,7 +419,7 @@ def test_definition_effect_creates_no_equality_or_theorem_relation():
     assert challenge()["veto"]["definitionImpliesEquality"] is False
 
 
-def test_occurrence_identity_is_history_cell_not_globally_reused_entry_pair():
+def test_occurrence_identity_binds_before_scope_not_globally_reused_entry_pair():
     graph = LinkGraph()
     scope = root_scope(graph)
     carrier = encode_text("x")
@@ -424,8 +428,12 @@ def test_occurrence_identity_is_history_cell_not_globally_reused_entry_pair():
 
     assert first.entry_ref == second.entry_ref
     assert first.occurrence_ref != second.occurrence_ref
-    assert graph.links[first.occurrence_ref].end == first.entry_ref
-    assert graph.links[second.occurrence_ref].end == second.entry_ref
+    assert graph.links[first.occurrence_ref] == Link(
+        first.before_scope_ref, first.entry_ref
+    )
+    assert graph.links[second.occurrence_ref] == Link(
+        second.before_scope_ref, second.entry_ref
+    )
 
 
 def test_effect_replay_is_read_only_and_rejects_forged_evidence():


### PR DESCRIPTION
Advances Gate `:` (#224) after the merged foundation-v2 direction decision #222 by re-deriving definition effects from the scoped dictionary instead of copying the host `DefinitionEnvironment`.

## Candidate C

```text
D = D ⟼ (parentScope ⟼ localHistory)
Entry = S ⟼ F
Occ = D_before ⟼ Entry
H' = H ⟼ Occ
D' = D' ⟼ (sameParentScope ⟼ H')
```

A child lexical scope is a new self-closed scope with explicit parent D and empty local history R.

The challenge tests persistent snapshots, local-history occurrence order, child shadowing, parent fallback, same-local distinct-form conflict, one-step/no-RHS-evaluation behavior, self/mutual stored refs, no hidden root definitions, no equality implication, and read-only forged-effect replay.

## Deliberate semantic re-evaluation

Unlike historical `DefinitionEnvironment`, repeated identical `S:F` in one lexical scope is challenged as an **idempotent mapping with distinct actual definition occurrences**, not automatically a conflict. The globally reusable `Entry=S⟼F` may be identical; `Occ=D_before⟼Entry` binds the exact before-scope occurrence, while `H'=H⟼Occ` preserves lexical occurrence order.

Historical AST-specific `DefinitionId(scopePath,ordinal)` and empty `()/[]` target addressability are classified for re-derivation rather than preserved by compatibility.

## Falsification result and fix

The first replay corpus deliberately created two structurally identical before-scope occurrences. The original candidate encoded only `H'=H⟼Entry`, so forged evidence could replace `D_before` with another structurally identical scope and still pass replay. CI correctly falsified that candidate (940/941 tests passed).

The candidate is now strengthened rather than the test weakened: the actual occurrence relation explicitly binds the exact before-scope ref via `Occ=D_before⟼Entry`; the history cell separately carries order. Forged-before replay must now fail even when the alternate scope has the same parent/history shape.

No production/historical contract changes.