### PR TITLE
Implement Gate P exact-occurrence binary link network substrate

### DIFF
--- a/contracts/mts-exact-occurrence-link-network-v0.7.json
+++ b/contracts/mts-exact-occurrence-link-network-v0.7.json
@@ -1,0 +1,65 @@
+{
+  "schema": "mts-exact-occurrence-link-network/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 240,
+  "parent": 237,
+  "primitive": {
+    "linkFields": ["start", "end"],
+    "semanticTags": [],
+    "exactOccurrenceIdentity": "network-local opaque ref",
+    "pairUniqueness": false,
+    "cycles": true,
+    "sharing": true
+  },
+  "root": {
+    "distinguishedBy": "exact occurrence ref",
+    "shapeSearchDefinesRoot": false,
+    "multipleSelfClosedOccurrencesAllowed": true
+  },
+  "identityBoundaries": {
+    "samePairImpliesSameOccurrence": false,
+    "isomorphismImpliesSemanticIdentity": false,
+    "snapshotSlotIsUniversalIdentity": false,
+    "backendAddressIsUniversalIdentity": false,
+    "refsFromIndependentLoadsCompareAsSameOccurrence": false
+  },
+  "portableSnapshot": {
+    "contains": ["ordered start/end local slots", "distinguished root local slot"],
+    "deterministicForOneFrozenNetwork": true,
+    "loadCreatesFreshIdentityScope": true,
+    "preservesTopology": true,
+    "preservesOccurrenceMultiplicity": true
+  },
+  "constructionBoundary": {
+    "reservationBuilderIsOntology": false,
+    "reservationPurpose": "finite construction of cyclic/shared topology",
+    "incompleteBuilderMayFreeze": false,
+    "foreignRefMayBeUsed": false,
+    "redefinitionAllowed": false
+  },
+  "higherLayerRoles": {
+    "contextTagOnLink": false,
+    "dictionaryTagOnLink": false,
+    "theoryTagOnLink": false,
+    "axiomTagOnLink": false,
+    "actTagOnLink": false,
+    "meaningTagOnLink": false,
+    "tokenOrAstKindOnLink": false,
+    "rolesRepresentableByOrdinaryLinksLater": true
+  },
+  "historicalBoundary": {
+    "semanticCarrierModuleModified": false,
+    "contextFrameAdapterAdded": false,
+    "parserModified": false,
+    "interpreterModified": false,
+    "productionCutover": false
+  },
+  "nextGate": "represent Foundation-v2 K/D/G/T/A/source structures over exact occurrences only after explicit decision",
+  "veto": {
+    "automaticPairInterning": false,
+    "graphEqualitySemanticPrimitive": false,
+    "implicitPersistence": false,
+    "downstreamRepin": false
+  }
+}

