### PR TITLE
Gate P: add one exact-evidence source front-end

### DIFF
--- a/contracts/mts-foundation-v2-source-v0.7.json
+++ b/contracts/mts-foundation-v2-source-v0.7.json
@@ -1,0 +1,84 @@
+{
+  "schema": "mts-foundation-v2-source/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 245,
+  "parent": 237,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-foundation-v2-state/v0.7",
+    "astring-link-topology-challenge/v0.7",
+    "mts-source-sequence-challenge/v0.7"
+  ],
+  "path": [
+    "raw bytes",
+    "canonical astring content C",
+    "exact source occurrence S",
+    "selected exact segmentation evidence",
+    "explicit D membership per slice",
+    "ordered resolved form sequence",
+    "explicit G membership",
+    "explicit T membership"
+  ],
+  "source": {
+    "contentTopology": "C_0=R; C_(n+1)=C_n ⟼ B(byte_n)",
+    "sourceOccurrenceTopology": "S = S ⟼ C",
+    "byteProtocolRefsAreSuppliedByLowerLayer": true,
+    "rawBytesAreSemanticIdentity": false,
+    "unicodeNormalization": "none",
+    "invalidUtf8ByteContentRepresentable": true
+  },
+  "selectedSegment": {
+    "spanTopology": "Span = sourcePrefix(start) ⟼ sourcePrefix(end)",
+    "sliceEvidenceTopology": "SliceEvidence = Span ⟼ sliceContent",
+    "lexemeOccurrenceTopology": "Lexeme = S ⟼ SliceEvidence",
+    "resolutionTopology": "Resolution = Lexeme ⟼ form",
+    "selectionTopology": "Selection = exactDictionaryMembership ⟼ Resolution",
+    "hostOffsetsAreTransportEvidenceNotSemanticIdentity": true
+  },
+  "dictionary": {
+    "entryTopology": "Entry = sliceContent ⟼ form",
+    "membershipTopology": "Membership = D ⟼ Entry",
+    "membershipMustBeExactSelectedEvidence": true,
+    "sameBytesMayResolveDifferentlyUnderDifferentDictionaries": true
+  },
+  "sequence": {
+    "selectionSequence": "fold(R, exact Selection occurrences in source order)",
+    "formSequence": "fold(R, resolved exact form occurrences in source order)",
+    "grammarMembership": "G ⟼ formSequence",
+    "theoryMembership": "T ⟼ formSequence",
+    "implicitLongestMatch": false,
+    "candidateSearchTrusted": false
+  },
+  "replay": {
+    "selectedBoundariesVerifiedAgainstCanonicalSourceHistory": true,
+    "sliceContentVerifiedAgainstExactSelectedBytes": true,
+    "dictionaryMembershipVerified": true,
+    "grammarMembershipVerified": true,
+    "theoryMembershipVerified": true,
+    "orderedSequencesVerified": true,
+    "readOnly": true,
+    "applicationLinkMaterialization": false
+  },
+  "productionBoundary": {
+    "legacyParserDependency": false,
+    "legacyAstDependency": false,
+    "tokenKindSemanticIdentity": false,
+    "perGlyphSemanticDispatch": false,
+    "sequenceToApamemorySemanticsOwnedByIssue": 242,
+    "persistentBackendOwnedByIssue": 124,
+    "interpreterMigrationDone": false,
+    "aproverRepinAllowed": false
+  },
+  "requiredVectors": [
+    "multi-byte UTF-8 glyph selected as one slice",
+    "same bytes under D1/D2 resolve differently",
+    "ambiguous split and whole-token segmentations both replay when explicitly admitted",
+    "forged span rejects",
+    "wrong dictionary rejects",
+    "forged G/T admission rejects",
+    "partial/non-contiguous partition rejects",
+    "read-only replay does not create described application links"
+  ],
+  "nextGate": "one interpreter/replay engine consuming this exact source evidence and explicit K/D/G/T/A state"
+}

