### PR TITLE
Gate P: add integrated source-to-rule proof conformance replay

### DIFF
--- a/contracts/mts-foundation-v2-integrated-proof-v0.7.json
+++ b/contracts/mts-foundation-v2-integrated-proof-v0.7.json
@@ -1,0 +1,63 @@
+{
+  "schema": "mts-foundation-v2-integrated-proof/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 257,
+  "parent": 237,
+  "dependsOn": [
+    "mts-foundation-v2-source/v0.7",
+    "mts-foundation-v2-state/v0.7",
+    "mts-foundation-v2-equality/v0.7",
+    "mts-foundation-v2-proof-rule/v0.7",
+    "mts-foundation-v2-run/v0.7"
+  ],
+  "artifact": {
+    "source": "one exact source occurrence selecting exactly one Rule through scoped D and explicit G/T source admission",
+    "premise": "one replayable true local equality actual act A_eq in exact K",
+    "ruleAdmission": "one exact direct T ⟼ Rule membership",
+    "application": "one replayable admitted one-step rule actual act A_rule",
+    "run": "exact ordered Run = [A_eq, A_rule]",
+    "claims": "exact first-level start/end equality claim links"
+  },
+  "integratedReplay": [
+    "replay source front-end evidence",
+    "require selected source form is exact proof Rule",
+    "require source and proof application share exact T",
+    "replay equality premise and require true",
+    "require proof application shares exact premise K",
+    "replay exact admitted proof rule",
+    "replay exact Run continuity",
+    "require Run acts are exactly A_eq then A_rule",
+    "require one shared exact K across premise/application/run",
+    "require network snapshot unchanged"
+  ],
+  "trustBoundary": {
+    "searchOrRankingTrusted": false,
+    "sourceRetokenizedByIntegratedChecker": false,
+    "operatorSemanticsReimplemented": false,
+    "ruleInferredFromHostEnum": false,
+    "equalityInferredByShape": false,
+    "proofReconstructedByHeuristic": false,
+    "implicitMaterialization": false,
+    "legacyParserInterpreterProofCheckerDependency": false
+  },
+  "requiredVectors": [
+    "valid source-selected Rule -> true equality -> admitted rule -> exact two-act Run",
+    "valid source selecting another exact Rule rejects cross-layer identity",
+    "source/proof exact theory mismatch rejects",
+    "invalid or false equality premise rejects",
+    "swapped Run order rejects",
+    "different exact K at Run boundary rejects",
+    "snapshot remains unchanged"
+  ],
+  "remainingReleaseBlockers": [
+    242,
+    124,
+    "historical compatibility classification",
+    "versioned accepted integrated conformance corpus",
+    "atomic production cutover",
+    "explicit Foundation-v2 acceptance"
+  ],
+  "aproverRepinAllowed": false,
+  "nextGate": "return to the deferred sequence-to-apamemory executable gate #242, then persistent L4 #124, before release hardening"
+}

