### PR TITLE
Gate P: integrate local exact equality into the unified replay engine

### DIFF
--- a/contracts/mts-foundation-v2-equality-v0.7.json
+++ b/contracts/mts-foundation-v2-equality-v0.7.json
@@ -1,0 +1,74 @@
+{
+  "schema": "mts-foundation-v2-equality/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 251,
+  "parent": 237,
+  "researchDecision": 225,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-foundation-v2-state/v0.7",
+    "mts-foundation-v2-interpreter-replay/v0.7"
+  ],
+  "context": {
+    "topology": "K = K ⟼ (parent ⟼ current)",
+    "representativePair": "Pair = member ⟼ representative",
+    "representativeBinding": "Binding = K ⟼ Pair",
+    "contextOccurrenceIsNotABindingAttachment": true,
+    "hiddenGlobalK": false
+  },
+  "representative": {
+    "semantics": "one explicit local hop only; otherwise member represents itself",
+    "missingMapping": "rep_K(x) = x",
+    "singleMapping": "rep_K(x) = exact representative",
+    "duplicateSameRepresentativeOccurrences": "allowed as one unambiguous mapping with occurrence multiplicity",
+    "distinctRepresentatives": "conflict",
+    "aliasChaining": false,
+    "transitiveClosure": false,
+    "lastWriteWins": false
+  },
+  "equality": {
+    "definition": "Equal_K(a,b) iff rep_K(a) and rep_K(b) are the same exact occurrence ref",
+    "shapeEquality": false,
+    "graphIsomorphismEquality": false,
+    "bisimulationEquality": false,
+    "sourceSpellingEquality": false,
+    "backendAddressEquality": false,
+    "automaticSubstitution": false,
+    "automaticCongruence": false,
+    "automaticTransitivity": false,
+    "automaticRecursiveRewrite": false
+  },
+  "evaluationAct": {
+    "sameInterpreterModule": true,
+    "actualAIsExactEvaluationOccurrence": true,
+    "hostBooleanIsOnlyConvenienceReturn": true,
+    "requiredRoles": [
+      "context",
+      "left",
+      "right",
+      "left-representative",
+      "right-representative"
+    ],
+    "bothEqualAndNonEqualActsReplayable": true,
+    "snapshotStable": true,
+    "implicitMaterialization": false
+  },
+  "relationDecomposition": {
+    "builtIntoEquality": false,
+    "allowedOnlyAsSeparatelyAdmittedTheoryRule": true,
+    "recursiveApplicationImplicit": false
+  },
+  "requiredVectors": [
+    "two members with same exact representative evaluate equal",
+    "missing bindings fall back to exact operands and can evaluate non-equal",
+    "two same-shape self-closed occurrences remain non-equal by default",
+    "a->b and b->c remains one-hop and does not close transitively",
+    "duplicate same-representative bindings remain unambiguous",
+    "distinct local representatives conflict",
+    "forged representative evidence rejects",
+    "conflicting actual-act field rejects",
+    "replay is read-only and independent of shape comparator/legacy interpreter"
+  ],
+  "nextGate": "integrate exact multistep/proof adjacency and separately admitted inference rules over the same actual-act replay engine"
+}

--- a/contracts/mts-foundation-v2-interpreter-replay-v0.7.json
+++ b/contracts/mts-foundation-v2-interpreter-replay-v0.7.json
@@ -3,33 +3,27 @@
   "status": "gate-p-candidate",
   "accepted": false,
   "issue": 247,
-  "refinedByIssue": 249,
+  "refinedByIssues": [249, 251],
   "parent": 237,
   "dependsOn": [
     "mts-exact-occurrence-link-network/v0.7",
     "mts-foundation-v2-state/v0.7",
     "mts-foundation-v2-source/v0.7",
     "mts-integrated-interpreter-act-challenge/v0.7",
-    "mts-foundation-v2-colon/v0.7"
+    "mts-foundation-v2-colon/v0.7",
+    "mts-foundation-v2-equality/v0.7"
   ],
   "engine": {
     "oneTrustedReplayPath": true,
     "supportedActs": [
       "one-pole relation resolution",
-      "persistent scoped dictionary colon effect"
+      "persistent scoped dictionary colon effect",
+      "local exact-representative equality evaluation"
     ],
-    "parallelDefinitionInterpreter": false
+    "parallelDefinitionInterpreter": false,
+    "parallelEqualityInterpreter": false
   },
   "relationResolution": {
-    "path": [
-      "replay exact selected source evidence",
-      "obtain exactly one selected form occurrence",
-      "read exact active K/current",
-      "bind current to the one open pole",
-      "verify exact result occurrence and poles",
-      "verify persistent K_after",
-      "verify actual act header and exact role-addressed fields"
-    ],
     "startOpen": "F = F ⟼ e => result = current ⟼ e",
     "endOpen": "F = b ⟼ F => result = b ⟼ current",
     "directionFromExactFormStructure": true,
@@ -45,10 +39,21 @@
     "impliesTheorem": false,
     "rhsRecursiveEvaluation": false
   },
+  "equality": {
+    "contract": "mts-foundation-v2-equality/v0.7",
+    "sameReplayModule": true,
+    "representativeSemantics": "one explicit local hop only",
+    "hostBooleanOnlyConvenience": true,
+    "actualActRecordsEvaluation": true,
+    "shapeEquality": false,
+    "automaticTransitivity": false,
+    "automaticSubstitution": false,
+    "automaticCongruence": false,
+    "relationDecompositionBuiltIn": false
+  },
   "context": {
-    "before": "K_before = K_before ⟼ (parent ⟼ current)",
-    "binding": "binding = exact current resolved from K_before",
-    "after": "K_after = K_after ⟼ (sameParent ⟼ exactResult)",
+    "topology": "K = K ⟼ (parent ⟼ current)",
+    "localRepresentativeAttachment": "K ⟼ (member ⟼ representative)",
     "ambientCurrentAllowed": false,
     "inputMutationAllowed": false
   },