--- a/core/foundation_v2_source.py
+++ b/core/foundation_v2_source.py
@@ -1,0 +1,424 @@
+"""Foundation-v2 source front-end over exact-occurrence link networks.
+
+The trusted operation in this module is *replay of selected evidence*.  Candidate
+segmentation/token search is intentionally outside the trusted core.  A caller
+supplies exact byte-protocol refs, an exact source occurrence, selected spans,
+explicit dictionary memberships and explicit grammar/theory admission.
+
+Host byte offsets and dataclasses are transport/checker machinery.  They are not
+semantic identity.  The semantic evidence is represented by ordinary links.
+No function here materializes the application relation described by source text.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from .exact_link_network import LinkNetwork, LinkNetworkBuilder, OccurrenceRef
+from .foundation_v2_state import define_membership, define_source_occurrence
+
+
+class SourceReplayError(ValueError):
+    """Selected source evidence is incomplete, forged or inconsistent."""
+
+
+@dataclass(frozen=True)
+class SourceOccurrence:
+    """Transport handle for one exact source occurrence and its canonical content."""
+
+    raw_bytes: bytes
+    content: OccurrenceRef
+    source: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class SegmentSpec:
+    """Untrusted selected span plus already-existing semantic evidence refs."""
+
+    start: int
+    end: int
+    form: OccurrenceRef
+    dictionary_membership: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class SegmentEvidence:
+    """Exact link evidence for one selected source slice."""
+
+    start: int
+    end: int
+    slice_content: OccurrenceRef
+    span: OccurrenceRef
+    slice_evidence: OccurrenceRef
+    lexeme: OccurrenceRef
+    resolution: OccurrenceRef
+    dictionary_membership: OccurrenceRef
+    selection: OccurrenceRef
+    form: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class SourceFrontEndEvidence:
+    """Replayable selected segmentation/resolution for one exact source occurrence."""
+
+    raw_bytes: bytes
+    content: OccurrenceRef
+    source: OccurrenceRef
+    dictionary: OccurrenceRef
+    grammar: OccurrenceRef
+    theory: OccurrenceRef
+    segments: tuple[SegmentEvidence, ...]
+    selection_sequence: OccurrenceRef
+    form_sequence: OccurrenceRef
+    grammar_membership: OccurrenceRef
+    theory_membership: OccurrenceRef
+
+
+class SourceFrontEndBuilder:
+    """Untrusted construction helper for canonical source/evidence fixtures.
+
+    ``byte_refs`` are the exact occurrences selected by the lower canonical byte
+    protocol.  This layer does not redefine the ``[bbbbbbbb]`` carrier; it folds
+    those exact byte refs into canonical source-content histories.
+    """
+
+    def __init__(
+        self,
+        builder: LinkNetworkBuilder,
+        root: OccurrenceRef,
+        byte_refs: Mapping[int, OccurrenceRef],
+    ) -> None:
+        if set(byte_refs) != set(range(256)):
+            raise SourceReplayError("byte vocabulary must contain exactly 0..255")
+        self._builder = builder
+        self._root = root
+        self._byte_refs = dict(byte_refs)
+        self._content_cache: dict[bytes, OccurrenceRef] = {b"": root}
+        self._sources: dict[OccurrenceRef, SourceOccurrence] = {}
+
+    def content_ref(self, data: bytes) -> OccurrenceRef:
+        """Return one canonical R-seeded history ref for exact bytes in this builder."""
+
+        data = bytes(data)
+        if data in self._content_cache:
+            return self._content_cache[data]
+
+        for size in range(1, len(data) + 1):
+            prefix = data[:size]
+            if prefix in self._content_cache:
+                continue
+            previous = self._content_cache[prefix[:-1]]
+            byte_ref = self._byte_refs[prefix[-1]]
+            current = self._builder.reserve()
+            self._builder.define(current, previous, byte_ref)
+            self._content_cache[prefix] = current
+        return self._content_cache[data]
+
+    def source_occurrence(self, data: bytes) -> SourceOccurrence:
+        """Create a fresh exact ``S = S ⟼ C`` occurrence over canonical content C."""
+
+        raw_bytes = bytes(data)
+        content = self.content_ref(raw_bytes)
+        source = define_source_occurrence(self._builder, content)
+        result = SourceOccurrence(raw_bytes=raw_bytes, content=content, source=source)
+        self._sources[source] = result
+        return result
+
+    def build_selected_evidence(
+        self,
+        source: SourceOccurrence,
+        specs: Sequence[SegmentSpec],
+        *,
+        dictionary: OccurrenceRef,
+        grammar: OccurrenceRef,
+        theory: OccurrenceRef,
+    ) -> SourceFrontEndEvidence:
+        """Build exact evidence for one caller-selected segmentation.
+
+        The function does not choose spans, perform longest-match, parse glyphs or
+        invent dictionary entries.  ``SegmentSpec.dictionary_membership`` must
+        already identify the dictionary evidence that trusted replay will check.
+        """
+
+        if self._sources.get(source.source) != source:
+            raise SourceReplayError("source occurrence was not issued by this builder")
+        _validate_spans(source.raw_bytes, specs)
+
+        prefix_refs = tuple(
+            self.content_ref(source.raw_bytes[:offset])
+            for offset in range(len(source.raw_bytes) + 1)
+        )
+        segment_evidence: list[SegmentEvidence] = []
+
+        for spec in specs:
+            slice_content = self.content_ref(source.raw_bytes[spec.start : spec.end])
+            span = self._new_link(prefix_refs[spec.start], prefix_refs[spec.end])
+            slice_evidence = self._new_link(span, slice_content)
+            lexeme = self._new_link(source.source, slice_evidence)
+            resolution = self._new_link(lexeme, spec.form)
+            selection = self._new_link(spec.dictionary_membership, resolution)
+            segment_evidence.append(
+                SegmentEvidence(
+                    start=spec.start,
+                    end=spec.end,
+                    slice_content=slice_content,
+                    span=span,
+                    slice_evidence=slice_evidence,
+                    lexeme=lexeme,
+                    resolution=resolution,
+                    dictionary_membership=spec.dictionary_membership,
+                    selection=selection,
+                    form=spec.form,
+                )
+            )
+
+        selection_sequence = self._fold(
+            tuple(segment.selection for segment in segment_evidence)
+        )
+        form_sequence = self._fold(tuple(segment.form for segment in segment_evidence))
+        grammar_membership = define_membership(self._builder, grammar, form_sequence)
+        theory_membership = define_membership(self._builder, theory, form_sequence)
+
+        return SourceFrontEndEvidence(
+            raw_bytes=source.raw_bytes,
+            content=source.content,
+            source=source.source,
+            dictionary=dictionary,
+            grammar=grammar,
+            theory=theory,
+            segments=tuple(segment_evidence),
+            selection_sequence=selection_sequence,
+            form_sequence=form_sequence,
+            grammar_membership=grammar_membership,
+            theory_membership=theory_membership,
+        )
+
+    def _new_link(self, start: OccurrenceRef, end: OccurrenceRef) -> OccurrenceRef:
+        ref = self._builder.reserve()
+        self._builder.define(ref, start, end)
+        return ref
+
+    def _fold(self, values: tuple[OccurrenceRef, ...]) -> OccurrenceRef:
+        current = self._root
+        for value in values:
+            current = self._new_link(current, value)
+        return current
+
+
+def replay_source_front_end(
+    network: LinkNetwork,
+    evidence: SourceFrontEndEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> tuple[OccurrenceRef, ...]:
+    """Replay selected UTF-8/astring → D/G/T evidence without effects.
+
+    Returns the exact resolved forms in source order.  This function does not
+    search for alternative segmentations and does not create any link.
+    """
+
+    if set(byte_refs) != set(range(256)):
+        raise SourceReplayError("byte vocabulary must contain exactly 0..255")
+    inverse_bytes = _inverse_byte_vocabulary(byte_refs)
+    before = network.snapshot()
+
+    source_link = network.link(evidence.source)
+    if source_link.start is not evidence.source or source_link.end is not evidence.content:
+        raise SourceReplayError("source occurrence does not match S = S ⟼ C")
+
+    decoded, prefix_refs = _decode_content(
+        network,
+        evidence.content,
+        network.root,
+        inverse_bytes,
+    )
+    if decoded != evidence.raw_bytes:
+        raise SourceReplayError("canonical source content does not match raw bytes")
+    _validate_segment_evidence_spans(evidence.raw_bytes, evidence.segments)
+
+    forms: list[OccurrenceRef] = []
+    selections: list[OccurrenceRef] = []
+    for segment in evidence.segments:
+        expected_slice = evidence.raw_bytes[segment.start : segment.end]
+        slice_bytes, _ = _decode_content(
+            network,
+            segment.slice_content,
+            network.root,
+            inverse_bytes,
+        )
+        if slice_bytes != expected_slice:
+            raise SourceReplayError("slice content does not match selected byte boundaries")
+
+        span = network.link(segment.span)
+        if (
+            span.start is not prefix_refs[segment.start]
+            or span.end is not prefix_refs[segment.end]
+        ):
+            raise SourceReplayError("forged source span boundaries")
+
+        slice_evidence = network.link(segment.slice_evidence)
+        if (
+            slice_evidence.start is not segment.span
+            or slice_evidence.end is not segment.slice_content
+        ):
+            raise SourceReplayError("forged slice-content evidence")
+
+        lexeme = network.link(segment.lexeme)
+        if lexeme.start is not evidence.source or lexeme.end is not segment.slice_evidence:
+            raise SourceReplayError("forged lexeme occurrence")
+
+        resolution = network.link(segment.resolution)
+        if resolution.start is not segment.lexeme or resolution.end is not segment.form:
+            raise SourceReplayError("forged lexeme resolution")
+
+        _verify_dictionary_membership(
+            network,
+            segment.dictionary_membership,
+            evidence.dictionary,
+            segment.slice_content,
+            segment.form,
+        )
+
+        selection = network.link(segment.selection)
+        if (
+            selection.start is not segment.dictionary_membership
+            or selection.end is not segment.resolution
+        ):
+            raise SourceReplayError("forged selected dictionary evidence")
+
+        forms.append(segment.form)
+        selections.append(segment.selection)
+
+    _verify_fold(network, evidence.selection_sequence, tuple(selections), network.root)
+    _verify_fold(network, evidence.form_sequence, tuple(forms), network.root)
+    _verify_direct_membership(
+        network,
+        evidence.grammar_membership,
+        evidence.grammar,
+        evidence.form_sequence,
+        "grammar",
+    )
+    _verify_direct_membership(
+        network,
+        evidence.theory_membership,
+        evidence.theory,
+        evidence.form_sequence,
+        "theory",
+    )
+
+    if network.snapshot() != before:
+        raise SourceReplayError("source replay mutated the network")
+    return tuple(forms)
+
+
+def _validate_spans(raw_bytes: bytes, specs: Sequence[SegmentSpec]) -> None:
+    boundaries = tuple((spec.start, spec.end) for spec in specs)
+    _validate_boundaries(raw_bytes, boundaries)
+
+
+def _validate_segment_evidence_spans(
+    raw_bytes: bytes,
+    segments: Sequence[SegmentEvidence],
+) -> None:
+    boundaries = tuple((segment.start, segment.end) for segment in segments)
+    _validate_boundaries(raw_bytes, boundaries)
+
+
+def _validate_boundaries(raw_bytes: bytes, boundaries: Sequence[tuple[int, int]]) -> None:
+    if not boundaries:
+        if raw_bytes:
+            raise SourceReplayError("non-empty source requires selected segments")
+        return
+    expected_start = 0
+    for start, end in boundaries:
+        if start != expected_start or end <= start or end > len(raw_bytes):
+            raise SourceReplayError("segments must form one exact contiguous source partition")
+        expected_start = end
+    if expected_start != len(raw_bytes):
+        raise SourceReplayError("selected segments do not cover the complete source")
+
+
+def _inverse_byte_vocabulary(
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> dict[OccurrenceRef, int]:
+    inverse: dict[OccurrenceRef, int] = {}
+    for value, ref in byte_refs.items():
+        if ref in inverse:
+            raise SourceReplayError("byte vocabulary refs must be occurrence-distinct")
+        inverse[ref] = value
+    return inverse
+
+
+def _decode_content(
+    network: LinkNetwork,
+    content: OccurrenceRef,
+    root: OccurrenceRef,
+    inverse_bytes: Mapping[OccurrenceRef, int],
+) -> tuple[bytes, tuple[OccurrenceRef, ...]]:
+    if content is root:
+        return b"", (root,)
+
+    reversed_bytes: list[int] = []
+    reversed_prefix_refs: list[OccurrenceRef] = [content]
+    current = content
+    visited: set[OccurrenceRef] = set()
+
+    while current is not root:
+        if current in visited:
+            raise SourceReplayError("cyclic canonical source-content history")
+        visited.add(current)
+        link = network.link(current)
+        try:
+            value = inverse_bytes[link.end]
+        except KeyError as exc:
+            raise SourceReplayError("source content contains a non-byte occurrence") from exc
+        reversed_bytes.append(value)
+        current = link.start
+        reversed_prefix_refs.append(current)
+
+    return (
+        bytes(reversed(reversed_bytes)),
+        tuple(reversed(reversed_prefix_refs)),
+    )
+
+
+def _verify_dictionary_membership(
+    network: LinkNetwork,
+    membership_ref: OccurrenceRef,
+    dictionary: OccurrenceRef,
+    slice_content: OccurrenceRef,
+    form: OccurrenceRef,
+) -> None:
+    membership = network.link(membership_ref)
+    if membership.start is not dictionary:
+        raise SourceReplayError("dictionary membership belongs to another dictionary")
+    entry = network.link(membership.end)
+    if entry.start is not slice_content or entry.end is not form:
+        raise SourceReplayError("dictionary entry does not resolve selected slice to selected form")
+
+
+def _verify_direct_membership(
+    network: LinkNetwork,
+    membership_ref: OccurrenceRef,
+    container: OccurrenceRef,
+    value: OccurrenceRef,
+    label: str,
+) -> None:
+    membership = network.link(membership_ref)
+    if membership.start is not container or membership.end is not value:
+        raise SourceReplayError(f"forged {label} membership")
+
+
+def _verify_fold(
+    network: LinkNetwork,
+    final: OccurrenceRef,
+    values: tuple[OccurrenceRef, ...],
+    root: OccurrenceRef,
+) -> None:
+    current = final
+    for expected in reversed(values):
+        link = network.link(current)
+        if link.end is not expected:
+            raise SourceReplayError("ordered sequence evidence contains the wrong occurrence")
+        current = link.start
+    if current is not root:
+        raise SourceReplayError("ordered sequence evidence does not terminate at exact root")

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -2,7 +2,7 @@
 
 Статус: **production/reference candidate**, не accepted release.
 
-Главный epic: #237. Текущий слой: #243. Sequence-deserialization: #242. Persistent L4 backend: #124.
+Главный epic: #237. Завершены exact-occurrence substrate #240/#241 и state/apamemory layer #243/#244. Текущий слой: source front-end #245. Sequence-deserialization: #242. Persistent L4 backend: #124.
 
 Цель Gate P — превратить завершённые research-решения Foundation v2 в **один** reference/production path, после чего опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
 
@@ -16,6 +16,7 @@ binary link ontology
 → exact-occurrence finite link networks
 → root-relative Anum structural descriptions where defined
 → canonical UTF-8/astring source carrier
+→ explicit selected source segmentation
 → explicit D/G/T relations
 → explicit K/current
 → actual interpretation acts A
@@ -58,8 +59,6 @@ astNode
 Sharing и cycles конечны и native. Два occurrences с одинаковыми полюсами могут оставаться различными.
 
 ## 3. Higher-layer state тоже является сетью связей
-
-Текущий Gate P state-layer проверяет следующие формы.
 
 Контекст:
 
@@ -108,7 +107,131 @@ A ⟼ Field
 
 Role refs разрешаются через явный `D_roles`; host enum не является их semantic identity.
 
-## 4. Апамять
+## 4. Один source front-end
+
+Gate P не должен иметь отдельные «настоящий tokenizer», «semantic parser» и затем второй semantic evaluator, каждый со своим скрытым набором смыслов. Production-facing source layer строится как проверяемый переход от байтов к **выбранным exact relations**.
+
+Каноническая цепочка #245:
+
+```text
+raw bytes
+→ canonical astring content C
+→ exact source occurrence S
+→ untrusted candidate segmentation
+→ selected exact source spans
+→ explicit D memberships
+→ ordered exact form sequence
+→ explicit G/T admission
+→ replayable source evidence
+```
+
+Кандидатный поиск может использовать индексы, trie, regex, longest-match heuristics или UI. Но trusted boundary не доверяет результату поиска по факту того, какой host-код его выдал. Она повторно проверяет выбранное evidence.
+
+### 4.1. Канонический content и occurrence источника
+
+Lower byte protocol предоставляет exact refs `B(byte)`. Astring content является R-seeded history:
+
+```text
+C0 = R
+C(n+1) = Cn ⟼ B(byte_n)
+```
+
+Конкретное появление исходника отдельно:
+
+```text
+S = S ⟼ C
+```
+
+Поэтому одинаковые bytes могут иметь общий canonical `C`, но разные exact source occurrences `S1`, `S2`.
+
+### 4.2. Выбранный slice — не token class
+
+Для выбранного байтового диапазона используются exact prefix refs источника:
+
+```text
+Span = sourcePrefix(start) ⟼ sourcePrefix(end)
+SliceEvidence = Span ⟼ sliceContent
+Lexeme = S ⟼ SliceEvidence
+```
+
+`start/end` в host artifact остаются transport/checker coordinates. Семантическое evidence задаётся самими exact refs границ, source occurrence и slice content.
+
+UTF-8 знак из нескольких байтов, например `⟼`, может быть одним выбранным slice. Он не обязан превращаться в набор byte-sized semantic token-ов.
+
+### 4.3. Разрешение через словарь
+
+Словарь остаётся явной сетью:
+
+```text
+Entry = sliceContent ⟼ form
+Membership = D ⟼ Entry
+```
+
+Для конкретного lexeme выбранное разрешение фиксируется:
+
+```text
+Resolution = Lexeme ⟼ form
+Selection = exactDictionaryMembership ⟼ Resolution
+```
+
+Это важно для неоднозначности. Один и тот же source может иметь:
+
+```text
+D1 → form1
+D2 → form2
+```
+
+без изменения source content.
+
+### 4.4. Порядок и G/T admission
+
+Порядок выбранных lexeme и resolved forms также является связевой структурой:
+
+```text
+SelectedSequence = fold(R, Selection_0 ... Selection_n)
+FormSequence     = fold(R, Form_0 ... Form_n)
+```
+
+Затем выбранная композиция должна быть явно допущена:
+
+```text
+G ⟼ FormSequence
+T ⟼ FormSequence
+```
+
+Точная будущая grammar/theory topology может расшириться, но production boundary уже запрещает неявное правило «раз host parser построил AST, значит композиция допустима».
+
+### 4.5. Что source replay не делает
+
+Source replay:
+
+```text
+проверяет байты и C/S;
+проверяет exact boundaries;
+проверяет D memberships;
+проверяет порядок forms;
+проверяет G/T admission.
+```
+
+Он **не** обязан:
+
+```text
+создавать application links;
+исполнять `:` или `=`;
+выбирать proof rule;
+делать Anum sequence materialization;
+менять апамять.
+```
+
+Поэтому:
+
+```text
+source resolution/replay != materialization
+```
+
+Это критично для апрувера: исходник и proof evidence можно проверять, не делая доказываемое истинным самим фактом чтения.
+
+## 5. Апамять
 
 Foundation v2 рассматривает апамять как **контроллер сети exact link occurrences**.
 
@@ -128,7 +251,7 @@ materialize / delete
 
 Это позволяет описывать и искать связь, не создавая её самим фактом запроса.
 
-## 5. Ачисло и будущая sequence deserialization
+## 6. Ачисло и будущая sequence deserialization
 
 Recursive Anum уже является root-relative structural description на принятой occurrence-tree области, но это ещё не полная operational semantics произвольной последовательности.
 
@@ -149,7 +272,18 @@ B ⟼ C
 
 До этого challenge нельзя молча расширять pair-only recursive grammar или делать `[`/`]` безусловными PUSH/POP opcode-ами.
 
-## 6. Что должна получить следующая версия для aprover
+Важно не смешивать #245 и #242:
+
+```text
+#245 source front-end
+    читает/разрешает/проверяет source evidence
+    без application effects
+
+#242 Anum→апамять
+    исследует явный materialization результирующей сети
+```
+
+## 7. Что должна получить следующая версия для aprover
 
 `aprover` должен потреблять опубликованный versioned contract и conformance corpus, а не повторно определять семантику МТС.
 
@@ -167,13 +301,12 @@ exact source/evidence
 
 Proof search, ranking и UI могут быть сложными и эвристическими. Валидность доказательства определяется replay выбранных exact relations.
 
-## 7. Что ещё блокирует release
+## 8. Что ещё блокирует release
 
 До repin `aprover` остаются как минимум:
 
 ```text
-current state layer #243
-→ one source front-end over explicit D/G/T
+source front-end #245
 → one interpreter/replay engine
 → sequence-to-apamemory gate #242
 → historical compatibility classification

--- a/tests/test_mts_foundation_v2_source.py
+++ b/tests/test_mts_foundation_v2_source.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_source import (
+    SegmentSpec,
+    SourceFrontEndBuilder,
+    SourceReplayError,
+    replay_source_front_end,
+)
+from core.foundation_v2_state import define_dictionary_membership
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _byte_vocabulary(builder: LinkNetworkBuilder):
+    return {value: _anchor(builder) for value in range(256)}
+
+
+def _base_fixture():
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    byte_refs = _byte_vocabulary(builder)
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+    dictionary = _anchor(builder)
+    grammar = _anchor(builder)
+    theory = _anchor(builder)
+    return builder, root, byte_refs, front_end, dictionary, grammar, theory
+
+
+def _membership(builder, front_end, dictionary, raw_slice, form):
+    content = front_end.content_ref(raw_slice)
+    _, membership = define_dictionary_membership(builder, dictionary, content, form)
+    return membership
+
+
+def test_multibyte_arrow_is_one_selected_slice_and_replay_is_read_only() -> None:
+    (
+        builder,
+        root,
+        byte_refs,
+        front_end,
+        dictionary,
+        grammar,
+        theory,
+    ) = _base_fixture()
+    form_a = _anchor(builder)
+    form_arrow = _anchor(builder)
+    form_b = _anchor(builder)
+    raw = "a⟼b".encode("utf-8")
+    arrow = "⟼".encode("utf-8")
+    source = front_end.source_occurrence(raw)
+
+    membership_a = _membership(builder, front_end, dictionary, b"a", form_a)
+    membership_arrow = _membership(builder, front_end, dictionary, arrow, form_arrow)
+    membership_b = _membership(builder, front_end, dictionary, b"b", form_b)
+    evidence = front_end.build_selected_evidence(
+        source,
+        (
+            SegmentSpec(0, 1, form_a, membership_a),
+            SegmentSpec(1, 1 + len(arrow), form_arrow, membership_arrow),
+            SegmentSpec(1 + len(arrow), len(raw), form_b, membership_b),
+        ),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    before = network.snapshot()
+    assert replay_source_front_end(network, evidence, byte_refs) == (
+        form_a,
+        form_arrow,
+        form_b,
+    )
+    assert network.snapshot() == before
+    assert evidence.segments[1].start == 1
+    assert evidence.segments[1].end == 1 + len(arrow)
+    assert not any(
+        network.link(ref).start is form_a and network.link(ref).end is form_b
+        for ref in network.refs
+    )
+
+
+def test_same_bytes_can_resolve_differently_under_explicit_dictionaries() -> None:
+    builder, root, byte_refs, front_end, _, grammar, theory = _base_fixture()
+    dictionary_one = _anchor(builder)
+    dictionary_two = _anchor(builder)
+    form_one = _anchor(builder)
+    form_two = _anchor(builder)
+    source = front_end.source_occurrence(b"x")
+
+    membership_one = _membership(builder, front_end, dictionary_one, b"x", form_one)
+    membership_two = _membership(builder, front_end, dictionary_two, b"x", form_two)
+    evidence_one = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form_one, membership_one),),
+        dictionary=dictionary_one,
+        grammar=grammar,
+        theory=theory,
+    )
+    evidence_two = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form_two, membership_two),),
+        dictionary=dictionary_two,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    assert replay_source_front_end(network, evidence_one, byte_refs) == (form_one,)
+    assert replay_source_front_end(network, evidence_two, byte_refs) == (form_two,)
+    assert evidence_one.content is evidence_two.content
+    assert evidence_one.source is evidence_two.source
+
+
+def test_ambiguous_segmentations_are_both_replayable_without_longest_match() -> None:
+    (
+        builder,
+        root,
+        byte_refs,
+        front_end,
+        dictionary,
+        grammar,
+        theory,
+    ) = _base_fixture()
+    form_a = _anchor(builder)
+    form_b = _anchor(builder)
+    form_ab = _anchor(builder)
+    source = front_end.source_occurrence(b"ab")
+
+    membership_a = _membership(builder, front_end, dictionary, b"a", form_a)
+    membership_b = _membership(builder, front_end, dictionary, b"b", form_b)
+    membership_ab = _membership(builder, front_end, dictionary, b"ab", form_ab)
+
+    split = front_end.build_selected_evidence(
+        source,
+        (
+            SegmentSpec(0, 1, form_a, membership_a),
+            SegmentSpec(1, 2, form_b, membership_b),
+        ),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    whole = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 2, form_ab, membership_ab),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    assert replay_source_front_end(network, split, byte_refs) == (form_a, form_b)
+    assert replay_source_front_end(network, whole, byte_refs) == (form_ab,)
+
+
+def test_forged_span_boundary_is_rejected() -> None:
+    (
+        builder,
+        root,
+        byte_refs,
+        front_end,
+        dictionary,
+        grammar,
+        theory,
+    ) = _base_fixture()
+    form = _anchor(builder)
+    source = front_end.source_occurrence(b"x")
+    membership = _membership(builder, front_end, dictionary, b"x", form)
+    evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form, membership),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    forged_span = _anchor(builder)
+    forged_segment = replace(evidence.segments[0], span=forged_span)
+    forged = replace(evidence, segments=(forged_segment,))
+    network = builder.freeze(root)
+
+    with pytest.raises(SourceReplayError, match="span boundaries"):
+        replay_source_front_end(network, forged, byte_refs)
+
+
+def test_membership_from_wrong_dictionary_is_rejected() -> None:
+    builder, root, byte_refs, front_end, dictionary, grammar, theory = _base_fixture()
+    other_dictionary = _anchor(builder)
+    form = _anchor(builder)
+    source = front_end.source_occurrence(b"x")
+    wrong_membership = _membership(builder, front_end, other_dictionary, b"x", form)
+    evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form, wrong_membership),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(SourceReplayError, match="another dictionary"):
+        replay_source_front_end(network, evidence, byte_refs)
+
+
+def test_forged_grammar_or_theory_admission_is_rejected() -> None:
+    (
+        builder,
+        root,
+        byte_refs,
+        front_end,
+        dictionary,
+        grammar,
+        theory,
+    ) = _base_fixture()
+    form = _anchor(builder)
+    source = front_end.source_occurrence(b"x")
+    membership = _membership(builder, front_end, dictionary, b"x", form)
+    evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form, membership),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    unrelated = _anchor(builder)
+    forged_grammar_membership = builder.reserve()
+    builder.define(forged_grammar_membership, grammar, unrelated)
+    forged = replace(evidence, grammar_membership=forged_grammar_membership)
+    network = builder.freeze(root)
+
+    with pytest.raises(SourceReplayError, match="grammar membership"):
+        replay_source_front_end(network, forged, byte_refs)
+
+
+def test_noncontiguous_or_partial_selected_partition_is_rejected_before_freeze() -> None:
+    (
+        builder,
+        _,
+        _,
+        front_end,
+        dictionary,
+        grammar,
+        theory,
+    ) = _base_fixture()
+    form = _anchor(builder)
+    source = front_end.source_occurrence(b"ab")
+    membership = _membership(builder, front_end, dictionary, b"a", form)
+
+    with pytest.raises(SourceReplayError, match="contiguous source partition"):
+        front_end.build_selected_evidence(
+            source,
+            (SegmentSpec(1, 2, form, membership),),
+            dictionary=dictionary,
+            grammar=grammar,
+            theory=theory,
+        )
+
+
+def test_duplicate_byte_refs_are_rejected_as_noncanonical_vocabulary() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    shared = _anchor(builder)
+    byte_refs = {value: _anchor(builder) for value in range(256)}
+    byte_refs[1] = shared
+    byte_refs[2] = shared
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+    source = front_end.source_occurrence(b"x")
+    dictionary = _anchor(builder)
+    grammar = _anchor(builder)
+    theory = _anchor(builder)
+    form = _anchor(builder)
+    membership = _membership(builder, front_end, dictionary, b"x", form)
+    evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form, membership),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(SourceReplayError, match="occurrence-distinct"):
+        replay_source_front_end(network, evidence, byte_refs)
+
+
+def test_trusted_source_module_has_no_legacy_parser_or_ast_dependency() -> None:
+    source = (ROOT / "core/foundation_v2_source.py").read_text(encoding="utf-8")
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert "TokenKind" not in source
+    assert "longest" not in source.lower().replace("longest-match", "")


### PR DESCRIPTION
Closes #245 after explicit decision if CI and replay evidence are accepted. Parent: #237. Depends on merged #244.

## Scope

This PR adds the next single Gate-P layer:

```text
raw bytes
→ canonical astring C
→ exact source S
→ selected exact spans
→ explicit D memberships
→ ordered forms
→ explicit G/T admission
→ read-only replay
```

## Implementation

- `core/foundation_v2_source.py` implements canonical R-seeded byte-content histories, exact `S=S⟼C`, selected span/lexeme/resolution evidence, ordered selected/form histories and trusted replay;
- candidate segmentation/search stays outside the trusted core;
- `contracts/mts-foundation-v2-source-v0.7.json` records the boundary;
- tests cover multi-byte UTF-8 `⟼`, D1/D2 resolution, ambiguous segmentations without implicit longest-match, forged boundaries/memberships/G/T evidence, partition errors and read-only behavior;
- `docs/specs/Foundation v2 Gate P.md` now documents the source path and makes the distinction `source resolution/replay != #242 sequence materialization` explicit.

## Non-goals / veto preserved

- no legacy parser/AST dependency;
- no `TokenKind` semantic identity;
- no per-glyph semantic switch;
- no hidden global D/G/T;
- no target application-link materialization;
- no #242 Anum→апамять acceptance;
- no persistent L4 work;
- no interpreter cutover yet;
- no `aprover` repin yet.