### PR TITLE
Gate P: add one read-only interpreter replay spine

### DIFF
--- a/contracts/mts-foundation-v2-interpreter-replay-v0.7.json
+++ b/contracts/mts-foundation-v2-interpreter-replay-v0.7.json
@@ -1,0 +1,99 @@
+{
+  "schema": "mts-foundation-v2-interpreter-replay/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 247,
+  "parent": 237,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-foundation-v2-state/v0.7",
+    "mts-foundation-v2-source/v0.7",
+    "mts-integrated-interpreter-act-challenge/v0.7"
+  ],
+  "scope": "one read-only one-pole relation-resolution act",
+  "path": [
+    "replay exact selected source evidence",
+    "obtain exactly one selected form occurrence",
+    "read exact active K/current",
+    "bind current to the one open pole",
+    "verify exact result occurrence and poles",
+    "verify persistent K_after",
+    "verify actual act header and exact role-addressed fields"
+  ],
+  "resolution": {
+    "startOpen": "F = F ⟼ e => result = current ⟼ e",
+    "endOpen": "F = b ⟼ F => result = b ⟼ current",
+    "directionFromExactFormStructure": true,
+    "glyphOrOpcodeDispatch": false,
+    "completedFormAcceptedByThisSlice": false,
+    "fullySelfClosedFormAcceptedByThisSlice": false,
+    "resultPairUniquenessRequired": false,
+    "selectedResultOccurrenceMustBeExact": true
+  },
+  "context": {
+    "before": "K_before = K_before ⟼ (parent ⟼ current)",
+    "binding": "binding = exact current resolved from K_before",
+    "after": "K_after = K_after ⟼ (sameParent ⟼ exactResult)",
+    "ambientCurrentAllowed": false,
+    "inputMutationAllowed": false
+  },
+  "act": {
+    "header": [
+      "P0 = D_roles ⟼ K_after",
+      "H = I ⟼ P0",
+      "A = A ⟼ H"
+    ],
+    "requiredRoleFields": [
+      "source",
+      "source-selection",
+      "form-sequence",
+      "dictionary",
+      "grammar",
+      "theory",
+      "form",
+      "before-context",
+      "binding",
+      "result",
+      "after-context"
+    ],
+    "fieldTopology": "A ⟼ (roleRef ⟼ value)",
+    "roleRefsAreExact": true,
+    "hostFieldNamesAreSemanticIdentity": false,
+    "duplicateOrConflictingRequiredFieldRejects": true
+  },
+  "replay": {
+    "sourceFrontEndReplayed": true,
+    "checkerReadOnly": true,
+    "networkSnapshotMustRemainEqual": true,
+    "searchRankingTrusted": false,
+    "applicationLinkMaterialization": false,
+    "persistentBackendEffect": false
+  },
+  "requiredVectors": [
+    "start-open form resolves using exact current",
+    "end-open form resolves symmetrically",
+    "selected exact result succeeds even when another occurrence has the same poles",
+    "forged binding rejects",
+    "substituting another same-pole result rejects when K_after/act select the original",
+    "completed form rejects in one-pole slice",
+    "forged source evidence rejects",
+    "conflicting actual-act field rejects",
+    "forged act header rejects",
+    "replay does not import legacy parser/AST/interpreter semantics"
+  ],
+  "deferredSameEngineExtensions": {
+    "colonPersistentDictionaryEffect": 224,
+    "localEqualityConstraint": 225,
+    "multiStepRun": 230,
+    "anumSequenceMaterialization": 242,
+    "persistentL4": 124
+  },
+  "productionBoundary": {
+    "legacyParserDependency": false,
+    "legacyAstDependency": false,
+    "legacyInterpreterDependency": false,
+    "productionCutoverDone": false,
+    "aproverRepinAllowed": false
+  },
+  "nextGate": "extend this same trusted engine with the already-decided explicit colon/equality semantics before integrated conformance and cutover"
+}

