### PR TITLE
Gate P: replay separately admitted one-step equality decomposition

### DIFF
--- a/contracts/mts-foundation-v2-proof-rule-v0.7.json
+++ b/contracts/mts-foundation-v2-proof-rule-v0.7.json
@@ -1,0 +1,87 @@
+{
+  "schema": "mts-foundation-v2-proof-rule/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 255,
+  "parent": 237,
+  "dependsOn": [
+    "mts-foundation-v2-equality/v0.7",
+    "mts-foundation-v2-run/v0.7",
+    "mts-foundation-v2-interpreter-replay/v0.7"
+  ],
+  "firstRule": {
+    "name": "decompose-equal-complete-links-one-step",
+    "premise": "a replayed true local equality evaluation Equal_K(L,R)",
+    "left": "L = l_start ⟼ l_end, complete exact occurrence",
+    "right": "R = r_start ⟼ r_end, complete exact occurrence",
+    "startClaim": "C_start = l_start ⟼ r_start",
+    "endClaim": "C_end = l_end ⟼ r_end",
+    "recursive": false,
+    "claimsMutateEqualityContext": false,
+    "claimsAreTheoremClosure": false
+  },
+  "admission": {
+    "membership": "RuleMembership = T ⟼ Rule",
+    "exactMembershipOccurrenceVerified": true,
+    "hostRuleEnumIsSemanticAuthority": false,
+    "ruleInferredFromOperandShape": false
+  },
+  "premiseReplay": {
+    "usesExistingEqualityReplay": true,
+    "premiseActMustBeExact": true,
+    "premiseMustEvaluateTrue": true,
+    "leftRightMustBeSameExactOccurrencesAsPremise": true,
+    "shapeEquivalentSubstitutionAllowed": false
+  },
+  "applicationAct": {
+    "sameGateRActualActArchitecture": true,
+    "observational": true,
+    "beforeContextEqualsAfterContextByExactOccurrence": true,
+    "requiredRoles": [
+      "premise-equality-act",
+      "theory",
+      "rule",
+      "rule-membership",
+      "left-relation",
+      "right-relation",
+      "start-claim",
+      "end-claim",
+      "before-context",
+      "after-context"
+    ]
+  },
+  "trustBoundary": {
+    "proofSearchTrusted": false,
+    "ruleSelectionTrustedByDefault": false,
+    "selectedEvidenceReplayed": true,
+    "snapshotStable": true,
+    "implicitMaterialization": false,
+    "automaticRepresentativeBindings": false,
+    "automaticNestedRuleFiring": false,
+    "logicalTransitivityInferred": false,
+    "substitutionInferred": false,
+    "congruenceInferred": false,
+    "graphIsomorphismEquality": false
+  },
+  "requiredVectors": [
+    "true local equality plus exact T membership yields exactly two first-level claims",
+    "false equality premise rejects",
+    "membership from another theory rejects",
+    "shape-equal but exact-distinct premise operand substitution rejects",
+    "partial/self-closed relation rejects",
+    "forged start/end claim rejects",
+    "observational rule cannot change exact K",
+    "conflicting required actual-act field rejects",
+    "nested relation poles stay opaque and are not recursively decomposed",
+    "rule replay adds no local representative binding and does not mutate snapshot"
+  ],
+  "aproverLayering": [
+    "untrusted proof search proposes exact evidence",
+    "replay premise actual act",
+    "verify exact T rule admission",
+    "replay exact one-step rule application",
+    "compose application actual act in exact Run",
+    "later integrated conformance decides release"
+  ],
+  "nextGate": "integrated Foundation-v2 proof/checker conformance over source, scoped D/G/T, K, acts, runs and admitted rules"
+}