--- a/core/exact_link_network.py
+++ b/core/exact_link_network.py
@@ -1,0 +1,202 @@
+"""Storage-neutral exact-occurrence binary-link network for Foundation-v2 Gate P.
+
+This module is intentionally smaller than the MTS language.  A semantic link has
+exactly two fields, ``start`` and ``end``.  Context, dictionary, theory, act,
+source, equality, token and AST roles are *not* link tags; higher layers may
+represent those roles with ordinary link occurrences.
+
+``OccurrenceRef`` is network-local identity.  A portable snapshot stores local
+slots, but loading it creates a fresh identity scope.  Consequently a backend
+address, a snapshot slot and a runtime occurrence ref are deliberately not one
+universal identifier.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+class LinkNetworkError(ValueError):
+    """Invalid exact-occurrence network construction or access."""
+
+
+@dataclass(frozen=True)
+class OccurrenceRef:
+    """Opaque identity of one exact occurrence inside one network scope."""
+
+    _scope: object = field(repr=False)
+    slot: int
+
+
+@dataclass(frozen=True)
+class Link:
+    """The only primitive semantic shape: an ordered binary relation."""
+
+    start: OccurrenceRef
+    end: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class NetworkSnapshot:
+    """Portable transport topology; integer slots are snapshot-local only."""
+
+    links: tuple[tuple[int, int], ...]
+    root: int
+
+
+class LinkNetwork:
+    """Immutable finite network preserving exact occurrence multiplicity."""
+
+    def __init__(
+        self,
+        scope: object,
+        refs: tuple[OccurrenceRef, ...],
+        links: tuple[Link, ...],
+        root: OccurrenceRef,
+    ) -> None:
+        if not links:
+            raise LinkNetworkError("LinkNetwork must contain at least one occurrence")
+        if len(refs) != len(links):
+            raise LinkNetworkError("reference/link cardinality mismatch")
+        self._scope = scope
+        self._refs = refs
+        self._links = links
+        self._root = root
+        self._validate_ref(root)
+        for ref, link in zip(refs, links, strict=True):
+            if ref.slot < 0 or ref.slot >= len(refs):
+                raise LinkNetworkError("invalid occurrence slot")
+            self._validate_ref(link.start)
+            self._validate_ref(link.end)
+
+    @property
+    def root(self) -> OccurrenceRef:
+        """Return the distinguished root occurrence by exact reference."""
+
+        return self._root
+
+    @property
+    def refs(self) -> tuple[OccurrenceRef, ...]:
+        """Return all exact occurrence refs in deterministic local-slot order."""
+
+        return self._refs
+
+    def link(self, ref: OccurrenceRef) -> Link:
+        """Read one exact occurrence; foreign-network refs are rejected."""
+
+        self._validate_ref(ref)
+        return self._links[ref.slot]
+
+    def snapshot(self) -> NetworkSnapshot:
+        """Return deterministic storage-neutral topology in local-slot form."""
+
+        return NetworkSnapshot(
+            links=tuple((link.start.slot, link.end.slot) for link in self._links),
+            root=self._root.slot,
+        )
+
+    @classmethod
+    def from_snapshot(cls, snapshot: NetworkSnapshot) -> "LinkNetwork":
+        """Load topology into a fresh identity scope."""
+
+        if not snapshot.links:
+            raise LinkNetworkError("snapshot must contain at least one occurrence")
+        count = len(snapshot.links)
+        if snapshot.root < 0 or snapshot.root >= count:
+            raise LinkNetworkError("snapshot root slot is out of range")
+        for pair in snapshot.links:
+            if len(pair) != 2:
+                raise LinkNetworkError("snapshot link must contain start/end slots")
+            start, end = pair
+            if not isinstance(start, int) or not isinstance(end, int):
+                raise LinkNetworkError("snapshot slots must be integers")
+            if start < 0 or start >= count or end < 0 or end >= count:
+                raise LinkNetworkError("snapshot endpoint slot is out of range")
+
+        scope = object()
+        refs = tuple(OccurrenceRef(scope, slot) for slot in range(count))
+        links = tuple(Link(refs[start], refs[end]) for start, end in snapshot.links)
+        return cls(scope, refs, links, refs[snapshot.root])
+
+    def _validate_ref(self, ref: OccurrenceRef) -> None:
+        if not isinstance(ref, OccurrenceRef):
+            raise LinkNetworkError("expected OccurrenceRef")
+        if ref._scope is not self._scope:
+            raise LinkNetworkError("foreign occurrence reference")
+        if ref.slot < 0 or ref.slot >= len(self._refs):
+            raise LinkNetworkError("occurrence slot is out of range")
+        if self._refs[ref.slot] is not ref:
+            # Prevent hand-crafted refs with the right scope/slot from becoming
+            # aliases of the exact object issued by this network/builder.
+            raise LinkNetworkError("occurrence reference was not issued by this network")
+
+
+class LinkNetworkBuilder:
+    """Host construction utility for finite cyclic/shared exact networks.
+
+    Reservation exists solely so cyclic endpoints can refer to occurrences that
+    are defined later.  It is construction machinery, not an ontological link
+    state or a semantic notion of an "undefined link".
+    """
+
+    def __init__(self) -> None:
+        self._scope = object()
+        self._refs: list[OccurrenceRef] = []
+        self._links: list[Link | None] = []
+        self._frozen = False
+
+    def reserve(self) -> OccurrenceRef:
+        self._require_mutable()
+        ref = OccurrenceRef(self._scope, len(self._refs))
+        self._refs.append(ref)
+        self._links.append(None)
+        return ref
+
+    def define(
+        self,
+        ref: OccurrenceRef,
+        start: OccurrenceRef,
+        end: OccurrenceRef,
+    ) -> None:
+        self._require_mutable()
+        self._validate_reserved(ref)
+        self._validate_reserved(start)
+        self._validate_reserved(end)
+        if self._links[ref.slot] is not None:
+            raise LinkNetworkError("occurrence is already defined")
+        self._links[ref.slot] = Link(start, end)
+
+    def define_many(
+        self,
+        definitions: Iterable[tuple[OccurrenceRef, OccurrenceRef, OccurrenceRef]],
+    ) -> None:
+        for ref, start, end in definitions:
+            self.define(ref, start, end)
+
+    def freeze(self, root: OccurrenceRef) -> LinkNetwork:
+        self._require_mutable()
+        self._validate_reserved(root)
+        missing = [ref.slot for ref, link in zip(self._refs, self._links) if link is None]
+        if missing:
+            raise LinkNetworkError(f"unbound occurrences: {missing}")
+        if not self._refs:
+            raise LinkNetworkError("cannot freeze an empty network")
+
+        refs = tuple(self._refs)
+        links = tuple(link for link in self._links if link is not None)
+        self._frozen = True
+        return LinkNetwork(self._scope, refs, links, root)
+
+    def _validate_reserved(self, ref: OccurrenceRef) -> None:
+        if not isinstance(ref, OccurrenceRef):
+            raise LinkNetworkError("expected OccurrenceRef")
+        if ref._scope is not self._scope:
+            raise LinkNetworkError("foreign occurrence reference")
+        if ref.slot < 0 or ref.slot >= len(self._refs):
+            raise LinkNetworkError("occurrence was not reserved by this builder")
+        if self._refs[ref.slot] is not ref:
+            raise LinkNetworkError("occurrence reference was not issued by this builder")
+
+    def _require_mutable(self) -> None:
+        if self._frozen:
+            raise LinkNetworkError("builder is already frozen")

--- a/tests/test_mts_exact_occurrence_link_network.py
+++ b/tests/test_mts_exact_occurrence_link_network.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import fields
+import json
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import (
+    Link,
+    LinkNetwork,
+    LinkNetworkBuilder,
+    LinkNetworkError,
+    NetworkSnapshot,
+    OccurrenceRef,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts/mts-exact-occurrence-link-network-v0.7.json"
+
+
+def read_contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def build_reference_network():
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    other_self = builder.reserve()
+    shared = builder.reserve()
+    left = builder.reserve()
+    right = builder.reserve()
+    duplicate1 = builder.reserve()
+    duplicate2 = builder.reserve()
+    mutual_a = builder.reserve()
+    mutual_b = builder.reserve()
+
+    builder.define(root, root, root)
+    builder.define(other_self, other_self, other_self)
+    builder.define(shared, root, other_self)
+    builder.define(left, shared, root)
+    builder.define(right, shared, other_self)
+    builder.define(duplicate1, left, right)
+    builder.define(duplicate2, left, right)
+    builder.define(mutual_a, mutual_b, root)
+    builder.define(mutual_b, mutual_a, root)
+    return builder.freeze(root), {
+        "root": root,
+        "other_self": other_self,
+        "shared": shared,
+        "left": left,
+        "right": right,
+        "duplicate1": duplicate1,
+        "duplicate2": duplicate2,
+        "mutual_a": mutual_a,
+        "mutual_b": mutual_b,
+    }
+
+
+def test_contract_is_candidate_and_does_not_authorize_cutover():
+    contract = read_contract()
+    assert contract["schema"] == "mts-exact-occurrence-link-network/v0.7"
+    assert contract["status"] == "gate-p-candidate"
+    assert contract["accepted"] is False
+    assert contract["issue"] == 240
+    assert contract["historicalBoundary"]["productionCutover"] is False
+    assert contract["veto"]["downstreamRepin"] is False
+
+
+def test_link_primitive_has_exactly_start_and_end():
+    assert [field.name for field in fields(Link)] == ["start", "end"]
+    contract = read_contract()
+    assert contract["primitive"]["linkFields"] == ["start", "end"]
+    assert contract["primitive"]["semanticTags"] == []
+
+
+def test_distinguished_root_is_exact_occurrence_not_self_closed_shape_search():
+    network, refs = build_reference_network()
+    root = refs["root"]
+    other = refs["other_self"]
+
+    assert network.root is root
+    assert network.link(root) == Link(root, root)
+    assert network.link(other) == Link(other, other)
+    assert root != other
+    assert network.root != other
+
+
+def test_duplicate_equal_pairs_remain_distinct_occurrences():
+    network, refs = build_reference_network()
+    first = refs["duplicate1"]
+    second = refs["duplicate2"]
+
+    assert first != second
+    assert network.link(first) == network.link(second)
+    assert network.link(first).start is refs["left"]
+    assert network.link(first).end is refs["right"]
+
+
+def test_sharing_is_preserved_by_exact_refs():
+    network, refs = build_reference_network()
+    assert network.link(refs["left"]).start is refs["shared"]
+    assert network.link(refs["right"]).start is refs["shared"]
+
+
+def test_mutual_cycle_is_finite_and_direct():
+    network, refs = build_reference_network()
+    a = refs["mutual_a"]
+    b = refs["mutual_b"]
+    assert network.link(a).start is b
+    assert network.link(b).start is a
+    assert network.link(a).end is refs["root"]
+    assert network.link(b).end is refs["root"]
+
+
+def test_snapshot_round_trip_preserves_topology_root_and_multiplicity():
+    network, refs = build_reference_network()
+    snapshot = network.snapshot()
+    restored = LinkNetwork.from_snapshot(snapshot)
+
+    assert restored.snapshot() == snapshot
+    assert restored.root.slot == refs["root"].slot
+    assert len(restored.refs) == len(network.refs)
+
+    first = restored.refs[refs["duplicate1"].slot]
+    second = restored.refs[refs["duplicate2"].slot]
+    assert first != second
+    assert restored.link(first) == restored.link(second)
+
+
+def test_round_trip_creates_fresh_identity_scope():
+    network, refs = build_reference_network()
+    restored = LinkNetwork.from_snapshot(network.snapshot())
+
+    assert restored.root != network.root
+    assert restored.refs[refs["shared"].slot] != refs["shared"]
+    with pytest.raises(LinkNetworkError, match="foreign occurrence reference"):
+        restored.link(refs["shared"])
+    with pytest.raises(LinkNetworkError, match="foreign occurrence reference"):
+        network.link(restored.refs[refs["shared"].slot])
+
+
+def test_foreign_builder_refs_reject():
+    left = LinkNetworkBuilder()
+    right = LinkNetworkBuilder()
+    l = left.reserve()
+    r = right.reserve()
+
+    with pytest.raises(LinkNetworkError, match="foreign occurrence reference"):
+        left.define(l, l, r)
+
+
+def test_handcrafted_alias_ref_rejects_even_with_scope_and_slot():
+    network, refs = build_reference_network()
+    original = refs["shared"]
+    forged = OccurrenceRef(original._scope, original.slot)
+    assert forged == original
+    assert forged is not original
+    with pytest.raises(LinkNetworkError, match="not issued by this network"):
+        network.link(forged)
+
+
+def test_incomplete_builder_rejects_freeze_and_redefinition_rejects():
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    other = builder.reserve()
+    builder.define(root, root, root)
+
+    with pytest.raises(LinkNetworkError, match="unbound occurrences"):
+        builder.freeze(root)
+
+    builder.define(other, other, root)
+    with pytest.raises(LinkNetworkError, match="already defined"):
+        builder.define(other, root, root)
+
+
+def test_builder_is_one_shot_after_freeze():
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    builder.define(root, root, root)
+    builder.freeze(root)
+
+    with pytest.raises(LinkNetworkError, match="already frozen"):
+        builder.reserve()
+
+
+def test_invalid_snapshots_reject():
+    invalid = [
+        NetworkSnapshot(links=(), root=0),
+        NetworkSnapshot(links=((0, 0),), root=1),
+        NetworkSnapshot(links=((1, 0),), root=0),
+        NetworkSnapshot(links=((-1, 0),), root=0),
+    ]
+    for snapshot in invalid:
+        with pytest.raises(LinkNetworkError):
+            LinkNetwork.from_snapshot(snapshot)
+
+
+def test_snapshot_slots_are_transport_local_not_runtime_refs():
+    network, refs = build_reference_network()
+    snapshot = network.snapshot()
+    assert isinstance(snapshot.root, int)
+    assert all(isinstance(slot, int) for pair in snapshot.links for slot in pair)
+    assert snapshot.root == refs["root"].slot
+    assert read_contract()["identityBoundaries"]["snapshotSlotIsUniversalIdentity"] is False
+
+
+def test_no_pair_interning_or_graph_equality_api_is_part_of_primitive_network():
+    forbidden = {
+        "intern",
+        "find_or_create",
+        "isomorphic",
+        "equals",
+        "meaning",
+        "kind",
+    }
+    public = set(dir(LinkNetwork)) | set(dir(LinkNetworkBuilder)) | set(Link.__dataclass_fields__)
+    assert forbidden.isdisjoint(public)
+    identity = read_contract()["identityBoundaries"]
+    assert identity["samePairImpliesSameOccurrence"] is False
+    assert identity["isomorphismImpliesSemanticIdentity"] is False

--- a/tests/test_mts_exact_occurrence_link_network.py
+++ b/tests/test_mts_exact_occurrence_link_network.py
@@ -142,13 +142,13 @@ def test_round_trip_creates_fresh_identity_scope():
 
 
 def test_foreign_builder_refs_reject():
-    left = LinkNetworkBuilder()
-    right = LinkNetworkBuilder()
-    l = left.reserve()
-    r = right.reserve()
+    left_builder = LinkNetworkBuilder()
+    right_builder = LinkNetworkBuilder()
+    left_ref = left_builder.reserve()
+    right_ref = right_builder.reserve()
 
     with pytest.raises(LinkNetworkError, match="foreign occurrence reference"):
-        left.define(l, l, r)
+        left_builder.define(left_ref, left_ref, right_ref)
 
 
 def test_handcrafted_alias_ref_rejects_even_with_scope_and_slot():


### PR DESCRIPTION
Refs #240, #237.

## What this adds

An isolated storage-neutral Foundation-v2 substrate:

- `OccurrenceRef` — opaque network-local exact occurrence identity;
- `Link(start,end)` — exactly two semantic fields;
- immutable `LinkNetwork`;
- construction-only `LinkNetworkBuilder` with reserve/define for finite cycles;
- deterministic `NetworkSnapshot` with local slots and root slot.

No parser, AST, interpreter, historical carrier, definition system, proof checker or L4 backend is modified.

## Important identity behavior

The primitive network intentionally does **not** intern `(start,end)` pairs.

Therefore it supports:
- distinguished root `R=(R,R)` by exact ref;
- another `X=(X,X)` with `X != R` by occurrence;
- `P1=(A,B)` and `P2=(A,B)` as distinct occurrences;
- mutual cycles and shared children.

A snapshot round-trip preserves topology and occurrence multiplicity but loads into a fresh runtime identity scope, so equal local slot numbers from independent networks do not become the same occurrence accidentally.

## Semantic exclusions

There are no link fields/tags for context, theory, axiom, act, meaning, token or AST kind. No pair interning, graph-isomorphism equality or physical-address identity API is introduced.

The builder's reservation state is explicitly host construction machinery, not a new ontological state of a link.

## Why this is safe now

#238/#239 already audited the current production surface and selected this substrate direction. This PR implements only that isolated P1 layer. Parser/interpreter production migration remains blocked until this gate is explicitly decided and higher K/D/G/T/A structures are challenged over it.