### PR TITLE
Gate P: add exact multistep actual-act run replay

### DIFF
--- a/contracts/mts-foundation-v2-run-v0.7.json
+++ b/contracts/mts-foundation-v2-run-v0.7.json
@@ -1,0 +1,62 @@
+{
+  "schema": "mts-foundation-v2-run/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 253,
+  "parent": 237,
+  "researchDecision": 230,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-foundation-v2-interpreter-replay/v0.7"
+  ],
+  "container": {
+    "base": "Run_0 = R",
+    "append": "Run_(i+1) = Run_i ⟼ A_i",
+    "finalExactOccurrenceIdentifiesSelectedRun": true,
+    "hostArrayIndexIsSemanticOrder": false
+  },
+  "stepBoundary": {
+    "beforeField": "A ⟼ (beforeRole ⟼ K_before)",
+    "afterField": "A ⟼ (afterRole ⟼ K_after)",
+    "actHeaderAfterMustMatch": true,
+    "noopAllowed": "K_before may be exact K_after"
+  },
+  "continuity": {
+    "rule": "A_i.after is the same exact occurrence as A_(i+1).before",
+    "shapeSimilarityEnough": false,
+    "graphIsomorphismEnough": false,
+    "persistentContexts": true,
+    "finiteContextReturnsAllowed": true
+  },
+  "trustBoundary": {
+    "selectedRunOnly": true,
+    "branchDiscoveryTrusted": false,
+    "branchRankingTrusted": false,
+    "individualActSemanticsReimplementedByRunChecker": false,
+    "logicalTransitivityInferred": false,
+    "theoremStatusInferred": false,
+    "substitutionInferred": false,
+    "congruenceInferred": false,
+    "contextShortcutMaterialized": false,
+    "replayReadOnly": true
+  },
+  "requiredVectors": [
+    "linear K0->K1->K2",
+    "reordered selected acts reject",
+    "shape-equivalent but occurrence-distinct K breaks continuity",
+    "two occurrence-distinct noop acts preserve exact order",
+    "finite K0->K1->K0 return",
+    "unselected branch candidate does not affect selected run",
+    "forged before/after field rejects",
+    "forged terminal rejects",
+    "run construction creates no K0->Kn shortcut",
+    "empty run is exact state identity"
+  ],
+  "productionBoundary": {
+    "legacyProofCheckerDependency": false,
+    "legacyInterpreterDependency": false,
+    "newLogicalCalculusIntroduced": false,
+    "aproverRepinAllowed": false
+  },
+  "nextGate": "separately admitted theory-rule/proof replay over selected exact acts and run continuity"
+}