--- a/core/foundation_v2_proof.py
+++ b/core/foundation_v2_proof.py
@@ -1,0 +1,212 @@
+"""Foundation-v2 proof-rule replay over exact actual acts.
+
+This module does not introduce a proof AST or a second interpreter.  It composes
+already-trusted primitives from the Gate-P replay spine.  The first rule is an
+explicitly theory-admitted, one-step decomposition of a *replayed true local
+equality* between two complete exact binary links.
+
+The rule produces exact claim occurrences only.  It does not mutate the local
+representative network, recursively decompose nested links, assert theorem
+closure, or materialize any application link while replaying.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .exact_link_network import LinkNetwork, OccurrenceRef
+from .foundation_v2_interpreter import (
+    EqualityEvaluationEvidence,
+    InterpreterReplayError,
+    replay_equality_evaluation,
+)
+from .foundation_v2_state import FoundationStateError, act_header, act_values
+
+
+class ProofRuleReplayError(ValueError):
+    """Selected proof-rule evidence is forged, inadmissible or inconsistent."""
+
+
+@dataclass(frozen=True)
+class DecomposeEqualityRoleRefs:
+    """Exact role refs used by one decomposition-rule actual act."""
+
+    premise_equality_act: OccurrenceRef
+    theory: OccurrenceRef
+    rule: OccurrenceRef
+    rule_membership: OccurrenceRef
+    left_relation: OccurrenceRef
+    right_relation: OccurrenceRef
+    start_claim: OccurrenceRef
+    end_claim: OccurrenceRef
+    before_context: OccurrenceRef
+    after_context: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class DecomposeEqualityEvidence:
+    """Exact evidence for one admitted equality-decomposition application."""
+
+    premise: EqualityEvaluationEvidence
+    interpreter: OccurrenceRef
+    theory: OccurrenceRef
+    rule: OccurrenceRef
+    rule_membership: OccurrenceRef
+    left_relation: OccurrenceRef
+    right_relation: OccurrenceRef
+    start_claim: OccurrenceRef
+    end_claim: OccurrenceRef
+    before_context: OccurrenceRef
+    after_context: OccurrenceRef
+    act: OccurrenceRef
+    role_dictionary: OccurrenceRef
+    roles: DecomposeEqualityRoleRefs
+
+
+def replay_decompose_equal_relations(
+    network: LinkNetwork,
+    evidence: DecomposeEqualityEvidence,
+) -> tuple[OccurrenceRef, OccurrenceRef]:
+    """Replay one explicitly admitted, non-recursive equality decomposition.
+
+    Premise:
+        a previously represented equality evaluation ``Equal_K(L, R)``.
+
+    Conclusions:
+        exact claim links ``L.start ⟼ R.start`` and ``L.end ⟼ R.end``.
+
+    The claims are evidence only.  No equality binding is added to ``K`` and no
+    nested decomposition is attempted.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        _verify_true_exact_premise(network, evidence)
+        _verify_rule_membership(network, evidence)
+
+        left = _complete_relation(network, evidence.left_relation, "left")
+        right = _complete_relation(network, evidence.right_relation, "right")
+
+        start_claim = network.link(evidence.start_claim)
+        if start_claim.start is not left.start or start_claim.end is not right.start:
+            raise ProofRuleReplayError("forged start-pole equality claim")
+
+        end_claim = network.link(evidence.end_claim)
+        if end_claim.start is not left.end or end_claim.end is not right.end:
+            raise ProofRuleReplayError("forged end-pole equality claim")
+
+        if evidence.before_context is not evidence.after_context:
+            raise ProofRuleReplayError(
+                "decomposition is observational and must preserve exact K"
+            )
+        if evidence.before_context is not evidence.premise.context:
+            raise ProofRuleReplayError(
+                "proof-rule context differs from exact equality-premise context"
+            )
+
+        _verify_act_header(network, evidence)
+        _verify_act_fields(network, evidence)
+        return evidence.start_claim, evidence.end_claim
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise ProofRuleReplayError("proof-rule replay mutated the network")
+
+
+def _verify_true_exact_premise(
+    network: LinkNetwork,
+    evidence: DecomposeEqualityEvidence,
+) -> None:
+    if evidence.premise.left is not evidence.left_relation:
+        raise ProofRuleReplayError("left relation differs from equality premise")
+    if evidence.premise.right is not evidence.right_relation:
+        raise ProofRuleReplayError("right relation differs from equality premise")
+    if evidence.premise.context is not evidence.before_context:
+        raise ProofRuleReplayError("equality premise belongs to another exact context")
+    try:
+        premise_true = replay_equality_evaluation(network, evidence.premise)
+    except InterpreterReplayError as exc:
+        raise ProofRuleReplayError("invalid equality-premise evidence") from exc
+    if not premise_true:
+        raise ProofRuleReplayError("equality-decomposition premise is false")
+
+
+def _verify_rule_membership(
+    network: LinkNetwork,
+    evidence: DecomposeEqualityEvidence,
+) -> None:
+    membership = network.link(evidence.rule_membership)
+    if membership.start is not evidence.theory or membership.end is not evidence.rule:
+        raise ProofRuleReplayError("selected rule is not admitted by exact theory membership")
+
+
+def _complete_relation(network: LinkNetwork, ref: OccurrenceRef, label: str):
+    link = network.link(ref)
+    if link.start is ref or link.end is ref:
+        raise ProofRuleReplayError(f"{label} relation is partial/self-closed")
+    return link
+
+
+def _verify_act_header(
+    network: LinkNetwork,
+    evidence: DecomposeEqualityEvidence,
+) -> None:
+    try:
+        header = act_header(network, evidence.act)
+    except FoundationStateError as exc:
+        raise ProofRuleReplayError("invalid proof-rule actual-act header") from exc
+    expected = (
+        evidence.interpreter,
+        evidence.role_dictionary,
+        evidence.after_context,
+    )
+    if header != expected:
+        raise ProofRuleReplayError(
+            "proof-rule actual-act header does not match I/D_roles/K_after"
+        )
+
+
+def _verify_act_fields(
+    network: LinkNetwork,
+    evidence: DecomposeEqualityEvidence,
+) -> None:
+    expected = (
+        (
+            evidence.roles.premise_equality_act,
+            evidence.premise.act,
+            "premise-equality-act",
+        ),
+        (evidence.roles.theory, evidence.theory, "theory"),
+        (evidence.roles.rule, evidence.rule, "rule"),
+        (
+            evidence.roles.rule_membership,
+            evidence.rule_membership,
+            "rule-membership",
+        ),
+        (
+            evidence.roles.left_relation,
+            evidence.left_relation,
+            "left-relation",
+        ),
+        (
+            evidence.roles.right_relation,
+            evidence.right_relation,
+            "right-relation",
+        ),
+        (evidence.roles.start_claim, evidence.start_claim, "start-claim"),
+        (evidence.roles.end_claim, evidence.end_claim, "end-claim"),
+        (
+            evidence.roles.before_context,
+            evidence.before_context,
+            "before-context",
+        ),
+        (
+            evidence.roles.after_context,
+            evidence.after_context,
+            "after-context",
+        ),
+    )
+    for role, value, label in expected:
+        values = act_values(network, evidence.act, role)
+        if values != (value,):
+            raise ProofRuleReplayError(
+                f"proof-rule actual-act field {label!r} is missing, duplicated or forged"
+            )