--- a/core/foundation_v2_checker.py
+++ b/core/foundation_v2_checker.py
@@ -1,0 +1,104 @@
+"""Integrated Foundation-v2 trusted proof/checker replay.
+
+This module intentionally contains no new operator semantics.  It composes the
+already-established source, equality, admitted-rule and exact-run replay layers
+and checks cross-layer exact occurrence identity.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .exact_link_network import LinkNetwork, OccurrenceRef
+from .foundation_v2_interpreter import (
+    InterpreterReplayError,
+    replay_equality_evaluation,
+)
+from .foundation_v2_proof import (
+    DecomposeEqualityEvidence,
+    ProofRuleReplayError,
+    replay_decompose_equal_relations,
+)
+from .foundation_v2_run import RunEvidence, RunReplayError, replay_run
+from .foundation_v2_source import (
+    SourceFrontEndEvidence,
+    SourceReplayError,
+    replay_source_front_end,
+)
+
+
+class IntegratedCheckerError(ValueError):
+    """Cross-layer Foundation-v2 proof evidence is inconsistent or forged."""
+
+
+@dataclass(frozen=True)
+class IntegratedProofEvidence:
+    """One selected exact Foundation-v2 proof artifact."""
+
+    source: SourceFrontEndEvidence
+    rule_application: DecomposeEqualityEvidence
+    run: RunEvidence
+
+
+def replay_integrated_proof(
+    network: LinkNetwork,
+    evidence: IntegratedProofEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> tuple[OccurrenceRef, OccurrenceRef]:
+    """Replay one source-selected rule proof without search or materialization."""
+
+    before_snapshot = network.snapshot()
+    try:
+        rule = evidence.rule_application.rule
+        theory = evidence.rule_application.theory
+        premise = evidence.rule_application.premise
+        context = premise.context
+
+        try:
+            selected_forms = replay_source_front_end(network, evidence.source, byte_refs)
+        except SourceReplayError as exc:
+            raise IntegratedCheckerError("invalid integrated source evidence") from exc
+        if selected_forms != (rule,):
+            raise IntegratedCheckerError(
+                "source must select exactly the same exact Rule used by proof application"
+            )
+        if evidence.source.theory is not theory:
+            raise IntegratedCheckerError(
+                "source admission and proof application use different exact theories"
+            )
+
+        try:
+            premise_result = replay_equality_evaluation(network, premise)
+        except InterpreterReplayError as exc:
+            raise IntegratedCheckerError("invalid equality premise") from exc
+        if not premise_result:
+            raise IntegratedCheckerError("integrated proof equality premise is false")
+
+        if evidence.rule_application.before_context is not context:
+            raise IntegratedCheckerError("proof application uses another exact K")
+        if evidence.rule_application.after_context is not context:
+            raise IntegratedCheckerError("observational proof rule changed exact K")
+
+        try:
+            claims = replay_decompose_equal_relations(network, evidence.rule_application)
+        except ProofRuleReplayError as exc:
+            raise IntegratedCheckerError("invalid admitted proof-rule application") from exc
+
+        expected_acts = (premise.act, evidence.rule_application.act)
+        if evidence.run.initial_context is not context:
+            raise IntegratedCheckerError("run starts from another exact K")
+        if evidence.run.terminal_context is not context:
+            raise IntegratedCheckerError("run terminates at another exact K")
+        try:
+            selected_acts = replay_run(network, evidence.run)
+        except RunReplayError as exc:
+            raise IntegratedCheckerError("invalid exact proof Run") from exc
+        if selected_acts != expected_acts:
+            raise IntegratedCheckerError(
+                "Run must contain exactly equality premise then rule application"
+            )
+
+        return claims
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise IntegratedCheckerError("integrated proof replay mutated the network")


### PR DESCRIPTION
Closes #257 after explicit decision if CI/evidence is accepted. Parent: #237. Depends on merged #256.

## First integrated Foundation-v2 proof artifact

This PR composes already-established trusted layers without adding new operator semantics:

```text
source `decompose`
→ scoped D selects exact Rule
→ explicit G/T source admission
→ true local equality actual A_eq in exact K
→ exact T ⟼ Rule admission
→ admitted one-step application A_rule
→ exact Run [A_eq, A_rule]
→ read-only integrated replay
```

## `core/foundation_v2_checker.py`

The integrated checker only:
- calls `replay_source_front_end`;
- requires source-selected form is the exact Rule used by proof application;
- requires source/proof share exact T;
- calls `replay_equality_evaluation` and requires true;
- requires one exact K across premise/application/run;
- calls `replay_decompose_equal_relations`;
- calls `replay_run`;
- requires exact run order `(A_eq, A_rule)`;
- verifies the network snapshot remains unchanged.

It does not tokenize/parse, search/rank rules, infer equality by shape, infer rule identity from host classes, reconstruct proofs heuristically, materialize facts, or call legacy parser/interpreter/proof checker.

## Conformance

Covers valid integrated replay plus cross-layer Rule mismatch, theory mismatch, invalid equality premise, swapped Run order, exact-K mismatch and read-only behavior.

Machine contract: `contracts/mts-foundation-v2-integrated-proof-v0.7.json`.

## Release consequence

After this integration gate, the semantic proof/checker core is ready to return to the deferred release blockers rather than add more operators: #242 sequence→апамять, then #124 persistent L4, then integrated versioned conformance/cutover/acceptance. `aprover` remains blocked until the accepted next MTS version is published.