--- a/core/foundation_v2_interpreter.py
+++ b/core/foundation_v2_interpreter.py
@@ -1,0 +1,198 @@
+"""Foundation-v2 read-only interpreter/replay spine.
+
+This module is the first production-facing vertical interpreter slice after the
+exact-occurrence state and source gates.  It consumes already-selected source
+evidence; it does not tokenize, parse, search, rank or materialize application
+links.
+
+The trusted operation replays one relation-resolution act:
+
+    source evidence -> exact active K/current -> one-pole form resolution
+    -> exact result -> persistent K_after -> exact actual act A
+
+Python dataclasses below are checker/transport API only.  Semantic identity lives
+in the exact link occurrences they reference.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .exact_link_network import LinkNetwork, OccurrenceRef
+from .foundation_v2_source import (
+    SourceFrontEndEvidence,
+    SourceReplayError,
+    replay_source_front_end,
+)
+from .foundation_v2_state import (
+    FoundationStateError,
+    act_header,
+    act_values,
+    current_of_context,
+    parent_of_context,
+)
+
+
+class InterpreterReplayError(ValueError):
+    """Selected interpreter evidence is incomplete, forged or inconsistent."""
+
+
+@dataclass(frozen=True)
+class RelationStepRoleRefs:
+    """Exact role refs supplied by the explicit Gate-R role vocabulary."""
+
+    source: OccurrenceRef
+    source_selection: OccurrenceRef
+    form_sequence: OccurrenceRef
+    dictionary: OccurrenceRef
+    grammar: OccurrenceRef
+    theory: OccurrenceRef
+    form: OccurrenceRef
+    before_context: OccurrenceRef
+    binding: OccurrenceRef
+    result: OccurrenceRef
+    after_context: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class RelationStepEvidence:
+    """Checker handle for one exact read-only relation-resolution act."""
+
+    source_evidence: SourceFrontEndEvidence
+    interpreter: OccurrenceRef
+    form: OccurrenceRef
+    before_context: OccurrenceRef
+    binding: OccurrenceRef
+    result: OccurrenceRef
+    after_context: OccurrenceRef
+    act: OccurrenceRef
+    role_dictionary: OccurrenceRef
+    roles: RelationStepRoleRefs
+
+
+def replay_relation_step(
+    network: LinkNetwork,
+    evidence: RelationStepEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> OccurrenceRef:
+    """Replay one selected Foundation-v2 relation-resolution act read-only.
+
+    Exactly one form must have been selected by the source front-end.  The
+    direction of resolution is derived from the exact self-closed form itself:
+
+    ``F = F ⟼ e``  -> bind the open start from ``↑``
+    ``F = b ⟼ F``  -> bind the open end from ``↑``
+
+    The selected result occurrence is checked by exact ref and poles.  Another
+    occurrence with the same poles neither invalidates nor replaces it.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        forms = _replay_source(network, evidence.source_evidence, byte_refs)
+        if forms != (evidence.form,):
+            raise InterpreterReplayError(
+                "relation-step source must select exactly the claimed form"
+            )
+
+        try:
+            parent = parent_of_context(network, evidence.before_context)
+            current = current_of_context(network, evidence.before_context)
+        except FoundationStateError as exc:
+            raise InterpreterReplayError("invalid before-context") from exc
+        if evidence.binding is not current:
+            raise InterpreterReplayError("binding is not exact current resolved from K")
+
+        expected_start, expected_end = _expected_result_poles(
+            network, evidence.form, evidence.binding
+        )
+        result_link = network.link(evidence.result)
+        if result_link.start is not expected_start or result_link.end is not expected_end:
+            raise InterpreterReplayError("result occurrence has forged poles")
+
+        try:
+            after_parent = parent_of_context(network, evidence.after_context)
+            after_current = current_of_context(network, evidence.after_context)
+        except FoundationStateError as exc:
+            raise InterpreterReplayError("invalid after-context") from exc
+        if after_parent is not parent:
+            raise InterpreterReplayError("after-context changed the explicit parent")
+        if after_current is not evidence.result:
+            raise InterpreterReplayError("after-context current is not the exact result")
+
+        _verify_act_header(network, evidence)
+        _verify_act_fields(network, evidence)
+        return evidence.result
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise InterpreterReplayError("interpreter replay mutated the network")
+
+
+def _replay_source(
+    network: LinkNetwork,
+    source: SourceFrontEndEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> tuple[OccurrenceRef, ...]:
+    try:
+        return replay_source_front_end(network, source, byte_refs)
+    except SourceReplayError as exc:
+        raise InterpreterReplayError("invalid source-front-end evidence") from exc
+
+
+def _expected_result_poles(
+    network: LinkNetwork,
+    form: OccurrenceRef,
+    binding: OccurrenceRef,
+) -> tuple[OccurrenceRef, OccurrenceRef]:
+    form_link = network.link(form)
+    start_open = form_link.start is form and form_link.end is not form
+    end_open = form_link.end is form and form_link.start is not form
+
+    if start_open:
+        return binding, form_link.end
+    if end_open:
+        return form_link.start, binding
+    raise InterpreterReplayError(
+        "selected form is not exactly one-pole self-closed"
+    )
+
+
+def _verify_act_header(network: LinkNetwork, evidence: RelationStepEvidence) -> None:
+    try:
+        header = act_header(network, evidence.act)
+    except FoundationStateError as exc:
+        raise InterpreterReplayError("invalid actual-act header") from exc
+    expected = (evidence.interpreter, evidence.role_dictionary, evidence.after_context)
+    if header != expected:
+        raise InterpreterReplayError("actual-act header does not match I/D_roles/K_after")
+
+
+def _verify_act_fields(network: LinkNetwork, evidence: RelationStepEvidence) -> None:
+    source = evidence.source_evidence
+    expected = (
+        (evidence.roles.source, source.source, "source"),
+        (
+            evidence.roles.source_selection,
+            source.selection_sequence,
+            "source-selection",
+        ),
+        (evidence.roles.form_sequence, source.form_sequence, "form-sequence"),
+        (evidence.roles.dictionary, source.dictionary, "dictionary"),
+        (evidence.roles.grammar, source.grammar, "grammar"),
+        (evidence.roles.theory, source.theory, "theory"),
+        (evidence.roles.form, evidence.form, "form"),
+        (
+            evidence.roles.before_context,
+            evidence.before_context,
+            "before-context",
+        ),
+        (evidence.roles.binding, evidence.binding, "binding"),
+        (evidence.roles.result, evidence.result, "result"),
+        (evidence.roles.after_context, evidence.after_context, "after-context"),
+    )
+    for role, value, label in expected:
+        values = act_values(network, evidence.act, role)
+        if values != (value,):
+            raise InterpreterReplayError(
+                f"actual-act field {label!r} is missing, duplicated or forged"
+            )

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -2,7 +2,7 @@
 
 Статус: **production/reference candidate**, не accepted release.
 
-Главный epic: #237. Завершены exact-occurrence substrate #240/#241 и state/apamemory layer #243/#244. Текущий слой: source front-end #245. Sequence-deserialization: #242. Persistent L4 backend: #124.
+Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory layer #243/#244 и source front-end #245/#246. Текущий слой: unified interpreter/replay #247. Sequence-deserialization: #242. Persistent L4 backend: #124.
 
 Цель Gate P — превратить завершённые research-решения Foundation v2 в **один** reference/production path, после чего опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
 
@@ -19,6 +19,7 @@ binary link ontology
 → explicit selected source segmentation
 → explicit D/G/T relations
 → explicit K/current
+→ structural relation resolution
 → actual interpretation acts A
 → trusted exact replay
 → proof checker / aprover
@@ -231,7 +232,212 @@ source resolution/replay != materialization
 
 Это критично для апрувера: исходник и proof evidence можно проверять, не делая доказываемое истинным самим фактом чтения.
 
-## 5. Апамять
+## 5. Один interpreter/replay spine
+
+После #245 интерпретатор больше не должен повторно превращать source в свои token/AST objects. Он получает уже replayable exact source evidence и продолжает **ту же связевую цепочку**.
+
+Первый production-facing vertical slice #247 намеренно минимален:
+
+```text
+exact source evidence
+        ↓
+selected one-pole form F
+        ↓
+exact active K
+        ↓
+↑ = current
+        ↓
+structural pole resolution
+        ↓
+exact result X
+        ↓
+persistent K_after
+        ↓
+actual act A
+```
+
+### 5.1. Направление операции не является opcode
+
+Если выбранная exact form имеет самозамкнутое начало:
+
+```text
+F = F ⟼ e
+```
+
+то начало ещё не различено внешним binding, а конец уже различён. В текущем act:
+
+```text
+binding = ↑
+X = binding ⟼ e
+```
+
+Для симметричной формы:
+
+```text
+F = b ⟼ F
+```
+
+получаем:
+
+```text
+binding = ↑
+X = b ⟼ binding
+```
+
+То есть interpreter не спрашивает:
+
+```text
+if token == "♂": ...
+if ast.kind == START_PROJECTION: ...
+```
+
+Он читает структуру выбранной exact form и explicit K. Операционное направление является следствием того, какой полюс уже различён в данном акте.
+
+### 5.2. `↑` не ambient state
+
+До акта:
+
+```text
+P_before = parent ⟼ current
+K_before = K_before ⟼ P_before
+```
+
+Trusted replay получает **конкретный exact K_before** и выводит:
+
+```text
+↑ = current
+binding = current
+```
+
+После проверенного результата:
+
+```text
+P_after = sameParent ⟼ X
+K_after = K_after ⟼ P_after
+```
+
+Старый K не мутирует. Новый K — новая exact occurrence persistent state.
+
+### 5.3. Результат выбирается exact occurrence, а не формой пары
+
+Пусть в апамяти существуют:
+
+```text
+X1 = a ⟼ b
+X2 = a ⟼ b
+X1 != X2
+```
+
+Trusted act может выбрать `X2`. Проверка обязана подтвердить:
+
+```text
+poles(X2) = (a,b)
+K_after.current = X2
+A.result = X2
+```
+
+но не имеет права сказать «пара `(a,b)` уникальна, значит X1=X2».
+
+Это связывает interpreter semantics с exact-occurrence моделью апамяти и сохраняет provenance отдельных актов/результатов.
+
+### 5.4. Actual act является проверяемой сетью
+
+Заголовок:
+
+```text
+P0 = D_roles ⟼ K_after
+H  = I ⟼ P0
+A  = A ⟼ H
+```
+
+Минимальные role-addressed fields первого vertical slice:
+
+```text
+source
+source-selection
+form-sequence
+dictionary
+grammar
+theory
+form
+before-context
+binding
+result
+after-context
+```
+
+Каждое поле:
+
+```text
+Field = roleRef ⟼ value
+A ⟼ Field
+```
+
+Trusted replay требует ровно одно согласованное значение каждой обязательной роли. Дублированное/конфликтующее evidence отклоняется.
+
+Host dataclass с удобными именами полей допустим как checker API, но не определяет ontology: semantic role identity задаётся exact `roleRef` из явного `D_roles`.
+
+### 5.5. Replay и исполнение апамяти пока разведены
+
+Текущий interpreter slice является **read-only**:
+
+```text
+replay(source,K,A)
+→ проверить выбранные exact relations
+→ вернуть exact result ref
+```
+
+Он не делает:
+
+```text
+materialize(result poles)
+materialize(K_after)
+materialize(A)
+```
+
+Эти occurrences уже должны входить в проверяемую сеть/evidence.
+
+Это намеренно. Сначала фиксируется trusted semantics, затем отдельный effect/L4 слой сможет создавать структуру, которую тот же replay независимо проверяет.
+
+Такой разрыв особенно важен для апрувера:
+
+```text
+proof search / executor
+    может строить candidate evidence
+
+trusted replay
+    только проверяет candidate evidence
+```
+
+и сам факт проверки не изменяет предмет доказательства.
+
+### 5.6. `:` и `=` должны расширить этот же engine
+
+После #247 нельзя создавать отдельный `DefinitionInterpreter`, `EqualityInterpreter` и ещё один общий evaluator с разными скрытыми состояниями.
+
+Принятые research decisions должны стать следующими режимами **одной replay architecture**:
+
+```text
+relation-resolution act
+colon definition effect/replay
+local equality constraint/replay
+```
+
+Для `:` уже выбран persistent scope snapshot:
+
+```text
+D = D ⟼ (parentScope ⟼ localHistory)
+Entry = S ⟼ F
+Occurrence = D_before ⟼ Entry
+history' = history ⟼ Occurrence
+D_after = new persistent scope snapshot
+```
+
+Для `=` выбран local exact representative constraint, без global congruence/substitution.
+
+Их интеграция должна переиспользовать exact source, K/D/G/T, actual A и общий replay boundary, а не создавать parallel semantics.
+
+## 6. Апамять
 
 Foundation v2 рассматривает апамять как **контроллер сети exact link occurrences**.
 
@@ -251,7 +457,7 @@ materialize / delete
 
 Это позволяет описывать и искать связь, не создавая её самим фактом запроса.
 
-## 6. Ачисло и будущая sequence deserialization
+## 7. Ачисло и будущая sequence deserialization
 
 Recursive Anum уже является root-relative structural description на принятой occurrence-tree области, но это ещё не полная operational semantics произвольной последовательности.
 
@@ -272,42 +478,47 @@ B ⟼ C
 
 До этого challenge нельзя молча расширять pair-only recursive grammar или делать `[`/`]` безусловными PUSH/POP opcode-ами.
 
-Важно не смешивать #245 и #242:
+Важно не смешивать #245/#247 и #242:
 
 ```text
 #245 source front-end
     читает/разрешает/проверяет source evidence
     без application effects
 
+#247 interpreter replay
+    проверяет selected semantic act над exact evidence
+    без application effects
+
 #242 Anum→апамять
     исследует явный materialization результирующей сети
 ```
 
-## 7. Что должна получить следующая версия для aprover
+## 8. Что должна получить следующая версия для aprover
 
 `aprover` должен потреблять опубликованный versioned contract и conformance corpus, а не повторно определять семантику МТС.
 
-Минимальная trusted цепочка будущего checker-а:
+Минимальная trusted цепочка будущего checker-а теперь становится конкретной:
 
 ```text
 exact source/evidence
 → selected dictionary/grammar/theory relations
 → exact active K
-→ selected declarative form + bindings
-→ actual act A
+→ selected declarative form + binding
+→ structural relation resolution
 → exact result / K_after
+→ actual act A
 → deterministic read-only replay
 ```
 
 Proof search, ranking и UI могут быть сложными и эвристическими. Валидность доказательства определяется replay выбранных exact relations.
 
-## 8. Что ещё блокирует release
+## 9. Что ещё блокирует release
 
 До repin `aprover` остаются как минимум:
 
 ```text
-source front-end #245
-→ one interpreter/replay engine
+interpreter/replay spine #247
+→ integrate `:` and local `=` into the same engine
 → sequence-to-apamemory gate #242
 → historical compatibility classification
 → explicit persistent L4 boundary #124

--- a/tests/test_mts_foundation_v2_interpreter.py
+++ b/tests/test_mts_foundation_v2_interpreter.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_interpreter import (
+    InterpreterReplayError,
+    RelationStepEvidence,
+    RelationStepRoleRefs,
+    replay_relation_step,
+)
+from core.foundation_v2_source import SegmentSpec, SourceFrontEndBuilder
+from core.foundation_v2_state import (
+    define_act_field,
+    define_act_header,
+    define_context,
+    define_dictionary_membership,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROLE_NAMES = (
+    "source",
+    "source-selection",
+    "form-sequence",
+    "dictionary",
+    "grammar",
+    "theory",
+    "form",
+    "before-context",
+    "binding",
+    "result",
+    "after-context",
+)
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _byte_vocabulary(builder: LinkNetworkBuilder):
+    return {value: _anchor(builder) for value in range(256)}
+
+
+def _new_link(builder: LinkNetworkBuilder, start, end):
+    ref = builder.reserve()
+    builder.define(ref, start, end)
+    return ref
+
+
+def _roles(builder: LinkNetworkBuilder) -> RelationStepRoleRefs:
+    refs = {name: _anchor(builder) for name in ROLE_NAMES}
+    return RelationStepRoleRefs(
+        source=refs["source"],
+        source_selection=refs["source-selection"],
+        form_sequence=refs["form-sequence"],
+        dictionary=refs["dictionary"],
+        grammar=refs["grammar"],
+        theory=refs["theory"],
+        form=refs["form"],
+        before_context=refs["before-context"],
+        binding=refs["binding"],
+        result=refs["result"],
+        after_context=refs["after-context"],
+    )
+
+
+def _role_items(roles: RelationStepRoleRefs):
+    return (
+        ("source", roles.source),
+        ("source-selection", roles.source_selection),
+        ("form-sequence", roles.form_sequence),
+        ("dictionary", roles.dictionary),
+        ("grammar", roles.grammar),
+        ("theory", roles.theory),
+        ("form", roles.form),
+        ("before-context", roles.before_context),
+        ("binding", roles.binding),
+        ("result", roles.result),
+        ("after-context", roles.after_context),
+    )
+
+
+def _fixture(
+    form_kind: str = "start-open",
+    *,
+    duplicate_result: bool = False,
+    forge_result_field: bool = False,
+):
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    byte_refs = _byte_vocabulary(builder)
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+
+    dictionary = _anchor(builder)
+    grammar = _anchor(builder)
+    theory = _anchor(builder)
+    interpreter = _anchor(builder)
+    role_dictionary = _anchor(builder)
+    parent = _anchor(builder)
+    binding = _anchor(builder)
+    fixed_pole = _anchor(builder)
+
+    if form_kind == "start-open":
+        form = builder.reserve()
+        builder.define(form, form, fixed_pole)
+        result_start, result_end = binding, fixed_pole
+    elif form_kind == "end-open":
+        form = builder.reserve()
+        builder.define(form, fixed_pole, form)
+        result_start, result_end = fixed_pole, binding
+    elif form_kind == "complete":
+        other = _anchor(builder)
+        form = _new_link(builder, fixed_pole, other)
+        result_start, result_end = binding, other
+    else:
+        raise AssertionError(form_kind)
+
+    source = front_end.source_occurrence(b"x")
+    slice_content = front_end.content_ref(b"x")
+    _, dictionary_membership = define_dictionary_membership(
+        builder, dictionary, slice_content, form
+    )
+    source_evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form, dictionary_membership),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+
+    before_context = define_context(builder, parent, binding)
+    result = _new_link(builder, result_start, result_end)
+    duplicate = None
+    if duplicate_result:
+        duplicate = _new_link(builder, result_start, result_end)
+        result = duplicate
+    after_context = define_context(builder, parent, result)
+
+    roles = _roles(builder)
+    for role_name, role_ref in _role_items(roles):
+        define_dictionary_membership(
+            builder,
+            role_dictionary,
+            front_end.content_ref(role_name.encode("utf-8")),
+            role_ref,
+        )
+
+    act = define_act_header(builder, interpreter, role_dictionary, after_context)
+    expected_fields = (
+        (roles.source, source_evidence.source),
+        (roles.source_selection, source_evidence.selection_sequence),
+        (roles.form_sequence, source_evidence.form_sequence),
+        (roles.dictionary, dictionary),
+        (roles.grammar, grammar),
+        (roles.theory, theory),
+        (roles.form, form),
+        (roles.before_context, before_context),
+        (roles.binding, binding),
+        (roles.result, result),
+        (roles.after_context, after_context),
+    )
+    for role, value in expected_fields:
+        define_act_field(builder, act, role, value)
+    if forge_result_field:
+        define_act_field(builder, act, roles.result, fixed_pole)
+
+    network = builder.freeze(root)
+    evidence = RelationStepEvidence(
+        source_evidence=source_evidence,
+        interpreter=interpreter,
+        form=form,
+        before_context=before_context,
+        binding=binding,
+        result=result,
+        after_context=after_context,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+    return network, byte_refs, evidence, duplicate, fixed_pole
+
+
+def test_start_open_relation_replays_from_exact_current_read_only() -> None:
+    network, byte_refs, evidence, _, fixed_pole = _fixture("start-open")
+    before = network.snapshot()
+
+    assert replay_relation_step(network, evidence, byte_refs) is evidence.result
+    result = network.link(evidence.result)
+    assert result.start is evidence.binding
+    assert result.end is fixed_pole
+    assert network.snapshot() == before
+
+
+def test_end_open_relation_replays_symmetrically() -> None:
+    network, byte_refs, evidence, _, fixed_pole = _fixture("end-open")
+
+    assert replay_relation_step(network, evidence, byte_refs) is evidence.result
+    result = network.link(evidence.result)
+    assert result.start is fixed_pole
+    assert result.end is evidence.binding
+
+
+def test_selected_duplicate_same_pole_result_remains_exact_and_valid() -> None:
+    network, byte_refs, evidence, selected_duplicate, _ = _fixture(
+        "start-open", duplicate_result=True
+    )
+    assert selected_duplicate is evidence.result
+
+    same_poles = [
+        ref
+        for ref in network.refs
+        if network.link(ref).start is evidence.binding
+        and network.link(ref).end is network.link(evidence.form).end
+    ]
+    assert len(same_poles) == 2
+    assert replay_relation_step(network, evidence, byte_refs) is selected_duplicate
+
+
+def test_forged_binding_rejects_even_when_source_is_valid() -> None:
+    network, byte_refs, evidence, _, fixed_pole = _fixture("start-open")
+    forged = replace(evidence, binding=fixed_pole)
+
+    with pytest.raises(InterpreterReplayError, match="binding is not exact current"):
+        replay_relation_step(network, forged, byte_refs)
+
+
+def test_other_same_pole_result_rejects_when_after_context_selects_original() -> None:
+    network, byte_refs, evidence, _, _ = _fixture(
+        "start-open", duplicate_result=True
+    )
+    expected_poles = network.link(evidence.result)
+    other = next(
+        ref
+        for ref in network.refs
+        if ref is not evidence.result
+        and network.link(ref).start is expected_poles.start
+        and network.link(ref).end is expected_poles.end
+    )
+    forged = replace(evidence, result=other)
+
+    with pytest.raises(InterpreterReplayError, match="after-context current"):
+        replay_relation_step(network, forged, byte_refs)
+
+
+def test_completed_form_is_not_silently_treated_as_partial() -> None:
+    network, byte_refs, evidence, _, _ = _fixture("complete")
+
+    with pytest.raises(InterpreterReplayError, match="not exactly one-pole"):
+        replay_relation_step(network, evidence, byte_refs)
+
+
+def test_forged_source_evidence_rejects_before_relation_resolution() -> None:
+    network, byte_refs, evidence, _, fixed_pole = _fixture("start-open")
+    forged_source = replace(evidence.source_evidence, dictionary=fixed_pole)
+    forged = replace(evidence, source_evidence=forged_source)
+
+    with pytest.raises(InterpreterReplayError, match="source-front-end evidence"):
+        replay_relation_step(network, forged, byte_refs)
+
+
+def test_conflicting_actual_act_field_rejects() -> None:
+    network, byte_refs, evidence, _, _ = _fixture(
+        "start-open", forge_result_field=True
+    )
+
+    with pytest.raises(InterpreterReplayError, match="field 'result'"):
+        replay_relation_step(network, evidence, byte_refs)
+
+
+def test_forged_act_header_rejects() -> None:
+    network, byte_refs, evidence, _, fixed_pole = _fixture("start-open")
+    forged = replace(evidence, role_dictionary=fixed_pole)
+
+    with pytest.raises(InterpreterReplayError, match="header does not match"):
+        replay_relation_step(network, forged, byte_refs)
+
+
+def test_interpreter_replay_has_no_legacy_parser_ast_or_interpreter_dependency() -> None:
+    source = (ROOT / "core/foundation_v2_interpreter.py").read_text(encoding="utf-8")
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert "mtc_interpreter" not in source
+    assert "TokenKind" not in source


### PR DESCRIPTION
Closes #247 after explicit decision if CI and replay evidence are accepted. Parent: #237. Depends on merged #244 and #246.

## Scope

This PR adds the first production-facing trusted interpreter vertical slice:

```text
exact source evidence
→ exactly one selected partial form
→ exact K/current (↑)
→ structural one-pole resolution
→ exact result occurrence
→ persistent K_after
→ exact actual act A + role fields
```

## Implementation

- `core/foundation_v2_interpreter.py` consumes `SourceFrontEndEvidence` from #245/#246 and does not re-tokenize or reparse source;
- direction is derived from exact form structure (`F=F⟼e` or `F=b⟼F`), never glyph/AST/opcode dispatch;
- result pair uniqueness is not assumed: the selected exact result occurrence is verified by poles, K_after and A evidence;
- `RelationStepRoleRefs` are checker handles for exact role refs, not a host role ontology;
- replay is snapshot-stable/read-only and never materializes application links.

## Tests

Covers:
- start-open and end-open resolution;
- `↑` from exact K/current;
- two same-pole result occurrences with one explicitly selected exact result;
- forged binding/result/source/header/role field rejection;
- completed form rejection in the one-pole slice;
- no legacy parser/AST/interpreter dependency.

## Documentation

`docs/specs/Foundation v2 Gate P.md` now explains the unified interpreter/replay spine, exact-result identity, actual-act evidence, and why `:` and `=` must extend this same engine instead of creating parallel interpreters.

## Explicit non-goals

- no `:` implementation yet (reuse decision #224 next in this same engine);
- no local `=` implementation yet (reuse decision #225 in this same engine);
- no multistep proof/run acceptance;
- no #242 Anum→апамять materialization;
- no #124 persistent backend;
- no legacy cutover or `aprover` repin yet.