### PR TITLE
Gate P: integrate source-selected proof replay end to end

### DIFF
--- a/contracts/mts-foundation-v2-integrated-proof-v0.7.json
+++ b/contracts/mts-foundation-v2-integrated-proof-v0.7.json
@@ -1,0 +1,63 @@
+{
+  "schema": "mts-foundation-v2-integrated-proof/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 257,
+  "parent": 237,
+  "dependsOn": [
+    "mts-foundation-v2-source/v0.7",
+    "mts-foundation-v2-state/v0.7",
+    "mts-foundation-v2-equality/v0.7",
+    "mts-foundation-v2-proof-rule/v0.7",
+    "mts-foundation-v2-run/v0.7"
+  ],
+  "artifact": {
+    "source": "one exact source occurrence selecting exactly one Rule through scoped D and explicit G/T source admission",
+    "premise": "one replayable true local equality actual act A_eq in exact K",
+    "ruleAdmission": "one exact direct T ⟼ Rule membership",
+    "application": "one replayable admitted one-step rule actual act A_rule",
+    "run": "exact ordered Run = [A_eq, A_rule]",
+    "claims": "exact first-level start/end equality claim links"
+  },
+  "integratedReplay": [
+    "replay source front-end evidence",
+    "require selected source form is exact proof Rule",
+    "require source and proof application share exact T",
+    "replay equality premise and require true",
+    "require proof application shares exact premise K",
+    "replay exact admitted proof rule",
+    "replay exact Run continuity",
+    "require Run acts are exactly A_eq then A_rule",
+    "require one shared exact K across premise/application/run",
+    "require network snapshot unchanged"
+  ],
+  "trustBoundary": {
+    "searchOrRankingTrusted": false,
+    "sourceRetokenizedByIntegratedChecker": false,
+    "operatorSemanticsReimplemented": false,
+    "ruleInferredFromHostEnum": false,
+    "equalityInferredByShape": false,
+    "proofReconstructedByHeuristic": false,
+    "implicitMaterialization": false,
+    "legacyParserInterpreterProofCheckerDependency": false
+  },
+  "requiredVectors": [
+    "valid source-selected Rule -> true equality -> admitted rule -> exact two-act Run",
+    "valid source selecting another exact Rule rejects cross-layer identity",
+    "valid source admitted under another exact theory rejects cross-layer identity",
+    "invalid equality premise rejects",
+    "swapped Run order rejects",
+    "different exact K at Run boundary rejects",
+    "snapshot remains unchanged"
+  ],
+  "remainingReleaseBlockers": [
+    242,
+    124,
+    "historical compatibility classification",
+    "versioned accepted integrated conformance corpus",
+    "atomic production cutover",
+    "explicit Foundation-v2 acceptance"
+  ],
+  "aproverRepinAllowed": false,
+  "nextGate": "return to deferred sequence-to-apamemory executable semantics #242, then persistent L4 #124, before release hardening"
+}