--- a/core/foundation_v2_run.py
+++ b/core/foundation_v2_run.py
@@ -1,0 +1,136 @@
+"""Foundation-v2 exact multistep run container and read-only replay.
+
+A run is an ordered chain of already-existing actual act occurrences:
+
+    Run_0 = R
+    Run_(i+1) = Run_i ⟼ A_i
+
+The trusted checker reconstructs that chain from exact links, validates explicit
+before/after context fields for every act and requires exact context continuity.
+It does not reimplement individual act semantics, choose branches, infer logical
+transitivity or materialize shortcut links.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from .exact_link_network import LinkNetwork, LinkNetworkBuilder, OccurrenceRef
+from .foundation_v2_state import (
+    FoundationStateError,
+    act_header,
+    act_values,
+    current_of_context,
+)
+
+
+class RunReplayError(ValueError):
+    """Selected multistep run evidence is forged or discontinuous."""
+
+
+@dataclass(frozen=True)
+class RunStepEvidence:
+    """Exact act boundary evidence used only for run composition."""
+
+    act: OccurrenceRef
+    before_context: OccurrenceRef
+    after_context: OccurrenceRef
+    before_role: OccurrenceRef
+    after_role: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class RunEvidence:
+    """Checker handle for one exact ordered selected run."""
+
+    run_root: OccurrenceRef
+    initial_context: OccurrenceRef
+    terminal_context: OccurrenceRef
+    steps: tuple[RunStepEvidence, ...]
+
+
+def define_run_chain(
+    builder: LinkNetworkBuilder,
+    root: OccurrenceRef,
+    acts: Sequence[OccurrenceRef],
+) -> OccurrenceRef:
+    """Construct the exact ordered container ``fold(R, A_0 ... A_n)``."""
+
+    current = root
+    for act in acts:
+        cell = builder.reserve()
+        builder.define(cell, current, act)
+        current = cell
+    return current
+
+
+def replay_run(network: LinkNetwork, evidence: RunEvidence) -> tuple[OccurrenceRef, ...]:
+    """Replay exact run ordering and persistent-context continuity read-only."""
+
+    before_snapshot = network.snapshot()
+    try:
+        _verify_run_chain(network, evidence)
+        if not evidence.steps:
+            if evidence.run_root is not network.root:
+                raise RunReplayError("empty run must terminate at exact root")
+            if evidence.initial_context is not evidence.terminal_context:
+                raise RunReplayError("empty run cannot change terminal context")
+            _validate_context(network, evidence.initial_context, "initial")
+            return ()
+
+        previous_after: OccurrenceRef | None = None
+        acts: list[OccurrenceRef] = []
+        for index, step in enumerate(evidence.steps):
+            _validate_context(network, step.before_context, f"step {index} before")
+            _validate_context(network, step.after_context, f"step {index} after")
+            _verify_step_act(network, step, index)
+
+            if index == 0 and step.before_context is not evidence.initial_context:
+                raise RunReplayError("first act does not start at exact initial context")
+            if previous_after is not None and step.before_context is not previous_after:
+                raise RunReplayError("adjacent acts do not share the same exact context")
+            previous_after = step.after_context
+            acts.append(step.act)
+
+        if previous_after is not evidence.terminal_context:
+            raise RunReplayError("last act does not end at exact terminal context")
+        return tuple(acts)
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise RunReplayError("run replay mutated the network")
+
+
+def _verify_run_chain(network: LinkNetwork, evidence: RunEvidence) -> None:
+    current = evidence.run_root
+    for step in reversed(evidence.steps):
+        if current is network.root:
+            raise RunReplayError("run chain ended before all selected acts")
+        cell = network.link(current)
+        if cell.end is not step.act:
+            raise RunReplayError("run chain order or exact act occurrence is forged")
+        current = cell.start
+    if current is not network.root:
+        raise RunReplayError("run chain does not terminate at exact root")
+
+
+def _validate_context(network: LinkNetwork, context: OccurrenceRef, label: str) -> None:
+    try:
+        current_of_context(network, context)
+    except FoundationStateError as exc:
+        raise RunReplayError(f"{label} context is invalid") from exc
+
+
+def _verify_step_act(network: LinkNetwork, step: RunStepEvidence, index: int) -> None:
+    try:
+        _, _, header_after = act_header(network, step.act)
+    except FoundationStateError as exc:
+        raise RunReplayError(f"step {index} has invalid actual-act header") from exc
+    if header_after is not step.after_context:
+        raise RunReplayError(f"step {index} act header selects another after-context")
+
+    before_values = act_values(network, step.act, step.before_role)
+    after_values = act_values(network, step.act, step.after_role)
+    if before_values != (step.before_context,):
+        raise RunReplayError(f"step {index} has forged/ambiguous before-context field")
+    if after_values != (step.after_context,):
+        raise RunReplayError(f"step {index} has forged/ambiguous after-context field")

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -2,7 +2,7 @@
 
 Статус: **production/reference candidate**, не accepted release.
 
-Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory #243/#244, source front-end #245/#246, relation replay #247/#248 и persistent scoped `D` + `:` #249/#250. Текущий слой: local exact representative `=` #251. Sequence-deserialization: #242. Persistent L4 backend: #124.
+Главный epic: #237. Завершены exact-occurrence substrate #240/#241, state/apamemory #243/#244, source front-end #245/#246, relation replay #247/#248, persistent scoped `D` + `:` #249/#250 и local `=` #251/#252. Текущий слой: exact multistep run #253. Sequence-deserialization: #242. Persistent L4 backend: #124.
 
 Цель Gate P — собрать **один** production/reference semantic path, затем опубликовать следующую версию МТС, которую сможет точно потреблять `aprover`.
 
@@ -20,7 +20,8 @@ binary link ontology
 → explicit K/current
 → one trusted interpreter/replay engine
 → relation / : / = acts
-→ exact multistep/proof replay
+→ exact ordered run of actual acts
+→ separately admitted theory-rule/proof replay
 → accepted contract
 → aprover
 ```
@@ -34,6 +35,7 @@ structure != exact occurrence identity
 read/find/replay != materialize
 candidate search != trusted replay
 local equality != global rewrite system
+act adjacency != logical transitivity
 ```
 
 ## 2. Production substrate
@@ -46,20 +48,7 @@ Link(start,end)
 LinkNetwork
 ```
 
-`Link` имеет только два полюса. На нём нет фундаментальных полей:
-
-```text
-meaning
-kind
-context
-theory
-axiom
-role
-token
-astNode
-```
-
-Sharing и cycles — native конечная структура. Два occurrences могут иметь одинаковые полюса и всё же оставаться различёнными:
+`Link` имеет только `start/end`; sharing и cycles являются native конечной структурой.
 
 ```text
 X1 = a ⟼ b
@@ -71,20 +60,15 @@ Shape/isomorphism и physical backend address не определяют semantic
 
 ## 3. Source, context и actual act — тоже связи
 
-### 3.1. Source content и occurrence
-
-Lower byte protocol предоставляет exact refs `B(byte)`.
+Source content и occurrence:
 
 ```text
 C0 = R
 C(n+1) = Cn ⟼ B(byte_n)
-
 S = S ⟼ C
 ```
 
-Одинаковые bytes могут разделять canonical `C`, но иметь разные exact source occurrences `S1`, `S2`.
-
-### 3.2. Контекст
+Context:
 
 ```text
 P = parent ⟼ current
@@ -92,44 +76,32 @@ K = K ⟼ P
 ↑ = current from exact active K
 ```
 
-`↑` не process-global variable. Trusted act обязан назвать exact `K`.
-
-### 3.3. Actual act
-
-Минимальный Gate-R bootstrap:
+Actual act:
 
 ```text
 P0 = D_roles ⟼ K_after
 H  = I ⟼ P0
 A  = A ⟼ H
-```
 
-Расширяемые поля:
-
-```text
 Field = roleRef ⟼ value
 A ⟼ Field
 ```
 
-`roleRef` разрешается через explicit scoped `D_roles`. Host field name — checker API, не semantic identity.
+Host field names — checker API, а semantic role identity задаётся exact refs.
 
 ## 4. Один source front-end
-
-Production source path не доверяет lexer/token/AST classes как смыслу:
 
 ```text
 raw bytes
 → canonical C
 → exact S
 → untrusted candidate segmentation
-→ selected exact source spans
+→ selected exact spans
 → visible scoped-D declaration occurrences
 → ordered exact forms
 → explicit G/T admission
 → read-only replay
 ```
-
-Candidate search может использовать trie, regex, indices, longest-match или UI. Trusted replay проверяет **selected evidence**.
 
 Selected slice:
 
@@ -141,21 +113,9 @@ Resolution = Lexeme ⟼ form
 Selection = visibleDefinitionOccurrence ⟼ Resolution
 ```
 
-UTF-8 `⟼` может быть одним многобайтным slice. Host byte offsets остаются transport/checker coordinates.
+UTF-8 `⟼` может быть одним многобайтным selected slice. Candidate search может использовать любые эвристики, но trusted replay проверяет selected exact evidence.
 
-Порядок:
-
-```text
-SelectedSequence = fold(R, Selection_0 ... Selection_n)
-FormSequence     = fold(R, Form_0 ... Form_n)
-
-G ⟼ FormSequence
-T ⟼ FormSequence
-```
-
-## 5. Один persistent scoped dictionary D
-
-Production path использует только persistent lexical scope snapshots:
+## 5. Persistent scoped dictionary D
 
 ```text
 ScopePayload = parentScope ⟼ localHistory
@@ -171,41 +131,26 @@ H_after    = H_before ⟼ Occurrence
 D_after    = D_after ⟼ (sameParentScope ⟼ H_after)
 ```
 
-Нужно различать `Entry` как mapping и `Occurrence` как конкретное declaration occurrence.
-
 Lookup:
-
-```text
-D.localHistory
-→ history cells backwards
-→ exact Occurrence
-→ exact Entry
-```
-
-Если локального mapping нет — explicit parent scope.
-
-Правила:
 
 ```text
 local first
 local mapping shadows parent
 local miss falls through to parent
 same local source + same form = one mapping, many declaration occurrences allowed
-distinct local forms for same source = conflict
+distinct local forms = conflict
 no last-write-wins
 ```
 
-Произвольное `D_old ⟼ Entry` где-то в сети не считается видимым без exact history/parent path.
+Arbitrary global `D_old⟼Entry` is not visible without exact history/parent reachability.
 
 ## 6. Один interpreter/replay engine
-
-После source front-end интерпретатор не строит вторую semantic representation. Его trusted input уже состоит из exact evidence.
 
 ### 6.1. Relation-resolution act
 
 ```text
 exact source evidence
-→ selected partial form F
+→ selected partial F
 → exact K/current
 → binding = ↑
 → structural pole resolution
@@ -214,46 +159,16 @@ exact source evidence
 → actual A
 ```
 
-Для:
-
 ```text
-F = F ⟼ e
+F = F ⟼ e  => X = current ⟼ e
+F = b ⟼ F  => X = b ⟼ current
 ```
 
-получаем:
+Direction comes from exact form structure, not glyph/AST/opcode.
 
-```text
-X = current ⟼ e
-```
+### 6.2. Persistent `:`
 
-Для:
-
-```text
-F = b ⟼ F
-```
-
-получаем:
-
-```text
-X = b ⟼ current
-```
-
-Направление выводится из exact structural form, не из glyph/AST/opcode.
-
-### 6.2. Exact result
-
-Если:
-
-```text
-X1 = a ⟼ b
-X2 = a ⟼ b
-```
-
-act может выбрать `X2`. Replay проверяет exact `X2` через poles, `K_after.current` и `A.result`; pair uniqueness не предполагается.
-
-### 6.3. Persistent `:` — тот же engine
-
-`:` replay проверяет уже присутствующую candidate effect network:
+The same engine verifies:
 
 ```text
 S = S ⟼ sourceContent
@@ -264,171 +179,167 @@ parent(D_after) = parent(D_before)
 history(D_after) = H_after
 ```
 
-Новый occurrence должен быть видим из `D_after`, но не ретроактивно из immutable `D_before`.
-
 ```text
 : != =
 : != theorem assertion
 : != recursive RHS evaluation
 ```
 
-Replay не materialize-ит Entry/history/D_after — он их проверяет.
-
-## 7. Local exact representative `=` — тот же engine
-
-Gate #251 интегрирует `=` как **локальное отношение внутри exact K**, а не как глобальное свойство всей асети.
-
-Context topology сохраняется:
+### 6.3. Local exact representative `=`
 
 ```text
 K = K ⟼ (parent ⟼ current)
-```
-
-Дополнительный local representative constraint:
-
-```text
-Pair    = member ⟼ representative
+Pair = member ⟼ representative
 Binding = K ⟼ Pair
 ```
 
-Важно: сам exact occurrence `K` является context topology и не считается equality binding, хотя его `start` тоже равен `K`.
-
-### 7.1. One-hop representative
-
 ```text
-rep_K(x) = explicit local representative, если mapping однозначен
-         = x, если mapping отсутствует
+rep_K(x) = one explicit local representative, else x
+Equal_K(a,b) iff rep_K(a) and rep_K(b) are the same exact occurrence
 ```
 
-И:
+Only one hop is used. Duplicate same-representative occurrences are unambiguous provenance; distinct representatives conflict.
+
+No automatic transitivity, substitution, congruence, global rewrite or graph-shape equality is imported. Equality evaluation is itself an actual `A`; host boolean is only convenience.
+
+Relation decomposition is not built into `=` and may only appear later as a separately admitted one-step `T` rule.
+
+## 7. Exact multistep run
+
+Gate #253 adds the production run-continuity layer needed by `aprover` without inventing a new proof calculus.
+
+### 7.1. Ordered run container
 
 ```text
-Equal_K(a,b)
-iff
-rep_K(a) and rep_K(b) are the same exact occurrence
+Run_0 = R
+Run_(i+1) = Run_i ⟼ A_i
 ```
 
-Никакого recursive alias chasing.
+The final exact `Run_n` identifies the selected run. Host array order is not semantic authority: trusted replay walks the exact run links backwards and confirms every exact `A_i` in order.
 
-Если:
+### 7.2. Generic act boundaries
+
+Each selected step supplies exact role refs for:
 
 ```text
-K: a → b
-K: b → c
+A ⟼ (beforeRole ⟼ K_before)
+A ⟼ (afterRole  ⟼ K_after)
 ```
 
-то:
+and the Gate-R act header must also select the same exact `K_after`.
+
+For an observational/no-context-change act:
 
 ```text
-rep_K(a) = b
-rep_K(b) = c
+K_before = K_after
 ```
 
-следовательно `Equal_K(a,b)` в таком состоянии **false**. Автоматическое транзитивное замыкание не выполняется.
+This permits relation, `:`, `=` and later admitted theory-rule acts to share one run protocol without the run checker reimplementing their operator semantics.
 
-### 7.2. Duplicate и conflict
+### 7.3. Exact continuity
 
-Повторные exact bindings:
+The semantic invariant is:
 
 ```text
-K: a → r
-K: a → r
+A_i.after = K_(i+1)
+A_(i+1).before = K_(i+1)
 ```
 
-могут существовать как два occurrence provenance, но mapping остаётся однозначным:
+using **the same exact occurrence ref**.
+
+Two contexts with the same parent/current topology are not interchangeable:
 
 ```text
-rep_K(a) = r
+K1  = K1  ⟼ (P ⟼ X)
+K1' = K1' ⟼ (P ⟼ X)
+K1 != K1'
 ```
 
-Если же:
+So:
 
 ```text
-K: a → r1
-K: a → r2
-r1 != r2
+A0.after = K1
+A1.before = K1'
 ```
 
-lookup/replay отклоняется как local representative conflict. Last-write-wins отсутствует.
+is a broken run even though the snapshots look the same.
 
-### 7.3. Shape не создаёт equality
+### 7.4. Cycles, branches and repeated acts
 
-Пусть:
+Finite returns are ordinary finite runs:
 
 ```text
-X1 = X1 ⟼ X1
-X2 = X2 ⟼ X2
-X1 != X2
+K0 --A0--> K1 --A1--> K0
 ```
 
-Без local representative evidence:
+No recursive graph unfolding is needed.
+
+Two candidate branches may coexist:
 
 ```text
-rep_K(X1) = X1
-rep_K(X2) = X2
-Equal_K(X1,X2) = false
+          A1 → K1
+K0 ──────┤
+          A2 → K2
 ```
 
-То есть другой self-cycle не становится `∞` и две одинаковые формы не становятся равными только по graph isomorphism.
+Trusted replay validates only the exact selected run. Branch discovery/ranking belongs to untrusted proof search.
 
-### 7.4. Equality evaluation является actual act
-
-Результат проверки не должен существовать только как временный host boolean.
-
-Actual `A` фиксирует exact evidence ролей:
+Otherwise-identical no-op acts can remain different exact occurrences:
 
 ```text
-context
-left
-right
-left-representative
-right-representative
+K0 --A0--> K0 --A1--> K0
+A0 != A1
 ```
 
-Host API может вернуть `true/false` для удобства, но доверенная семантика — это replay exact `K`, exact representative bindings и actual `A`.
+and the run chain preserves their exact order.
 
-И equal, и non-equal evaluation являются допустимыми actual acts.
+### 7.5. What adjacency does not mean
 
-### 7.5. Чего `=` намеренно не делает
-
-Нет автоматических:
+From:
 
 ```text
-transitivity
+K0 --A0--> K1 --A1--> K2
+```
+
+the run checker does **not** infer or materialize:
+
+```text
+K0 → K2
+```
+
+and does not derive:
+
+```text
+logical transitivity
+modus ponens
+theorem status
 substitution
 congruence
-global rewriting
-recursive rewriting
-shape/isomorphism equality
-bisimulation equality
 ```
 
-Relation decomposition:
+Run continuity is execution/provenance structure, not a logical rule.
+
+### 7.6. Layered trust boundary for aprover
 
 ```text
-(a⟼b) = (c⟼d)
-→ a=c, b=d
+untrusted proof search
+→ selected exact acts + Run_n
+→ replay each act with the unified interpreter engine
+→ replay exact run continuity
+→ replay separately admitted T rules
 ```
 
-**не встроена в equality core**. Она допустима только как отдельно admitted one-step rule через `T` в последующем proof/inference gate и не запускается рекурсивно сама собой.
+This separation means the algorithm that *found* a proof does not need to be trusted if the chosen proof can be replayed deterministically.
 
 ## 8. Апамять как controller сети
 
 Подробно: [Апамять и управление сетью связей](Апамять%20и%20управление%20сетью%20связей.md).
 
-Operational split:
-
 ```text
-read / find / enumerate / replay
-        │
-        └── наблюдают существующую сеть
-
-materialize / delete
-        │
-        └── явные effects
+read / find / enumerate / replay != materialize / delete
 ```
 
-Поэтому:
+Therefore:
 
 ```text
 source carrier != result network
@@ -436,65 +347,47 @@ query description != queried fact
 replay evidence != application effect
 ```
 
-И local equality даёт ещё один прикладной пример: «равенство» не вычисляется скрытым comparator по всей памяти, а является explicit context-local relation, которую можно хранить, искать и replay-ить как часть сети.
+Context, dictionary scopes, local equality bindings, actual acts and run containers are all ordinary link-network evidence. This is the practical value of apamemory: program state and proof provenance can live in the same exact relational substrate as application data without becoming hidden host metadata.
 
-## 9. Ачисло и будущая sequence deserialization
+## 9. Ачисло и future sequence deserialization
 
-Recursive Anum уже является root-relative structural description на occurrence-tree области, но это не полная operational semantics произвольной последовательности.
+Recursive Anum is already a root-relative structural description on its occurrence-tree domain, but full sequence materialization remains #242.
 
-Отдельный gate #242 проверит исторический принцип:
+Candidate historical principle:
 
 ```text
 ∞ A B C
 ```
 
-как последовательностное описание, которое после **явной** materialization может построить:
+may explicitly materialize:
 
 ```text
 A ⟼ B
 B ⟼ C
 ```
 
-с nested-context semantics.
+with nested-context semantics, but only after executable #242 acceptance.
 
-Не смешиваем:
+We keep separate:
 
 ```text
-source front-end     = read/resolve source evidence
-interpreter replay   = validate selected semantic act
-Anum→апамять         = explicit result-network materialization
+source front-end   = read/resolve source evidence
+interpreter replay = validate selected semantic act
+run replay         = validate exact act order/K continuity
+Anum→апамять       = explicit result-network materialization
 ```
 
-## 10. Что должна получить следующая версия для aprover
+## 10. Next proof gate
 
-`aprover` должен потреблять published versioned contract + conformance corpus, а не заново определять МТС.
+After #253, the next step toward `aprover` is **separately admitted theory-rule replay**, not another global operator semantics.
 
-Trusted checker path:
+In particular, relation decomposition may be represented as an explicit `T`-admitted one-step rule that emits local pole constraints, but it must not become a hidden built-in consequence of `=` and must not recurse automatically.
 
-```text
-exact source/evidence
-→ scoped D resolution + G/T admission
-→ exact K/current/local representatives
-→ selected act semantics
-→ exact result/state transition
-→ actual A
-→ exact multistep adjacency
-→ deterministic read-only replay
-```
-
-Proof search, ranking, indices и UI могут быть эвристическими. Доверенная часть проверяет selected exact relations.
-
-## 11. Следующий слой после #251
-
-После local `=` следующий gate должен быть не ещё одним оператором, а **multistep/proof integration** над уже существующими actual acts.
-
-Нужно переиспользовать принятое exact-adjacency направление #230/#227 и затем отдельно admitted theory rules. Это будет непосредственный мост к новой версии МТС для `aprover`.
-
-## 12. Что ещё блокирует release
+## 11. Remaining release path
 
 ```text
-local `=` #251
-→ multistep/proof integration
+exact multistep run #253
+→ separately admitted theory-rule/proof replay
 → sequence-to-apamemory #242
 → persistent L4 boundary #124
 → historical compatibility classification
@@ -505,10 +398,10 @@ local `=` #251
 → repin aprover
 ```
 
-Запрещён итоговый режим:
+Forbidden final state:
 
 ```text
 legacy semantics + Foundation-v2 semantics selectable by flag
 ```
 
-После acceptance активный production tree должен иметь один canonical semantic path. Историю сохраняет Git.
+After acceptance the active production tree must contain one canonical semantic path; Git preserves history.

--- a/tests/test_mts_foundation_v2_run.py
+++ b/tests/test_mts_foundation_v2_run.py
@@ -218,6 +218,12 @@ def test_empty_run_is_exact_identity_not_state_change() -> None:
     )
     network = builder.freeze(root)
 
+    # Diagnostic exact-identity assertions are intentional: the run contract must
+    # use the same network-issued occurrence identity as the substrate itself.
+    assert network.root is root
+    assert evidence.run_root is root
+    assert evidence.run_root is network.root
+    assert evidence.initial_context is evidence.terminal_context
     assert replay_run(network, evidence) == ()
 
 

--- a/tests/test_mts_foundation_v2_run.py
+++ b/tests/test_mts_foundation_v2_run.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_run import (
+    RunEvidence,
+    RunReplayError,
+    RunStepEvidence,
+    define_run_chain,
+    replay_run,
+)
+from core.foundation_v2_state import (
+    define_act_field,
+    define_act_header,
+    define_context,
+    define_dictionary_scope,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _context(builder: LinkNetworkBuilder, parent=None, current=None):
+    return define_context(
+        builder,
+        parent if parent is not None else _anchor(builder),
+        current if current is not None else _anchor(builder),
+    )
+
+
+def _act(builder, root, before, after, before_role=None, after_role=None):
+    interpreter = _anchor(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    before_role = before_role or _anchor(builder)
+    after_role = after_role or _anchor(builder)
+    act = define_act_header(builder, interpreter, role_dictionary, after)
+    define_act_field(builder, act, before_role, before)
+    define_act_field(builder, act, after_role, after)
+    return RunStepEvidence(
+        act=act,
+        before_context=before,
+        after_context=after,
+        before_role=before_role,
+        after_role=after_role,
+    )
+
+
+def _run(builder, root, steps, initial, terminal):
+    run_root = define_run_chain(builder, root, tuple(step.act for step in steps))
+    return RunEvidence(
+        run_root=run_root,
+        initial_context=initial,
+        terminal_context=terminal,
+        steps=tuple(steps),
+    )
+
+
+def test_linear_run_replays_exact_k_continuity_read_only() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    k2 = _context(builder)
+    step0 = _act(builder, root, k0, k1)
+    step1 = _act(builder, root, k1, k2)
+    evidence = _run(builder, root, (step0, step1), k0, k2)
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    assert replay_run(network, evidence) == (step0.act, step1.act)
+    assert network.snapshot() == before
+
+
+def test_reordered_selected_steps_reject_against_exact_run_chain() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    k2 = _context(builder)
+    step0 = _act(builder, root, k0, k1)
+    step1 = _act(builder, root, k1, k2)
+    good = _run(builder, root, (step0, step1), k0, k2)
+    forged = replace(good, steps=(step1, step0))
+    network = builder.freeze(root)
+
+    with pytest.raises(RunReplayError, match="order or exact act"):
+        replay_run(network, forged)
+
+
+def test_shape_equivalent_but_distinct_context_breaks_continuity() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    parent = _anchor(builder)
+    current = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder, parent, current)
+    k1_copy = _context(builder, parent, current)
+    k2 = _context(builder)
+    step0 = _act(builder, root, k0, k1)
+    step1 = _act(builder, root, k1_copy, k2)
+    evidence = _run(builder, root, (step0, step1), k0, k2)
+    network = builder.freeze(root)
+
+    assert k1 is not k1_copy
+    with pytest.raises(RunReplayError, match="same exact context"):
+        replay_run(network, evidence)
+
+
+def test_two_occurrence_distinct_noop_acts_survive_order() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    before_role = _anchor(builder)
+    after_role = _anchor(builder)
+    step0 = _act(builder, root, k0, k0, before_role, after_role)
+    step1 = _act(builder, root, k0, k0, before_role, after_role)
+    evidence = _run(builder, root, (step0, step1), k0, k0)
+    network = builder.freeze(root)
+
+    assert step0.act is not step1.act
+    assert replay_run(network, evidence) == (step0.act, step1.act)
+
+
+def test_finite_context_return_replays_without_recursive_unfolding() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    step0 = _act(builder, root, k0, k1)
+    step1 = _act(builder, root, k1, k0)
+    evidence = _run(builder, root, (step0, step1), k0, k0)
+    network = builder.freeze(root)
+
+    assert replay_run(network, evidence) == (step0.act, step1.act)
+
+
+def test_unselected_branch_candidate_does_not_affect_selected_run() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    k_branch = _context(builder)
+    selected = _act(builder, root, k0, k1)
+    branch = _act(builder, root, k0, k_branch)
+    evidence = _run(builder, root, (selected,), k0, k1)
+    network = builder.freeze(root)
+
+    assert branch.act is not selected.act
+    assert replay_run(network, evidence) == (selected.act,)
+
+
+def test_forged_before_field_rejects() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    wrong = _context(builder)
+    step = _act(builder, root, k0, k1)
+    define_act_field(builder, step.act, step.before_role, wrong)
+    evidence = _run(builder, root, (step,), k0, k1)
+    network = builder.freeze(root)
+
+    with pytest.raises(RunReplayError, match="before-context field"):
+        replay_run(network, evidence)
+
+
+def test_forged_terminal_rejects() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    wrong_terminal = _context(builder)
+    step = _act(builder, root, k0, k1)
+    evidence = _run(builder, root, (step,), k0, wrong_terminal)
+    network = builder.freeze(root)
+
+    with pytest.raises(RunReplayError, match="terminal context"):
+        replay_run(network, evidence)
+
+
+def test_run_construction_does_not_materialize_context_shortcut() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    k1 = _context(builder)
+    k2 = _context(builder)
+    step0 = _act(builder, root, k0, k1)
+    step1 = _act(builder, root, k1, k2)
+    evidence = _run(builder, root, (step0, step1), k0, k2)
+    network = builder.freeze(root)
+
+    assert replay_run(network, evidence)
+    assert not any(
+        network.link(ref).start is k0 and network.link(ref).end is k2
+        for ref in network.refs
+    )
+
+
+def test_empty_run_is_exact_identity_not_state_change() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    evidence = RunEvidence(
+        run_root=root,
+        initial_context=k0,
+        terminal_context=k0,
+        steps=(),
+    )
+    network = builder.freeze(root)
+
+    assert replay_run(network, evidence) == ()
+
+
+def test_run_module_has_no_legacy_proof_or_interpreter_dependency() -> None:
+    source = (ROOT / "core/foundation_v2_run.py").read_text(encoding="utf-8")
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert "mtc_interpreter" not in source
+    assert "proof_checker" not in source
+    assert "transitiv" not in source.lower()

--- a/tests/test_mts_foundation_v2_run.py
+++ b/tests/test_mts_foundation_v2_run.py
@@ -218,8 +218,6 @@ def test_empty_run_is_exact_identity_not_state_change() -> None:
     )
     network = builder.freeze(root)
 
-    # Diagnostic exact-identity assertions are intentional: the run contract must
-    # use the same network-issued occurrence identity as the substrate itself.
     assert network.root is root
     assert evidence.run_root is root
     assert evidence.run_root is network.root
@@ -233,4 +231,6 @@ def test_run_module_has_no_legacy_proof_or_interpreter_dependency() -> None:
     assert "mtc_ast" not in source
     assert "mtc_interpreter" not in source
     assert "proof_checker" not in source
-    assert "transitiv" not in source.lower()
+    assert "def transitive" not in source.lower()
+    assert "transitive_closure" not in source.lower()
+    assert "derive_transitive" not in source.lower()


### PR DESCRIPTION
Closes #253 after explicit decision if CI/evidence is accepted. Parent: #237. Reuses final Gate-L decision #230/#227 and composes the already-accepted Gate-P actual acts.

## Exact run container

```text
Run_0 = R
Run_(i+1) = Run_i ⟼ A_i
```

Trusted replay reconstructs exact order from the link chain; host array indices are only checker handles.

## Exact K continuity

Each step supplies exact before/after role refs:

```text
A ⟼ (beforeRole ⟼ K_before)
A ⟼ (afterRole  ⟼ K_after)
```

and the actual-act header must select the same K_after. Adjacent steps require the **same exact occurrence**:

```text
A_i.after is A_(i+1).before
```

Shape-equivalent but distinct K snapshots reject.

## Evidence

Tests cover linear runs, reordering, shape-equal/exact-distinct context mismatch, occurrence-distinct no-op acts, finite K0→K1→K0 returns, unselected branches, forged fields/terminal state, empty run identity and absence of a materialized K0→Kn shortcut.

## Trust boundary

Run replay does not reimplement relation/`:`/`=` semantics and does not infer logical transitivity, theorem status, substitution or congruence. The intended aprover stack is:

```text
untrusted proof search
→ replay selected individual acts
→ replay exact Run continuity
→ replay separately admitted T rules
```

`docs/specs/Foundation v2 Gate P.md` documents this layering.

## Still out of scope

- separately admitted theory-rule/proof semantics (next);
- #242 Anum→апамять materialization;
- #124 persistent L4;
- cutover / aprover repin.