### PR TITLE
Gate P: unify scoped dictionaries and replay persistent colon effects

### DIFF
--- a/contracts/mts-foundation-v2-colon-v0.7.json
+++ b/contracts/mts-foundation-v2-colon-v0.7.json
@@ -1,0 +1,82 @@
+{
+  "schema": "mts-foundation-v2-colon/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 249,
+  "parent": 237,
+  "researchDecision": 224,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-foundation-v2-state/v0.7",
+    "mts-foundation-v2-source/v0.7",
+    "mts-foundation-v2-interpreter-replay/v0.7"
+  ],
+  "scope": {
+    "before": "D_before = D_before ⟼ (parentScope ⟼ H_before)",
+    "entry": "Entry = sourceContent ⟼ form",
+    "occurrence": "Occurrence = D_before ⟼ Entry",
+    "historyAppend": "H_after = H_before ⟼ Occurrence",
+    "after": "D_after = D_after ⟼ (sameParentScope ⟼ H_after)",
+    "persistent": true,
+    "parentImmutable": true
+  },
+  "lookup": {
+    "order": "local history first, then explicit parent scope",
+    "selectedEvidence": "exact historical definition occurrence visible from current D",
+    "sameLocalSourceSameForm": "one mapping, multiple declaration occurrences allowed",
+    "distinctLocalForms": "conflict",
+    "childLocalMapping": "shadows parent",
+    "childMiss": "falls through to parent",
+    "lastWriteWins": false,
+    "globalScanCountsAsVisibility": false
+  },
+  "colonReplay": {
+    "sameInterpreterModule": true,
+    "sourceOccurrenceTopology": "S = S ⟼ sourceContent",
+    "entryVerified": true,
+    "occurrenceBoundToExactBeforeScope": true,
+    "oneExactHistoryAppendVerified": true,
+    "afterScopeSameParentVerified": true,
+    "newOccurrenceVisibleInAfter": true,
+    "newOccurrenceNotRetroactivelyVisibleInBefore": true,
+    "snapshotStable": true,
+    "rhsRecursiveEvaluation": false,
+    "impliesEquality": false,
+    "impliesTheorem": false,
+    "implicitL4Materialization": false
+  },
+  "actualAct": {
+    "header": "A uses existing Gate-R I/D_roles/K header; colon may keep K unchanged",
+    "requiredRoles": [
+      "source",
+      "source-content",
+      "form",
+      "before-dictionary",
+      "entry",
+      "definition-occurrence",
+      "history-before",
+      "history-after",
+      "after-dictionary",
+      "context"
+    ],
+    "roleRefsExact": true
+  },
+  "migration": {
+    "flatDictionaryProductionPathRetained": false,
+    "sourceFrontEndUsesScopedVisibility": true,
+    "theoryGrammarMembershipRemainsSeparate": true,
+    "parallelDefinitionInterpreterAdded": false
+  },
+  "requiredVectors": [
+    "one persistent definition replays read-only",
+    "repeated identical definition keeps distinct occurrences but one mapping",
+    "distinct local forms conflict",
+    "child mapping shadows parent",
+    "child miss falls through to parent",
+    "unreachable global occurrence is not visible",
+    "wrong D_before rejects",
+    "wrong history predecessor rejects",
+    "changed parent in D_after rejects"
+  ],
+  "nextGate": "integrate local exact representative equality decision #225 into this same replay engine"
+}

--- a/contracts/mts-foundation-v2-interpreter-replay-v0.7.json
+++ b/contracts/mts-foundation-v2-interpreter-replay-v0.7.json
@@ -3,32 +3,47 @@
   "status": "gate-p-candidate",
   "accepted": false,
   "issue": 247,
+  "refinedByIssue": 249,
   "parent": 237,
   "dependsOn": [
     "mts-exact-occurrence-link-network/v0.7",
     "mts-foundation-v2-state/v0.7",
     "mts-foundation-v2-source/v0.7",
-    "mts-integrated-interpreter-act-challenge/v0.7"
+    "mts-integrated-interpreter-act-challenge/v0.7",
+    "mts-foundation-v2-colon/v0.7"
   ],
-  "scope": "one read-only one-pole relation-resolution act",
-  "path": [
-    "replay exact selected source evidence",
-    "obtain exactly one selected form occurrence",
-    "read exact active K/current",
-    "bind current to the one open pole",
-    "verify exact result occurrence and poles",
-    "verify persistent K_after",
-    "verify actual act header and exact role-addressed fields"
-  ],
-  "resolution": {
+  "engine": {
+    "oneTrustedReplayPath": true,
+    "supportedActs": [
+      "one-pole relation resolution",
+      "persistent scoped dictionary colon effect"
+    ],
+    "parallelDefinitionInterpreter": false
+  },
+  "relationResolution": {
+    "path": [
+      "replay exact selected source evidence",
+      "obtain exactly one selected form occurrence",
+      "read exact active K/current",
+      "bind current to the one open pole",
+      "verify exact result occurrence and poles",
+      "verify persistent K_after",
+      "verify actual act header and exact role-addressed fields"
+    ],
     "startOpen": "F = F ⟼ e => result = current ⟼ e",
     "endOpen": "F = b ⟼ F => result = b ⟼ current",
     "directionFromExactFormStructure": true,
     "glyphOrOpcodeDispatch": false,
-    "completedFormAcceptedByThisSlice": false,
-    "fullySelfClosedFormAcceptedByThisSlice": false,
     "resultPairUniquenessRequired": false,
     "selectedResultOccurrenceMustBeExact": true
+  },
+  "colon": {
+    "contract": "mts-foundation-v2-colon/v0.7",
+    "dictionaryModel": "persistent scoped D only",
+    "sameReplayModule": true,
+    "impliesEquality": false,
+    "impliesTheorem": false,
+    "rhsRecursiveEvaluation": false
   },
   "context": {
     "before": "K_before = K_before ⟼ (parent ⟼ current)",
@@ -43,46 +58,21 @@
       "H = I ⟼ P0",
       "A = A ⟼ H"
     ],
-    "requiredRoleFields": [
-      "source",
-      "source-selection",
-      "form-sequence",
-      "dictionary",
-      "grammar",
-      "theory",
-      "form",
-      "before-context",
-      "binding",
-      "result",
-      "after-context"
-    ],
     "fieldTopology": "A ⟼ (roleRef ⟼ value)",
+    "roleDictionaryIsScoped": true,
     "roleRefsAreExact": true,
     "hostFieldNamesAreSemanticIdentity": false,
     "duplicateOrConflictingRequiredFieldRejects": true
   },
   "replay": {
-    "sourceFrontEndReplayed": true,
+    "sourceFrontEndReplayedForRelationActs": true,
     "checkerReadOnly": true,
     "networkSnapshotMustRemainEqual": true,
     "searchRankingTrusted": false,
     "applicationLinkMaterialization": false,
     "persistentBackendEffect": false
   },
-  "requiredVectors": [
-    "start-open form resolves using exact current",
-    "end-open form resolves symmetrically",
-    "selected exact result succeeds even when another occurrence has the same poles",
-    "forged binding rejects",
-    "substituting another same-pole result rejects when K_after/act select the original",
-    "completed form rejects in one-pole slice",
-    "forged source evidence rejects",
-    "conflicting actual-act field rejects",
-    "forged act header rejects",
-    "replay does not import legacy parser/AST/interpreter semantics"
-  ],
   "deferredSameEngineExtensions": {
-    "colonPersistentDictionaryEffect": 224,
     "localEqualityConstraint": 225,
     "multiStepRun": 230,
     "anumSequenceMaterialization": 242,
@@ -95,5 +85,5 @@
     "productionCutoverDone": false,
     "aproverRepinAllowed": false
   },
-  "nextGate": "extend this same trusted engine with the already-decided explicit colon/equality semantics before integrated conformance and cutover"
+  "nextGate": "integrate local equality decision #225 into this same trusted engine, then move toward multistep/integrated conformance"
 }

--- a/contracts/mts-foundation-v2-source-v0.7.json
+++ b/contracts/mts-foundation-v2-source-v0.7.json
@@ -3,6 +3,7 @@
   "status": "gate-p-candidate",
   "accepted": false,
   "issue": 245,
+  "refinedByIssue": 249,
   "parent": 237,
   "dependsOn": [
     "mts-exact-occurrence-link-network/v0.7",
@@ -15,7 +16,7 @@
     "canonical astring content C",
     "exact source occurrence S",
     "selected exact segmentation evidence",
-    "explicit D membership per slice",
+    "exact visible scoped-D declaration occurrence per slice",
     "ordered resolved form sequence",
     "explicit G membership",
     "explicit T membership"
@@ -33,13 +34,18 @@
     "sliceEvidenceTopology": "SliceEvidence = Span ⟼ sliceContent",
     "lexemeOccurrenceTopology": "Lexeme = S ⟼ SliceEvidence",
     "resolutionTopology": "Resolution = Lexeme ⟼ form",
-    "selectionTopology": "Selection = exactDictionaryMembership ⟼ Resolution",
+    "selectionTopology": "Selection = exactVisibleDefinitionOccurrence ⟼ Resolution",
     "hostOffsetsAreTransportEvidenceNotSemanticIdentity": true
   },
   "dictionary": {
+    "scopeTopology": "D = D ⟼ (parentScope ⟼ localHistory)",
     "entryTopology": "Entry = sliceContent ⟼ form",
-    "membershipTopology": "Membership = D ⟼ Entry",
-    "membershipMustBeExactSelectedEvidence": true,
+    "definitionOccurrenceTopology": "Occurrence = D_before ⟼ Entry",
+    "selectedOccurrenceMustBeVisibleFromCurrentScope": true,
+    "visibilityProof": "walk exact local-history predecessors, then explicit parent scopes",
+    "localMappingShadowsParent": true,
+    "distinctLocalFormsConflict": true,
+    "flatDirectMembershipIsCanonical": false,
     "sameBytesMayResolveDifferentlyUnderDifferentDictionaries": true
   },
   "sequence": {
@@ -53,7 +59,7 @@
   "replay": {
     "selectedBoundariesVerifiedAgainstCanonicalSourceHistory": true,
     "sliceContentVerifiedAgainstExactSelectedBytes": true,
-    "dictionaryMembershipVerified": true,
+    "scopedDictionaryVisibilityVerified": true,
     "grammarMembershipVerified": true,
     "theoryMembershipVerified": true,
     "orderedSequencesVerified": true,
@@ -74,11 +80,12 @@
     "multi-byte UTF-8 glyph selected as one slice",
     "same bytes under D1/D2 resolve differently",
     "ambiguous split and whole-token segmentations both replay when explicitly admitted",
+    "visible historical declaration occurrence remains valid under later snapshot",
+    "unreachable declaration occurrence rejects",
     "forged span rejects",
-    "wrong dictionary rejects",
     "forged G/T admission rejects",
     "partial/non-contiguous partition rejects",
     "read-only replay does not create described application links"
   ],
-  "nextGate": "one interpreter/replay engine consuming this exact source evidence and explicit K/D/G/T/A state"
+  "nextGate": "same interpreter/replay engine with persistent scoped colon effect and then local equality"
 }

--- a/contracts/mts-foundation-v2-state-v0.7.json
+++ b/contracts/mts-foundation-v2-state-v0.7.json
@@ -3,6 +3,7 @@
   "status": "gate-p-candidate",
   "accepted": false,
   "issue": 243,
+  "refinedByIssue": 249,
   "parent": 237,
   "substrate": "mts-exact-occurrence-link-network/v0.7",
   "principle": "higher semantic roles are ordinary exact link occurrences; Link itself has only start/end",
@@ -20,13 +21,24 @@
     "persistentUpdateRequired": true
   },
   "dictionary": {
+    "scopeTopology": "D = D ⟼ (parentScope ⟼ localHistory)",
+    "rootScopeCandidate": "D0 = D0 ⟼ (R ⟼ R)",
     "entryTopology": "Entry = sourceContent ⟼ form",
-    "membershipTopology": "Membership = D ⟼ Entry",
+    "definitionOccurrenceTopology": "Occurrence = D_before ⟼ Entry",
+    "historyAppendTopology": "H_after = H_before ⟼ Occurrence",
+    "afterScopeTopology": "D_after = D_after ⟼ (sameParentScope ⟼ H_after)",
+    "lookup": "local history first, then explicit parent scope",
+    "sameLocalSourceSameFormIsIdempotentMapping": true,
+    "distinctLocalFormsConflict": true,
+    "localMappingShadowsParent": true,
+    "lastWriteWins": false,
+    "flatDirectMembershipIsCanonicalProductionModel": false,
     "sameSourceMayResolveDifferentlyUnderDifferentDictionaries": true,
     "hostGlobalSymbolMapAllowedAsSemanticAuthority": false
   },
   "theoryAndGrammar": {
     "membershipTopology": "container ⟼ admitted exact occurrence",
+    "separateFromDictionaryScopeSemantics": true,
     "isAxiomTag": false,
     "tokenOrAstKindSemanticIdentity": false,
     "searchRankingTrusted": false,
@@ -43,7 +55,7 @@
       "Field = roleRef ⟼ value",
       "Attachment = A ⟼ Field"
     ],
-    "roleNamesResolvedThroughExplicitDictionary": true,
+    "roleNamesResolvedThroughExplicitScopedDictionary": true,
     "hostRoleEnumIsSemanticIdentity": false,
     "twoActsWithSameVisibleFieldsMayRemainDistinctOccurrences": true
   },
@@ -66,5 +78,5 @@
     "anumSequenceMaterializationAccepted": false,
     "aproverRepinAllowed": false
   },
-  "nextGate": "single source/interpreter production path over this explicit state layer; sequence-to-apamemory materialization remains issue #242 before final L4 cutover"
+  "nextGate": "integrate scoped dictionary definition/effect replay and then local equality in the same trusted engine before cutover"
 }

--- a/core/foundation_v2_interpreter.py
+++ b/core/foundation_v2_interpreter.py
@@ -1,16 +1,15 @@
 """Foundation-v2 read-only interpreter/replay spine.
 
-This module is the first production-facing vertical interpreter slice after the
-exact-occurrence state and source gates.  It consumes already-selected source
-evidence; it does not tokenize, parse, search, rank or materialize application
-links.
+This module is the production-facing trusted replay spine after the exact-
+occurrence state and source gates. It consumes already-selected exact evidence;
+it does not tokenize, parse, search, rank or materialize application links.
 
-The trusted operation replays one relation-resolution act:
+The same engine currently replays:
 
-    source evidence -> exact active K/current -> one-pole form resolution
-    -> exact result -> persistent K_after -> exact actual act A
+- one-pole relation resolution against exact K/current;
+- one persistent scoped-dictionary ``:`` effect.
 
-Python dataclasses below are checker/transport API only.  Semantic identity lives
+Python dataclasses below are checker/transport API only. Semantic identity lives
 in the exact link occurrences they reference.
 """
 from __future__ import annotations
@@ -25,11 +24,15 @@ from .foundation_v2_source import (
     replay_source_front_end,
 )
 from .foundation_v2_state import (
+    DictionaryLookupError,
     FoundationStateError,
     act_header,
     act_values,
     current_of_context,
+    lookup_scoped_dictionary,
     parent_of_context,
+    read_dictionary_scope,
+    verify_visible_dictionary_occurrence,
 )
 
 