@@ -65,7 +70,6 @@
     "duplicateOrConflictingRequiredFieldRejects": true
   },
   "replay": {
-    "sourceFrontEndReplayedForRelationActs": true,
     "checkerReadOnly": true,
     "networkSnapshotMustRemainEqual": true,
     "searchRankingTrusted": false,
@@ -73,7 +77,6 @@
     "persistentBackendEffect": false
   },
   "deferredSameEngineExtensions": {
-    "localEqualityConstraint": 225,
     "multiStepRun": 230,
     "anumSequenceMaterialization": 242,
     "persistentL4": 124
@@ -85,5 +88,5 @@
     "productionCutoverDone": false,
     "aproverRepinAllowed": false
   },
-  "nextGate": "integrate local equality decision #225 into this same trusted engine, then move toward multistep/integrated conformance"
+  "nextGate": "integrate exact multistep/proof adjacency and separately admitted inference rules over the same actual-act replay engine"
 }

--- a/core/foundation_v2_interpreter.py
+++ b/core/foundation_v2_interpreter.py
@@ -7,7 +7,8 @@ it does not tokenize, parse, search, rank or materialize application links.
 The same engine currently replays:
 
 - one-pole relation resolution against exact K/current;
-- one persistent scoped-dictionary ``:`` effect.
+- one persistent scoped-dictionary ``:`` effect;
+- one local exact-representative ``=`` evaluation.
 
 Python dataclasses below are checker/transport API only. Semantic identity lives
 in the exact link occurrences they reference.