--- a/docs/specs/Foundation v2 Proof replay.md
+++ b/docs/specs/Foundation v2 Proof replay.md
@@ -1,0 +1,300 @@
+# Foundation v2 — proof-rule replay candidate
+
+Статус: **Gate P candidate**, не accepted proof calculus и не разрешение на repin `aprover`.
+
+Связанные задачи: Gate P #237, local `=` #251/#252, exact run #253/#254, текущий proof-rule gate #255, future sequence→апамять #242, persistent L4 #124.
+
+## 1. Зачем нужен отдельный proof-rule слой
+
+Foundation v2 уже различает:
+
+```text
+поиск candidate
+проверку отдельного actual act
+проверку exact порядка acts
+логическое правило вывода
+```
+
+Эти вещи нельзя схлопывать.
+
+Например из того, что два соседних actual acts образуют корректный run:
+
+```text
+K0 --A0--> K1 --A1--> K2
+```
+
+не следует никакое скрытое:
+
+```text
+K0 → K2
+```
+
+и не появляется логическая транзитивность.
+
+Аналогично local equality:
+
+```text
+Equal_K(L,R) = true
+```
+
+сама по себе не должна рекурсивно разбирать `L/R` и создавать новые equality bindings. Если decomposition нужна доказательству, она должна быть **отдельно выбранным и admitted правилом**.
+
+## 2. Первый rule candidate
+
+Первое правило намеренно узкое: одношаговая decomposition истинного local equality двух завершённых бинарных связей.
+
+Premise:
+
+```text
+L = l_start ⟼ l_end
+R = r_start ⟼ r_end
+
+Equal_K(L,R) = true
+```
+
+Rule application предъявляет две exact claim-связи:
+
+```text
+C_start = l_start ⟼ r_start
+C_end   = l_end   ⟼ r_end
+```
+
+Это **claims**, а не автоматические representative bindings.
+
+После replay правила контекст K остаётся тем же:
+
+```text
+K_before = K_after = K
+```
+
+и из наличия `C_start/C_end` ещё не следует, что их полюса локально отождествлены. Следующий proof act обязан явно использовать нужную semantics.
+
+## 3. Rule должен быть явно допущен теорией
+
+Trusted checker не делает:
+
+```text
+if operands_are_links:
+    decompose()
+```
+
+В сети должно существовать exact evidence:
+
+```text
+RuleMembership = T ⟼ Rule
+```
+
+И application act должен назвать именно:
+
+```text
+T
+Rule
+RuleMembership
+```
+
+Поэтому две разные теории могут разрешать разные наборы proof rules над одной и той же low-level сетью без изменения самих данных.
+
+## 4. Premise — это replayed actual equality act
+
+Правило не доверяет host-флагу `premise=true`.
+
+Оно получает exact `EqualityEvaluationEvidence` и повторно проверяет существующую local equality semantics:
+
+```text
+rep_K(L)
+rep_K(R)
+```
+
+Premise допускается только если:
+
+```text
+rep_K(L) is rep_K(R)
+```
+
+и actual equality act содержит exact operands/representatives/context.
+
+Подмена:
+
+```text
+L → L'
+```
+
+где `L'` имеет те же полюса, но является другим occurrence, запрещена. Shape similarity не заменяет exact premise identity.
+
+## 5. Actual proof-rule act
+
+Application правила — ещё один exact actual act того же Gate-R семейства.
+
+Минимальное evidence:
+
+```text
+premise-equality-act
+theory
+rule
+rule-membership
+left-relation
+right-relation
+start-claim
+end-claim
+before-context
+after-context
+```
+
+Заголовок:
+
+```text
+P0 = D_roles ⟼ K_after
+H  = I ⟼ P0
+A  = A ⟼ H
+```
+
+Для этого observational rule:
+
+```text
+K_after = K_before
+```
+
+Так application естественно входит в exact `Run` как no-context-change step.
+
+## 6. Trusted replay
+
+Проверка выполняется в следующем порядке:
+
+```text
+1. replay exact equality premise A_eq
+2. require premise == true
+3. verify exact T ⟼ Rule membership
+4. verify L/R are complete exact links
+5. verify C_start = L.start ⟼ R.start
+6. verify C_end   = L.end   ⟼ R.end
+7. verify exact application A header/fields
+8. require exact K_before is K_after
+9. require network snapshot unchanged
+```
+
+Ни один шаг не требует доверять proof search.
+
+## 7. Правило строго одношаговое
+
+Если полюса сами являются связями:
+
+```text
+L.start  = a ⟼ b
+R.start  = c ⟼ d
+```
+
+первое применение выдаёт только:
+
+```text
+C_start = L.start ⟼ R.start
+```
+
+Оно **не** продолжает автоматически:
+
+```text
+a ⟼ c
+b ⟼ d
+```
+
+Для следующего уровня нужен новый явно выбранный rule application с собственным exact premise/admission/actual act.
+
+Это сохраняет конечность, provenance и контролируемую силу proof calculus.
+
+## 8. Связь с апамятью
+
+Этот слой хорошо показывает прикладное значение апамяти как controller-а сетей связей.
+
+В одной exact network могут одновременно находиться:
+
+```text
+application data
+K и local representatives
+T и rule membership
+actual equality act
+proof-rule actual act
+claim links
+Run, фиксирующий порядок acts
+```
+
+Но наличие этих links не означает скрытого выполнения всех возможных правил.
+
+Апамять предоставляет:
+
+```text
+find / enumerate candidate evidence
+```
+
+поисковой стороне, а trusted checker делает:
+
+```text
+replay selected exact evidence
+```
+
+без materialization новых facts.
+
+Поэтому можно построить быстрый эвристический `aprover`, не включая алгоритм поиска в trusted computing base.
+
+## 9. Что намеренно запрещено
+
+```text
+recursive rule firing by default
+global theorem closure
+automatic representative binding
+graph-isomorphism equality
+hidden modus ponens
+hidden transitivity
+hidden congruence/substitution
+host enum as Rule identity
+proof AST as ontology
+```
+
+Rule identity, theory admission, operands, claims и actual application — exact link occurrences.
+
+## 10. Ожидаемая архитектура aprover
+
+```text
+                    untrusted
+                       │
+              candidate proof search
+             indices / heuristics / UI
+                       │
+                       ▼
+                selected evidence
+                       │
+              ─────────┼─────────
+                       │ trusted
+                       ▼
+              source/D/G/T replay
+                       │
+                       ▼
+                 act replay
+             relation / : / =
+                       │
+                       ▼
+             admitted rule replay
+                       │
+                       ▼
+               exact Run replay
+                       │
+                       ▼
+                proof accepted
+```
+
+Именно versioned contracts + conformance corpus `anum_docs` должны стать источником этой trusted semantics. `aprover` после Foundation-v2 acceptance должен потреблять их, а не реализовывать собственное толкование МТС.
+
+## 11. Следующий gate
+
+После #255 нужен уже не ещё один одиночный operator, а integrated proof/checker conformance:
+
+```text
+source
++ scoped D
++ explicit G/T
++ K/local equality
++ actual acts
++ admitted rule
++ exact Run
+→ one replayable proof artifact
+```
+
+Только после такой интеграции имеет смысл двигаться к sequence→апамять #242, persistent L4 #124, production cutover и публикации следующей accepted версии МТС.