@@ -70,22 +73,47 @@ class RelationStepEvidence:
     roles: RelationStepRoleRefs
 
 
+@dataclass(frozen=True)
+class ColonRoleRefs:
+    """Exact role refs required to replay one persistent ``:`` effect."""
+
+    source: OccurrenceRef
+    source_content: OccurrenceRef
+    form: OccurrenceRef
+    before_dictionary: OccurrenceRef
+    entry: OccurrenceRef
+    definition_occurrence: OccurrenceRef
+    history_before: OccurrenceRef
+    history_after: OccurrenceRef
+    after_dictionary: OccurrenceRef
+    context: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class ColonEffectEvidence:
+    """Checker handle for one already-materialized persistent definition effect."""
+
+    interpreter: OccurrenceRef
+    source: OccurrenceRef
+    source_content: OccurrenceRef
+    form: OccurrenceRef
+    before_dictionary: OccurrenceRef
+    entry: OccurrenceRef
+    definition_occurrence: OccurrenceRef
+    history_after: OccurrenceRef
+    after_dictionary: OccurrenceRef
+    context: OccurrenceRef
+    act: OccurrenceRef
+    role_dictionary: OccurrenceRef
+    roles: ColonRoleRefs
+
+
 def replay_relation_step(
     network: LinkNetwork,
     evidence: RelationStepEvidence,
     byte_refs: Mapping[int, OccurrenceRef],
 ) -> OccurrenceRef:
-    """Replay one selected Foundation-v2 relation-resolution act read-only.
-
-    Exactly one form must have been selected by the source front-end.  The
-    direction of resolution is derived from the exact self-closed form itself:
-
-    ``F = F ⟼ e``  -> bind the open start from ``↑``
-    ``F = b ⟼ F``  -> bind the open end from ``↑``
-
-    The selected result occurrence is checked by exact ref and poles.  Another
-    occurrence with the same poles neither invalidates nor replaces it.
-    """
+    """Replay one selected Foundation-v2 relation-resolution act read-only."""
 
     before_snapshot = network.snapshot()
     try:
@@ -120,12 +148,110 @@ def replay_relation_step(
         if after_current is not evidence.result:
             raise InterpreterReplayError("after-context current is not the exact result")
 
-        _verify_act_header(network, evidence)
-        _verify_act_fields(network, evidence)
+        _verify_relation_act_header(network, evidence)
+        _verify_relation_act_fields(network, evidence)
         return evidence.result
     finally:
         if network.snapshot() != before_snapshot:
             raise InterpreterReplayError("interpreter replay mutated the network")
+
+
+def replay_colon_effect(
+    network: LinkNetwork,
+    evidence: ColonEffectEvidence,
+) -> OccurrenceRef:
+    """Replay one persistent scoped-dictionary definition effect read-only.
+
+    The relation ``sourceContent ⟼ form`` is dictionary data, not equality or a
+    theorem. The exact declaration occurrence is bound to ``D_before`` and
+    appended once to its local history; ``D_after`` is a fresh persistent scope
+    snapshot with the same lexical parent.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        source_link = network.link(evidence.source)
+        if (
+            source_link.start is not evidence.source
+            or source_link.end is not evidence.source_content
+        ):
+            raise InterpreterReplayError("colon source does not match S = S ⟼ C")
+
+        try:
+            parent_before, history_before = read_dictionary_scope(
+                network, evidence.before_dictionary
+            )
+        except DictionaryLookupError as exc:
+            raise InterpreterReplayError("invalid before dictionary scope") from exc
+
+        entry = network.link(evidence.entry)
+        if entry.start is not evidence.source_content or entry.end is not evidence.form:
+            raise InterpreterReplayError("colon Entry does not match sourceContent ⟼ form")
+
+        occurrence = network.link(evidence.definition_occurrence)
+        if (
+            occurrence.start is not evidence.before_dictionary
+            or occurrence.end is not evidence.entry
+        ):
+            raise InterpreterReplayError(
+                "definition occurrence is not bound to exact D_before and Entry"
+            )
+
+        history_after = network.link(evidence.history_after)
+        if (
+            history_after.start is not history_before
+            or history_after.end is not evidence.definition_occurrence
+        ):
+            raise InterpreterReplayError("colon history is not one exact append")
+
+        try:
+            parent_after, selected_history_after = read_dictionary_scope(
+                network, evidence.after_dictionary
+            )
+        except DictionaryLookupError as exc:
+            raise InterpreterReplayError("invalid after dictionary scope") from exc
+        if parent_after is not parent_before:
+            raise InterpreterReplayError("colon effect changed lexical parent scope")
+        if selected_history_after is not evidence.history_after:
+            raise InterpreterReplayError("D_after does not select exact appended history")
+
+        try:
+            verify_visible_dictionary_occurrence(
+                network,
+                evidence.after_dictionary,
+                evidence.definition_occurrence,
+                evidence.source_content,
+                evidence.form,
+            )
+        except DictionaryLookupError as exc:
+            raise InterpreterReplayError(
+                "new definition is not a valid visible mapping in D_after"
+            ) from exc
+
+        # The newly created declaration occurrence must not retroactively become
+        # visible from the immutable predecessor snapshot, even when an older
+        # identical mapping already exists there.
+        try:
+            verify_visible_dictionary_occurrence(
+                network,
+                evidence.before_dictionary,
+                evidence.definition_occurrence,
+                evidence.source_content,
+                evidence.form,
+            )
+        except DictionaryLookupError:
+            pass
+        else:
+            raise InterpreterReplayError(
+                "new definition occurrence is retroactively visible from D_before"
+            )
+
+        _verify_colon_act_header(network, evidence)
+        _verify_colon_act_fields(network, evidence, history_before)
+        return evidence.after_dictionary
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise InterpreterReplayError("colon replay mutated the network")
 
 
 def _replay_source(
@@ -152,12 +278,13 @@ def _expected_result_poles(
         return binding, form_link.end
     if end_open:
         return form_link.start, binding
-    raise InterpreterReplayError(
-        "selected form is not exactly one-pole self-closed"
-    )
+    raise InterpreterReplayError("selected form is not exactly one-pole self-closed")
 
 
-def _verify_act_header(network: LinkNetwork, evidence: RelationStepEvidence) -> None:
+def _verify_relation_act_header(
+    network: LinkNetwork,
+    evidence: RelationStepEvidence,
+) -> None:
     try:
         header = act_header(network, evidence.act)
     except FoundationStateError as exc:
@@ -167,7 +294,10 @@ def _verify_act_header(network: LinkNetwork, evidence: RelationStepEvidence) -> 
         raise InterpreterReplayError("actual-act header does not match I/D_roles/K_after")
 
 
-def _verify_act_fields(network: LinkNetwork, evidence: RelationStepEvidence) -> None:
+def _verify_relation_act_fields(
+    network: LinkNetwork,
+    evidence: RelationStepEvidence,
+) -> None:
     source = evidence.source_evidence
     expected = (
         (evidence.roles.source, source.source, "source"),
@@ -190,8 +320,67 @@ def _verify_act_fields(network: LinkNetwork, evidence: RelationStepEvidence) -> 
         (evidence.roles.result, evidence.result, "result"),
         (evidence.roles.after_context, evidence.after_context, "after-context"),
     )
+    _verify_exact_act_fields(network, evidence.act, expected)
+
+
+def _verify_colon_act_header(
+    network: LinkNetwork,
+    evidence: ColonEffectEvidence,
+) -> None:
+    try:
+        header = act_header(network, evidence.act)
+    except FoundationStateError as exc:
+        raise InterpreterReplayError("invalid colon actual-act header") from exc
+    expected = (evidence.interpreter, evidence.role_dictionary, evidence.context)
+    if header != expected:
+        raise InterpreterReplayError(
+            "colon actual-act header does not match I/D_roles/K"
+        )
+
+
+def _verify_colon_act_fields(
+    network: LinkNetwork,
+    evidence: ColonEffectEvidence,
+    history_before: OccurrenceRef,
+) -> None:
+    expected = (
+        (evidence.roles.source, evidence.source, "source"),
+        (
+            evidence.roles.source_content,
+            evidence.source_content,
+            "source-content",
+        ),
+        (evidence.roles.form, evidence.form, "form"),
+        (
+            evidence.roles.before_dictionary,
+            evidence.before_dictionary,
+            "before-dictionary",
+        ),
+        (evidence.roles.entry, evidence.entry, "entry"),
+        (
+            evidence.roles.definition_occurrence,
+            evidence.definition_occurrence,
+            "definition-occurrence",
+        ),
+        (evidence.roles.history_before, history_before, "history-before"),
+        (evidence.roles.history_after, evidence.history_after, "history-after"),
+        (
+            evidence.roles.after_dictionary,
+            evidence.after_dictionary,
+            "after-dictionary",
+        ),
+        (evidence.roles.context, evidence.context, "context"),
+    )
+    _verify_exact_act_fields(network, evidence.act, expected)
+
+
+def _verify_exact_act_fields(
+    network: LinkNetwork,
+    act: OccurrenceRef,
+    expected: tuple[tuple[OccurrenceRef, OccurrenceRef, str], ...],
+) -> None:
     for role, value, label in expected:
-        values = act_values(network, evidence.act, role)
+        values = act_values(network, act, role)
         if values != (value,):
             raise InterpreterReplayError(
                 f"actual-act field {label!r} is missing, duplicated or forged"

--- a/core/foundation_v2_source.py
+++ b/core/foundation_v2_source.py
@@ -1,12 +1,13 @@
 """Foundation-v2 source front-end over exact-occurrence link networks.
 
-The trusted operation in this module is *replay of selected evidence*.  Candidate
-segmentation/token search is intentionally outside the trusted core.  A caller
+The trusted operation in this module is *replay of selected evidence*. Candidate
+segmentation/token search is intentionally outside the trusted core. A caller
 supplies exact byte-protocol refs, an exact source occurrence, selected spans,
-explicit dictionary memberships and explicit grammar/theory admission.
+exact visible scoped-dictionary declaration occurrences and explicit
+grammar/theory admission.
 
-Host byte offsets and dataclasses are transport/checker machinery.  They are not
-semantic identity.  The semantic evidence is represented by ordinary links.
+Host byte offsets and dataclasses are transport/checker machinery. They are not
+semantic identity. The semantic evidence is represented by ordinary links.
 No function here materializes the application relation described by source text.
 """
 from __future__ import annotations
@@ -15,7 +16,12 @@ from dataclasses import dataclass
 from typing import Mapping, Sequence
 
 from .exact_link_network import LinkNetwork, LinkNetworkBuilder, OccurrenceRef
-from .foundation_v2_state import define_membership, define_source_occurrence
+from .foundation_v2_state import (
+    DictionaryLookupError,
+    define_membership,
+    define_source_occurrence,
+    verify_visible_dictionary_occurrence,
+)
 
 
 class SourceReplayError(ValueError):
@@ -38,7 +44,7 @@ class SegmentSpec:
     start: int
     end: int
     form: OccurrenceRef
-    dictionary_membership: OccurrenceRef
+    dictionary_occurrence: OccurrenceRef
 
 
 @dataclass(frozen=True)
@@ -52,7 +58,7 @@ class SegmentEvidence:
     slice_evidence: OccurrenceRef
     lexeme: OccurrenceRef
     resolution: OccurrenceRef
-    dictionary_membership: OccurrenceRef
+    dictionary_occurrence: OccurrenceRef
     selection: OccurrenceRef
     form: OccurrenceRef
 
@@ -78,7 +84,7 @@ class SourceFrontEndBuilder:
     """Untrusted construction helper for canonical source/evidence fixtures.
 
     ``byte_refs`` are the exact occurrences selected by the lower canonical byte
-    protocol.  This layer does not redefine the ``[bbbbbbbb]`` carrier; it folds
+    protocol. This layer does not redefine the ``[bbbbbbbb]`` carrier; it folds
     those exact byte refs into canonical source-content histories.
     """
 
@@ -136,8 +142,9 @@ class SourceFrontEndBuilder:
         """Build exact evidence for one caller-selected segmentation.
 
         The function does not choose spans, perform longest-match, parse glyphs or
-        invent dictionary entries.  ``SegmentSpec.dictionary_membership`` must
-        already identify the dictionary evidence that trusted replay will check.
+        invent dictionary definitions. ``SegmentSpec.dictionary_occurrence`` must
+        already identify exact declaration evidence that trusted scoped lookup
+        will prove visible from ``dictionary``.
         """
 
         if self._sources.get(source.source) != source:
@@ -156,7 +163,7 @@ class SourceFrontEndBuilder:
             slice_evidence = self._new_link(span, slice_content)
             lexeme = self._new_link(source.source, slice_evidence)
             resolution = self._new_link(lexeme, spec.form)
-            selection = self._new_link(spec.dictionary_membership, resolution)
+            selection = self._new_link(spec.dictionary_occurrence, resolution)
             segment_evidence.append(
                 SegmentEvidence(
                     start=spec.start,
@@ -166,7 +173,7 @@ class SourceFrontEndBuilder:
                     slice_evidence=slice_evidence,
                     lexeme=lexeme,
                     resolution=resolution,
-                    dictionary_membership=spec.dictionary_membership,
+                    dictionary_occurrence=spec.dictionary_occurrence,
                     selection=selection,
                     form=spec.form,
                 )
@@ -210,9 +217,9 @@ def replay_source_front_end(
     evidence: SourceFrontEndEvidence,
     byte_refs: Mapping[int, OccurrenceRef],
 ) -> tuple[OccurrenceRef, ...]:
-    """Replay selected UTF-8/astring → D/G/T evidence without effects.
+    """Replay selected UTF-8/astring → scoped D/G/T evidence without effects.
 
-    Returns the exact resolved forms in source order.  This function does not
+    Returns the exact resolved forms in source order. This function does not
     search for alternative segmentations and does not create any link.
     """
 
@@ -270,17 +277,20 @@ def replay_source_front_end(
         if resolution.start is not segment.lexeme or resolution.end is not segment.form:
             raise SourceReplayError("forged lexeme resolution")
 
-        _verify_dictionary_membership(
-            network,
-            segment.dictionary_membership,
-            evidence.dictionary,
-            segment.slice_content,
-            segment.form,
-        )
+        try:
+            verify_visible_dictionary_occurrence(
+                network,
+                evidence.dictionary,
+                segment.dictionary_occurrence,
+                segment.slice_content,
+                segment.form,
+            )
+        except DictionaryLookupError as exc:
+            raise SourceReplayError("selected scoped dictionary evidence is invalid") from exc
 
         selection = network.link(segment.selection)
         if (
-            selection.start is not segment.dictionary_membership
+            selection.start is not segment.dictionary_occurrence
             or selection.end is not segment.resolution
         ):
             raise SourceReplayError("forged selected dictionary evidence")
@@ -379,21 +389,6 @@ def _decode_content(
         bytes(reversed(reversed_bytes)),
         tuple(reversed(reversed_prefix_refs)),
     )
-
-
-def _verify_dictionary_membership(
-    network: LinkNetwork,
-    membership_ref: OccurrenceRef,
-    dictionary: OccurrenceRef,
-    slice_content: OccurrenceRef,
-    form: OccurrenceRef,
-) -> None:
-    membership = network.link(membership_ref)
-    if membership.start is not dictionary:
-        raise SourceReplayError("dictionary membership belongs to another dictionary")
-    entry = network.link(membership.end)
-    if entry.start is not slice_content or entry.end is not form:
-        raise SourceReplayError("dictionary entry does not resolve selected slice to selected form")
 
 
 def _verify_direct_membership(

--- a/core/foundation_v2_state.py
+++ b/core/foundation_v2_state.py
@@ -1,22 +1,56 @@
 """Foundation-v2 higher-layer state over the exact-occurrence link substrate.
 
-This module deliberately adds no semantic fields to :class:`Link`.  Contexts,
+This module deliberately adds no semantic fields to :class:`Link`. Contexts,
 dictionaries, theories, grammar evidence and interpretation acts are represented
-only by ordinary exact link occurrences.  The Python functions below are
+only by ordinary exact link occurrences. The Python functions below are
 construction/read helpers for the candidate topology; their function names are
 not MTS ontology.
 
-The module is intentionally storage-neutral and read-only after a network has
-been frozen.  It does not materialize persistent L4 links and does not define
-Anum sequence deserialization (tracked separately by issue #242).
+Foundation-v2 dictionaries use one persistent lexical-scope model. A dictionary
+snapshot is start-self-closed and points to ``parentScope ⟼ localHistory``.
+Definitions append exact occurrences to that history; lookup replays the explicit
+history/parent links rather than consulting a mutable host map.
+
+The module is storage-neutral and read-only after a network has been frozen. It
+does not materialize persistent L4 links and does not define Anum sequence
+deserialization (tracked separately by issue #242).
 """
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 from .exact_link_network import LinkNetwork, LinkNetworkBuilder, OccurrenceRef
 
 
 class FoundationStateError(ValueError):
     """The supplied exact occurrences do not match the candidate topology."""
+
+
+class DictionaryLookupError(FoundationStateError):
+    """A scoped dictionary cannot be replayed or resolved consistently."""
+
+
+class DictionaryConflictError(DictionaryLookupError):
+    """One lexical scope contains distinct forms for the same source content."""
+
+
+@dataclass(frozen=True)
+class DictionaryEffectRefs:
+    """Construction handles for one persistent definition effect."""
+
+    entry: OccurrenceRef
+    occurrence: OccurrenceRef
+    history_after: OccurrenceRef
+    after_scope: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class ScopedDictionaryResolution:
+    """Exact visible occurrences supporting one scoped dictionary resolution."""
+
+    scope: OccurrenceRef
+    form: OccurrenceRef
+    occurrences: tuple[OccurrenceRef, ...]
 
 
 def define_source_occurrence(
@@ -64,37 +98,149 @@ def parent_of_context(network: LinkNetwork, context: OccurrenceRef) -> Occurrenc
     return pair.start
 
 
-def define_dictionary_membership(
+def define_dictionary_scope(
     builder: LinkNetworkBuilder,
-    dictionary: OccurrenceRef,
+    parent_scope: OccurrenceRef,
+    local_history: OccurrenceRef,
+) -> OccurrenceRef:
+    """Create ``D = D ⟼ (parentScope ⟼ localHistory)``."""
+
+    payload = builder.reserve()
+    scope = builder.reserve()
+    builder.define(payload, parent_scope, local_history)
+    builder.define(scope, scope, payload)
+    return scope
+
+
+def define_dictionary_effect(
+    builder: LinkNetworkBuilder,
+    before_scope: OccurrenceRef,
+    parent_scope: OccurrenceRef,
+    history_before: OccurrenceRef,
     source_content: OccurrenceRef,
     form: OccurrenceRef,
-) -> tuple[OccurrenceRef, OccurrenceRef]:
-    """Create ``entry=source⟼form`` and ``membership=D⟼entry``."""
+) -> DictionaryEffectRefs:
+    """Construct one persistent ``:``-style dictionary update.
+
+    The helper is construction-only; trusted replay later verifies that the
+    supplied parent/history really belong to ``before_scope``.
+    """
 
     entry = builder.reserve()
-    membership = builder.reserve()
+    occurrence = builder.reserve()
+    history_after = builder.reserve()
     builder.define(entry, source_content, form)
-    builder.define(membership, dictionary, entry)
-    return entry, membership
+    builder.define(occurrence, before_scope, entry)
+    builder.define(history_after, history_before, occurrence)
+    after_scope = define_dictionary_scope(builder, parent_scope, history_after)
+    return DictionaryEffectRefs(
+        entry=entry,
+        occurrence=occurrence,
+        history_after=history_after,
+        after_scope=after_scope,
+    )
 
 
-def dictionary_forms(
+def read_dictionary_scope(
+    network: LinkNetwork,
+    dictionary: OccurrenceRef,
+) -> tuple[OccurrenceRef, OccurrenceRef]:
+    """Return exact ``(parentScope, localHistory)`` for one dictionary snapshot."""
+
+    if dictionary is network.root:
+        raise DictionaryLookupError("exact root is a dictionary sentinel, not a scope")
+    scope = network.link(dictionary)
+    if scope.start is not dictionary:
+        raise DictionaryLookupError("dictionary scope is not start-self-closed")
+    payload = network.link(scope.end)
+    return payload.start, payload.end
+
+
+def lookup_scoped_dictionary(
     network: LinkNetwork,
     dictionary: OccurrenceRef,
     source_content: OccurrenceRef,
-) -> tuple[OccurrenceRef, ...]:
-    """Return exact forms admitted by matching dictionary membership links."""
+) -> ScopedDictionaryResolution | None:
+    """Resolve source content using local-history-first lexical scope semantics."""
 
-    forms: list[OccurrenceRef] = []
-    for membership_ref in network.refs:
-        membership = network.link(membership_ref)
-        if membership.start is not dictionary:
-            continue
-        entry = network.link(membership.end)
+    visited_scopes: set[OccurrenceRef] = set()
+    current_scope = dictionary
+    while current_scope is not network.root:
+        if current_scope in visited_scopes:
+            raise DictionaryLookupError("dictionary parent cycle")
+        visited_scopes.add(current_scope)
+
+        parent, _ = read_dictionary_scope(network, current_scope)
+        local = _local_dictionary_matches(network, current_scope, source_content)
+        if local:
+            forms = {form for _, form in local}
+            if len(forms) != 1:
+                raise DictionaryConflictError(
+                    "dictionary scope contains distinct local forms for one source"
+                )
+            form = next(iter(forms))
+            return ScopedDictionaryResolution(
+                scope=current_scope,
+                form=form,
+                occurrences=tuple(occurrence for occurrence, _ in local),
+            )
+        current_scope = parent
+    return None
+
+
+def verify_visible_dictionary_occurrence(
+    network: LinkNetwork,
+    dictionary: OccurrenceRef,
+    occurrence: OccurrenceRef,
+    source_content: OccurrenceRef,
+    form: OccurrenceRef,
+) -> None:
+    """Verify an exact declaration occurrence is the visible scoped resolution."""
+
+    resolution = lookup_scoped_dictionary(network, dictionary, source_content)
+    if resolution is None:
+        raise DictionaryLookupError("source content is not visible in dictionary")
+    if resolution.form is not form:
+        raise DictionaryLookupError("visible dictionary form differs from selected form")
+    if occurrence not in resolution.occurrences:
+        raise DictionaryLookupError(
+            "selected declaration occurrence is not visible from current dictionary"
+        )
+
+
+def _local_dictionary_matches(
+    network: LinkNetwork,
+    dictionary: OccurrenceRef,
+    source_content: OccurrenceRef,
+) -> list[tuple[OccurrenceRef, OccurrenceRef]]:
+    parent, history = read_dictionary_scope(network, dictionary)
+    matches: list[tuple[OccurrenceRef, OccurrenceRef]] = []
+    visited_history: set[OccurrenceRef] = set()
+
+    while history is not network.root:
+        if history in visited_history:
+            raise DictionaryLookupError("dictionary local-history cycle")
+        visited_history.add(history)
+
+        cell = network.link(history)
+        previous_history = cell.start
+        occurrence = cell.end
+        occurrence_link = network.link(occurrence)
+        before_scope = occurrence_link.start
+        entry_ref = occurrence_link.end
+
+        before_parent, before_history = read_dictionary_scope(network, before_scope)
+        if before_parent is not parent or before_history is not previous_history:
+            raise DictionaryLookupError(
+                "definition occurrence is not bound to the exact predecessor snapshot"
+            )
+
+        entry = network.link(entry_ref)
         if entry.start is source_content:
-            forms.append(entry.end)
-    return tuple(forms)
+            matches.append((occurrence, entry.end))
+        history = previous_history
+
+    return matches
 
 
 def define_membership(
@@ -114,7 +260,7 @@ def has_exact_membership(
     container: OccurrenceRef,
     value: OccurrenceRef,
 ) -> bool:
-    """Check direct membership without structural equality or materialization."""
+    """Check direct G/T-style membership without equality or materialization."""
 
     return any(
         network.link(ref).start is container and network.link(ref).end is value

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -2,41 +2,42 @@
 
 Статус: **production/reference candidate**, не accepted release.
 
-Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory layer #243/#244 и source front-end #245/#246. Текущий слой: unified interpreter/replay #247. Sequence-deserialization: #242. Persistent L4 backend: #124.
+Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory layer #243/#244, source front-end #245/#246 и первый relation replay #247/#248. Текущий слой: persistent scoped dictionary + `:` #249. Sequence-deserialization: #242. Persistent L4 backend: #124.
 
-Цель Gate P — превратить завершённые research-решения Foundation v2 в **один** reference/production path, после чего опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
+Цель Gate P — собрать **один** production/reference semantic path, после чего опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
 
-## 1. Что уже считается обязательным направлением
-
-Новая версия должна строиться снизу вверх:
+## 1. Каноническая лестница Foundation v2
 
 ```text
 binary link ontology
 → distinguished R/O/C/L/U bootstrap
 → exact-occurrence finite link networks
-→ root-relative Anum structural descriptions where defined
-→ canonical UTF-8/astring source carrier
-→ explicit selected source segmentation
-→ explicit D/G/T relations
+→ root-relative Anum descriptions where defined
+→ canonical UTF-8/astring source content
+→ exact source occurrence
+→ selected exact segmentation
+→ scoped D + explicit G/T evidence
 → explicit K/current
-→ structural relation resolution
-→ actual interpretation acts A
-→ trusted exact replay
-→ proof checker / aprover
+→ one trusted interpreter/replay engine
+→ actual acts A
+→ multistep/proof replay
+→ accepted contract
+→ aprover
 ```
 
-При этом:
+Ключевые границы:
 
 ```text
 source != semantic form
 form != theory membership
-structural equality != exact occurrence identity
+structure != exact occurrence identity
 read/find/replay != materialize
+candidate search != trusted replay
 ```
 
 ## 2. Production substrate
 
-Текущий Foundation-v2 substrate:
+Foundation-v2 substrate:
 
 ```text
 OccurrenceRef
@@ -44,7 +45,7 @@ Link(start,end)
 LinkNetwork
 ```
 
-`Link` не имеет semantic tags. В частности, на нём нет полей:
+`Link` имеет только два полюса. На нём нет фундаментальных полей:
 
 ```text
 meaning
@@ -57,270 +58,7 @@ token
 astNode
 ```
 
-Sharing и cycles конечны и native. Два occurrences с одинаковыми полюсами могут оставаться различными.
-
-## 3. Higher-layer state тоже является сетью связей
-
-Контекст:
-
-```text
-P = parent ⟼ current
-K = K ⟼ P
-↑ = current from exact active K
-```
-
-Source occurrence:
-
-```text
-S = S ⟼ C
-```
-
-где `C` — canonical source content, а `S` — конкретное occurrence источника.
-
-Dictionary:
-
-```text
-Entry = C ⟼ F
-D ⟼ Entry
-```
-
-Theory / grammar evidence:
-
-```text
-T ⟼ F
-G ⟼ selectedEvidence
-```
-
-Actual interpretation act использует finite structural bootstrap:
-
-```text
-P0 = D_roles ⟼ K_after
-H  = I ⟼ P0
-A  = A ⟼ H
-```
-
-а расширяемые поля:
-
-```text
-Field = roleRef ⟼ value
-A ⟼ Field
-```
-
-Role refs разрешаются через явный `D_roles`; host enum не является их semantic identity.
-
-## 4. Один source front-end
-
-Gate P не должен иметь отдельные «настоящий tokenizer», «semantic parser» и затем второй semantic evaluator, каждый со своим скрытым набором смыслов. Production-facing source layer строится как проверяемый переход от байтов к **выбранным exact relations**.
-
-Каноническая цепочка #245:
-
-```text
-raw bytes
-→ canonical astring content C
-→ exact source occurrence S
-→ untrusted candidate segmentation
-→ selected exact source spans
-→ explicit D memberships
-→ ordered exact form sequence
-→ explicit G/T admission
-→ replayable source evidence
-```
-
-Кандидатный поиск может использовать индексы, trie, regex, longest-match heuristics или UI. Но trusted boundary не доверяет результату поиска по факту того, какой host-код его выдал. Она повторно проверяет выбранное evidence.
-
-### 4.1. Канонический content и occurrence источника
-
-Lower byte protocol предоставляет exact refs `B(byte)`. Astring content является R-seeded history:
-
-```text
-C0 = R
-C(n+1) = Cn ⟼ B(byte_n)
-```
-
-Конкретное появление исходника отдельно:
-
-```text
-S = S ⟼ C
-```
-
-Поэтому одинаковые bytes могут иметь общий canonical `C`, но разные exact source occurrences `S1`, `S2`.
-
-### 4.2. Выбранный slice — не token class
-
-Для выбранного байтового диапазона используются exact prefix refs источника:
-
-```text
-Span = sourcePrefix(start) ⟼ sourcePrefix(end)
-SliceEvidence = Span ⟼ sliceContent
-Lexeme = S ⟼ SliceEvidence
-```
-
-`start/end` в host artifact остаются transport/checker coordinates. Семантическое evidence задаётся самими exact refs границ, source occurrence и slice content.
-
-UTF-8 знак из нескольких байтов, например `⟼`, может быть одним выбранным slice. Он не обязан превращаться в набор byte-sized semantic token-ов.
-
-### 4.3. Разрешение через словарь
-
-Словарь остаётся явной сетью:
-
-```text
-Entry = sliceContent ⟼ form
-Membership = D ⟼ Entry
-```
-
-Для конкретного lexeme выбранное разрешение фиксируется:
-
-```text
-Resolution = Lexeme ⟼ form
-Selection = exactDictionaryMembership ⟼ Resolution
-```
-
-Это важно для неоднозначности. Один и тот же source может иметь:
-
-```text
-D1 → form1
-D2 → form2
-```
-
-без изменения source content.
-
-### 4.4. Порядок и G/T admission
-
-Порядок выбранных lexeme и resolved forms также является связевой структурой:
-
-```text
-SelectedSequence = fold(R, Selection_0 ... Selection_n)
-FormSequence     = fold(R, Form_0 ... Form_n)
-```
-
-Затем выбранная композиция должна быть явно допущена:
-
-```text
-G ⟼ FormSequence
-T ⟼ FormSequence
-```
-
-Точная будущая grammar/theory topology может расшириться, но production boundary уже запрещает неявное правило «раз host parser построил AST, значит композиция допустима».
-
-### 4.5. Что source replay не делает
-
-Source replay:
-
-```text
-проверяет байты и C/S;
-проверяет exact boundaries;
-проверяет D memberships;
-проверяет порядок forms;
-проверяет G/T admission.
-```
-
-Он **не** обязан:
-
-```text
-создавать application links;
-исполнять `:` или `=`;
-выбирать proof rule;
-делать Anum sequence materialization;
-менять апамять.
-```
-
-Поэтому:
-
-```text
-source resolution/replay != materialization
-```
-
-Это критично для апрувера: исходник и proof evidence можно проверять, не делая доказываемое истинным самим фактом чтения.
-
-## 5. Один interpreter/replay spine
-
-После #245 интерпретатор больше не должен повторно превращать source в свои token/AST objects. Он получает уже replayable exact source evidence и продолжает **ту же связевую цепочку**.
-
-Первый production-facing vertical slice #247 намеренно минимален:
-
-```text
-exact source evidence
-        ↓
-selected one-pole form F
-        ↓
-exact active K
-        ↓
-↑ = current
-        ↓
-structural pole resolution
-        ↓
-exact result X
-        ↓
-persistent K_after
-        ↓
-actual act A
-```
-
-### 5.1. Направление операции не является opcode
-
-Если выбранная exact form имеет самозамкнутое начало:
-
-```text
-F = F ⟼ e
-```
-
-то начало ещё не различено внешним binding, а конец уже различён. В текущем act:
-
-```text
-binding = ↑
-X = binding ⟼ e
-```
-
-Для симметричной формы:
-
-```text
-F = b ⟼ F
-```
-
-получаем:
-
-```text
-binding = ↑
-X = b ⟼ binding
-```
-
-То есть interpreter не спрашивает:
-
-```text
-if token == "♂": ...
-if ast.kind == START_PROJECTION: ...
-```
-
-Он читает структуру выбранной exact form и explicit K. Операционное направление является следствием того, какой полюс уже различён в данном акте.
-
-### 5.2. `↑` не ambient state
-
-До акта:
-
-```text
-P_before = parent ⟼ current
-K_before = K_before ⟼ P_before
-```
-
-Trusted replay получает **конкретный exact K_before** и выводит:
-
-```text
-↑ = current
-binding = current
-```
-
-После проверенного результата:
-
-```text
-P_after = sameParent ⟼ X
-K_after = K_after ⟼ P_after
-```
-
-Старый K не мутирует. Новый K — новая exact occurrence persistent state.
-
-### 5.3. Результат выбирается exact occurrence, а не формой пары
-
-Пусть в апамяти существуют:
+Sharing и cycles являются native конечной структурой. Два occurrences могут иметь одинаковые полюса и всё же оставаться различёнными:
 
 ```text
 X1 = a ⟼ b
@@ -328,21 +66,42 @@ X2 = a ⟼ b
 X1 != X2
 ```
 
-Trusted act может выбрать `X2`. Проверка обязана подтвердить:
+Поэтому shape/isomorphism и physical backend address не определяют semantic identity.
+
+## 3. Source, context и actual act — тоже связи
+
+### 3.1. Source content и occurrence
+
+Lower byte protocol предоставляет exact refs `B(byte)`.
+
+Канонический astring content:
 
 ```text
-poles(X2) = (a,b)
-K_after.current = X2
-A.result = X2
+C0 = R
+C(n+1) = Cn ⟼ B(byte_n)
 ```
 
-но не имеет права сказать «пара `(a,b)` уникальна, значит X1=X2».
+Конкретное появление исходника:
 
-Это связывает interpreter semantics с exact-occurrence моделью апамяти и сохраняет provenance отдельных актов/результатов.
+```text
+S = S ⟼ C
+```
 
-### 5.4. Actual act является проверяемой сетью
+Поэтому одинаковые bytes могут разделять один canonical `C`, но иметь разные exact source occurrences `S1`, `S2`.
 
-Заголовок:
+### 3.2. Контекст
+
+```text
+P = parent ⟼ current
+K = K ⟼ P
+↑ = current from exact active K
+```
+
+`↑` не является process-global переменной. Trusted act обязан назвать конкретный exact `K`.
+
+### 3.3. Actual act
+
+Минимальный Gate-R bootstrap:
 
 ```text
 P0 = D_roles ⟼ K_after
@@ -350,124 +109,357 @@ H  = I ⟼ P0
 A  = A ⟼ H
 ```
 
-Минимальные role-addressed fields первого vertical slice:
-
-```text
-source
-source-selection
-form-sequence
-dictionary
-grammar
-theory
-form
-before-context
-binding
-result
-after-context
-```
-
-Каждое поле:
+Расширяемые поля:
 
 ```text
 Field = roleRef ⟼ value
 A ⟼ Field
 ```
 
-Trusted replay требует ровно одно согласованное значение каждой обязательной роли. Дублированное/конфликтующее evidence отклоняется.
+`roleRef` разрешается через явный scoped `D_roles`. Host enum может быть API-удобством, но не semantic identity роли.
 
-Host dataclass с удобными именами полей допустим как checker API, но не определяет ontology: semantic role identity задаётся exact `roleRef` из явного `D_roles`.
+## 4. Один source front-end
 
-### 5.5. Replay и исполнение апамяти пока разведены
-
-Текущий interpreter slice является **read-only**:
+Production-facing source path не доверяет lexer/token/AST classes как смыслу.
 
 ```text
-replay(source,K,A)
-→ проверить выбранные exact relations
-→ вернуть exact result ref
+raw bytes
+→ canonical C
+→ exact S
+→ untrusted candidate segmentation
+→ selected exact source spans
+→ visible scoped-D declaration occurrences
+→ ordered exact forms
+→ explicit G/T admission
+→ read-only replay
 ```
 
-Он не делает:
+Кандидатный поиск может использовать trie, regex, индексы, longest-match или UI. Trusted replay проверяет **выбранное evidence**, а не алгоритм, который его предложил.
+
+### 4.1. Selected slice
 
 ```text
-materialize(result poles)
-materialize(K_after)
-materialize(A)
+Span = sourcePrefix(start) ⟼ sourcePrefix(end)
+SliceEvidence = Span ⟼ sliceContent
+Lexeme = S ⟼ SliceEvidence
+Resolution = Lexeme ⟼ form
 ```
 
-Эти occurrences уже должны входить в проверяемую сеть/evidence.
+Host byte offsets — transport/checker coordinates. Семантическое evidence задаётся exact refs границ, source occurrence и slice content.
 
-Это намеренно. Сначала фиксируется trusted semantics, затем отдельный effect/L4 слой сможет создавать структуру, которую тот же replay независимо проверяет.
+UTF-8 `⟼` может быть одним многобайтным selected slice; trusted semantics не обязана дробить его на byte-sized tokens.
 
-Такой разрыв особенно важен для апрувера:
+### 4.2. Ordered result
 
 ```text
-proof search / executor
-    может строить candidate evidence
+SelectedSequence = fold(R, Selection_0 ... Selection_n)
+FormSequence     = fold(R, Form_0 ... Form_n)
 
-trusted replay
-    только проверяет candidate evidence
+G ⟼ FormSequence
+T ⟼ FormSequence
 ```
 
-и сам факт проверки не изменяет предмет доказательства.
+`G/T` membership остаётся отдельным от lexical dictionary semantics. То, что host parser построил какой-то AST, не означает admission формы.
 
-### 5.6. `:` и `=` должны расширить этот же engine
+## 5. Один persistent scoped dictionary D
 
-После #247 нельзя создавать отдельный `DefinitionInterpreter`, `EqualityInterpreter` и ещё один общий evaluator с разными скрытыми состояниями.
+Ранний Gate-P candidate `D ⟼ Entry` оказался недостаточным после интеграции уже принятой семантики `:`. В production path теперь остаётся одна модель — persistent lexical scope snapshots.
 
-Принятые research decisions должны стать следующими режимами **одной replay architecture**:
+### 5.1. Scope snapshot
 
 ```text
-relation-resolution act
-colon definition effect/replay
-local equality constraint/replay
+ScopePayload = parentScope ⟼ localHistory
+D = D ⟼ ScopePayload
 ```
 
-Для `:` уже выбран persistent scope snapshot:
+Кандидат пустого root-scope:
 
 ```text
-D = D ⟼ (parentScope ⟼ localHistory)
-Entry = S ⟼ F
+D0 = D0 ⟼ (R ⟼ R)
+```
+
+Кандидат пустого child-scope:
+
+```text
+Child0 = Child0 ⟼ (D_parent ⟼ R)
+```
+
+### 5.2. Definition occurrence
+
+Для:
+
+```text
+sourceContent : form
+```
+
+структура эффекта:
+
+```text
+Entry      = sourceContent ⟼ form
 Occurrence = D_before ⟼ Entry
-history' = history ⟼ Occurrence
-D_after = new persistent scope snapshot
+H_after    = H_before ⟼ Occurrence
+D_after    = D_after ⟼ (sameParentScope ⟼ H_after)
 ```
 
-Для `=` выбран local exact representative constraint, без global congruence/substitution.
+Здесь необходимо различать:
 
-Их интеграция должна переиспользовать exact source, K/D/G/T, actual A и общий replay boundary, а не создавать parallel semantics.
+```text
+Entry
+```
 
-## 6. Апамять
+как semantic mapping и:
 
-Foundation v2 рассматривает апамять как **контроллер сети exact link occurrences**.
+```text
+Occurrence
+```
+
+как конкретное occurrence объявления в конкретном snapshot.
+
+Два одинаковых объявления могут иметь один mapping, но разные declaration occurrences.
+
+### 5.3. Lookup
+
+Trusted lookup под текущим exact `D` идёт только по явно представленной структуре:
+
+```text
+D.localHistory
+→ history cells backwards
+→ exact Occurrence
+→ exact Entry
+```
+
+Если локального определения нет:
+
+```text
+D.parentScope
+→ lookup(parent)
+```
+
+Правила:
+
+```text
+local first
+local mapping shadows parent
+local miss falls through to parent
+same local source + same form = one mapping, many declaration occurrences allowed
+distinct local forms for same source = conflict
+no last-write-wins
+```
+
+Особенно важно: произвольная связь где-то в сети
+
+```text
+D_old ⟼ Entry
+```
+
+не становится видимой только потому, что её можно найти глобальным scan. Trusted replay должен доказать достижимость exact declaration occurrence через `localHistory/parentScope` выбранного `D`.
+
+### 5.4. Source resolution использует historical occurrence
+
+Для selected lexeme:
+
+```text
+Resolution = Lexeme ⟼ form
+Selection  = visibleDefinitionOccurrence ⟼ Resolution
+```
+
+`visibleDefinitionOccurrence` может быть создано против более раннего snapshot `D_before`, но оставаться видимым в позднем `D_current`, если exact history chain это доказывает.
+
+Так source front-end и `:` используют **одну и ту же** dictionary semantics.
+
+## 6. Один interpreter/replay engine
+
+После source front-end интерпретатор не строит вторую semantic representation.
+
+Его trusted вход уже состоит из exact evidence.
+
+### 6.1. Relation-resolution act
+
+Первый vertical slice:
+
+```text
+exact source evidence
+→ one selected partial form F
+→ exact K/current
+→ binding = ↑
+→ structural pole resolution
+→ exact result X
+→ persistent K_after
+→ actual A
+```
+
+Если:
+
+```text
+F = F ⟼ e
+```
+
+то:
+
+```text
+X = current ⟼ e
+```
+
+Если:
+
+```text
+F = b ⟼ F
+```
+
+то:
+
+```text
+X = b ⟼ current
+```
+
+Направление выводится из exact structural form, а не из `TokenKind`, glyph switch или AST opcode.
+
+### 6.2. Exact result
+
+Если память содержит:
+
+```text
+X1 = a ⟼ b
+X2 = a ⟼ b
+```
+
+act может выбрать `X2`. Replay проверяет:
+
+```text
+poles(X2) = (a,b)
+K_after.current = X2
+A.result = X2
+```
+
+и не схлопывает `X1/X2` по форме пары.
+
+### 6.3. Persistent `:` — тот же engine
+
+Gate #249 добавляет `:` не отдельным DefinitionInterpreter, а вторым replay act того же engine.
+
+Replay `:` проверяет уже присутствующее evidence:
+
+```text
+D_before
+source occurrence S
+sourceContent
+form
+Entry
+Occurrence
+H_before
+H_after
+D_after
+actual A
+```
+
+Он обязан подтвердить:
+
+```text
+S = S ⟼ sourceContent
+Entry = sourceContent ⟼ form
+Occurrence = D_before ⟼ Entry
+H_after = H_before ⟼ Occurrence
+parent(D_after) = parent(D_before)
+history(D_after) = H_after
+```
+
+а затем проверить, что новый exact `Occurrence` видим из `D_after`, но не стал ретроактивно видимым из immutable `D_before`.
+
+При этом:
+
+```text
+: != =
+: != theorem assertion
+: != recursive RHS evaluation
+```
+
+И replay остаётся read-only: он не создаёт `Entry`, `Occurrence`, history или `D_after`; он проверяет candidate effect network.
+
+## 7. Апамять как controller сети
 
 Подробно: [Апамять и управление сетью связей](Апамять%20и%20управление%20сетью%20связей.md).
 
-Ключевой operational boundary:
+Ключевой operational split:
 
 ```text
 read / find / enumerate / replay
         │
-        └── не изменяют сеть
+        └── наблюдают существующую сеть
 
 materialize / delete
         │
         └── явные effects
 ```
 
-Это позволяет описывать и искать связь, не создавая её самим фактом запроса.
+Это не мелкая backend-деталь, а необходимая семантическая граница.
 
-## 7. Ачисло и будущая sequence deserialization
+Если описание искомой связи автоматически создаёт эту связь, запрос существования становится бессмысленным.
+
+Поэтому:
+
+```text
+source carrier != result network
+query description != queried fact
+replay evidence != application effect
+```
+
+### 7.1. Простой пример
+
+До:
+
+```text
+a       b
+
+нет exact occurrence a ⟼ b
+```
+
+`find(a,b)`:
+
+```text
+→ {}
+```
+
+и сеть остаётся той же.
+
+Только explicit effect:
+
+```text
+x = materialize(a,b)
+```
+
+даёт:
+
+```text
+a ─────x─────▶ b
+```
+
+### 7.2. Почему это важно для `:`
+
+Запись/описание:
+
+```text
+name : form
+```
+
+сама по себе не обязана менять dictionary state. Executor может построить candidate effect network, а trusted replay отдельно проверит:
+
+```text
+D_before → history append → D_after
+```
+
+Так semantic effect становится проверяемым объектом, а не скрытой мутацией host map.
+
+## 8. Ачисло и будущая sequence deserialization
 
 Recursive Anum уже является root-relative structural description на принятой occurrence-tree области, но это ещё не полная operational semantics произвольной последовательности.
 
-Отдельный gate #242 должен проверить более широкий исторический принцип:
+Отдельный gate #242 проверит более широкий исторический принцип:
 
 ```text
 ∞ A B C
 ```
 
-как последовательностное описание, которое после **явной** десериализации/materialization может построить сеть:
+как последовательностное описание, которое после **явной** десериализации/materialization может построить:
 
 ```text
 A ⟼ B
@@ -476,62 +468,84 @@ B ⟼ C
 
 с корректной nested-context semantics.
 
-До этого challenge нельзя молча расширять pair-only recursive grammar или делать `[`/`]` безусловными PUSH/POP opcode-ами.
-
-Важно не смешивать #245/#247 и #242:
+Не смешиваем:
 
 ```text
-#245 source front-end
-    читает/разрешает/проверяет source evidence
-    без application effects
+source front-end
+    read/resolve source evidence
 
-#247 interpreter replay
-    проверяет selected semantic act над exact evidence
-    без application effects
+interpreter replay
+    validate selected semantic act
 
-#242 Anum→апамять
-    исследует явный materialization результирующей сети
+Anum→апамять
+    explicit result-network materialization
 ```
 
-## 8. Что должна получить следующая версия для aprover
+Поэтому текущий Gate P не превращает `[`/`]` в безусловные host PUSH/POP opcodes и не расширяет pair-only recursive grammar одной красивой картинкой.
 
-`aprover` должен потреблять опубликованный versioned contract и conformance corpus, а не повторно определять семантику МТС.
+## 9. Следующий слой: local `=`
 
-Минимальная trusted цепочка будущего checker-а теперь становится конкретной:
+После закрытия #249 следующий semantic gate должен интегрировать уже принятое решение #225 **в этот же engine**.
+
+Минимальная equality semantics:
+
+```text
+K ⟼ (member ⟼ representative)
+rep_K(x) = one explicit local representative, else x
+Equal_K(a,b) iff rep_K(a) and rep_K(b) are the same exact ref
+```
+
+Без автоматических:
+
+```text
+transitivity
+substitution
+congruence
+global rewriting
+shape equality
+```
+
+Relation decomposition допустима только как отдельно admitted one-step theory rule.
+
+## 10. Что должна получить следующая версия для aprover
+
+`aprover` должен потреблять published versioned contract + conformance corpus, а не заново определять МТС.
+
+Trusted checker path:
 
 ```text
 exact source/evidence
-→ selected dictionary/grammar/theory relations
+→ scoped D resolution + G/T admission
 → exact active K
-→ selected declarative form + binding
-→ structural relation resolution
-→ exact result / K_after
-→ actual act A
+→ selected form/bindings
+→ selected act semantics
+→ exact result/state transition
+→ actual A
 → deterministic read-only replay
 ```
 
-Proof search, ranking и UI могут быть сложными и эвристическими. Валидность доказательства определяется replay выбранных exact relations.
+Proof search, ranking, индексы и UI могут быть эвристическими. Доверенная часть проверяет выбранные exact relations.
 
-## 9. Что ещё блокирует release
-
-До repin `aprover` остаются как минимум:
+## 11. Что ещё блокирует release
 
 ```text
-interpreter/replay spine #247
-→ integrate `:` and local `=` into the same engine
-→ sequence-to-apamemory gate #242
+scoped D + `:` #249
+→ local `=` in same engine
+→ multistep/proof integration
+→ sequence-to-apamemory #242
+→ persistent L4 boundary #124
 → historical compatibility classification
-→ explicit persistent L4 boundary #124
 → integrated end-to-end conformance
 → explicit acceptance decision
 → atomic production cutover
-→ published next MTS contract/version
+→ publish next MTS version
+→ repin aprover
 ```
 
-Запрещён конечный результат вида:
+Запрещён итоговый режим:
 
 ```text
-legacy semantics + Foundation-v2 semantics selectable by mode
+legacy semantics + Foundation-v2 semantics selectable by flag
 ```
 
-После acceptance активный production tree должен иметь один canonical semantic path; Git хранит исторические версии.
+После acceptance активный production tree должен иметь один canonical semantic path. Историю сохраняет Git.

--- a/docs/specs/Апамять и управление сетью связей.md
+++ b/docs/specs/Апамять и управление сетью связей.md
@@ -2,199 +2,177 @@
 
 Статус: **Foundation v2 / Gate P candidate**, не опубликованный accepted L4 contract.
 
-Связанные задачи: Gate P #237, текущий state-layer #243, будущая последовательностная десериализация #242, persistent backend #124.
+Связанные задачи: Gate P #237, exact-occurrence substrate #240, state/apamemory #243, source #245, interpreter/replay #247, scoped dictionary/`:` #249, будущая последовательностная десериализация #242, persistent backend #124.
 
-Этот документ объясняет прикладную роль **апамяти** в МТС. Здесь апамять рассматривается прежде всего как **контроллер сети связей**: она хранит и различает exact occurrences связей, позволяет читать и искать их, а изменение сети выполняет только через явные effect-операции.
-
-Документ намеренно не определяет конкретный persistent backend и не принимает без executable challenge полную семантику десериализации произвольной последовательности ачисла. Эти границы принадлежат #124 и #242.
-
-## 1. Зачем МТС нужна апамять
-
-Постулат МТС:
+Апамять в МТС удобнее всего понимать как **контроллер сети связей**. Она не обязана быть «объектной БД», в которой Link — запись с типом, полями и скрытой семантикой. Её базовая ответственность проще и фундаментальнее:
 
 ```text
-всё есть связь
+хранить различённые occurrences связей;
+читать их полюса;
+искать связи по известным полюсам/формам;
+сохранять sharing и cycles;
+явно создавать и удалять occurrences;
+давать интерпретатору exact evidence для replay.
 ```
 
-становится вычислительно полезным только тогда, когда существует среда, способная работать не с внешними объектами и их полями, а непосредственно с сетью связей:
+## 1. Базовый объект апамяти
+
+На Foundation-v2 substrate:
 
 ```text
 Link = start ⟼ end
 ```
 
-Апамять предоставляет такую среду.
+а identity задаётся exact occurrence внутри конкретной сети.
 
-Её удобно понимать не как обычную объектную базу данных, а как контроллер конечной сети:
-
-```text
-              ┌─────────────────────────┐
-              │        апамять          │
-              │                         │
-запрос ──────▶│ read / find / enumerate │──────▶ exact refs / отсутствие
-              │                         │
-эффект ──────▶│ materialize / delete    │──────▶ новая версия сети
-              │                         │
-              │ snapshot / replay       │──────▶ переносимое свидетельство
-              └─────────────────────────┘
-```
-
-На Foundation-v2 substrate каждая различённая связь имеет **network-local exact occurrence identity**. Два occurrence могут иметь одинаковые полюса и всё же оставаться разными связями рассматриваемой сети.
-
-Поэтому базовая модель не требует глобального pair interning:
+Поэтому допустимо:
 
 ```text
-P1 = A ⟼ B
-P2 = A ⟼ B
-
-P1 != P2        # exact occurrence distinction
+X1 = A ⟼ B
+X2 = A ⟼ B
+X1 != X2
 ```
 
-Это существенно для доказательств, provenance, actual interpreter acts и других случаев, где два структурно одинаковых события не должны схлопываться только из-за совпадения формы.
+Одинаковые полюса не обязаны означать одну и ту же связь.
 
-## 2. Чтение не должно создавать то, что ищется
+Это важно для:
 
-Один из главных инвариантов апамяти:
+```text
+provenance;
+actual interpreter acts;
+proof steps;
+двух одинаковых событий в разное время/контексте;
+разных declarations одного и того же mapping;
+shared/cyclic network identity.
+```
+
+Concrete persistent backend позднее может иметь дополнительные индексы и policies, но Foundation v2 не превращает pair interning или physical address в онтологию.
+
+## 2. Главный operational split
+
+Апамять должна жёстко различать **наблюдение** и **эффект**.
+
+```text
+read / find / enumerate / replay
+        │
+        └── не меняют сеть
+
+materialize / delete
+        │
+        └── меняют сеть явно
+```
+
+Главный инвариант:
 
 ```text
 read/find/interpret/replay != materialize
 ```
 
-Если память содержит:
+Это одно из наиболее прикладных следствий МТС.
+
+### Почему это необходимо
+
+Пусть память содержит `A` и `B`, но не содержит связи между ними:
 
 ```text
-A
-B
+A               B
+
+links(A,B) = {}
 ```
 
-но не содержит occurrence:
+Мы хотим спросить:
 
 ```text
-X = A ⟼ B
+существует ли A ⟼ B ?
 ```
 
-запрос:
+Если само описание запроса сначала создаёт `A⟼B`, ответ всегда станет положительным. Поиск потеряет смысл.
+
+Правильное поведение:
 
 ```text
-find(A, B)
+find(A,B)
+→ {}
 ```
 
-должен вернуть отсутствие результата и **не изменить память**.
+и сеть остаётся неизменной.
 
-До запроса:
+Только явный effect:
 
 ```text
-A       B
-
-нет A ⟼ B
+X = materialize(A,B)
 ```
 
-После неуспешного `find(A,B)`:
+даёт:
 
 ```text
-A       B
-
-по-прежнему нет A ⟼ B
+A ─────────X────────▶ B
 ```
 
-Только явная effect-операция имеет право изменить сеть:
+После этого:
 
 ```text
-materialize(A, B)
+find(A,B) -> {X}
 ```
 
-После неё может появиться новая exact occurrence:
+Если policy допускает multiplicity:
 
 ```text
-A ───────X──────▶ B
+X1 = materialize(A,B)
+X2 = materialize(A,B)
+
+X1 != X2
+find(A,B) -> {X1,X2}
 ```
 
-то есть:
+## 3. Апамять не должна путать описание и описываемую сеть
+
+Это особенно видно на ачислах.
+
+Ачисло может передавать элементы будущей связи в **несвязанном** виде.
+
+Концептуально source carrier:
 
 ```text
-X = A ⟼ B
+∞ ... a ... b ...
 ```
 
-Это различие особенно важно для ассоциативного поиска. Если само описание искомой связи автоматически создавало бы эту связь, запрос «существует ли A⟼B?» всегда делал бы собственный положительный ответ истинным.
-
-## 3. Source carrier и результирующая сеть — разные вещи
-
-Ачисло может описывать связь, **не содержа эту связь в натуре**.
-
-Историческая интуиция МТС:
-
-```text
-carrier((∞ ⟼ a) ⟼ b)
-```
-
-содержит последовательностную связевую структуру, позволяющую передать `a` и `b`, но из этого не следует, что в апамяти уже существует:
+может позволять десериализатору построить:
 
 ```text
 a ⟼ b
 ```
 
-Нужно различать:
+но до явной десериализации/materialization target occurrence не обязана существовать.
+
+Поэтому различаются:
 
 ```text
 source/raw carrier
-        ↓ decode / resolve
-structural description / materialization plan
-        ↓ explicit effect
+        ↓
+read / decode / resolve
+        ↓
+structural description / selected evidence
+        ↓
+explicit effect
+        ↓
 result network
 ```
 
-Поэтому:
+И:
 
 ```text
-load(source)        != materialize(result)
-decode(source)      != materialize(result)
-find(description)   != materialize(result)
+source carrier != result network
+load(source) != materialize(result)
+decode(source) != materialize(result)
+find(description) != materialize(result)
 ```
 
-Этот принцип связывает L3 сериализацию с L4 апамятью и одновременно объясняет, почему десериализатор ачисла может быть минимальной формой ассоциативного интерпретатора: он читает **описание**, строит/разрешает структурный результат и только при явно выбранном effect режиме изменяет целевую сеть.
+## 4. Минимальная поверхность контроллера
 
-Полная sequence semantics этого перехода принадлежит отдельному executable gate #242.
+На архитектурном уровне удобно выделить четыре группы операций.
 
-## 4. Exact occurrence важнее графического сходства
-
-Рассмотрим две самозамкнутые связи:
-
-```text
-R = R ⟼ R
-X = X ⟼ X
-```
-
-Если `R` — distinguished акорень, из одной формы `x=x⟼x` не следует:
-
-```text
-X = R
-```
-
-В апамяти это две exact occurrences.
-
-То же относится к обычной паре:
-
-```text
-P1 = A ⟼ B
-P2 = A ⟼ B
-```
-
-Апамять может индексировать их по одинаковой паре полюсов, но Foundation-v2 substrate не обязан схлопывать их identity.
-
-Следовательно, операция поиска пары логически может иметь результат:
-
-```text
-find(A,B) -> {P1, P2, ...}
-```
-
-а не обязательно один глобально канонический `LinkRef`.
-
-Конкретный backend может вводить более сильную policy, например pair uniqueness для определённого content-layer, но такая policy должна быть отдельным контрактом и не может незаметно становиться онтологией МТС.
-
-## 5. Минимальная поверхность контроллера
-
-На архитектурном уровне полезно различать следующие группы операций.
-
-### 5.1. Наблюдение
+### 4.1. Наблюдение exact occurrence
 
 ```text
 read(ref)
@@ -202,98 +180,357 @@ poles(ref)
 snapshot()
 ```
 
-Они получают уже существующую структуру и не изменяют сеть.
+Пример:
 
-### 5.2. Ассоциативный поиск
+```text
+X = A ⟼ B
+
+poles(X) -> (A,B)
+```
+
+### 4.2. Ассоциативный поиск
 
 ```text
 find(start?, end?)
-enumerate(pattern)
 outgoing(start)
 incoming(end)
+enumerate(pattern)
 ```
-
-Здесь неизвестная позиция означает ограничение поиска, а не просьбу создать отсутствующую связь.
 
 Например:
 
 ```text
-find(start=A, end=?)
+find(A, ?)
 ```
 
 может вернуть все exact occurrences, начинающиеся в `A`.
 
-### 5.3. Явный эффект
+Неизвестный полюс — ограничение запроса, а не команда materialize.
+
+### 4.3. Явный эффект
 
 ```text
-materialize(start, end)
+materialize(start,end)
 delete(ref)
 ```
 
-Только здесь сеть меняется.
+Только здесь меняется network state.
 
-### 5.4. Перенос и replay
+### 4.4. Evidence/replay
 
 ```text
 snapshot
-portable evidence
-replay selected exact relations
+selected exact refs
+portable local slots
+replay selected relations
 ```
 
-Переносимое описание использует локальные slots/refs как evidence одной сети, но они не становятся универсальными адресами МТС во всех процессах и backend-ах.
+Replay проверяет, что candidate result действительно следует из предъявленной структуры и состояния, но не создаёт его заново.
 
-## 6. Апамять и интерпретатор
+## 5. Апамять и exact identity
 
-Апамять и интерпретатор связаны, но это не одна и та же роль.
+Две связи могут быть shape-isomorphic и оставаться разными.
 
-Интерпретатор работает с явным состоянием:
+Например:
 
 ```text
-K  context/current
-D  dictionary
-G  grammar/segmentation evidence
-T  theory
-I  interpreter identity
-A  actual interpretation act
+R = R ⟼ R
+X = X ⟼ X
 ```
 
-Foundation v2 требует, чтобы эти состояния сами были связями внутри exact-occurrence network.
+Если `R` — distinguished акорень, из формы `x=x⟼x` не следует:
 
-Например контекст:
+```text
+X = R
+```
+
+Аналогично:
+
+```text
+P1 = A ⟼ B
+P2 = A ⟼ B
+```
+
+Апамять может индексировать оба occurrence по одной паре `(A,B)`, но trusted semantics выбирает exact ref.
+
+Это особенно заметно в interpreter replay:
+
+```text
+candidate result poles = (A,B)
+```
+
+недостаточно. Нужно ещё exact evidence:
+
+```text
+result = P2
+K_after.current = P2
+A.result = P2
+```
+
+## 6. Context state также хранится как сеть
+
+Интерпретатор не должен иметь скрытый process-global stack/current как семантику.
+
+Foundation-v2 candidate:
 
 ```text
 P = parent ⟼ current
 K = K ⟼ P
 ```
 
-и тогда:
+Тогда:
 
 ```text
 ↑ = current
 ```
 
-разрешается из **явно выбранного exact K**, а не из process-global переменной.
+разрешается из явно выбранного exact `K`.
 
-Словарь:
-
-```text
-Entry = sourceContent ⟼ form
-D ⟼ Entry
-```
-
-Теория:
+Например:
 
 ```text
-T ⟼ form
+P0 = Outer ⟼ X
+K0 = K0 ⟼ P0
 ```
 
-Наличие `T⟼form` означает admission формы в конкретную теорию, а не поле `form.isAxiom=true`.
+и:
 
-Апамять предоставляет сеть, exact identity и операции наблюдения. Интерпретатор выбирает и replay-ит конкретные отношения в этой сети. Поиск кандидатов может быть сложным и эвристическим, но trusted replay проверяет уже выбранные exact relations.
+```text
+↑ -> X
+```
 
-## 7. Actual act тоже является сетью связей
+После шага интерпретации старый контекст не мутирует:
 
-Foundation-v2 Gate R оставил минимальный конечный bootstrap заголовка actual act:
+```text
+P1 = Outer ⟼ Y
+K1 = K1 ⟼ P1
+```
+
+Получаем persistent history состояний:
+
+```text
+K0   current=X
+K1   current=Y
+```
+
+Оба остаются проверяемыми exact occurrences.
+
+## 7. Словарь в апамяти — persistent scoped network
+
+Словарь больше не моделируется mutable host map.
+
+Scope snapshot:
+
+```text
+ScopePayload = parentScope ⟼ localHistory
+D = D ⟼ ScopePayload
+```
+
+Пустой root scope:
+
+```text
+D0 = D0 ⟼ (R ⟼ R)
+```
+
+### 7.1. Определение `:` как явный effect
+
+Пусть нужно определить:
+
+```text
+name : Form
+```
+
+Canonical effect evidence:
+
+```text
+Entry      = nameContent ⟼ Form
+Occurrence = D_before ⟼ Entry
+H_after    = H_before ⟼ Occurrence
+D_after    = D_after ⟼ (sameParent ⟼ H_after)
+```
+
+До эффекта:
+
+```text
+D_before
+   │
+   ▼
+(parent ─────────▶ H_before)
+```
+
+После candidate execution:
+
+```text
+Entry = nameContent ─────────▶ Form
+
+Occurrence = D_before ───────▶ Entry
+
+H_before ─────H_after────────▶ Occurrence
+
+D_after
+   │
+   ▼
+(parent ─────────▶ H_after)
+```
+
+Trusted replay не создаёт эти links. Он проверяет уже построенную candidate network.
+
+### 7.2. Почему нужны Entry и Occurrence отдельно
+
+`Entry` отвечает на вопрос:
+
+```text
+что означает source content?
+```
+
+`Occurrence` отвечает:
+
+```text
+где и в каком exact dictionary snapshot это было объявлено?
+```
+
+Поэтому повторное одинаковое объявление:
+
+```text
+name : Form
+name : Form
+```
+
+может дать:
+
+```text
+Entry1 и Entry2 структурно одинаковы по source/form
+Occurrence1 != Occurrence2
+```
+
+Lookup всё равно получает один mapping `name -> Form`, но provenance двух declarations не теряется.
+
+### 7.3. Lookup
+
+Для текущего `D`:
+
+```text
+D.localHistory
+→ newest history cell
+→ previous history
+→ ...
+```
+
+Каждая history cell указывает на exact declaration occurrence.
+
+Правила:
+
+```text
+local first
+local unique form shadows parent
+local miss falls through to parent
+same local source + same form is allowed repeatedly
+distinct local forms for same source = conflict
+no last-write-wins
+```
+
+Пример shadowing:
+
+```text
+Parent: x -> Int
+Child : x -> Point
+```
+
+Lookup из Child:
+
+```text
+x -> Point
+```
+
+Но другой знак, отсутствующий в Child, продолжает разрешаться через Parent.
+
+### 7.4. Глобальный scan не является scope visibility
+
+Пусть где-то в сети существует:
+
+```text
+OldD ⟼ EntryX
+```
+
+Этого недостаточно, чтобы `EntryX` был видим в текущем `D`.
+
+Нужно доказать exact путь:
+
+```text
+current D
+→ localHistory chain
+→ declaration Occurrence
+```
+
+или переход через explicit parent scope.
+
+Это превращает область видимости из host-language правила в проверяемую сеть связей.
+
+## 8. Source resolution и словарь используют одну модель
+
+Source front-end получает selected slice:
+
+```text
+Lexeme
+```
+
+и selected exact declaration occurrence:
+
+```text
+Occurrence
+```
+
+Trusted replay проверяет, что occurrence действительно видим из текущего exact `D`, а `Entry` внутри него связывает именно:
+
+```text
+sliceContent ⟼ selectedForm
+```
+
+Затем:
+
+```text
+Resolution = Lexeme ⟼ selectedForm
+Selection  = Occurrence ⟼ Resolution
+```
+
+Так источник, dictionary scope и semantic form связаны одной exact evidence network.
+
+## 9. Interpreter act как сеть
+
+Relation-resolution act использует:
+
+```text
+source evidence
+D/G/T
+K
+selected form
+binding=↑
+result
+K_after
+A
+```
+
+Например start-open form:
+
+```text
+F = F ⟼ E
+```
+
+при:
+
+```text
+↑ = B
+```
+
+ожидает exact result:
+
+```text
+X = B ⟼ E
+```
+
+Но replay не вызывает `materialize(B,E)`. Он проверяет предъявленный `X`.
+
+Actual act:
 
 ```text
 P0 = D_roles ⟼ K_after
@@ -301,108 +538,63 @@ H  = I ⟼ P0
 A  = A ⟼ H
 ```
 
-После обнаружения `D_roles` дополнительные поля акта выражаются связями:
+и role-addressed evidence:
 
 ```text
-Field = roleRef ⟼ value
-A ⟼ Field
+A ⟼ (roleSource ⟼ S)
+A ⟼ (roleForm ⟼ F)
+A ⟼ (roleResult ⟼ X)
+...
 ```
 
-Например внешне мы можем говорить о полях:
+Два acts с одинаковыми видимыми параметрами могут быть разными exact occurrences.
+
+## 10. Апамять и `:`: executor против replay
+
+Для `:` удобно разделить две роли.
+
+### Executor/search side
+
+Может:
 
 ```text
-source
-theory
-before-context
-result
+найти текущий D;
+построить Entry;
+построить declaration Occurrence;
+построить новый history cell;
+построить D_after;
+построить A.
 ```
 
-но внутри сети это не enum-поля объекта `Act`. Это exact role refs, разрешённые через явный словарь ролей.
+Это explicit candidate effect.
 
-Два actual acts с одинаковыми видимыми параметрами остаются двумя событиями:
+### Trusted replay side
+
+Только проверяет:
 
 ```text
-A1 != A2
+точный D_before;
+Entry = sourceContent⟼form;
+Occurrence = D_before⟼Entry;
+ровно один history append;
+тот же lexical parent;
+точный D_after;
+видимость нового occurrence;
+actual A;
+неизменность snapshot во время проверки.
 ```
 
-если это две exact occurrences.
+Таким образом mutation не прячется внутри parser/evaluator.
 
-Это важно для апрувера: два шага доказательства могут использовать одну и ту же форму и прийти к одному результату, но всё равно являются двумя различёнными актами в proof/replay network.
+## 11. Мотивирующий пример сложного ачисла
 
-## 8. Наглядный простой пример: поиск и создание
-
-Пусть в памяти уже есть exact occurrences `a` и `b`.
-
-### До
-
-```text
-      a              b
-
-    links(a,b) = {}
-```
-
-Запрос:
-
-```text
-find(a,b)
-```
-
-даёт:
-
-```text
-{}
-```
-
-Сеть не изменилась.
-
-Теперь выполняется явный effect:
-
-```text
-x = materialize(a,b)
-```
-
-### После
-
-```text
-      a ─────────────▶ b
-              x
-```
-
-Теперь:
-
-```text
-find(a,b) -> {x}
-```
-
-Если policy разрешает occurrence multiplicity, второй materialization может дать:
-
-```text
-x1 = a ⟼ b
-x2 = a ⟼ b
-x1 != x2
-```
-
-и поиск вернёт оба exact refs.
-
-## 9. Мотивирующий пример сложного ачисла
-
-Рассмотрим строковое представление:
+Рассмотрим:
 
 ```text
 ∞[window][cursor][position][[[x][int]][point]]
 ```
 
-Этот пример полезен именно потому, что показывает две разные сети.
-
-### 9.1. До десериализации
-
-Источник является последовательностным carrier-описанием. Концептуально:
-
-```text
-∞ -> [window] -> [cursor] -> [position] -> nested-source
-```
-
-Это **не означает**, что уже существуют target links:
+До десериализации это source/carrier description. Сам факт наличия carrier не означает существования target links:
 
 ```text
 window ⟼ cursor
@@ -411,18 +603,12 @@ x ⟼ int
 ...
 ```
 
-### 9.2. Кандидат результирующей сети после явной sequence materialization
-
-Исследуемая в #242 гипотеза даёт внутренние связи:
+Исследуемая в #242 candidate semantics после **явного** sequence materialization:
 
 ```text
 XI = [x] ⟼ [int]
 Q  = XI  ⟼ [point]
-```
 
-и внешнюю последовательностную сеть:
-
-```text
 [window]   ⟼ [cursor]
 [cursor]   ⟼ [position]
 [position] ⟼ Q
@@ -445,75 +631,82 @@ Q  = XI  ⟼ [point]
                 [x] [int]
 ```
 
-Но этот раздел является **мотивирующим примером**, а не acceptance семантики. Точный алгоритм последовательностной десериализации, скобочных context transitions, round-trip и materialization plan должен пройти executable gate #242.
+Но это пока **мотивирующий future example**, а не принятая sequence semantics. #242 должен отдельно доказать exact algorithm, nested contexts, round-trip и effect boundary.
 
-Такое разделение важно: документация может показывать цель и прикладной смысл, не превращая красивую картинку в недоказанную аксиому.
-
-## 10. Апамять как прикладной мост МТС
-
-Через апамять абстрактное утверждение «всё есть связь» превращается в вычислительную модель:
+Ключевой смысл примера уже нормативно полезен:
 
 ```text
-описать связь
-найти связь
-найти все связи нужной формы
-различить одинаково выглядящие occurrences
-связать связи с другими связями
-явно создать новую связь
-явно удалить связь
-зафиксировать акт интерпретации
-повторно проверить выбранный акт
+source network до десериализации
+!=
+result network после materialization
 ```
 
-То есть сеть данных, словарь, программа интерпретации, состояние контекста и proof evidence могут использовать один и тот же базовый carrier:
+## 12. Что апамять даёт прикладно
+
+Одна и та же link-network substrate позволяет:
 
 ```text
-Link(start,end)
+хранить данные;
+строить associative indices;
+искать relation patterns;
+выражать lexical scope;
+хранить dictionary history;
+хранить interpreter context;
+фиксировать actual acts;
+хранить proof evidence;
+replay-ить доказательство;
+сохранять sharing/cycles без бесконечного unfolding.
 ```
 
-Различие ролей возникает из связей в сети, а не из набора внешних классов объектов.
+То есть прикладная ценность МТС не в том, что обычные объекты переименованы в «связи». Ценность появляется, если **данные, метаданные, программа разрешения, контекст и доказательство действительно живут в одной проверяемой связевой среде**.
 
-В этом практическая ценность МТС как архитектуры: один контроллер сетей связей может служить основанием для associative memory, VM/interpreter, knowledge representation и proof replay, не делая эти прикладные роли отдельными онтологиями.
+## 13. Граница с persistent backend
 
-## 11. Граница с persistent backend
-
-Этот документ не требует, чтобы exact occurrence identity была физическим адресом.
-
-Нужно различать:
+Foundation v2 различает:
 
 ```text
-semantic exact occurrence внутри одной сети
-portable snapshot-local slot
+exact occurrence внутри одной semantic network
+snapshot-local slot
 runtime ref
-persistent backend record/address
+persistent record/address
 external handle
 ```
 
-Persistent backend обязан уметь сохранять необходимую topology, sharing, cycles и evidence, но его адреса не становятся автоматически универсальными semantic ids.
+Persistent backend обязан сохранять topology, sharing, cycles и нужное evidence, но его physical address не становится автоматически universal semantic id.
 
-Backend contract и recovery/index semantics принадлежат #124.
+Индексы могут ускорять:
 
-## 12. Граница с апрувером
+```text
+find(start,end)
+outgoing(start)
+incoming(end)
+lookup dictionary source
+history traversal
+```
 
-Следующая версия МТС для `aprover` должна дать апруверу не набор неявных Python/TypeScript правил, а versioned contract, в котором proof checking опирается на explicit link evidence:
+но индекс — ускоритель поиска, а не источник истины. Trusted replay должен быть сводим к exact relation evidence.
+
+Backend/recovery/index contract принадлежит #124.
+
+## 14. Граница с апрувером
+
+Следующая версия МТС должна дать `aprover` versioned contract и conformance corpus.
+
+Ожидаемая trusted цепочка:
 
 ```text
 source/evidence
-→ selected D/G/T memberships
-→ exact K
-→ selected form/bindings
+→ scoped D resolution + G/T admission
+→ exact K/current
+→ selected act semantics
+→ exact result/state transition
 → actual A
-→ K_after/result
 → deterministic replay
 ```
 
-Апрувер может использовать эвристический proof search, UI и индексы апамяти для поиска кандидатов. Trusted часть должна проверять выбранный путь без скрытого global state и без implicit materialization.
+Proof search может использовать эвристики и индексы апамяти. Проверка доказательства не должна зависеть от того, какой heuristic нашёл candidate.
 
-Именно поэтому апамять является не второстепенным storage detail, а одним из наиболее наглядных прикладных проявлений Foundation v2.
-
-## 13. Инварианты дальнейшей работы
-
-До acceptance Gate P сохраняются ограничения:
+## 15. Инварианты до acceptance Gate P
 
 ```text
 Link имеет только start/end;
@@ -521,9 +714,11 @@ exact occurrence identity явна;
 read/find/replay не меняют сеть;
 materialization всегда явна;
 source carrier не равен result network;
+D является persistent scoped network;
+нет flat/scoped dictionary compatibility mode;
 роль не является host tag;
 AST/token class не является semantic identity;
 backend address не является переносимой semantic identity;
 sequence-deserialization #242 не принимается без executable vectors;
-aprover не repin-ится до публикации новой accepted версии МТС.
+aprover не repin-ится до публикации accepted следующей версии МТС.
 ```

--- a/tests/test_mts_foundation_v2_colon.py
+++ b/tests/test_mts_foundation_v2_colon.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_interpreter import (
+    ColonEffectEvidence,
+    ColonRoleRefs,
+    InterpreterReplayError,
+    replay_colon_effect,
+)
+from core.foundation_v2_state import (
+    DictionaryConflictError,
+    DictionaryLookupError,
+    define_act_field,
+    define_act_header,
+    define_context,
+    define_dictionary_effect,
+    define_dictionary_scope,
+    lookup_scoped_dictionary,
+    verify_visible_dictionary_occurrence,
+)
+
+
+ROLE_NAMES = (
+    "source",
+    "source-content",
+    "form",
+    "before-dictionary",
+    "entry",
+    "definition-occurrence",
+    "history-before",
+    "history-after",
+    "after-dictionary",
+    "context",
+)
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _roles(builder: LinkNetworkBuilder) -> ColonRoleRefs:
+    refs = {name: _anchor(builder) for name in ROLE_NAMES}
+    return ColonRoleRefs(
+        source=refs["source"],
+        source_content=refs["source-content"],
+        form=refs["form"],
+        before_dictionary=refs["before-dictionary"],
+        entry=refs["entry"],
+        definition_occurrence=refs["definition-occurrence"],
+        history_before=refs["history-before"],
+        history_after=refs["history-after"],
+        after_dictionary=refs["after-dictionary"],
+        context=refs["context"],
+    )
+
+
+def _role_items(roles: ColonRoleRefs):
+    return (
+        (roles.source, "source"),
+        (roles.source_content, "source-content"),
+        (roles.form, "form"),
+        (roles.before_dictionary, "before-dictionary"),
+        (roles.entry, "entry"),
+        (roles.definition_occurrence, "definition-occurrence"),
+        (roles.history_before, "history-before"),
+        (roles.history_after, "history-after"),
+        (roles.after_dictionary, "after-dictionary"),
+        (roles.context, "context"),
+    )
+
+
+def _build_role_dictionary(builder, root, roles):
+    dictionary = define_dictionary_scope(builder, root, root)
+    history = root
+    for role_ref, _ in _role_items(roles):
+        role_name_content = _anchor(builder)
+        effect = define_dictionary_effect(
+            builder,
+            dictionary,
+            root,
+            history,
+            role_name_content,
+            role_ref,
+        )
+        dictionary = effect.after_scope
+        history = effect.history_after
+    return dictionary
+
+
+def _colon_fixture(
+    *,
+    before_dictionary=None,
+    parent_scope=None,
+    history_before=None,
+    source_content=None,
+    form=None,
+    builder=None,
+    root=None,
+):
+    if builder is None:
+        builder = LinkNetworkBuilder()
+    if root is None:
+        root = _anchor(builder)
+    if parent_scope is None:
+        parent_scope = root
+    if history_before is None:
+        history_before = root
+    if before_dictionary is None:
+        before_dictionary = define_dictionary_scope(
+            builder, parent_scope, history_before
+        )
+    if source_content is None:
+        source_content = _anchor(builder)
+    if form is None:
+        form = _anchor(builder)
+
+    source = builder.reserve()
+    builder.define(source, source, source_content)
+    effect = define_dictionary_effect(
+        builder,
+        before_dictionary,
+        parent_scope,
+        history_before,
+        source_content,
+        form,
+    )
+
+    interpreter = _anchor(builder)
+    context_parent = _anchor(builder)
+    context_current = _anchor(builder)
+    context = define_context(builder, context_parent, context_current)
+    roles = _roles(builder)
+    role_dictionary = _build_role_dictionary(builder, root, roles)
+    act = define_act_header(builder, interpreter, role_dictionary, context)
+
+    expected_fields = (
+        (roles.source, source),
+        (roles.source_content, source_content),
+        (roles.form, form),
+        (roles.before_dictionary, before_dictionary),
+        (roles.entry, effect.entry),
+        (roles.definition_occurrence, effect.occurrence),
+        (roles.history_before, history_before),
+        (roles.history_after, effect.history_after),
+        (roles.after_dictionary, effect.after_scope),
+        (roles.context, context),
+    )
+    for role, value in expected_fields:
+        define_act_field(builder, act, role, value)
+
+    evidence = ColonEffectEvidence(
+        interpreter=interpreter,
+        source=source,
+        source_content=source_content,
+        form=form,
+        before_dictionary=before_dictionary,
+        entry=effect.entry,
+        definition_occurrence=effect.occurrence,
+        history_after=effect.history_after,
+        after_dictionary=effect.after_scope,
+        context=context,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+    return builder, root, evidence, effect
+
+
+def test_colon_replays_one_persistent_definition_without_mutation() -> None:
+    builder, root, evidence, effect = _colon_fixture()
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    assert replay_colon_effect(network, evidence) is effect.after_scope
+    resolution = lookup_scoped_dictionary(
+        network, effect.after_scope, evidence.source_content
+    )
+    assert resolution is not None
+    assert resolution.form is evidence.form
+    assert resolution.occurrences == (effect.occurrence,)
+    assert network.snapshot() == before
+
+
+def test_repeated_identical_definition_keeps_two_occurrences_one_mapping() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    source_content = _anchor(builder)
+    form = _anchor(builder)
+    base = define_dictionary_scope(builder, root, root)
+    first = define_dictionary_effect(
+        builder, base, root, root, source_content, form
+    )
+    builder, _, evidence, second = _colon_fixture(
+        builder=builder,
+        root=root,
+        before_dictionary=first.after_scope,
+        parent_scope=root,
+        history_before=first.history_after,
+        source_content=source_content,
+        form=form,
+    )
+    network = builder.freeze(root)
+
+    assert replay_colon_effect(network, evidence) is second.after_scope
+    resolution = lookup_scoped_dictionary(
+        network, second.after_scope, source_content
+    )
+    assert resolution is not None
+    assert resolution.form is form
+    assert resolution.occurrences == (second.occurrence, first.occurrence)
+
+
+def test_distinct_local_forms_conflict_instead_of_last_write_wins() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    source_content = _anchor(builder)
+    form_one = _anchor(builder)
+    form_two = _anchor(builder)
+    base = define_dictionary_scope(builder, root, root)
+    first = define_dictionary_effect(
+        builder, base, root, root, source_content, form_one
+    )
+    builder, _, evidence, second = _colon_fixture(
+        builder=builder,
+        root=root,
+        before_dictionary=first.after_scope,
+        parent_scope=root,
+        history_before=first.history_after,
+        source_content=source_content,
+        form=form_two,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(DictionaryConflictError):
+        lookup_scoped_dictionary(network, second.after_scope, source_content)
+    with pytest.raises(InterpreterReplayError, match="valid visible mapping"):
+        replay_colon_effect(network, evidence)
+
+
+def test_child_scope_shadows_parent_and_missing_name_falls_through() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    source_x = _anchor(builder)
+    source_y = _anchor(builder)
+    parent_x = _anchor(builder)
+    parent_y = _anchor(builder)
+    child_x = _anchor(builder)
+
+    parent0 = define_dictionary_scope(builder, root, root)
+    p1 = define_dictionary_effect(builder, parent0, root, root, source_x, parent_x)
+    p2 = define_dictionary_effect(
+        builder, p1.after_scope, root, p1.history_after, source_y, parent_y
+    )
+    child0 = define_dictionary_scope(builder, p2.after_scope, root)
+    child1 = define_dictionary_effect(
+        builder, child0, p2.after_scope, root, source_x, child_x
+    )
+    network = builder.freeze(root)
+
+    resolved_x = lookup_scoped_dictionary(network, child1.after_scope, source_x)
+    resolved_y = lookup_scoped_dictionary(network, child1.after_scope, source_y)
+    assert resolved_x is not None and resolved_x.form is child_x
+    assert resolved_y is not None and resolved_y.form is parent_y
+
+
+def test_global_unreachable_occurrence_does_not_count_as_visibility() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    source_content = _anchor(builder)
+    form = _anchor(builder)
+    visible_base = define_dictionary_scope(builder, root, root)
+    other_base = define_dictionary_scope(builder, root, root)
+    other = define_dictionary_effect(
+        builder, other_base, root, root, source_content, form
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(DictionaryLookupError):
+        verify_visible_dictionary_occurrence(
+            network,
+            visible_base,
+            other.occurrence,
+            source_content,
+            form,
+        )
+
+
+def test_colon_rejects_occurrence_bound_to_wrong_before_snapshot() -> None:
+    builder, root, evidence, _ = _colon_fixture()
+    wrong_before = define_dictionary_scope(builder, root, root)
+    forged_occurrence = builder.reserve()
+    builder.define(forged_occurrence, wrong_before, evidence.entry)
+    forged = replace(evidence, definition_occurrence=forged_occurrence)
+    network = builder.freeze(root)
+
+    with pytest.raises(InterpreterReplayError, match="exact D_before"):
+        replay_colon_effect(network, forged)
+
+
+def test_colon_rejects_changed_parent_in_after_scope() -> None:
+    builder, root, evidence, _ = _colon_fixture()
+    wrong_parent = define_dictionary_scope(builder, root, root)
+    forged_after = define_dictionary_scope(
+        builder, wrong_parent, evidence.history_after
+    )
+    forged = replace(evidence, after_dictionary=forged_after)
+    network = builder.freeze(root)
+
+    with pytest.raises(InterpreterReplayError, match="changed lexical parent"):
+        replay_colon_effect(network, forged)
+
+
+def test_colon_rejects_forged_history_append() -> None:
+    builder, root, evidence, _ = _colon_fixture()
+    unrelated = _anchor(builder)
+    forged_history = builder.reserve()
+    builder.define(forged_history, unrelated, evidence.definition_occurrence)
+    forged = replace(evidence, history_after=forged_history)
+    network = builder.freeze(root)
+
+    with pytest.raises(InterpreterReplayError, match="one exact append"):
+        replay_colon_effect(network, forged)

--- a/tests/test_mts_foundation_v2_interpreter.py
+++ b/tests/test_mts_foundation_v2_interpreter.py
@@ -17,7 +17,8 @@ from core.foundation_v2_state import (
     define_act_field,
     define_act_header,
     define_context,
-    define_dictionary_membership,
+    define_dictionary_effect,
+    define_dictionary_scope,
 )
 
 
@@ -86,6 +87,13 @@ def _role_items(roles: RelationStepRoleRefs):
     )
 
 
+def _define_scoped_mapping(builder, root, before, history, source_content, form):
+    effect = define_dictionary_effect(
+        builder, before, root, history, source_content, form
+    )
+    return effect.after_scope, effect.history_after, effect.occurrence
+
+
 def _fixture(
     form_kind: str = "start-open",
     *,
@@ -97,11 +105,9 @@ def _fixture(
     byte_refs = _byte_vocabulary(builder)
     front_end = SourceFrontEndBuilder(builder, root, byte_refs)
 
-    dictionary = _anchor(builder)
     grammar = _anchor(builder)
     theory = _anchor(builder)
     interpreter = _anchor(builder)
-    role_dictionary = _anchor(builder)
     parent = _anchor(builder)
     binding = _anchor(builder)
     fixed_pole = _anchor(builder)
@@ -123,12 +129,13 @@ def _fixture(
 
     source = front_end.source_occurrence(b"x")
     slice_content = front_end.content_ref(b"x")
-    _, dictionary_membership = define_dictionary_membership(
-        builder, dictionary, slice_content, form
+    dictionary = define_dictionary_scope(builder, root, root)
+    dictionary, _, dictionary_occurrence = _define_scoped_mapping(
+        builder, root, dictionary, root, slice_content, form
     )
     source_evidence = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form, dictionary_membership),),
+        (SegmentSpec(0, 1, form, dictionary_occurrence),),
         dictionary=dictionary,
         grammar=grammar,
         theory=theory,
@@ -143,10 +150,14 @@ def _fixture(
     after_context = define_context(builder, parent, result)
 
     roles = _roles(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    role_history = root
     for role_name, role_ref in _role_items(roles):
-        define_dictionary_membership(
+        role_dictionary, role_history, _ = _define_scoped_mapping(
             builder,
+            root,
             role_dictionary,
+            role_history,
             front_end.content_ref(role_name.encode("utf-8")),
             role_ref,
         )

--- a/tests/test_mts_foundation_v2_source.py
+++ b/tests/test_mts_foundation_v2_source.py
@@ -12,7 +12,7 @@ from core.foundation_v2_source import (
     SourceReplayError,
     replay_source_front_end,
 )
-from core.foundation_v2_state import define_dictionary_membership
+from core.foundation_v2_state import define_dictionary_effect, define_dictionary_scope
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -33,44 +33,51 @@ def _base_fixture():
     root = _anchor(builder)
     byte_refs = _byte_vocabulary(builder)
     front_end = SourceFrontEndBuilder(builder, root, byte_refs)
-    dictionary = _anchor(builder)
     grammar = _anchor(builder)
     theory = _anchor(builder)
-    return builder, root, byte_refs, front_end, dictionary, grammar, theory
+    return builder, root, byte_refs, front_end, grammar, theory
 
 
-def _membership(builder, front_end, dictionary, raw_slice, form):
-    content = front_end.content_ref(raw_slice)
-    _, membership = define_dictionary_membership(builder, dictionary, content, form)
-    return membership
+def _dictionary_with(builder, root, front_end, mappings):
+    dictionary = define_dictionary_scope(builder, root, root)
+    parent = root
+    history = root
+    occurrences = []
+    for raw_slice, form in mappings:
+        effect = define_dictionary_effect(
+            builder,
+            dictionary,
+            parent,
+            history,
+            front_end.content_ref(raw_slice),
+            form,
+        )
+        occurrences.append(effect.occurrence)
+        dictionary = effect.after_scope
+        history = effect.history_after
+    return dictionary, tuple(occurrences)
 
 
 def test_multibyte_arrow_is_one_selected_slice_and_replay_is_read_only() -> None:
-    (
-        builder,
-        root,
-        byte_refs,
-        front_end,
-        dictionary,
-        grammar,
-        theory,
-    ) = _base_fixture()
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form_a = _anchor(builder)
     form_arrow = _anchor(builder)
     form_b = _anchor(builder)
     raw = "a⟼b".encode("utf-8")
     arrow = "⟼".encode("utf-8")
     source = front_end.source_occurrence(raw)
-
-    membership_a = _membership(builder, front_end, dictionary, b"a", form_a)
-    membership_arrow = _membership(builder, front_end, dictionary, arrow, form_arrow)
-    membership_b = _membership(builder, front_end, dictionary, b"b", form_b)
+    dictionary, occurrences = _dictionary_with(
+        builder,
+        root,
+        front_end,
+        ((b"a", form_a), (arrow, form_arrow), (b"b", form_b)),
+    )
     evidence = front_end.build_selected_evidence(
         source,
         (
-            SegmentSpec(0, 1, form_a, membership_a),
-            SegmentSpec(1, 1 + len(arrow), form_arrow, membership_arrow),
-            SegmentSpec(1 + len(arrow), len(raw), form_b, membership_b),
+            SegmentSpec(0, 1, form_a, occurrences[0]),
+            SegmentSpec(1, 1 + len(arrow), form_arrow, occurrences[1]),
+            SegmentSpec(1 + len(arrow), len(raw), form_b, occurrences[2]),
         ),
         dictionary=dictionary,
         grammar=grammar,
@@ -94,25 +101,26 @@ def test_multibyte_arrow_is_one_selected_slice_and_replay_is_read_only() -> None
 
 
 def test_same_bytes_can_resolve_differently_under_explicit_dictionaries() -> None:
-    builder, root, byte_refs, front_end, _, grammar, theory = _base_fixture()
-    dictionary_one = _anchor(builder)
-    dictionary_two = _anchor(builder)
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form_one = _anchor(builder)
     form_two = _anchor(builder)
     source = front_end.source_occurrence(b"x")
-
-    membership_one = _membership(builder, front_end, dictionary_one, b"x", form_one)
-    membership_two = _membership(builder, front_end, dictionary_two, b"x", form_two)
+    dictionary_one, occurrences_one = _dictionary_with(
+        builder, root, front_end, ((b"x", form_one),)
+    )
+    dictionary_two, occurrences_two = _dictionary_with(
+        builder, root, front_end, ((b"x", form_two),)
+    )
     evidence_one = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form_one, membership_one),),
+        (SegmentSpec(0, 1, form_one, occurrences_one[0]),),
         dictionary=dictionary_one,
         grammar=grammar,
         theory=theory,
     )
     evidence_two = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form_two, membership_two),),
+        (SegmentSpec(0, 1, form_two, occurrences_two[0]),),
         dictionary=dictionary_two,
         grammar=grammar,
         theory=theory,
@@ -126,29 +134,23 @@ def test_same_bytes_can_resolve_differently_under_explicit_dictionaries() -> Non
 
 
 def test_ambiguous_segmentations_are_both_replayable_without_longest_match() -> None:
-    (
-        builder,
-        root,
-        byte_refs,
-        front_end,
-        dictionary,
-        grammar,
-        theory,
-    ) = _base_fixture()
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form_a = _anchor(builder)
     form_b = _anchor(builder)
     form_ab = _anchor(builder)
     source = front_end.source_occurrence(b"ab")
-
-    membership_a = _membership(builder, front_end, dictionary, b"a", form_a)
-    membership_b = _membership(builder, front_end, dictionary, b"b", form_b)
-    membership_ab = _membership(builder, front_end, dictionary, b"ab", form_ab)
+    dictionary, occurrences = _dictionary_with(
+        builder,
+        root,
+        front_end,
+        ((b"a", form_a), (b"b", form_b), (b"ab", form_ab)),
+    )
 
     split = front_end.build_selected_evidence(
         source,
         (
-            SegmentSpec(0, 1, form_a, membership_a),
-            SegmentSpec(1, 2, form_b, membership_b),
+            SegmentSpec(0, 1, form_a, occurrences[0]),
+            SegmentSpec(1, 2, form_b, occurrences[1]),
         ),
         dictionary=dictionary,
         grammar=grammar,
@@ -156,7 +158,7 @@ def test_ambiguous_segmentations_are_both_replayable_without_longest_match() -> 
     )
     whole = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 2, form_ab, membership_ab),),
+        (SegmentSpec(0, 2, form_ab, occurrences[2]),),
         dictionary=dictionary,
         grammar=grammar,
         theory=theory,
@@ -167,22 +169,39 @@ def test_ambiguous_segmentations_are_both_replayable_without_longest_match() -> 
     assert replay_source_front_end(network, whole, byte_refs) == (form_ab,)
 
 
-def test_forged_span_boundary_is_rejected() -> None:
-    (
+def test_visible_historical_occurrence_is_valid_under_later_snapshot() -> None:
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
+    form_x = _anchor(builder)
+    form_y = _anchor(builder)
+    source = front_end.source_occurrence(b"x")
+    dictionary, occurrences = _dictionary_with(
         builder,
         root,
-        byte_refs,
         front_end,
-        dictionary,
-        grammar,
-        theory,
-    ) = _base_fixture()
-    form = _anchor(builder)
-    source = front_end.source_occurrence(b"x")
-    membership = _membership(builder, front_end, dictionary, b"x", form)
+        ((b"x", form_x), (b"y", form_y)),
+    )
     evidence = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form, membership),),
+        (SegmentSpec(0, 1, form_x, occurrences[0]),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    assert replay_source_front_end(network, evidence, byte_refs) == (form_x,)
+
+
+def test_forged_span_boundary_is_rejected() -> None:
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
+    form = _anchor(builder)
+    source = front_end.source_occurrence(b"x")
+    dictionary, occurrences = _dictionary_with(
+        builder, root, front_end, ((b"x", form),)
+    )
+    evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 1, form, occurrences[0]),),
         dictionary=dictionary,
         grammar=grammar,
         theory=theory,
@@ -196,41 +215,37 @@ def test_forged_span_boundary_is_rejected() -> None:
         replay_source_front_end(network, forged, byte_refs)
 
 
-def test_membership_from_wrong_dictionary_is_rejected() -> None:
-    builder, root, byte_refs, front_end, dictionary, grammar, theory = _base_fixture()
-    other_dictionary = _anchor(builder)
+def test_occurrence_not_visible_from_selected_dictionary_is_rejected() -> None:
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form = _anchor(builder)
     source = front_end.source_occurrence(b"x")
-    wrong_membership = _membership(builder, front_end, other_dictionary, b"x", form)
+    dictionary, _ = _dictionary_with(builder, root, front_end, ((b"x", form),))
+    _, other_occurrences = _dictionary_with(
+        builder, root, front_end, ((b"x", form),)
+    )
     evidence = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form, wrong_membership),),
+        (SegmentSpec(0, 1, form, other_occurrences[0]),),
         dictionary=dictionary,
         grammar=grammar,
         theory=theory,
     )
     network = builder.freeze(root)
 
-    with pytest.raises(SourceReplayError, match="another dictionary"):
+    with pytest.raises(SourceReplayError, match="scoped dictionary evidence"):
         replay_source_front_end(network, evidence, byte_refs)
 
 
 def test_forged_grammar_or_theory_admission_is_rejected() -> None:
-    (
-        builder,
-        root,
-        byte_refs,
-        front_end,
-        dictionary,
-        grammar,
-        theory,
-    ) = _base_fixture()
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form = _anchor(builder)
     source = front_end.source_occurrence(b"x")
-    membership = _membership(builder, front_end, dictionary, b"x", form)
+    dictionary, occurrences = _dictionary_with(
+        builder, root, front_end, ((b"x", form),)
+    )
     evidence = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form, membership),),
+        (SegmentSpec(0, 1, form, occurrences[0]),),
         dictionary=dictionary,
         grammar=grammar,
         theory=theory,
@@ -246,23 +261,17 @@ def test_forged_grammar_or_theory_admission_is_rejected() -> None:
 
 
 def test_noncontiguous_or_partial_selected_partition_is_rejected_before_freeze() -> None:
-    (
-        builder,
-        _,
-        _,
-        front_end,
-        dictionary,
-        grammar,
-        theory,
-    ) = _base_fixture()
+    builder, root, _, front_end, grammar, theory = _base_fixture()
     form = _anchor(builder)
     source = front_end.source_occurrence(b"ab")
-    membership = _membership(builder, front_end, dictionary, b"a", form)
+    dictionary, occurrences = _dictionary_with(
+        builder, root, front_end, ((b"a", form),)
+    )
 
     with pytest.raises(SourceReplayError, match="contiguous source partition"):
         front_end.build_selected_evidence(
             source,
-            (SegmentSpec(1, 2, form, membership),),
+            (SegmentSpec(1, 2, form, occurrences[0]),),
             dictionary=dictionary,
             grammar=grammar,
             theory=theory,
@@ -278,14 +287,15 @@ def test_duplicate_byte_refs_are_rejected_as_noncanonical_vocabulary() -> None:
     byte_refs[2] = shared
     front_end = SourceFrontEndBuilder(builder, root, byte_refs)
     source = front_end.source_occurrence(b"x")
-    dictionary = _anchor(builder)
     grammar = _anchor(builder)
     theory = _anchor(builder)
     form = _anchor(builder)
-    membership = _membership(builder, front_end, dictionary, b"x", form)
+    dictionary, occurrences = _dictionary_with(
+        builder, root, front_end, ((b"x", form),)
+    )
     evidence = front_end.build_selected_evidence(
         source,
-        (SegmentSpec(0, 1, form, membership),),
+        (SegmentSpec(0, 1, form, occurrences[0]),),
         dictionary=dictionary,
         grammar=grammar,
         theory=theory,
@@ -296,8 +306,9 @@ def test_duplicate_byte_refs_are_rejected_as_noncanonical_vocabulary() -> None:
         replay_source_front_end(network, evidence, byte_refs)
 
 
-def test_trusted_source_module_has_no_legacy_parser_or_ast_dependency() -> None:
+def test_trusted_source_module_has_no_flat_dictionary_or_legacy_parser_path() -> None:
     source = (ROOT / "core/foundation_v2_source.py").read_text(encoding="utf-8")
+    assert "dictionary_membership" not in source
     assert "mtc_parser" not in source
     assert "mtc_ast" not in source
     assert "TokenKind" not in source

--- a/tests/test_mts_foundation_v2_state.py
+++ b/tests/test_mts_foundation_v2_state.py
@@ -11,12 +11,14 @@ from core.foundation_v2_state import (
     define_act_field,
     define_act_header,
     define_context,
-    define_dictionary_membership,
+    define_dictionary_effect,
+    define_dictionary_scope,
     define_membership,
     define_source_occurrence,
-    dictionary_forms,
     has_exact_membership,
+    lookup_scoped_dictionary,
     parent_of_context,
+    verify_visible_dictionary_occurrence,
 )
 
 
@@ -40,21 +42,45 @@ def test_explicit_context_resolves_current_without_ambient_stack() -> None:
     assert network.snapshot() == before
 
 
-def test_same_source_can_resolve_differently_under_two_dictionaries() -> None:
+def test_same_source_can_resolve_differently_under_two_scoped_dictionaries() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)
     source_content = _anchor(builder)
     form_one = _anchor(builder)
     form_two = _anchor(builder)
-    dictionary_one = _anchor(builder)
-    dictionary_two = _anchor(builder)
 
-    define_dictionary_membership(builder, dictionary_one, source_content, form_one)
-    define_dictionary_membership(builder, dictionary_two, source_content, form_two)
+    base_one = define_dictionary_scope(builder, root, root)
+    effect_one = define_dictionary_effect(
+        builder, base_one, root, root, source_content, form_one
+    )
+    base_two = define_dictionary_scope(builder, root, root)
+    effect_two = define_dictionary_effect(
+        builder, base_two, root, root, source_content, form_two
+    )
     network = builder.freeze(root)
 
-    assert dictionary_forms(network, dictionary_one, source_content) == (form_one,)
-    assert dictionary_forms(network, dictionary_two, source_content) == (form_two,)
+    resolution_one = lookup_scoped_dictionary(
+        network, effect_one.after_scope, source_content
+    )
+    resolution_two = lookup_scoped_dictionary(
+        network, effect_two.after_scope, source_content
+    )
+    assert resolution_one is not None and resolution_one.form is form_one
+    assert resolution_two is not None and resolution_two.form is form_two
+    verify_visible_dictionary_occurrence(
+        network,
+        effect_one.after_scope,
+        effect_one.occurrence,
+        source_content,
+        form_one,
+    )
+    verify_visible_dictionary_occurrence(
+        network,
+        effect_two.after_scope,
+        effect_two.occurrence,
+        source_content,
+        form_two,
+    )
 
 
 def test_theory_and_grammar_membership_are_ordinary_exact_links() -> None:
@@ -98,7 +124,7 @@ def test_gate_r_header_keeps_two_actual_acts_occurrence_distinct() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)
     interpreter = _anchor(builder)
-    role_dictionary = _anchor(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
     parent = _anchor(builder)
     result = _anchor(builder)
     after_context = define_context(builder, parent, result)
@@ -116,7 +142,7 @@ def test_role_addressed_act_fields_are_additive_link_data() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)
     interpreter = _anchor(builder)
-    role_dictionary = _anchor(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
     parent = _anchor(builder)
     current = _anchor(builder)
     after_context = define_context(builder, parent, current)
@@ -137,24 +163,22 @@ def test_role_addressed_act_fields_are_additive_link_data() -> None:
     assert network.snapshot() == before
 
 
-def test_role_names_are_resolved_by_explicit_role_dictionary() -> None:
+def test_role_names_are_resolved_by_explicit_scoped_role_dictionary() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)
-    role_dictionary = _anchor(builder)
     role_name_source = _anchor(builder)
     role_source = _anchor(builder)
     role_other = _anchor(builder)
-
-    define_dictionary_membership(
-        builder,
-        role_dictionary,
-        role_name_source,
-        role_source,
+    base = define_dictionary_scope(builder, root, root)
+    effect = define_dictionary_effect(
+        builder, base, root, root, role_name_source, role_source
     )
     network = builder.freeze(root)
 
-    assert dictionary_forms(network, role_dictionary, role_name_source) == (role_source,)
-    assert role_other not in dictionary_forms(network, role_dictionary, role_name_source)
+    resolution = lookup_scoped_dictionary(network, effect.after_scope, role_name_source)
+    assert resolution is not None
+    assert resolution.form is role_source
+    assert role_other is not resolution.form
 
 
 def test_non_context_and_non_act_shapes_reject_structural_readers() -> None:


### PR DESCRIPTION
Closes #249 after explicit decision if CI/evidence is accepted. Parent: #237. Depends on merged #244/#246/#248 and reuses final research decision #224.

## Integration problem resolved

The earlier Gate-P source candidate treated dictionary evidence as direct `D ⟼ Entry`, while accepted `:` research requires persistent lexical snapshots whose historical declaration occurrences live in `localHistory`. This PR removes that duality.

## One canonical D

```text
D = D ⟼ (parentScope ⟼ localHistory)
Entry = sourceContent ⟼ form
Occurrence = D_before ⟼ Entry
H_after = H_before ⟼ Occurrence
D_after = D_after ⟼ (sameParentScope ⟼ H_after)
```

Source replay now accepts an exact historical `Occurrence` only when it is visibly reachable from the selected current D through validated local-history/predecessor links and explicit parent scopes.

Rules:
- local first;
- one local mapping shadows parent;
- local miss falls through to parent;
- repeated same source/same form keeps distinct declaration occurrences but one mapping;
- distinct local forms conflict;
- no last-write-wins;
- no arbitrary global `D_old⟼Entry` scan counts as visibility.

## Same interpreter engine

`core/foundation_v2_interpreter.py` now also replays the already-materialized persistent `:` effect read-only. It verifies exact before scope, Entry, declaration occurrence, one history append, same lexical parent, D_after visibility, predecessor immutability, actual A and role fields. `:` does not imply `=` or theorem and does not recursively evaluate RHS.

## Migration, not compatibility mode

- Foundation-v2 source fixtures moved to scoped D;
- role dictionaries moved to scoped D;
- flat direct dictionary membership is removed from the Foundation-v2 path;
- G/T direct memberships remain separate because theory/grammar admission is not lexical dictionary scope.

## Still out of scope

- local `=` (next, same engine, decision #225);
- #242 Anum sequence→апамять materialization;
- #124 persistent backend;
- cutover and aprover repin.