@@ -26,9 +27,11 @@ from .foundation_v2_source import (
 from .foundation_v2_state import (
     DictionaryLookupError,
     FoundationStateError,
+    RepresentativeConflictError,
     act_header,
     act_values,
     current_of_context,
+    local_representative,
     lookup_scoped_dictionary,
     parent_of_context,
     read_dictionary_scope,
@@ -108,6 +111,32 @@ class ColonEffectEvidence:
     roles: ColonRoleRefs
 
 
+@dataclass(frozen=True)
+class EqualityRoleRefs:
+    """Exact role refs required to replay one local equality evaluation."""
+
+    context: OccurrenceRef
+    left: OccurrenceRef
+    right: OccurrenceRef
+    left_representative: OccurrenceRef
+    right_representative: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class EqualityEvaluationEvidence:
+    """Checker handle for one exact local equality-evaluation act."""
+
+    interpreter: OccurrenceRef
+    context: OccurrenceRef
+    left: OccurrenceRef
+    right: OccurrenceRef
+    left_representative: OccurrenceRef
+    right_representative: OccurrenceRef
+    act: OccurrenceRef
+    role_dictionary: OccurrenceRef
+    roles: EqualityRoleRefs
+
+
 def replay_relation_step(
     network: LinkNetwork,
     evidence: RelationStepEvidence,
@@ -160,13 +189,7 @@ def replay_colon_effect(
     network: LinkNetwork,
     evidence: ColonEffectEvidence,
 ) -> OccurrenceRef:
-    """Replay one persistent scoped-dictionary definition effect read-only.
-
-    The relation ``sourceContent ⟼ form`` is dictionary data, not equality or a
-    theorem. The exact declaration occurrence is bound to ``D_before`` and
-    appended once to its local history; ``D_after`` is a fresh persistent scope
-    snapshot with the same lexical parent.
-    """
+    """Replay one persistent scoped-dictionary definition effect read-only."""
 
     before_snapshot = network.snapshot()
     try:
@@ -228,9 +251,6 @@ def replay_colon_effect(
                 "new definition is not a valid visible mapping in D_after"
             ) from exc
 
-        # The newly created declaration occurrence must not retroactively become
-        # visible from the immutable predecessor snapshot, even when an older
-        # identical mapping already exists there.
         try:
             verify_visible_dictionary_occurrence(
                 network,
@@ -252,6 +272,40 @@ def replay_colon_effect(
     finally:
         if network.snapshot() != before_snapshot:
             raise InterpreterReplayError("colon replay mutated the network")
+
+
+def replay_equality_evaluation(
+    network: LinkNetwork,
+    evidence: EqualityEvaluationEvidence,
+) -> bool:
+    """Replay one local exact-representative equality evaluation read-only.
+
+    The host boolean is only a convenience result. The exact actual act ``A``
+    records the evaluated context, operands and one-hop representatives.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        try:
+            current_of_context(network, evidence.context)
+            left_rep = local_representative(network, evidence.context, evidence.left)
+            right_rep = local_representative(network, evidence.context, evidence.right)
+        except RepresentativeConflictError as exc:
+            raise InterpreterReplayError("conflicting local representative") from exc
+        except FoundationStateError as exc:
+            raise InterpreterReplayError("invalid equality context") from exc
+
+        if evidence.left_representative is not left_rep:
+            raise InterpreterReplayError("forged left representative evidence")
+        if evidence.right_representative is not right_rep:
+            raise InterpreterReplayError("forged right representative evidence")
+
+        _verify_equality_act_header(network, evidence)
+        _verify_equality_act_fields(network, evidence)
+        return left_rep is right_rep
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise InterpreterReplayError("equality replay mutated the network")
 
 
 def _replay_source(
@@ -370,6 +424,43 @@ def _verify_colon_act_fields(
             "after-dictionary",
         ),
         (evidence.roles.context, evidence.context, "context"),
+    )
+    _verify_exact_act_fields(network, evidence.act, expected)
+
+
+def _verify_equality_act_header(
+    network: LinkNetwork,
+    evidence: EqualityEvaluationEvidence,
+) -> None:
+    try:
+        header = act_header(network, evidence.act)
+    except FoundationStateError as exc:
+        raise InterpreterReplayError("invalid equality actual-act header") from exc
+    expected = (evidence.interpreter, evidence.role_dictionary, evidence.context)
+    if header != expected:
+        raise InterpreterReplayError(
+            "equality actual-act header does not match I/D_roles/K"
+        )
+
+
+def _verify_equality_act_fields(
+    network: LinkNetwork,
+    evidence: EqualityEvaluationEvidence,
+) -> None:
+    expected = (
+        (evidence.roles.context, evidence.context, "context"),
+        (evidence.roles.left, evidence.left, "left"),
+        (evidence.roles.right, evidence.right, "right"),
+        (
+            evidence.roles.left_representative,
+            evidence.left_representative,
+            "left-representative",
+        ),
+        (
+            evidence.roles.right_representative,
+            evidence.right_representative,
+            "right-representative",
+        ),
     )
     _verify_exact_act_fields(network, evidence.act, expected)
 

--- a/core/foundation_v2_state.py
+++ b/core/foundation_v2_state.py
@@ -1,15 +1,19 @@
 """Foundation-v2 higher-layer state over the exact-occurrence link substrate.
 
 This module deliberately adds no semantic fields to :class:`Link`. Contexts,
-dictionaries, theories, grammar evidence and interpretation acts are represented
-only by ordinary exact link occurrences. The Python functions below are
-construction/read helpers for the candidate topology; their function names are
-not MTS ontology.
+dictionaries, theories, grammar evidence, local equality constraints and
+interpretation acts are represented only by ordinary exact link occurrences.
+The Python functions below are construction/read helpers for the candidate
+topology; their function names are not MTS ontology.
 
 Foundation-v2 dictionaries use one persistent lexical-scope model. A dictionary
 snapshot is start-self-closed and points to ``parentScope ⟼ localHistory``.
 Definitions append exact occurrences to that history; lookup replays the explicit
 history/parent links rather than consulting a mutable host map.
+
+Local equality is deliberately weaker: a context K may carry explicit one-hop
+``member ⟼ representative`` attachments. No global congruence, transitive alias
+closure or shape equality is provided here.
 
 The module is storage-neutral and read-only after a network has been frozen. It
 does not materialize persistent L4 links and does not define Anum sequence
@@ -34,6 +38,10 @@ class DictionaryConflictError(DictionaryLookupError):
     """One lexical scope contains distinct forms for the same source content."""
 
 
+class RepresentativeConflictError(FoundationStateError):
+    """One local context maps a member to distinct exact representatives."""
+
+
 @dataclass(frozen=True)
 class DictionaryEffectRefs:
     """Construction handles for one persistent definition effect."""
@@ -51,6 +59,15 @@ class ScopedDictionaryResolution:
     scope: OccurrenceRef
     form: OccurrenceRef
     occurrences: tuple[OccurrenceRef, ...]
+
+
+@dataclass(frozen=True)
+class LocalRepresentativeResolution:
+    """One-hop representative plus exact K-attachment occurrences supporting it."""
+
+    member: OccurrenceRef
+    representative: OccurrenceRef
+    bindings: tuple[OccurrenceRef, ...]
 
 
 def define_source_occurrence(
@@ -96,6 +113,79 @@ def parent_of_context(network: LinkNetwork, context: OccurrenceRef) -> Occurrenc
         raise FoundationStateError("context is not start-self-closed")
     pair = network.link(context_link.end)
     return pair.start
+
+
+def define_local_representative_binding(
+    builder: LinkNetworkBuilder,
+    context: OccurrenceRef,
+    member: OccurrenceRef,
+    representative: OccurrenceRef,
+) -> tuple[OccurrenceRef, OccurrenceRef]:
+    """Create ``Pair=member⟼representative`` and ``Binding=K⟼Pair``."""
+
+    pair = builder.reserve()
+    binding = builder.reserve()
+    builder.define(pair, member, representative)
+    builder.define(binding, context, pair)
+    return pair, binding
+
+
+def local_representative_resolution(
+    network: LinkNetwork,
+    context: OccurrenceRef,
+    member: OccurrenceRef,
+) -> LocalRepresentativeResolution:
+    """Resolve exactly one local representative value, without alias chaining.
+
+    Repeated exact binding occurrences to the same representative are tolerated
+    as one unambiguous mapping. Distinct representative values conflict.
+    Missing mapping falls back to the member itself and has no binding evidence.
+    """
+
+    # Validate the distinguished context occurrence before considering attachments.
+    current_of_context(network, context)
+
+    matches: list[tuple[OccurrenceRef, OccurrenceRef]] = []
+    for binding_ref in network.refs:
+        if binding_ref is context:
+            # K itself is start-self-closed context topology, not a representative
+            # attachment even though its start is also K.
+            continue
+        binding = network.link(binding_ref)
+        if binding.start is not context:
+            continue
+        pair = network.link(binding.end)
+        if pair.start is member:
+            matches.append((binding_ref, pair.end))
+
+    if not matches:
+        return LocalRepresentativeResolution(
+            member=member,
+            representative=member,
+            bindings=(),
+        )
+
+    representatives = {representative for _, representative in matches}
+    if len(representatives) != 1:
+        raise RepresentativeConflictError(
+            "context contains distinct local representatives for one member"
+        )
+    representative = next(iter(representatives))
+    return LocalRepresentativeResolution(
+        member=member,
+        representative=representative,
+        bindings=tuple(binding for binding, _ in matches),
+    )
+
+
+def local_representative(
+    network: LinkNetwork,
+    context: OccurrenceRef,
+    member: OccurrenceRef,
+) -> OccurrenceRef:
+    """Return the one-hop exact representative of ``member`` in exact ``K``."""
+
+    return local_representative_resolution(network, context, member).representative
 
 
 def define_dictionary_scope(

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -2,9 +2,9 @@
 
 Статус: **production/reference candidate**, не accepted release.
 
-Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory layer #243/#244, source front-end #245/#246 и первый relation replay #247/#248. Текущий слой: persistent scoped dictionary + `:` #249. Sequence-deserialization: #242. Persistent L4 backend: #124.
+Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory #243/#244, source front-end #245/#246, relation replay #247/#248 и persistent scoped `D` + `:` #249/#250. Текущий слой: local exact representative `=` #251. Sequence-deserialization: #242. Persistent L4 backend: #124.
 
-Цель Gate P — собрать **один** production/reference semantic path, после чего опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
+Цель Gate P — собрать **один** production/reference semantic path, затем опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
 
 ## 1. Каноническая лестница Foundation v2
 
@@ -19,8 +19,8 @@ binary link ontology
 → scoped D + explicit G/T evidence
 → explicit K/current
 → one trusted interpreter/replay engine
-→ actual acts A
-→ multistep/proof replay
+→ relation / : / = acts
+→ exact multistep/proof replay
 → accepted contract
 → aprover
 ```
@@ -33,6 +33,7 @@ form != theory membership
 structure != exact occurrence identity
 read/find/replay != materialize
 candidate search != trusted replay
+local equality != global rewrite system
 ```
 
 ## 2. Production substrate
@@ -58,7 +59,7 @@ token
 astNode
 ```
 
-Sharing и cycles являются native конечной структурой. Два occurrences могут иметь одинаковые полюса и всё же оставаться различёнными:
+Sharing и cycles — native конечная структура. Два occurrences могут иметь одинаковые полюса и всё же оставаться различёнными:
 
 ```text
 X1 = a ⟼ b
@@ -66,7 +67,7 @@ X2 = a ⟼ b
 X1 != X2
 ```
 
-Поэтому shape/isomorphism и physical backend address не определяют semantic identity.
+Shape/isomorphism и physical backend address не определяют semantic identity.
 
 ## 3. Source, context и actual act — тоже связи
 
@@ -74,20 +75,14 @@ X1 != X2
 
 Lower byte protocol предоставляет exact refs `B(byte)`.
 
-Канонический astring content:
-
 ```text
 C0 = R
 C(n+1) = Cn ⟼ B(byte_n)
-```
 
-Конкретное появление исходника:
-
-```text
 S = S ⟼ C
 ```
 
-Поэтому одинаковые bytes могут разделять один canonical `C`, но иметь разные exact source occurrences `S1`, `S2`.
+Одинаковые bytes могут разделять canonical `C`, но иметь разные exact source occurrences `S1`, `S2`.
 
 ### 3.2. Контекст
 
@@ -97,7 +92,7 @@ K = K ⟼ P
 ↑ = current from exact active K
 ```
 
-`↑` не является process-global переменной. Trusted act обязан назвать конкретный exact `K`.
+`↑` не process-global variable. Trusted act обязан назвать exact `K`.
 
 ### 3.3. Actual act
 
@@ -116,11 +111,11 @@ Field = roleRef ⟼ value
 A ⟼ Field
 ```
 
-`roleRef` разрешается через явный scoped `D_roles`. Host enum может быть API-удобством, но не semantic identity роли.
+`roleRef` разрешается через explicit scoped `D_roles`. Host field name — checker API, не semantic identity.
 
 ## 4. Один source front-end
 
-Production-facing source path не доверяет lexer/token/AST classes как смыслу.
+Production source path не доверяет lexer/token/AST classes как смыслу:
 
 ```text
 raw bytes
@@ -134,22 +129,21 @@ raw bytes
 → read-only replay
 ```
 
-Кандидатный поиск может использовать trie, regex, индексы, longest-match или UI. Trusted replay проверяет **выбранное evidence**, а не алгоритм, который его предложил.
+Candidate search может использовать trie, regex, indices, longest-match или UI. Trusted replay проверяет **selected evidence**.
 
-### 4.1. Selected slice
+Selected slice:
 
 ```text
 Span = sourcePrefix(start) ⟼ sourcePrefix(end)
 SliceEvidence = Span ⟼ sliceContent
 Lexeme = S ⟼ SliceEvidence
 Resolution = Lexeme ⟼ form
+Selection = visibleDefinitionOccurrence ⟼ Resolution
 ```
 
-Host byte offsets — transport/checker coordinates. Семантическое evidence задаётся exact refs границ, source occurrence и slice content.
+UTF-8 `⟼` может быть одним многобайтным slice. Host byte offsets остаются transport/checker coordinates.
 
-UTF-8 `⟼` может быть одним многобайтным selected slice; trusted semantics не обязана дробить его на byte-sized tokens.
-
-### 4.2. Ordered result
+Порядок:
 
 ```text
 SelectedSequence = fold(R, Selection_0 ... Selection_n)
@@ -159,40 +153,16 @@ G ⟼ FormSequence
 T ⟼ FormSequence
 ```
 
-`G/T` membership остаётся отдельным от lexical dictionary semantics. То, что host parser построил какой-то AST, не означает admission формы.
-
 ## 5. Один persistent scoped dictionary D
 
-Ранний Gate-P candidate `D ⟼ Entry` оказался недостаточным после интеграции уже принятой семантики `:`. В production path теперь остаётся одна модель — persistent lexical scope snapshots.
-
-### 5.1. Scope snapshot
+Production path использует только persistent lexical scope snapshots:
 
 ```text
 ScopePayload = parentScope ⟼ localHistory
 D = D ⟼ ScopePayload
 ```
 
-Кандидат пустого root-scope:
-
-```text
-D0 = D0 ⟼ (R ⟼ R)
-```
-
-Кандидат пустого child-scope:
-
-```text
-Child0 = Child0 ⟼ (D_parent ⟼ R)
-```
-
-### 5.2. Definition occurrence
-
-Для:
-
-```text
-sourceContent : form
-```
-
-структура эффекта:
+Definition effect:
 
 ```text
 Entry      = sourceContent ⟼ form
@@ -201,25 +171,9 @@ H_after    = H_before ⟼ Occurrence
 D_after    = D_after ⟼ (sameParentScope ⟼ H_after)
 ```
 
-Здесь необходимо различать:
+Нужно различать `Entry` как mapping и `Occurrence` как конкретное declaration occurrence.
 
-```text
-Entry
-```
-
-как semantic mapping и:
-
-```text
-Occurrence
-```
-
-как конкретное occurrence объявления в конкретном snapshot.
-
-Два одинаковых объявления могут иметь один mapping, но разные declaration occurrences.
-
-### 5.3. Lookup
-
-Trusted lookup под текущим exact `D` идёт только по явно представленной структуре:
+Lookup:
 
 ```text
 D.localHistory
@@ -228,12 +182,7 @@ D.localHistory
 → exact Entry
 ```
 
-Если локального определения нет:
-
-```text
-D.parentScope
-→ lookup(parent)
-```
+Если локального mapping нет — explicit parent scope.
 
 Правила:
 
@@ -246,40 +195,17 @@ distinct local forms for same source = conflict
 no last-write-wins
 ```
 
-Особенно важно: произвольная связь где-то в сети
-
-```text
-D_old ⟼ Entry
-```
-
-не становится видимой только потому, что её можно найти глобальным scan. Trusted replay должен доказать достижимость exact declaration occurrence через `localHistory/parentScope` выбранного `D`.
-
-### 5.4. Source resolution использует historical occurrence
-
-Для selected lexeme:
-
-```text
-Resolution = Lexeme ⟼ form
-Selection  = visibleDefinitionOccurrence ⟼ Resolution
-```
-
-`visibleDefinitionOccurrence` может быть создано против более раннего snapshot `D_before`, но оставаться видимым в позднем `D_current`, если exact history chain это доказывает.
-
-Так source front-end и `:` используют **одну и ту же** dictionary semantics.
+Произвольное `D_old ⟼ Entry` где-то в сети не считается видимым без exact history/parent path.
 
 ## 6. Один interpreter/replay engine
 
-После source front-end интерпретатор не строит вторую semantic representation.
-
-Его trusted вход уже состоит из exact evidence.
+После source front-end интерпретатор не строит вторую semantic representation. Его trusted input уже состоит из exact evidence.
 
 ### 6.1. Relation-resolution act
 
-Первый vertical slice:
-
 ```text
 exact source evidence
-→ one selected partial form F
+→ selected partial form F
 → exact K/current
 → binding = ↑
 → structural pole resolution
@@ -288,71 +214,46 @@ exact source evidence
 → actual A
 ```
 
-Если:
+Для:
 
 ```text
 F = F ⟼ e
 ```
 
-то:
+получаем:
 
 ```text
 X = current ⟼ e
 ```
 
-Если:
+Для:
 
 ```text
 F = b ⟼ F
 ```
 
-то:
+получаем:
 
 ```text
 X = b ⟼ current
 ```
 
-Направление выводится из exact structural form, а не из `TokenKind`, glyph switch или AST opcode.
+Направление выводится из exact structural form, не из glyph/AST/opcode.
 
 ### 6.2. Exact result
 
-Если память содержит:
+Если:
 
 ```text
 X1 = a ⟼ b
 X2 = a ⟼ b
 ```
 
-act может выбрать `X2`. Replay проверяет:
-
-```text
-poles(X2) = (a,b)
-K_after.current = X2
-A.result = X2
-```
-
-и не схлопывает `X1/X2` по форме пары.
+act может выбрать `X2`. Replay проверяет exact `X2` через poles, `K_after.current` и `A.result`; pair uniqueness не предполагается.
 
 ### 6.3. Persistent `:` — тот же engine
 
-Gate #249 добавляет `:` не отдельным DefinitionInterpreter, а вторым replay act того же engine.
-
-Replay `:` проверяет уже присутствующее evidence:
-
-```text
-D_before
-source occurrence S
-sourceContent
-form
-Entry
-Occurrence
-H_before
-H_after
-D_after
-actual A
-```
-
-Он обязан подтвердить:
+`:` replay проверяет уже присутствующую candidate effect network:
 
 ```text
 S = S ⟼ sourceContent
@@ -363,9 +264,7 @@ parent(D_after) = parent(D_before)
 history(D_after) = H_after
 ```
 
-а затем проверить, что новый exact `Occurrence` видим из `D_after`, но не стал ретроактивно видимым из immutable `D_before`.
-
-При этом:
+Новый occurrence должен быть видим из `D_after`, но не ретроактивно из immutable `D_before`.
 
 ```text
 : != =
@@ -373,13 +272,151 @@ history(D_after) = H_after
 : != recursive RHS evaluation
 ```
 
-И replay остаётся read-only: он не создаёт `Entry`, `Occurrence`, history или `D_after`; он проверяет candidate effect network.
+Replay не materialize-ит Entry/history/D_after — он их проверяет.
 
-## 7. Апамять как controller сети
+## 7. Local exact representative `=` — тот же engine
+
+Gate #251 интегрирует `=` как **локальное отношение внутри exact K**, а не как глобальное свойство всей асети.
+
+Context topology сохраняется:
+
+```text
+K = K ⟼ (parent ⟼ current)
+```
+
+Дополнительный local representative constraint:
+
+```text
+Pair    = member ⟼ representative
+Binding = K ⟼ Pair
+```
+
+Важно: сам exact occurrence `K` является context topology и не считается equality binding, хотя его `start` тоже равен `K`.
+
+### 7.1. One-hop representative
+
+```text
+rep_K(x) = explicit local representative, если mapping однозначен
+         = x, если mapping отсутствует
+```
+
+И:
+
+```text
+Equal_K(a,b)
+iff
+rep_K(a) and rep_K(b) are the same exact occurrence
+```
+
+Никакого recursive alias chasing.
+
+Если:
+
+```text
+K: a → b
+K: b → c
+```
+
+то:
+
+```text
+rep_K(a) = b
+rep_K(b) = c
+```
+
+следовательно `Equal_K(a,b)` в таком состоянии **false**. Автоматическое транзитивное замыкание не выполняется.
+
+### 7.2. Duplicate и conflict
+
+Повторные exact bindings:
+
+```text
+K: a → r
+K: a → r
+```
+
+могут существовать как два occurrence provenance, но mapping остаётся однозначным:
+
+```text
+rep_K(a) = r
+```
+
+Если же:
+
+```text
+K: a → r1
+K: a → r2
+r1 != r2
+```
+
+lookup/replay отклоняется как local representative conflict. Last-write-wins отсутствует.
+
+### 7.3. Shape не создаёт equality
+
+Пусть:
+
+```text
+X1 = X1 ⟼ X1
+X2 = X2 ⟼ X2
+X1 != X2
+```
+
+Без local representative evidence:
+
+```text
+rep_K(X1) = X1
+rep_K(X2) = X2
+Equal_K(X1,X2) = false
+```
+
+То есть другой self-cycle не становится `∞` и две одинаковые формы не становятся равными только по graph isomorphism.
+
+### 7.4. Equality evaluation является actual act
+
+Результат проверки не должен существовать только как временный host boolean.
+
+Actual `A` фиксирует exact evidence ролей:
+
+```text
+context
+left
+right
+left-representative
+right-representative
+```
+
+Host API может вернуть `true/false` для удобства, но доверенная семантика — это replay exact `K`, exact representative bindings и actual `A`.
+
+И equal, и non-equal evaluation являются допустимыми actual acts.
+
+### 7.5. Чего `=` намеренно не делает
+
+Нет автоматических:
+
+```text
+transitivity
+substitution
+congruence
+global rewriting
+recursive rewriting
+shape/isomorphism equality
+bisimulation equality
+```
+
+Relation decomposition:
+
+```text
+(a⟼b) = (c⟼d)
+→ a=c, b=d
+```
+
+**не встроена в equality core**. Она допустима только как отдельно admitted one-step rule через `T` в последующем proof/inference gate и не запускается рекурсивно сама собой.
+
+## 8. Апамять как controller сети
 
 Подробно: [Апамять и управление сетью связей](Апамять%20и%20управление%20сетью%20связей.md).
 
-Ключевой operational split:
+Operational split:
 
 ```text
 read / find / enumerate / replay
@@ -391,10 +428,6 @@ materialize / delete
         └── явные effects
 ```
 
-Это не мелкая backend-деталь, а необходимая семантическая граница.
-
-Если описание искомой связи автоматически создаёт эту связь, запрос существования становится бессмысленным.
-
 Поэтому:
 
 ```text
@@ -403,109 +436,34 @@ query description != queried fact
 replay evidence != application effect
 ```
 
-### 7.1. Простой пример
+И local equality даёт ещё один прикладной пример: «равенство» не вычисляется скрытым comparator по всей памяти, а является explicit context-local relation, которую можно хранить, искать и replay-ить как часть сети.
 
-До:
+## 9. Ачисло и будущая sequence deserialization
 
-```text
-a       b
+Recursive Anum уже является root-relative structural description на occurrence-tree области, но это не полная operational semantics произвольной последовательности.
 
-нет exact occurrence a ⟼ b
-```
-
-`find(a,b)`:
-
-```text
-→ {}
-```
-
-и сеть остаётся той же.
-
-Только explicit effect:
-
-```text
-x = materialize(a,b)
-```
-
-даёт:
-
-```text
-a ─────x─────▶ b
-```
-
-### 7.2. Почему это важно для `:`
-
-Запись/описание:
-
-```text
-name : form
-```
-
-сама по себе не обязана менять dictionary state. Executor может построить candidate effect network, а trusted replay отдельно проверит:
-
-```text
-D_before → history append → D_after
-```
-
-Так semantic effect становится проверяемым объектом, а не скрытой мутацией host map.
-
-## 8. Ачисло и будущая sequence deserialization
-
-Recursive Anum уже является root-relative structural description на принятой occurrence-tree области, но это ещё не полная operational semantics произвольной последовательности.
-
-Отдельный gate #242 проверит более широкий исторический принцип:
+Отдельный gate #242 проверит исторический принцип:
 
 ```text
 ∞ A B C
 ```
 
-как последовательностное описание, которое после **явной** десериализации/materialization может построить:
+как последовательностное описание, которое после **явной** materialization может построить:
 
 ```text
 A ⟼ B
 B ⟼ C
 ```
 
-с корректной nested-context semantics.
+с nested-context semantics.
 
 Не смешиваем:
 
 ```text
-source front-end
-    read/resolve source evidence
-
-interpreter replay
-    validate selected semantic act
-
-Anum→апамять
-    explicit result-network materialization
+source front-end     = read/resolve source evidence
+interpreter replay   = validate selected semantic act
+Anum→апамять         = explicit result-network materialization
 ```
-
-Поэтому текущий Gate P не превращает `[`/`]` в безусловные host PUSH/POP opcodes и не расширяет pair-only recursive grammar одной красивой картинкой.
-
-## 9. Следующий слой: local `=`
-
-После закрытия #249 следующий semantic gate должен интегрировать уже принятое решение #225 **в этот же engine**.
-
-Минимальная equality semantics:
-
-```text
-K ⟼ (member ⟼ representative)
-rep_K(x) = one explicit local representative, else x
-Equal_K(a,b) iff rep_K(a) and rep_K(b) are the same exact ref
-```
-
-Без автоматических:
-
-```text
-transitivity
-substitution
-congruence
-global rewriting
-shape equality
-```
-
-Relation decomposition допустима только как отдельно admitted one-step theory rule.
 
 ## 10. Что должна получить следующая версия для aprover
 
@@ -516,21 +474,26 @@ Trusted checker path:
 ```text
 exact source/evidence
 → scoped D resolution + G/T admission
-→ exact active K
-→ selected form/bindings
+→ exact K/current/local representatives
 → selected act semantics
 → exact result/state transition
 → actual A
+→ exact multistep adjacency
 → deterministic read-only replay
 ```
 
-Proof search, ranking, индексы и UI могут быть эвристическими. Доверенная часть проверяет выбранные exact relations.
+Proof search, ranking, indices и UI могут быть эвристическими. Доверенная часть проверяет selected exact relations.
 
-## 11. Что ещё блокирует release
+## 11. Следующий слой после #251
+
+После local `=` следующий gate должен быть не ещё одним оператором, а **multistep/proof integration** над уже существующими actual acts.
+
+Нужно переиспользовать принятое exact-adjacency направление #230/#227 и затем отдельно admitted theory rules. Это будет непосредственный мост к новой версии МТС для `aprover`.
+
+## 12. Что ещё блокирует release
 
 ```text
-scoped D + `:` #249
-→ local `=` in same engine
+local `=` #251
 → multistep/proof integration
 → sequence-to-apamemory #242
 → persistent L4 boundary #124

--- a/tests/test_mts_foundation_v2_equality.py
+++ b/tests/test_mts_foundation_v2_equality.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_interpreter import (
+    EqualityEvaluationEvidence,
+    EqualityRoleRefs,
+    InterpreterReplayError,
+    replay_equality_evaluation,
+)
+from core.foundation_v2_state import (
+    RepresentativeConflictError,
+    define_act_field,
+    define_act_header,
+    define_context,
+    define_dictionary_effect,
+    define_dictionary_scope,
+    define_local_representative_binding,
+    local_representative,
+    local_representative_resolution,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROLE_NAMES = (
+    "context",
+    "left",
+    "right",
+    "left-representative",
+    "right-representative",
+)
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _roles(builder: LinkNetworkBuilder) -> EqualityRoleRefs:
+    refs = {name: _anchor(builder) for name in ROLE_NAMES}
+    return EqualityRoleRefs(
+        context=refs["context"],
+        left=refs["left"],
+        right=refs["right"],
+        left_representative=refs["left-representative"],
+        right_representative=refs["right-representative"],
+    )
+
+
+def _role_items(roles: EqualityRoleRefs):
+    return (
+        ("context", roles.context),
+        ("left", roles.left),
+        ("right", roles.right),
+        ("left-representative", roles.left_representative),
+        ("right-representative", roles.right_representative),
+    )
+
+
+def _role_dictionary(builder, root, roles):
+    dictionary = define_dictionary_scope(builder, root, root)
+    history = root
+    for _, role_ref in _role_items(roles):
+        name_content = _anchor(builder)
+        effect = define_dictionary_effect(
+            builder,
+            dictionary,
+            root,
+            history,
+            name_content,
+            role_ref,
+        )
+        dictionary = effect.after_scope
+        history = effect.history_after
+    return dictionary
+
+
+def _make_evidence(builder, root, context, left, right, left_rep, right_rep):
+    interpreter = _anchor(builder)
+    roles = _roles(builder)
+    role_dictionary = _role_dictionary(builder, root, roles)
+    act = define_act_header(builder, interpreter, role_dictionary, context)
+    for role, value in (
+        (roles.context, context),
+        (roles.left, left),
+        (roles.right, right),
+        (roles.left_representative, left_rep),
+        (roles.right_representative, right_rep),
+    ):
+        define_act_field(builder, act, role, value)
+    return EqualityEvaluationEvidence(
+        interpreter=interpreter,
+        context=context,
+        left=left,
+        right=right,
+        left_representative=left_rep,
+        right_representative=right_rep,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+
+
+def test_equal_members_share_one_exact_local_representative() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    parent = _anchor(builder)
+    current = _anchor(builder)
+    context = define_context(builder, parent, current)
+    left = _anchor(builder)
+    right = _anchor(builder)
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, left, representative)
+    define_local_representative_binding(builder, context, right, representative)
+    evidence = _make_evidence(
+        builder, root, context, left, right, representative, representative
+    )
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    assert replay_equality_evaluation(network, evidence) is True
+    assert network.snapshot() == before
+
+
+def test_missing_mapping_falls_back_to_exact_member_and_can_be_false() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    left = _anchor(builder)
+    right = _anchor(builder)
+    evidence = _make_evidence(builder, root, context, left, right, left, right)
+    network = builder.freeze(root)
+
+    assert local_representative(network, context, left) is left
+    assert local_representative(network, context, right) is right
+    assert replay_equality_evaluation(network, evidence) is False
+
+
+def test_two_same_shape_self_closed_occurrences_are_not_equal_by_shape() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    left = _anchor(builder)
+    right = _anchor(builder)
+    assert left is not right
+    evidence = _make_evidence(builder, root, context, left, right, left, right)
+    network = builder.freeze(root)
+
+    assert network.link(left).start is left and network.link(left).end is left
+    assert network.link(right).start is right and network.link(right).end is right
+    assert replay_equality_evaluation(network, evidence) is False
+
+
+def test_alias_chain_is_deliberately_one_hop_not_transitive() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    left = _anchor(builder)
+    middle = _anchor(builder)
+    final = _anchor(builder)
+    define_local_representative_binding(builder, context, left, middle)
+    define_local_representative_binding(builder, context, middle, final)
+    evidence = _make_evidence(builder, root, context, left, middle, middle, final)
+    network = builder.freeze(root)
+
+    assert local_representative(network, context, left) is middle
+    assert local_representative(network, context, middle) is final
+    assert replay_equality_evaluation(network, evidence) is False
+
+
+def test_duplicate_same_representative_bindings_are_unambiguous_not_last_write_wins() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    member = _anchor(builder)
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, member, representative)
+    define_local_representative_binding(builder, context, member, representative)
+    evidence = _make_evidence(
+        builder, root, context, member, representative, representative, representative
+    )
+    network = builder.freeze(root)
+
+    resolution = local_representative_resolution(network, context, member)
+    assert resolution.representative is representative
+    assert len(resolution.bindings) == 2
+    assert replay_equality_evaluation(network, evidence) is True
+
+
+def test_distinct_local_representatives_conflict() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    member = _anchor(builder)
+    rep_one = _anchor(builder)
+    rep_two = _anchor(builder)
+    define_local_representative_binding(builder, context, member, rep_one)
+    define_local_representative_binding(builder, context, member, rep_two)
+    evidence = _make_evidence(builder, root, context, member, rep_one, rep_one, rep_one)
+    network = builder.freeze(root)
+
+    with pytest.raises(RepresentativeConflictError):
+        local_representative(network, context, member)
+    with pytest.raises(InterpreterReplayError, match="conflicting local representative"):
+        replay_equality_evaluation(network, evidence)
+
+
+def test_forged_representative_evidence_rejects() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    left = _anchor(builder)
+    right = _anchor(builder)
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, left, representative)
+    evidence = _make_evidence(builder, root, context, left, right, representative, right)
+    forged = replace(evidence, left_representative=right)
+    network = builder.freeze(root)
+
+    with pytest.raises(InterpreterReplayError, match="forged left representative"):
+        replay_equality_evaluation(network, forged)
+
+
+def test_conflicting_actual_act_field_rejects_even_when_equality_is_true() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    left = _anchor(builder)
+    right = _anchor(builder)
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, left, representative)
+    define_local_representative_binding(builder, context, right, representative)
+    evidence = _make_evidence(
+        builder, root, context, left, right, representative, representative
+    )
+    forged_value = _anchor(builder)
+    define_act_field(
+        builder,
+        evidence.act,
+        evidence.roles.left_representative,
+        forged_value,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(InterpreterReplayError, match="left-representative"):
+        replay_equality_evaluation(network, evidence)
+
+
+def test_equality_engine_has_no_shape_comparator_or_legacy_dependency() -> None:
+    source = (ROOT / "core/foundation_v2_interpreter.py").read_text(encoding="utf-8")
+    assert "carrier_isomorphic" not in source
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert "mtc_interpreter" not in source
+    assert "union_find" not in source.lower()


### PR DESCRIPTION
Closes #251 after explicit decision if CI/evidence is accepted. Parent: #237. Depends on merged #250 and reuses final equality decision #225.

## One local equality model

```text
K = K ⟼ (parent ⟼ current)
Pair = member ⟼ representative
Binding = K ⟼ Pair

rep_K(x) = one explicit local representative, else x
Equal_K(a,b) iff rep_K(a) and rep_K(b) are the same exact occurrence
```

The exact context occurrence `K` itself is skipped when enumerating representative attachments.

## Semantics

- one-hop only; no alias-chain closure;
- repeated same-representative bindings are allowed as occurrence provenance but remain one unambiguous mapping;
- distinct representatives for the same member conflict;
- missing mapping falls back to the exact member;
- same-shape/self-closed occurrences remain unequal by default;
- no graph isomorphism, transitivity, substitution, congruence or global rewriting;
- relation decomposition is explicitly not built into equality and remains a separately admitted future theory rule.

## Same trusted engine

`core/foundation_v2_interpreter.py` now replays equality alongside relation resolution and persistent `:`. Both true and false evaluations are actual acts. The host bool is only an API convenience; exact A records context, operands and one-hop representatives.

## Evidence/tests

New conformance covers true/false equality, fallback identity, same-shape distinction, one-hop non-transitivity, duplicate provenance, representative conflict, forged representative evidence, conflicting act fields and snapshot-stable replay.

`docs/specs/Foundation v2 Gate P.md` is updated with practical local-equality/apamemory examples and the explicit boundary against global rewrite semantics.

## Still out of scope

- separately admitted relation-decomposition/proof rule;
- multistep proof integration (next);
- #242 Anum→апамять materialization;
- #124 persistent L4;
- cutover / aprover repin.