--- a/core/foundation_v2_checker.py
+++ b/core/foundation_v2_checker.py
@@ -1,0 +1,101 @@
+"""Integrated Foundation-v2 trusted proof/checker replay.
+
+This module intentionally contains no new operator semantics. It composes the
+already-established source, equality, admitted-rule and exact-run replay layers
+and checks cross-layer exact occurrence identity.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .exact_link_network import LinkNetwork, OccurrenceRef
+from .foundation_v2_interpreter import InterpreterReplayError, replay_equality_evaluation
+from .foundation_v2_proof import (
+    DecomposeEqualityEvidence,
+    ProofRuleReplayError,
+    replay_decompose_equal_relations,
+)
+from .foundation_v2_run import RunEvidence, RunReplayError, replay_run
+from .foundation_v2_source import (
+    SourceFrontEndEvidence,
+    SourceReplayError,
+    replay_source_front_end,
+)
+
+
+class IntegratedCheckerError(ValueError):
+    """Cross-layer Foundation-v2 proof evidence is inconsistent or forged."""
+
+
+@dataclass(frozen=True)
+class IntegratedProofEvidence:
+    """One selected exact Foundation-v2 proof artifact."""
+
+    source: SourceFrontEndEvidence
+    rule_application: DecomposeEqualityEvidence
+    run: RunEvidence
+
+
+def replay_integrated_proof(
+    network: LinkNetwork,
+    evidence: IntegratedProofEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> tuple[OccurrenceRef, OccurrenceRef]:
+    """Replay one source-selected rule proof without search or materialization."""
+
+    before_snapshot = network.snapshot()
+    try:
+        rule = evidence.rule_application.rule
+        theory = evidence.rule_application.theory
+        premise = evidence.rule_application.premise
+        context = premise.context
+
+        try:
+            selected_forms = replay_source_front_end(network, evidence.source, byte_refs)
+        except SourceReplayError as exc:
+            raise IntegratedCheckerError("invalid integrated source evidence") from exc
+        if selected_forms != (rule,):
+            raise IntegratedCheckerError(
+                "source must select exactly the same exact Rule used by proof application"
+            )
+        if evidence.source.theory is not theory:
+            raise IntegratedCheckerError(
+                "source admission and proof application use different exact theories"
+            )
+
+        try:
+            premise_result = replay_equality_evaluation(network, premise)
+        except InterpreterReplayError as exc:
+            raise IntegratedCheckerError("invalid equality premise") from exc
+        if not premise_result:
+            raise IntegratedCheckerError("integrated proof equality premise is false")
+
+        if evidence.rule_application.before_context is not context:
+            raise IntegratedCheckerError("proof application uses another exact K")
+        if evidence.rule_application.after_context is not context:
+            raise IntegratedCheckerError("observational proof rule changed exact K")
+
+        try:
+            claims = replay_decompose_equal_relations(network, evidence.rule_application)
+        except ProofRuleReplayError as exc:
+            raise IntegratedCheckerError("invalid admitted proof-rule application") from exc
+
+        expected_acts = (premise.act, evidence.rule_application.act)
+        if evidence.run.initial_context is not context:
+            raise IntegratedCheckerError("run starts from another exact K")
+        if evidence.run.terminal_context is not context:
+            raise IntegratedCheckerError("run terminates at another exact K")
+        try:
+            selected_acts = replay_run(network, evidence.run)
+        except RunReplayError as exc:
+            raise IntegratedCheckerError("invalid exact proof Run") from exc
+        if selected_acts != expected_acts:
+            raise IntegratedCheckerError(
+                "Run must contain exactly equality premise then rule application"
+            )
+
+        return claims
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise IntegratedCheckerError("integrated proof replay mutated the network")

--- a/docs/research/Foundation v2 P9 integrated proof conformance.md
+++ b/docs/research/Foundation v2 P9 integrated proof conformance.md
@@ -1,0 +1,239 @@
+# Foundation v2 P9 — integrated proof/checker conformance
+
+Статус: **Gate P candidate / research integration record**, не accepted версия МТС.
+
+Issue: #257. Parent Gate P: #237.
+
+Этот документ фиксирует первый end-to-end сценарий будущего trusted checker-а `aprover`. Он не вводит новый оператор и не расширяет proof calculus; его цель — проверить, что уже принятые candidate-слои действительно образуют одну машину.
+
+## Полная цепочка
+
+```text
+UTF-8 source `decompose`
+        │
+        ▼
+canonical astring content C
+        │
+        ▼
+exact source occurrence S
+        │
+        ▼
+selected source slice
+        │
+        ▼
+scoped D declaration occurrence
+        │
+        ▼
+exact Rule
+        │
+        ├────────── G admission of form sequence
+        └────────── T admission of form sequence
+        │
+        ▼
+true local equality actual act A_eq
+        │
+        ▼
+exact direct admission T ⟼ Rule
+        │
+        ▼
+one-step proof-rule actual act A_rule
+        │
+        ▼
+exact Run = [A_eq, A_rule]
+        │
+        ▼
+read-only integrated replay
+```
+
+## 1. Source выбирает правило, а не host opcode
+
+Пусть пользователь/поисковая сторона выбрали исходник:
+
+```text
+decompose
+```
+
+Scoped dictionary содержит точное declaration occurrence, через которое source content разрешается в exact `Rule`.
+
+Trusted source replay проверяет:
+
+```text
+bytes
+→ canonical C
+→ exact S
+→ exact slice boundaries
+→ visible declaration occurrence in D
+→ exact Rule
+→ exact G/T source admission
+```
+
+Integrated checker затем требует:
+
+```text
+source-selected Rule
+is
+proof-application Rule
+```
+
+Не одинаковый label, не та же форма, не тот же host enum — **тот же exact occurrence**.
+
+## 2. Theory identity также сквозная
+
+Source evidence и proof application обязаны использовать одну exact `T`:
+
+```text
+source.theory is application.theory
+```
+
+Отдельно proof-rule replay проверяет прямое admission evidence:
+
+```text
+RuleMembership = T ⟼ Rule
+```
+
+Поэтому валидный source под другой теорией `T2` не может незаметно подменить правило, применяемое под `T1`.
+
+## 3. Premise — реальный local equality act
+
+В exact context `K` находятся representative constraints, например:
+
+```text
+K ⟼ (L ⟼ R0)
+K ⟼ (R ⟼ R0)
+```
+
+Отсюда только в данном K:
+
+```text
+rep_K(L) = R0
+rep_K(R) = R0
+Equal_K(L,R) = true
+```
+
+Equality evaluation фиксируется actual occurrence `A_eq`. Integrated checker не принимает внешний boolean `true`: он вызывает trusted equality replay и повторно проверяет exact K/operands/representatives/A.
+
+## 4. Rule application
+
+Для завершённых связей:
+
+```text
+L = l_start ⟼ l_end
+R = r_start ⟼ r_end
+```
+
+отдельно admitted one-step rule проверяет exact claims:
+
+```text
+C_start = l_start ⟼ r_start
+C_end   = l_end   ⟼ r_end
+```
+
+и actual application `A_rule`.
+
+Правило observational:
+
+```text
+K_before is K_after
+```
+
+Claims не становятся equality bindings автоматически и nested links не разлагаются рекурсивно.
+
+## 5. Run фиксирует provenance доказательства
+
+Выбранный proof artifact содержит exact order:
+
+```text
+Run0 = R
+Run1 = Run0 ⟼ A_eq
+Run2 = Run1 ⟼ A_rule
+```
+
+Trusted run replay требует именно:
+
+```text
+(A_eq, A_rule)
+```
+
+и exact context continuity. Перестановка acts или подмена occurrence с теми же видимыми полями не должна приниматься.
+
+## 6. Integrated checker ничего не ищет
+
+Production-facing entry point:
+
+```text
+replay_integrated_proof(network, evidence, byte_refs)
+```
+
+не должен:
+
+```text
+лексить/парсить source заново;
+искать Rule;
+ранжировать proof candidates;
+выводить equality по shape;
+выбирать theory;
+рекурсивно применять rules;
+materialize-ить claims/K/A;
+обращаться к legacy proof checker.
+```
+
+Он только компонует существующие trusted replay layers и проверяет cross-layer exact identity.
+
+## 7. Почему это важно для апамяти
+
+В одной сети теперь могут одновременно жить:
+
+```text
+application links
+source carrier/evidence
+scoped dictionaries
+G/T admissions
+context K
+local representatives
+actual acts
+proof claims
+Run
+```
+
+При этом controller апамяти сохраняет фундаментальное разделение:
+
+```text
+find / select / replay != materialize
+```
+
+Поисковая часть `aprover` может использовать любые индексы и эвристики апамяти, но proof acceptance сводится к replay selected exact relations.
+
+Это даёт практическую архитектуру:
+
+```text
+             APAMEMORY
+                 │
+       ┌─────────┴─────────┐
+       │                   │
+untrusted search       trusted replay
+indices/heuristics     exact evidence only
+       │                   │
+       └──── candidate ─────┘
+                 │
+                 ▼
+          accepted / reject
+```
+
+## 8. Что P9 ещё не означает
+
+P9 не является публикацией Foundation v2 и не разрешает repin `aprover`.
+
+После успешного integrated proof conformance остаются release blockers:
+
+```text
+#242  executable Anum sequence → апамять materialization
+#124  persistent L4/backend contract
+historical compatibility classification
+atomic removal/cutover of old production semantic path
+versioned integrated conformance corpus
+explicit Foundation-v2 acceptance decision
+published next MTS contract/version
+aprover repin
+```
+
+Следующий шаг после P9 должен вернуться именно к этим deferred blockers, а не добавлять новые операторы без необходимости.

--- a/tests/test_mts_foundation_v2_checker.py
+++ b/tests/test_mts_foundation_v2_checker.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_checker import (
+    IntegratedCheckerError,
+    IntegratedProofEvidence,
+    replay_integrated_proof,
+)
+from core.foundation_v2_interpreter import EqualityEvaluationEvidence, EqualityRoleRefs
+from core.foundation_v2_proof import DecomposeEqualityEvidence, DecomposeEqualityRoleRefs
+from core.foundation_v2_run import RunEvidence, RunStepEvidence, define_run_chain
+from core.foundation_v2_source import SegmentSpec, SourceFrontEndBuilder
+from core.foundation_v2_state import (
+    define_act_field,
+    define_act_header,
+    define_context,
+    define_dictionary_effect,
+    define_dictionary_scope,
+    define_local_representative_binding,
+    define_membership,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _anchor(builder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _link(builder, start, end):
+    ref = builder.reserve()
+    builder.define(ref, start, end)
+    return ref
+
+
+def _byte_refs(builder):
+    return {value: _anchor(builder) for value in range(256)}
+
+
+def _source_evidence(builder, root, byte_refs, rule, theory, grammar=None):
+    grammar = grammar or _anchor(builder)
+    front = SourceFrontEndBuilder(builder, root, byte_refs)
+    source = front.source_occurrence(b"decompose")
+    d0 = define_dictionary_scope(builder, root, root)
+    definition = define_dictionary_effect(
+        builder,
+        d0,
+        root,
+        root,
+        front.content_ref(b"decompose"),
+        rule,
+    )
+    return front.build_selected_evidence(
+        source,
+        (SegmentSpec(0, len(b"decompose"), rule, definition.occurrence),),
+        dictionary=definition.after_scope,
+        grammar=grammar,
+        theory=theory,
+    )
+
+
+def _fixture():
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    byte_refs = _byte_refs(builder)
+    context = define_context(builder, _anchor(builder), _anchor(builder))
+    theory = _anchor(builder)
+    rule = _anchor(builder)
+    source = _source_evidence(builder, root, byte_refs, rule, theory)
+
+    ls, le, rs, re = (_anchor(builder) for _ in range(4))
+    left = _link(builder, ls, le)
+    right = _link(builder, rs, re)
+    representative = _anchor(builder)
+    define_local_representative_binding(builder, context, left, representative)
+    define_local_representative_binding(builder, context, right, representative)
+
+    eq_roles = EqualityRoleRefs(*(_anchor(builder) for _ in range(5)))
+    eq_i = _anchor(builder)
+    eq_droles = define_dictionary_scope(builder, root, root)
+    eq_act = define_act_header(builder, eq_i, eq_droles, context)
+    for role, value in (
+        (eq_roles.context, context),
+        (eq_roles.left, left),
+        (eq_roles.right, right),
+        (eq_roles.left_representative, representative),
+        (eq_roles.right_representative, representative),
+    ):
+        define_act_field(builder, eq_act, role, value)
+    premise = EqualityEvaluationEvidence(
+        interpreter=eq_i,
+        context=context,
+        left=left,
+        right=right,
+        left_representative=representative,
+        right_representative=representative,
+        act=eq_act,
+        role_dictionary=eq_droles,
+        roles=eq_roles,
+    )
+
+    membership = define_membership(builder, theory, rule)
+    start_claim = _link(builder, ls, rs)
+    end_claim = _link(builder, le, re)
+    proof_roles = DecomposeEqualityRoleRefs(*(_anchor(builder) for _ in range(10)))
+    proof_i = _anchor(builder)
+    proof_droles = define_dictionary_scope(builder, root, root)
+    proof_act = define_act_header(builder, proof_i, proof_droles, context)
+    for role, value in (
+        (proof_roles.premise_equality_act, eq_act),
+        (proof_roles.theory, theory),
+        (proof_roles.rule, rule),
+        (proof_roles.rule_membership, membership),
+        (proof_roles.left_relation, left),
+        (proof_roles.right_relation, right),
+        (proof_roles.start_claim, start_claim),
+        (proof_roles.end_claim, end_claim),
+        (proof_roles.before_context, context),
+        (proof_roles.after_context, context),
+    ):
+        define_act_field(builder, proof_act, role, value)
+    proof = DecomposeEqualityEvidence(
+        premise=premise,
+        interpreter=proof_i,
+        theory=theory,
+        rule=rule,
+        rule_membership=membership,
+        left_relation=left,
+        right_relation=right,
+        start_claim=start_claim,
+        end_claim=end_claim,
+        before_context=context,
+        after_context=context,
+        act=proof_act,
+        role_dictionary=proof_droles,
+        roles=proof_roles,
+    )
+
+    eq_step = RunStepEvidence(eq_act, context, context, eq_roles.context, eq_roles.context)
+    proof_step = RunStepEvidence(
+        proof_act,
+        context,
+        context,
+        proof_roles.before_context,
+        proof_roles.after_context,
+    )
+    run = RunEvidence(
+        run_root=define_run_chain(builder, root, (eq_act, proof_act)),
+        initial_context=context,
+        terminal_context=context,
+        steps=(eq_step, proof_step),
+    )
+    evidence = IntegratedProofEvidence(source=source, rule_application=proof, run=run)
+    return builder, root, byte_refs, evidence, rule, theory, context
+
+
+def test_integrated_source_to_rule_to_run_replays_read_only() -> None:
+    builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    assert replay_integrated_proof(network, evidence, byte_refs) == (
+        evidence.rule_application.start_claim,
+        evidence.rule_application.end_claim,
+    )
+    assert network.snapshot() == before
+
+
+def test_valid_source_selecting_another_exact_rule_rejects_cross_layer() -> None:
+    builder, root, byte_refs, evidence, rule, theory, _ = _fixture()
+    other_rule = _anchor(builder)
+    other_source = _source_evidence(builder, root, byte_refs, other_rule, theory)
+    forged = replace(evidence, source=other_source)
+    network = builder.freeze(root)
+
+    assert other_rule is not rule
+    with pytest.raises(IntegratedCheckerError, match="same exact Rule"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_valid_source_under_another_exact_theory_rejects_cross_layer() -> None:
+    builder, root, byte_refs, evidence, rule, theory, _ = _fixture()
+    other_theory = _anchor(builder)
+    other_source = _source_evidence(builder, root, byte_refs, rule, other_theory)
+    forged = replace(evidence, source=other_source)
+    network = builder.freeze(root)
+
+    assert other_theory is not theory
+    with pytest.raises(IntegratedCheckerError, match="different exact theories"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_invalid_equality_premise_rejects_integrated_artifact() -> None:
+    builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    forged_rep = _anchor(builder)
+    forged_premise = replace(
+        evidence.rule_application.premise,
+        left_representative=forged_rep,
+    )
+    forged_rule = replace(evidence.rule_application, premise=forged_premise)
+    forged = replace(evidence, rule_application=forged_rule)
+    network = builder.freeze(root)
+
+    with pytest.raises(IntegratedCheckerError, match="invalid equality premise"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_swapped_exact_run_order_rejects() -> None:
+    builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    swapped = replace(evidence.run, steps=tuple(reversed(evidence.run.steps)))
+    forged = replace(evidence, run=swapped)
+    network = builder.freeze(root)
+
+    with pytest.raises(IntegratedCheckerError, match="invalid exact proof Run"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_another_exact_run_context_rejects_before_run_replay() -> None:
+    builder, root, byte_refs, evidence, _, _, context = _fixture()
+    other_context = define_context(builder, _anchor(builder), _anchor(builder))
+    forged_run = replace(evidence.run, initial_context=other_context)
+    forged = replace(evidence, run=forged_run)
+    network = builder.freeze(root)
+
+    assert other_context is not context
+    with pytest.raises(IntegratedCheckerError, match="another exact K"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_integrated_checker_has_no_search_parser_or_legacy_proof_dependency() -> None:
+    source = (ROOT / "core/foundation_v2_checker.py").read_text(encoding="utf-8")
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert "mtc_interpreter" not in source
+    assert "proof_checker" not in source
+    assert "carrier_isomorphic" not in source
+    assert "materialize(" not in source


### PR DESCRIPTION
Closes #257 after explicit decision if CI/evidence is accepted. Supersedes closed unmerged PR #258 after correcting its cross-layer theory-mismatch test vector. Parent: #237. Depends on merged #256.

## Integrated trusted artifact

```text
source `decompose`
→ scoped D selects exact Rule
→ explicit G/T source admission
→ true local equality actual A_eq in exact K
→ exact T ⟼ Rule admission
→ admitted one-step A_rule
→ exact Run [A_eq, A_rule]
→ deterministic read-only replay
```

`core/foundation_v2_checker.py` only composes existing replay layers and checks cross-layer exact identity. It does not add operator semantics, tokenize/parse, search/rank rules, infer equality by shape, reconstruct proofs heuristically, materialize facts, or call legacy parser/interpreter/proof checker.

## Corrected negative corpus

The new branch replaces #258's invalid theory-mismatch fixture with a **fully valid source artifact admitted under another exact theory**, so the test genuinely checks cross-layer `T1 != T2` rather than merely corrupting source evidence.

Other vectors cover valid replay, valid source selecting another exact Rule, invalid equality premise, swapped exact Run order, exact-K mismatch and snapshot stability.

Machine contract: `contracts/mts-foundation-v2-integrated-proof-v0.7.json`.

## Release consequence

This should close the proof/checker semantic integration phase. The next work should return to deferred release blockers, starting with #242 Anum→апамять sequence materialization, then #124 persistent L4, before cutover/version acceptance and `aprover` repin.