--- a/tests/test_mts_foundation_v2_proof.py
+++ b/tests/test_mts_foundation_v2_proof.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_interpreter import (
+    EqualityEvaluationEvidence,
+    EqualityRoleRefs,
+)
+from core.foundation_v2_proof import (
+    DecomposeEqualityEvidence,
+    DecomposeEqualityRoleRefs,
+    ProofRuleReplayError,
+    replay_decompose_equal_relations,
+)
+from core.foundation_v2_state import (
+    define_act_field,
+    define_act_header,
+    define_context,
+    define_dictionary_scope,
+    define_local_representative_binding,
+    define_membership,
+    local_representative,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _link(builder: LinkNetworkBuilder, start, end):
+    ref = builder.reserve()
+    builder.define(ref, start, end)
+    return ref
+
+
+def _equality_roles(builder: LinkNetworkBuilder) -> EqualityRoleRefs:
+    return EqualityRoleRefs(
+        context=_anchor(builder),
+        left=_anchor(builder),
+        right=_anchor(builder),
+        left_representative=_anchor(builder),
+        right_representative=_anchor(builder),
+    )
+
+
+def _proof_roles(builder: LinkNetworkBuilder) -> DecomposeEqualityRoleRefs:
+    return DecomposeEqualityRoleRefs(
+        premise_equality_act=_anchor(builder),
+        theory=_anchor(builder),
+        rule=_anchor(builder),
+        rule_membership=_anchor(builder),
+        left_relation=_anchor(builder),
+        right_relation=_anchor(builder),
+        start_claim=_anchor(builder),
+        end_claim=_anchor(builder),
+        before_context=_anchor(builder),
+        after_context=_anchor(builder),
+    )
+
+
+def _equality_premise(
+    builder: LinkNetworkBuilder,
+    root,
+    context,
+    left,
+    right,
+    left_rep,
+    right_rep,
+) -> EqualityEvaluationEvidence:
+    interpreter = _anchor(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    roles = _equality_roles(builder)
+    act = define_act_header(builder, interpreter, role_dictionary, context)
+    for role, value in (
+        (roles.context, context),
+        (roles.left, left),
+        (roles.right, right),
+        (roles.left_representative, left_rep),
+        (roles.right_representative, right_rep),
+    ):
+        define_act_field(builder, act, role, value)
+    return EqualityEvaluationEvidence(
+        interpreter=interpreter,
+        context=context,
+        left=left,
+        right=right,
+        left_representative=left_rep,
+        right_representative=right_rep,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+
+
+def _proof_evidence(
+    builder: LinkNetworkBuilder,
+    root,
+    premise: EqualityEvaluationEvidence,
+    *,
+    left=None,
+    right=None,
+    theory=None,
+    rule=None,
+    rule_membership=None,
+    start_claim=None,
+    end_claim=None,
+    before_context=None,
+    after_context=None,
+    conflicting_field: bool = False,
+):
+    left = left or premise.left
+    right = right or premise.right
+    theory = theory or _anchor(builder)
+    rule = rule or _anchor(builder)
+    rule_membership = rule_membership or define_membership(builder, theory, rule)
+    left_link = None
+    right_link = None
+    # Construction helper may be used with a deliberately partial operand. Only
+    # create default claims when both operands have ordinary accessible poles.
+    try:
+        left_link = builder._links[left.slot]  # type: ignore[attr-defined]
+        right_link = builder._links[right.slot]  # type: ignore[attr-defined]
+    except (AttributeError, KeyError):
+        pass
+    if start_claim is None:
+        assert left_link is not None and right_link is not None
+        start_claim = _link(builder, left_link.start, right_link.start)
+    if end_claim is None:
+        assert left_link is not None and right_link is not None
+        end_claim = _link(builder, left_link.end, right_link.end)
+
+    before_context = before_context or premise.context
+    after_context = after_context or before_context
+    interpreter = _anchor(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    roles = _proof_roles(builder)
+    act = define_act_header(builder, interpreter, role_dictionary, after_context)
+    fields = (
+        (roles.premise_equality_act, premise.act),
+        (roles.theory, theory),
+        (roles.rule, rule),
+        (roles.rule_membership, rule_membership),
+        (roles.left_relation, left),
+        (roles.right_relation, right),
+        (roles.start_claim, start_claim),
+        (roles.end_claim, end_claim),
+        (roles.before_context, before_context),
+        (roles.after_context, after_context),
+    )
+    for role_ref, value in fields:
+        define_act_field(builder, act, role_ref, value)
+    if conflicting_field:
+        define_act_field(builder, act, roles.start_claim, _anchor(builder))
+
+    return DecomposeEqualityEvidence(
+        premise=premise,
+        interpreter=interpreter,
+        theory=theory,
+        rule=rule,
+        rule_membership=rule_membership,
+        left_relation=left,
+        right_relation=right,
+        start_claim=start_claim,
+        end_claim=end_claim,
+        before_context=before_context,
+        after_context=after_context,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+
+
+def _true_fixture(*, nested_poles: bool = False):
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+
+    if nested_poles:
+        left_start = _link(builder, _anchor(builder), _anchor(builder))
+        left_end = _link(builder, _anchor(builder), _anchor(builder))
+        right_start = _link(builder, _anchor(builder), _anchor(builder))
+        right_end = _link(builder, _anchor(builder), _anchor(builder))
+    else:
+        left_start = _anchor(builder)
+        left_end = _anchor(builder)
+        right_start = _anchor(builder)
+        right_end = _anchor(builder)
+
+    left = _link(builder, left_start, left_end)
+    right = _link(builder, right_start, right_end)
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, left, representative)
+    define_local_representative_binding(builder, context, right, representative)
+    premise = _equality_premise(
+        builder, root, context, left, right, representative, representative
+    )
+    evidence = _proof_evidence(builder, root, premise)
+    return builder, root, context, left, right, premise, evidence
+
+
+def test_true_equality_decomposes_once_under_exact_admitted_rule() -> None:
+    builder, root, context, left, right, _, evidence = _true_fixture()
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    claims = replay_decompose_equal_relations(network, evidence)
+    assert claims == (evidence.start_claim, evidence.end_claim)
+    assert network.snapshot() == before
+
+    left_link = network.link(left)
+    right_link = network.link(right)
+    assert network.link(evidence.start_claim).start is left_link.start
+    assert network.link(evidence.start_claim).end is right_link.start
+    assert network.link(evidence.end_claim).start is left_link.end
+    assert network.link(evidence.end_claim).end is right_link.end
+
+    # Claims do not become local equality bindings merely by being conclusions.
+    assert local_representative(network, context, left_link.start) is left_link.start
+    assert local_representative(network, context, right_link.start) is right_link.start
+
+
+def test_false_equality_premise_rejects_rule_application() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    left = _link(builder, _anchor(builder), _anchor(builder))
+    right = _link(builder, _anchor(builder), _anchor(builder))
+    premise = _equality_premise(builder, root, context, left, right, left, right)
+    evidence = _proof_evidence(builder, root, premise)
+    network = builder.freeze(root)
+
+    with pytest.raises(ProofRuleReplayError, match="premise is false"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_rule_membership_from_another_theory_rejects() -> None:
+    builder, root, _, _, _, premise, _ = _true_fixture()
+    selected_theory = _anchor(builder)
+    other_theory = _anchor(builder)
+    rule = _anchor(builder)
+    wrong_membership = define_membership(builder, other_theory, rule)
+    evidence = _proof_evidence(
+        builder,
+        root,
+        premise,
+        theory=selected_theory,
+        rule=rule,
+        rule_membership=wrong_membership,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(ProofRuleReplayError, match="not admitted"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_exact_relation_substitution_rejects_even_when_shape_matches() -> None:
+    builder, root, _, left, _, premise, _ = _true_fixture()
+    left_link = builder._links[left.slot]  # type: ignore[attr-defined]
+    left_copy = _link(builder, left_link.start, left_link.end)
+    evidence = _proof_evidence(builder, root, premise, left=left_copy)
+    network = builder.freeze(root)
+
+    assert left_copy is not left
+    with pytest.raises(ProofRuleReplayError, match="differs from equality premise"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_partial_relation_rejects_even_with_true_local_equality_premise() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    fixed = _anchor(builder)
+    left = builder.reserve()
+    builder.define(left, left, fixed)
+    right = _link(builder, _anchor(builder), _anchor(builder))
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, left, representative)
+    define_local_representative_binding(builder, context, right, representative)
+    premise = _equality_premise(
+        builder, root, context, left, right, representative, representative
+    )
+    evidence = _proof_evidence(builder, root, premise)
+    network = builder.freeze(root)
+
+    with pytest.raises(ProofRuleReplayError, match="partial/self-closed"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_forged_start_claim_rejects() -> None:
+    builder, root, _, _, _, premise, good = _true_fixture()
+    forged_claim = _link(builder, _anchor(builder), _anchor(builder))
+    evidence = _proof_evidence(
+        builder,
+        root,
+        premise,
+        theory=good.theory,
+        rule=good.rule,
+        rule_membership=good.rule_membership,
+        start_claim=forged_claim,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(ProofRuleReplayError, match="start-pole"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_observational_rule_cannot_change_exact_context() -> None:
+    builder, root, context, _, _, premise, _ = _true_fixture()
+    other_context = define_context(builder, _anchor(builder), _anchor(builder))
+    evidence = _proof_evidence(
+        builder,
+        root,
+        premise,
+        before_context=context,
+        after_context=other_context,
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(ProofRuleReplayError, match="must preserve exact K"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_conflicting_required_proof_act_field_rejects() -> None:
+    builder, root, _, _, _, premise, _ = _true_fixture()
+    evidence = _proof_evidence(builder, root, premise, conflicting_field=True)
+    network = builder.freeze(root)
+
+    with pytest.raises(ProofRuleReplayError, match="start-claim"):
+        replay_decompose_equal_relations(network, evidence)
+
+
+def test_nested_poles_produce_only_selected_first_level_claims() -> None:
+    builder, root, _, left, right, _, evidence = _true_fixture(nested_poles=True)
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    assert replay_decompose_equal_relations(network, evidence) == (
+        evidence.start_claim,
+        evidence.end_claim,
+    )
+    assert network.snapshot() == before
+
+    left_start = network.link(left).start
+    right_start = network.link(right).start
+    assert network.link(evidence.start_claim).start is left_start
+    assert network.link(evidence.start_claim).end is right_start
+    # The rule does not recurse into the nested start relations.
+    nested_left = network.link(left_start)
+    nested_right = network.link(right_start)
+    assert not any(
+        network.link(ref).start is nested_left.start
+        and network.link(ref).end is nested_right.start
+        for ref in network.refs
+        if ref not in (left_start, right_start)
+    )
+
+
+def test_proof_rule_module_has_no_legacy_or_shape_equality_dependency() -> None:
+    source = (ROOT / "core/foundation_v2_proof.py").read_text(encoding="utf-8")
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert "mtc_interpreter" not in source
+    assert "proof_checker" not in source
+    assert "carrier_isomorphic" not in source
+    assert "define_local_representative_binding" not in source

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -27,6 +27,7 @@ ACTIVE_SPECS = {
     "Протокол абитов ачисел.md",
     "Пучки значений МТС v0.2.md",
     "Foundation v2 Gate P.md",
+    "Foundation v2 Proof replay.md",
     "Апамять и управление сетью связей.md",
 }
 ACTIVE_MARKDOWN = (


### PR DESCRIPTION
Closes #255 after explicit decision if CI/evidence is accepted. Parent: #237. Depends on merged #252/#254.

## First Foundation-v2 proof rule

This PR adds one narrowly admitted rule, deliberately outside the core semantics of `=`:

```text
premise: replayed true Equal_K(L,R)
L = l_start ⟼ l_end
R = r_start ⟼ r_end

conclusions:
C_start = l_start ⟼ r_start
C_end   = l_end   ⟼ r_end
```

The rule is observational and exactly one-step. It does not mutate K, add representative bindings, recursively decompose nested links, assert theorem closure, or materialize facts during replay.

## Explicit T admission

The selected exact rule occurrence must be admitted by exact evidence:

```text
RuleMembership = T ⟼ Rule
```

No host rule enum, AST/proof opcode or operand-shape heuristic is semantic authority.

## Trusted replay

`core/foundation_v2_proof.py`:
- replays the existing equality actual act and requires `true`;
- requires exact L/R to be the same occurrences as the premise operands;
- verifies exact T/rule membership;
- rejects partial/self-closed L/R;
- verifies exact start/end claim links;
- requires exact K_before == K_after;
- verifies Gate-R actual application A and role fields;
- remains snapshot-stable/read-only.

## Conformance

Tests include false premise, wrong theory membership, shape-equal/exact-distinct operand substitution, partial relation, forged claim, changed context, conflicting A field, nested opaque poles/no recursive firing, no equality-binding effect and no legacy/shape-equality dependency.

## Documentation

Adds active `docs/specs/Foundation v2 Proof replay.md` explaining the proof-search/trusted-replay split, the exact admitted rule, its relationship to apamemory, and the intended `aprover` trust boundary. Machine contract: `contracts/mts-foundation-v2-proof-rule-v0.7.json`.

## Still out of scope

- general proof calculus/theorem closure;
- recursive rule firing;
- #242 sequence→апамять materialization;
- #124 persistent L4;
- cutover / aprover repin.