### PR TITLE
Gate P: materialize nested Anum sequences into exact apamemory states

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,65 +8,76 @@
 L = A ⟼ B
 ```
 
-означает: связь `L` имеет начало `A` и конец `B`.
-
-Главная идея МТС предельно проста:
+Главный постулат:
 
 ```text
 всё есть связь
 ```
 
-В частности, контекст, словарь, теория, исходный текст, акт интерпретации, доказательство и состояние памяти не обязаны быть внешними объектами или метаданными — они сами могут быть представлены сетями связей.
+Контекст, словарь, теория, source, actual act, доказательство и состояние памяти не обязаны быть внешними объектами — они сами могут быть представлены сетями связей.
 
 ---
 
-## Текущий статус
+# Текущий статус
 
-В репозитории одновременно существуют два слоя, которые важно не смешивать.
+В репозитории существуют два явно разделённых слоя.
 
-### Принятые версии v0.2–v0.5
+## Historical accepted v0.2–v0.5
 
-Контракты `v0.2`–`v0.5` остаются **принятыми историческими версиями** и сохраняются как воспроизводимая база совместимости. Они включают старую формальную нотацию, typed AST, `ContextFrame`, корневую программу и соответствующие conformance-корпуса.
+Versioned contracts v0.2–v0.5 остаются принятыми и воспроизводимыми. Они сохраняют historical parser/typed-AST/`ContextFrame`, десятиформульную root program, старые Anum denotation contracts и conformance corpus.
 
-Они не удалены и не переписаны задним числом.
+Они не переписываются задним числом.
 
-### Foundation v2 — следующая версия МТС
+## Foundation v2 — candidate следующей версии
 
 Текущее развитие идёт через [Foundation v2 Gate P](docs/specs/Foundation%20v2%20Gate%20P.md).
 
-Foundation v2 уже имеет production-facing executable candidate для:
+Уже существует executable production/reference candidate для:
 
 ```text
 exact-occurrence binary links
 → explicit K / D / G / T / I / A
 → canonical source evidence
 → read-only interpreter replay
-→ persistent scoped dictionary `:`
-→ local representative equality `=`
-→ exact multistep Run
-→ explicitly T-admitted proof rule
-→ integrated trusted proof replay
+→ persistent scoped `:`
+→ local representative `=`
+→ exact Run
+→ T-admitted proof rule
+→ integrated proof checker
+→ Anum nested sequence materialization
 ```
 
-Но **Foundation v2 ещё не опубликована как новая accepted версия МТС**. До этого должны быть закрыты materialization, persistent L4, cutover и итоговый versioned conformance gate.
+Foundation v2 **ещё не является accepted release**. Следующий большой blocker после sequence gate — persistent L4 #124, затем cutover/versioned conformance/acceptance.
 
 ---
 
-# 1. Что существует в МТС
+# 1. Онтология
 
-Минимальная онтология — бинарная ориентированная связь:
+Примитивная семантическая форма:
 
 ```text
-Link = start ⟼ end
+Link(start, end)
 ```
 
-У связи нет обязательного внешнего типа, имени, класса или набора свойств. Всё дополнительное содержание должно быть выражено отношениями самой сети либо явно вынесено в уровень реализации.
+У primitive `Link` нет обязательных semantic tags вроде:
+
+```text
+type
+context
+meaning
+rule
+source
+```
+
+Если роль существенна, она выражается связями.
 
 Подробнее: [Основания МТС](docs/theory/Основания%20МТС.md).
 
-## Exact occurrence важнее формы
+---
 
-Одинаковая структура не означает тождество сущностей.
+# 2. Exact occurrence identity
+
+Одинаковая форма не означает тождество:
 
 ```text
 P1 = A ⟼ B
@@ -75,9 +86,7 @@ P2 = A ⟼ B
 P1 ≠ P2
 ```
 
-`P1` и `P2` могут быть двумя разными точными вхождениями одной и той же пары полюсов.
-
-То же относится к самозамкнутым связям:
+Также:
 
 ```text
 R = R ⟼ R
@@ -86,241 +95,217 @@ X = X ⟼ X
 R ≠ X
 ```
 
-Поэтому Foundation v2 не использует:
+Foundation v2 поэтому не принимает как universal identity:
 
 ```text
-графовый изоморфизм = семантическое тождество
-адрес backend-а       = универсальное семантическое имя
-одинаковая пара       = одна автоматически интернированная связь
+pair interning
+graph isomorphism
+AST path
+source spelling
+snapshot slot
+physical backend address
 ```
 
-Эта граница принципиальна для циклов, sharing, provenance и доказательств.
+Exact occurrence identity необходима для multiplicity, cycles, sharing, provenance и proof acts.
 
 ---
 
-# 2. Корень и самозамыкание
+# 3. Explicit context K
 
-МТС допускает самозамыкание как обычную структуру связи:
-
-```text
-R = R ⟼ R
-```
-
-Самозамыкание само по себе не является скрытым opcode и не задаёт глобальный класс всех объектов такой формы.
-
-Foundation v2 использует небольшой набор **различённых exact occurrences** bootstrap-уровня (`R/O/C/L/U`). Это опорные элементы конкретной системы, а не правило вида «любая связь такой формы автоматически означает X».
-
-Историческая десятиформульная корневая программа v0.2–v0.5 сохранена отдельно и рассматривается как принятый предыдущий контракт, а не как повод переносить старую `ContextFrame`-семантику в новую foundation.
-
-Подробнее: [Система аксиом МТС](docs/theory/Система%20аксиом%20МТС.md).
-
----
-
-# 3. Контекст — тоже сеть связей
-
-Foundation v2 не требует скрытого стека `ContextFrame`.
-
-Минимальный persistent context представим как:
+Контекст хранится сетью:
 
 ```text
 P = parent ⟼ current
 K = K ⟼ P
 ```
 
-Тогда `K` — exact occurrence текущего снимка контекста, а `current` извлекается из предъявленного `K`.
-
-Смена текущего объекта создаёт новый снимок:
+`K` — exact snapshot.
 
 ```text
-K0 → K1 → K2
+↑ = current(K)
 ```
 
-а не мутирует невидимое глобальное состояние.
+не является hidden global variable или ambient `ContextFrame` stack.
 
-Это даёт важное свойство: любой акт можно повторно проверить, если предъявлены exact `K_before` и `K_after`.
+Старые ContextFrame/`◁`/`▷` остаются historical v0.2 semantics.
 
 ---
 
-# 4. Исходный текст не является семантикой
+# 4. Source не равен смыслу
 
-Текст программы или доказательства — это входной носитель, а не identity смысловой сущности.
-
-Текущая Foundation-v2 цепочка выглядит так:
+Foundation-v2 source path:
 
 ```text
 raw UTF-8
-→ canonical astring content C
+→ canonical content C
 → exact source occurrence S
-→ selected exact segmentation
-→ scoped dictionary D
-→ explicit grammar G / theory T admission
-→ resolved exact form
+→ selected segmentation
+→ scoped D
+→ explicit G/T admission
+→ exact form
 ```
 
-Один и тот же набор байтов может разрешаться по-разному в разных словарях или теориях. Поэтому нельзя считать host-token, AST-класс или spelling семантической идентичностью.
+Поэтому:
+
+```text
+same bytes != same source occurrence
+source occurrence != semantic form
+semantic form != theory admission
+```
+
+Token/AST class не является semantic authority.
 
 Подробнее: [Формальная нотация МТС](docs/specs/Формальная%20нотация%20МТС.md).
 
 ---
 
-# 5. Словарь `D` — persistent scoped сеть
+# 5. Persistent dictionary D
 
-Словарь не является глобальным `dict<string, object>`.
-
-Концептуально Foundation v2 использует persistent scope/history:
+Dictionary state также является сетью:
 
 ```text
-ScopePayload = parentScope ⟼ localHistory
-D            = D ⟼ ScopePayload
-
-Entry        = sourceContent ⟼ form
-Occurrence   = D_before ⟼ Entry
-H_after      = H_before ⟼ Occurrence
-D_after      = D_after ⟼ (parentScope ⟼ H_after)
+D = D ⟼ (parentScope ⟼ localHistory)
 ```
 
-Определение через `:` — явный effect, создающий новое состояние словаря.
-
-При этом чтение остаётся чтением:
+Definition effect:
 
 ```text
-lookup / find / replay ≠ materialize
+Entry      = sourceContent ⟼ form
+Occurrence = D_before ⟼ Entry
+H_after    = H_before ⟼ Occurrence
+D_after    = D_after ⟼ (sameParent ⟼ H_after)
 ```
 
-Это различие проходит через всю Foundation v2.
+`:` — explicit persistent effect, а не host assignment и не theorem assertion.
 
 ---
 
-# 6. Интерпретатор и actual act
+# 6. Read/replay не materialize-ит
+
+Фундаментальный operational split:
+
+```text
+READ SIDE
+read / find / enumerate / resolve / replay
+
+EFFECT SIDE
+materialize / define / delete / persist transition
+```
+
+Главный инвариант:
+
+```text
+find / replay != materialize
+```
+
+Если описание связи само создаёт искомую связь, ассоциативный поиск теряет смысл.
+
+---
+
+# 7. Local `=`
+
+Текущее Foundation-v2 equality — local representative constraint:
+
+```text
+K ⟼ (member ⟼ representative)
+```
+
+```text
+Equal_K(a,b)
+⇔ rep_K(a) is rep_K(b)
+```
+
+Нет автоматических:
+
+```text
+transitivity chains
+substitution
+congruence
+recursive rewriting
+global union-find
+```
+
+Логический вывод требует отдельного `T`-admitted rule.
+
+---
+
+# 8. Actual act и Run
 
 МТС различает:
 
 ```text
-описание интерпретатора I
-и
-фактически произошедший акт A
+I — interpreter / capability
+A — конкретный actual act
 ```
 
-`A` содержит exact evidence того, что было выбрано и проверено: source, форму, словарь, теорию, контекст, binding, result и другие необходимые роли.
+Actual act хранит exact evidence выбранного случая.
 
-Trusted replay не обязан доверять тому, кто нашёл этот акт. Он повторно проверяет предъявленную сеть.
-
-Отсюда фундаментальное разделение:
-
-```text
-untrusted search / ranking
-        ↓ candidate
-trusted exact replay
-        ↓
-accept / reject
-```
-
-Именно эта граница нужна будущему `aprover`.
-
----
-
-# 7. Локальное равенство, а не глобальная подстановка
-
-Foundation v2 отказалась от идеи, что `=` автоматически создаёт глобальную конгруэнтность или rewrite-систему.
-
-Локальное representative-ограничение может быть представлено так:
-
-```text
-Pair    = member ⟼ representative
-Binding = K ⟼ Pair
-```
-
-Тогда:
-
-```text
-rep_K(x) = явный локальный representative,
-           иначе сам x
-
-Equal_K(a,b)
-⇔ rep_K(a) и rep_K(b) — один exact occurrence
-```
-
-Это **одношаговая локальная** семантика.
-
-Из
-
-```text
-a → b
-b → c
-```
-
-не появляется автоматически:
-
-```text
-a → c
-```
-
-Нет скрытой транзитивности, substitution, congruence или глобального union-find.
-
-Если требуется логическое правило — оно должно быть отдельно предъявлено и допущено теорией `T`.
-
----
-
-# 8. Proof rules и Run
-
-Последовательность actual acts сама является сетью:
+Многошаговый provenance:
 
 ```text
 Run_0     = R
 Run_(i+1) = Run_i ⟼ A_i
 ```
 
-Соседние шаги обязаны иметь exact continuity контекста:
+с exact continuity:
 
 ```text
 A_i.after is A_(i+1).before
 ```
 
-Но adjacency не означает логическую транзитивность и не создаёт shortcut `K0 → Kn`.
+Run фиксирует order, но не создаёт logical transitivity.
 
-Первый Foundation-v2 proof-rule candidate — отдельно допущенная теорией одношаговая decomposition истинного локального равенства двух завершённых связей:
+---
+
+# 9. Proof и будущий aprover
+
+Первый proof-rule candidate существует только через:
 
 ```text
-Equal_K(L,R) = true
-
-L = ls ⟼ le
-R = rs ⟼ re
-
 T ⟼ Rule
-
-Rule(L,R)
-→ ls ⟼ rs
-→ le ⟼ re
 ```
 
-Это правило не встроено в `=` и не запускается рекурсивно само.
+и одношагово decomposes истинное local equality завершённых links.
+
+Integrated checker уже replay-ит:
+
+```text
+source `decompose`
+→ scoped D/G/T
+→ exact Rule
+→ true equality A_eq
+→ T ⟼ Rule
+→ A_rule
+→ Run[A_eq,A_rule]
+→ accept / reject
+```
+
+Ключевая архитектура `aprover`:
+
+```text
+untrusted proof search / indices / heuristics
+                  ↓ candidate
+trusted exact replay
+                  ↓
+             accept / reject
+```
+
+Поисковый алгоритм может быть сложным и недоверенным, если selected evidence проверяется маленьким trusted core.
 
 Подробнее: [Foundation v2 Proof replay](docs/specs/Foundation%20v2%20Proof%20replay.md).
 
 ---
 
-# 9. Апамять — контроллер сетей связей
+# 10. Апамять — controller сети связей
 
-Один из наиболее наглядных прикладных результатов МТС — архитектура **апамяти**.
+Апамять — прикладная operational форма МТС.
 
-Апамять лучше понимать не как «базу объектов», а как контроллер exact-occurrence сети связей:
-
-```text
-создать связь
-найти связи по полюсам
-перечислить exact occurrences
-сохранить sharing и циклы
-вести persistent состояния
-проверять selected evidence
-явно materialize-ить effect
-```
-
-При этом данные и управляющая структура могут находиться в одной и той же онтологии:
+Она хранит и обслуживает exact network:
 
 ```text
 application links
 K contexts
-D dictionaries
+D histories
 G/T admissions
 source evidence
 actual acts
@@ -328,101 +313,230 @@ proof claims
 Runs
 ```
 
-Например запись ачислового/структурного выражения:
+Индекс может быстро вернуть candidates, но не определяет истину.
 
 ```text
-∞[window][cursor][position][[[x][int]][point]]
+find(A,B) -> exact occurrences
 ```
 
-может рассматриваться не просто как строка для парсера, а как инструкция/описание того, какие отношения должны быть разрешены, найдены или материализованы в сети.
+не создаёт отсутствующую связь.
 
-Ключевой принцип:
-
-```text
-find / read / replay
-        ≠
-materialize / delete
-```
-
-Это позволяет использовать быстрые индексы и эвристики для поиска, не делая их частью доверенной семантики.
+Только explicit materialization создаёт новый occurrence.
 
 Подробнее: [Апамять и управление сетью связей](docs/specs/Апамять%20и%20управление%20сетью%20связей.md).
 
 ---
 
-# 10. Ачисла
+# 11. Ачисла: source sequence и result network
 
-Ачисло — рекурсивное структурное описание, исторически использующее четыре абита:
+Historical Anum использует четыре абита:
 
 ```text
 [ ] 0 1
 ```
 
-Для Foundation v2 важно уточнение: рекурсивное ачисло не объявляется универсальной identity произвольной асети.
+Historical recursive denotation v0.2 остаётся accepted occurrence-tree contract.
 
-Оно является **root-relative structural description** на своей области применимости, прежде всего для occurrence-tree представлений. Для сетей с sharing и произвольными циклами требуется exact occurrence identity.
+Foundation v2 уточняет более общий sequence mode:
 
-Документы:
+```text
+source carrier != target network
+```
 
-- [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md)
-- [Протокол абитов ачисел](docs/specs/Протокол%20абитов%20ачисел.md)
+Например source carrier:
 
-Следующий release gate #242 должен связать последовательность ачисла с явной materialization-семантикой апамяти.
+```text
+∞ A B
+```
+
+не обязан уже содержать:
+
+```text
+A ⟼ B
+```
+
+Explicit sequence materialization создаёт target relation только на effect side.
 
 ---
 
-# 11. Что уже является executable Foundation v2
+# 12. Foundation-v2 sequence materialization #242
 
-Production-facing candidate modules сейчас разделены по обязанностям:
+Machine contract candidate:
+
+```text
+contracts/mts-anum-sequence-materialization-v0.7.json
+```
+
+Production-facing module:
+
+```text
+core/foundation_v2_materialization.py
+```
+
+Semantics:
+
+```text
+∞ A B C
+→ new exact A⟼B
+→ new exact B⟼C
+```
+
+Root `∞` — sentinel, а не первый adjacency operand.
+
+Nested group:
+
+```text
+[A]   → exact A
+[A B] → X = A ⟼ B, return exact X
+```
+
+Поэтому:
+
+```text
+∞ [A B] C
+→ X = A ⟼ B
+→ Y = X ⟼ C
+```
+
+Вложенный context возвращает построенную relation как один элемент внешней последовательности.
+
+---
+
+# 13. Наглядный Anum/apamemory пример
+
+```text
+∞[window][cursor][position][[[x][int]][point]]
+```
+
+Sequence candidate строит:
+
+```text
+XI = X ⟼ Int
+Q  = XI ⟼ Point
+WC = Window ⟼ Cursor
+CP = Cursor ⟼ Position
+PQ = Position ⟼ Q
+```
+
+```text
+Window ─────▶ Cursor ─────▶ Position
+                              │
+                              ▼
+                              Q
+                             / \
+                            /   \
+                          XI   Point
+                         /  \
+                        X   Int
+```
+
+До explicit effect source carrier не обязан содержать эти target relations.
+
+Это наглядно показывает, зачем МТС различает описание, поиск и materialization.
+
+Подробнее: [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md).
+
+---
+
+# 14. Materialization не наследует pair interning
+
+Старый historical `core/anum_memory.py` использовал canonical pair interning.
+
+Foundation v2 не наследует эту semantics.
+
+Если уже существует:
+
+```text
+P1 = A ⟼ B
+```
+
+новый explicit sequence effect может создать:
+
+```text
+P2 = A ⟼ B
+```
+
+при этом:
+
+```text
+P1 ≠ P2
+```
+
+Каждая adjacency sequence effect создаёт новый exact occurrence. Возможный reuse должен быть отдельным explicit planning decision, а не скрытым следствием одинаковой пары.
+
+---
+
+# 15. Persistent before/after state
+
+Foundation-v2 exact network поддерживает additive evolution:
+
+```text
+before
+  ↓ explicit effect
+ after
+```
+
+В одном runtime lineage:
+
+- старые exact refs сохраняются;
+- старые links не изменяются;
+- новые occurrences append-ятся;
+- duplicate pairs разрешены;
+- root сохраняется.
+
+Independent snapshot reload создаёт fresh runtime identity scope, поэтому snapshot slot не становится universal identity.
+
+---
+
+# 16. Текущие Foundation-v2 modules
 
 ```text
 core/exact_link_network.py
-    exact-occurrence binary-link substrate
+    exact-occurrence substrate + additive evolution
 
 core/foundation_v2_state.py
-    K / scoped D / memberships / actual-act state
+    K / scoped D / memberships / A
 
 core/foundation_v2_source.py
     canonical source and selected segmentation replay
 
 core/foundation_v2_interpreter.py
-    relation / `:` / `=` trusted replay
+    relation / `:` / `=` replay
 
 core/foundation_v2_run.py
     exact ordered actual-act Run
 
 core/foundation_v2_proof.py
-    separately T-admitted proof-rule replay
+    T-admitted proof-rule replay
 
 core/foundation_v2_checker.py
-    integrated source → proof → Run replay
+    integrated source→proof→Run replay
+
+core/foundation_v2_materialization.py
+    nested Anum sequence explicit materialization/replay
 ```
 
-Это всё ещё **candidate следующей версии**, а не разрешение удалить старые accepted contracts.
+Все они пока candidate следующей версии.
 
 ---
 
-# 12. Путь к следующей версии МТС
+# 17. Путь к accepted Foundation v2
 
-После завершения semantic proof/checker core фокус должен идти по release chain:
+После sequence gate #242 основной release chain:
 
 ```text
-#261  обновление главной документации
-  ↓
-#242  Anum sequence → апамять materialization
-  ↓
-#124  persistent L4/backend contract
-  ↓
+#124 persistent L4/backend contract
+↓
 historical compatibility classification
-  ↓
-atomic production cutover + удаление старого semantic path
-  ↓
+↓
+atomic production cutover + old semantic-path deletion
+↓
 versioned integrated conformance corpus
-  ↓
+↓
 explicit Foundation-v2 acceptance
-  ↓
+↓
 следующая опубликованная версия МТС
-  ↓
+↓
 aprover repin
 ```
 
@@ -430,9 +544,9 @@ aprover repin
 
 ---
 
-# 13. Как читать репозиторий сейчас
+# 18. Как читать репозиторий
 
-Для понимания **текущей** МТС рекомендуется такой порядок:
+Для текущей МТС:
 
 1. [Основания МТС](docs/theory/Основания%20МТС.md)
 2. [Система аксиом МТС](docs/theory/Система%20аксиом%20МТС.md)
@@ -442,27 +556,23 @@ aprover repin
 6. [Foundation v2 Proof replay](docs/specs/Foundation%20v2%20Proof%20replay.md)
 7. [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md)
 
-Для воспроизведения **исторически принятых** версий:
+Для historical accepted behavior:
 
 - [Reference model МТС v0.2](docs/specs/Reference%20model%20МТС%20v0.2.md)
-- `contracts/mts-contract-v0.2.json` … `contracts/mts-contract-v0.5.json`
-- соответствующие conformance-корпуса
-- `tests/mtc_formulas.mtc` — неизменяемая корневая программа исторической линии
-
-`docs/research/` содержит исследовательские записи и provenance решений; они не заменяют активные спецификации.
+- versioned `contracts/mts-contract-v0.2.json` … `v0.5`
+- historical conformance corpora.
 
 ---
 
-## Главный инвариант текущей работы
+## Главный инвариант
 
 ```text
 одна онтология связей
 + exact occurrence identity
-+ явное состояние
-+ явное evidence
-+ недоверенный поиск
-+ доверенное replay
-+ явная materialization
++ explicit state/evidence
++ untrusted discovery
++ deterministic trusted replay
++ explicit materialization
 ```
 
-Именно из этой комбинации МТС превращается из абстрактной теории связей в основу для ассоциативной памяти, интерпретатора и проверяемого доказателя.
+Эта комбинация связывает фундаментальную МТС с ассоциативной памятью и проверяемым `aprover`.

--- a/contracts/mts-anum-sequence-materialization-v0.7.json
+++ b/contracts/mts-anum-sequence-materialization-v0.7.json
@@ -1,0 +1,65 @@
+{
+  "schema": "mts-anum-sequence-materialization/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 242,
+  "parent": 237,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-foundation-v2-state/v0.7"
+  ],
+  "sourceBoundary": {
+    "input": "already-selected root-relative nested sequence description over exact existing occurrences",
+    "rawBracketsAreHostOpcodes": false,
+    "tokenOrAstIdentityIsSemantic": false,
+    "sourceCarrierEqualsTargetNetwork": false,
+    "rootSentinelParticipatesInAdjacency": false
+  },
+  "sequenceSemantics": {
+    "topLevel": "∞ A B C -> create A⟼B and B⟼C",
+    "singleton": "one item returns that exact item and creates no relation",
+    "nestedGroup": "recursively materialize the group and return its last created relation as one outer value",
+    "multiItemResult": "the last exact adjacency relation created by the sequence",
+    "emptySequenceAllowed": false
+  },
+  "effectBoundary": {
+    "beforeImmutable": true,
+    "afterSameRuntimeIdentityLineage": true,
+    "existingRefsPreservedByExactIdentity": true,
+    "existingLinksImmutable": true,
+    "newOccurrencesAppended": true,
+    "everyAdjacencyCreatesNewExactOccurrence": true,
+    "samePairImpliesReuse": false,
+    "pairInterning": false,
+    "replayReadOnly": true,
+    "findReadOnly": true
+  },
+  "identityBoundary": {
+    "sameLineageBeforeAfterMayShareExactRefs": true,
+    "independentSnapshotReloadCreatesFreshRuntimeIdentity": true,
+    "snapshotSlotIsUniversalSemanticIdentity": false,
+    "backendAddressIsSemanticIdentity": false,
+    "structuralEqualityImpliesExactIdentity": false
+  },
+  "requiredVectors": [
+    "source carrier for ∞ab lacks a⟼b before materialization",
+    "∞ab creates exactly one new a⟼b occurrence",
+    "∞abc creates exactly a⟼b then b⟼c and returns b⟼c",
+    "∞[ab]c creates inner a⟼b then outer (a⟼b)⟼c",
+    "∞[window][cursor][position][[[x][int]][point]] creates XI, Q, W⟼C, C⟼P, P⟼Q in deterministic nested-first order",
+    "singleton nested group returns its exact item without a new link",
+    "existing equal-pair occurrence is not implicitly reused",
+    "find of absent target does not mutate before state",
+    "replay rejects forged poles, extra occurrences, wrong result or changed base topology",
+    "snapshot round-trip preserves topology but not cross-load runtime identity",
+    "historical v0.2 recursive denotation contracts remain unchanged and are not silently replaced"
+  ],
+  "compatibility": {
+    "historicalV02PairDenotationStillAccepted": true,
+    "historicalAnumMemoryPairInterningInherited": false,
+    "sequenceModeReplacesRecursivePairGrammar": false,
+    "sequenceModeIsFoundationV2MaterializationCandidate": true
+  },
+  "nextGate": "persistent L4/backend contract #124, then integrated release conformance and cutover",
+  "aproverRepinAllowed": false
+}

--- a/core/exact_link_network.py
+++ b/core/exact_link_network.py
@@ -1,14 +1,19 @@
 """Storage-neutral exact-occurrence binary-link network for Foundation-v2 Gate P.
 
-This module is intentionally smaller than the MTS language.  A semantic link has
-exactly two fields, ``start`` and ``end``.  Context, dictionary, theory, act,
+This module is intentionally smaller than the MTS language. A semantic link has
+exactly two fields, ``start`` and ``end``. Context, dictionary, theory, act,
 source, equality, token and AST roles are *not* link tags; higher layers may
 represent those roles with ordinary link occurrences.
 
-``OccurrenceRef`` is network-local identity.  A portable snapshot stores local
-slots, but loading it creates a fresh identity scope.  Consequently a backend
-address, a snapshot slot and a runtime occurrence ref are deliberately not one
-universal identifier.
+``OccurrenceRef`` is network-lineage-local identity. A portable snapshot stores
+local slots, but loading it creates a fresh identity scope. Consequently a
+backend address, a snapshot slot and a runtime occurrence ref are deliberately
+not one universal identifier.
+
+An immutable network may be evolved into a new immutable state in the *same*
+runtime identity lineage. Existing occurrence objects and links are preserved
+exactly; only newly reserved occurrences may be added. This is the substrate
+boundary needed by explicit Foundation-v2 materialization effects.
 """
 from __future__ import annotations
 
@@ -95,6 +100,16 @@ class LinkNetwork:
             root=self._root.slot,
         )
 
+    def evolve(self) -> "LinkNetworkEvolutionBuilder":
+        """Create an additive builder for a new state in this identity lineage.
+
+        The original network stays immutable. Existing ``OccurrenceRef`` objects
+        are retained by identity in the evolved state; only new occurrences may
+        be reserved and defined. No pair interning is performed.
+        """
+
+        return LinkNetworkEvolutionBuilder(self)
+
     @classmethod
     def from_snapshot(cls, snapshot: NetworkSnapshot) -> "LinkNetwork":
         """Load topology into a fresh identity scope."""
@@ -135,7 +150,7 @@ class LinkNetworkBuilder:
     """Host construction utility for finite cyclic/shared exact networks.
 
     Reservation exists solely so cyclic endpoints can refer to occurrences that
-    are defined later.  It is construction machinery, not an ontological link
+    are defined later. It is construction machinery, not an ontological link
     state or a semantic notion of an "undefined link".
     """
 
@@ -200,3 +215,91 @@ class LinkNetworkBuilder:
     def _require_mutable(self) -> None:
         if self._frozen:
             raise LinkNetworkError("builder is already frozen")
+
+
+class LinkNetworkEvolutionBuilder:
+    """Additive persistent-state builder preserving existing exact identity.
+
+    This builder represents an explicit effect boundary. It never mutates the
+    base network. Existing occurrences are immutable and keep the exact same
+    ``OccurrenceRef`` objects in the returned state. Newly reserved occurrences
+    are appended in the same runtime identity scope and may point to old or new
+    occurrences. Duplicate pole pairs are deliberately allowed.
+    """
+
+    def __init__(self, base: LinkNetwork) -> None:
+        self._base = base
+        self._scope = base._scope
+        self._refs: list[OccurrenceRef] = list(base._refs)
+        self._links: list[Link | None] = list(base._links)
+        self._base_count = len(self._refs)
+        self._frozen = False
+
+    @property
+    def base_count(self) -> int:
+        """Number of exact occurrences inherited from the immutable base state."""
+
+        return self._base_count
+
+    def reserve(self) -> OccurrenceRef:
+        self._require_mutable()
+        ref = OccurrenceRef(self._scope, len(self._refs))
+        self._refs.append(ref)
+        self._links.append(None)
+        return ref
+
+    def define(
+        self,
+        ref: OccurrenceRef,
+        start: OccurrenceRef,
+        end: OccurrenceRef,
+    ) -> None:
+        self._require_mutable()
+        self._validate_reserved(ref)
+        self._validate_reserved(start)
+        self._validate_reserved(end)
+        if ref.slot < self._base_count:
+            raise LinkNetworkError("base occurrence is immutable during evolution")
+        if self._links[ref.slot] is not None:
+            raise LinkNetworkError("occurrence is already defined")
+        self._links[ref.slot] = Link(start, end)
+
+    def define_many(
+        self,
+        definitions: Iterable[tuple[OccurrenceRef, OccurrenceRef, OccurrenceRef]],
+    ) -> None:
+        for ref, start, end in definitions:
+            self.define(ref, start, end)
+
+    def freeze(self, root: OccurrenceRef | None = None) -> LinkNetwork:
+        """Return a new immutable state in the same exact-identity lineage."""
+
+        self._require_mutable()
+        selected_root = self._base.root if root is None else root
+        self._validate_reserved(selected_root)
+        missing = [
+            ref.slot
+            for ref, link in zip(self._refs[self._base_count :], self._links[self._base_count :])
+            if link is None
+        ]
+        if missing:
+            raise LinkNetworkError(f"unbound evolved occurrences: {missing}")
+
+        refs = tuple(self._refs)
+        links = tuple(link for link in self._links if link is not None)
+        self._frozen = True
+        return LinkNetwork(self._scope, refs, links, selected_root)
+
+    def _validate_reserved(self, ref: OccurrenceRef) -> None:
+        if not isinstance(ref, OccurrenceRef):
+            raise LinkNetworkError("expected OccurrenceRef")
+        if ref._scope is not self._scope:
+            raise LinkNetworkError("foreign occurrence reference")
+        if ref.slot < 0 or ref.slot >= len(self._refs):
+            raise LinkNetworkError("occurrence was not reserved in this lineage")
+        if self._refs[ref.slot] is not ref:
+            raise LinkNetworkError("occurrence reference was not issued by this lineage")
+
+    def _require_mutable(self) -> None:
+        if self._frozen:
+            raise LinkNetworkError("evolution builder is already frozen")

--- a/core/foundation_v2_materialization.py
+++ b/core/foundation_v2_materialization.py
@@ -1,0 +1,312 @@
+"""Foundation-v2 Anum sequence materialization over exact-occurrence networks.
+
+The source/Anum front-end and this module are deliberately separate. Brackets,
+tokens and parser nodes are not interpreted here. The trusted input is an
+already-selected nested sequence description whose leaves are exact existing
+occurrences. Materialization is an explicit persistent effect: the immutable
+``before`` network is preserved and an ``after`` state in the same runtime
+identity lineage is produced with newly appended exact link occurrences.
+
+Sequence semantics:
+
+``∞ A B C`` -> create ``A⟼B`` and ``B⟼C``.
+
+A nested group is evaluated recursively and returns one exact value to its
+outer sequence. A singleton group returns its contained value without creating
+a link. A group of two or more values creates every adjacent relation and
+returns the last created relation occurrence.
+
+Every adjacency creates a *new* exact occurrence. Pair interning and implicit
+reuse are intentionally absent; a search/reuse policy belongs to the untrusted
+planning side and must be explicit if introduced later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .exact_link_network import LinkNetwork, LinkNetworkError, OccurrenceRef
+
+
+class SequenceMaterializationError(ValueError):
+    """Selected sequence/materialization evidence is invalid or forged."""
+
+
+@dataclass(frozen=True)
+class SequenceAtom:
+    """One already-resolved exact occurrence used as a sequence value."""
+
+    value: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class SequenceGroup:
+    """One nested sequence; host nesting is a checker handle, not semantic ID."""
+
+    items: tuple["SequenceItem", ...]
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise SequenceMaterializationError("nested sequence group cannot be empty")
+
+
+SequenceItem = SequenceAtom | SequenceGroup
+
+
+@dataclass(frozen=True)
+class SequenceDescription:
+    """Selected root-relative sequence description for one materialization."""
+
+    root: OccurrenceRef
+    items: tuple[SequenceItem, ...]
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise SequenceMaterializationError("top-level sequence cannot be empty")
+
+
+@dataclass(frozen=True)
+class MaterializedEdge:
+    """One exact new occurrence created by the explicit sequence effect."""
+
+    ref: OccurrenceRef
+    start: OccurrenceRef
+    end: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class SequenceMaterialization:
+    """Persistent before→after effect evidence for one selected sequence."""
+
+    description: SequenceDescription
+    after: LinkNetwork
+    created: tuple[MaterializedEdge, ...]
+    result: OccurrenceRef
+
+
+def find_links(
+    network: LinkNetwork,
+    *,
+    start: OccurrenceRef | None = None,
+    end: OccurrenceRef | None = None,
+) -> tuple[OccurrenceRef, ...]:
+    """Read-only exact occurrence search; never materializes a missing pair."""
+
+    before = network.snapshot()
+    if start is not None:
+        network.link(start)
+    if end is not None:
+        network.link(end)
+
+    found = tuple(
+        ref
+        for ref in network.refs
+        if (start is None or network.link(ref).start is start)
+        and (end is None or network.link(ref).end is end)
+    )
+    if network.snapshot() != before:
+        raise SequenceMaterializationError("read-only find mutated the network")
+    return found
+
+
+def materialize_sequence(
+    before: LinkNetwork,
+    description: SequenceDescription,
+) -> SequenceMaterialization:
+    """Explicitly materialize one nested sequence into a new immutable state."""
+
+    before_snapshot = before.snapshot()
+    _require_description_root(before, description)
+    evolution = before.evolve()
+    created: list[MaterializedEdge] = []
+
+    result = _materialize_items(
+        before,
+        evolution,
+        description.items,
+        created,
+    )
+    after = evolution.freeze()
+
+    if before.snapshot() != before_snapshot:
+        raise SequenceMaterializationError("materialization mutated the before network")
+
+    evidence = SequenceMaterialization(
+        description=description,
+        after=after,
+        created=tuple(created),
+        result=result,
+    )
+    replay_sequence_materialization(before, evidence)
+    return evidence
+
+
+def replay_sequence_materialization(
+    before: LinkNetwork,
+    evidence: SequenceMaterialization,
+) -> OccurrenceRef:
+    """Replay one already-materialized sequence effect without changing either state."""
+
+    before_snapshot = before.snapshot()
+    after_snapshot = evidence.after.snapshot()
+    try:
+        _require_description_root(before, evidence.description)
+        _verify_persistent_lineage(before, evidence.after, evidence.created)
+
+        cursor = _ReplayCursor(evidence.created)
+        result = _replay_items(
+            before,
+            evidence.after,
+            evidence.description.items,
+            cursor,
+        )
+        if cursor.position != len(evidence.created):
+            raise SequenceMaterializationError(
+                "materialization contains extra created occurrences"
+            )
+        if result is not evidence.result:
+            raise SequenceMaterializationError("forged materialization result occurrence")
+        return result
+    except LinkNetworkError as exc:
+        raise SequenceMaterializationError("invalid exact occurrence evidence") from exc
+    finally:
+        if before.snapshot() != before_snapshot:
+            raise SequenceMaterializationError("replay mutated the before network")
+        if evidence.after.snapshot() != after_snapshot:
+            raise SequenceMaterializationError("replay mutated the after network")
+
+
+def _require_description_root(
+    network: LinkNetwork,
+    description: SequenceDescription,
+) -> None:
+    if description.root is not network.root:
+        raise SequenceMaterializationError(
+            "sequence must be rooted at the exact distinguished network root"
+        )
+
+
+def _materialize_items(
+    before: LinkNetwork,
+    evolution,
+    items: tuple[SequenceItem, ...],
+    created: list[MaterializedEdge],
+) -> OccurrenceRef:
+    values = tuple(
+        _materialize_item(before, evolution, item, created) for item in items
+    )
+    if len(values) == 1:
+        return values[0]
+
+    last: OccurrenceRef | None = None
+    for start, end in zip(values, values[1:]):
+        ref = evolution.reserve()
+        evolution.define(ref, start, end)
+        created.append(MaterializedEdge(ref=ref, start=start, end=end))
+        last = ref
+    assert last is not None
+    return last
+
+
+def _materialize_item(
+    before: LinkNetwork,
+    evolution,
+    item: SequenceItem,
+    created: list[MaterializedEdge],
+) -> OccurrenceRef:
+    if isinstance(item, SequenceAtom):
+        try:
+            before.link(item.value)
+        except LinkNetworkError as exc:
+            raise SequenceMaterializationError(
+                "sequence atom is not an exact occurrence of the before network"
+            ) from exc
+        return item.value
+    return _materialize_items(before, evolution, item.items, created)
+
+
+def _verify_persistent_lineage(
+    before: LinkNetwork,
+    after: LinkNetwork,
+    created: tuple[MaterializedEdge, ...],
+) -> None:
+    base_count = len(before.refs)
+    if len(after.refs) != base_count + len(created):
+        raise SequenceMaterializationError(
+            "after network cardinality does not match explicit created evidence"
+        )
+    if after.root is not before.root:
+        raise SequenceMaterializationError("materialization changed the exact root")
+
+    for index, ref in enumerate(before.refs):
+        if after.refs[index] is not ref:
+            raise SequenceMaterializationError(
+                "after network does not preserve exact base occurrence identity"
+            )
+        if after.link(ref) is not before.link(ref):
+            raise SequenceMaterializationError(
+                "materialization changed an existing base link"
+            )
+
+    appended = after.refs[base_count:]
+    if len(appended) != len(created):
+        raise SequenceMaterializationError("created evidence cardinality mismatch")
+    for ref, edge in zip(appended, created, strict=True):
+        if ref is not edge.ref:
+            raise SequenceMaterializationError(
+                "created occurrence order differs from exact appended network order"
+            )
+
+
+@dataclass
+class _ReplayCursor:
+    created: tuple[MaterializedEdge, ...]
+    position: int = 0
+
+    def consume(self) -> MaterializedEdge:
+        if self.position >= len(self.created):
+            raise SequenceMaterializationError(
+                "materialization is missing an expected sequence relation"
+            )
+        edge = self.created[self.position]
+        self.position += 1
+        return edge
+
+
+def _replay_items(
+    before: LinkNetwork,
+    after: LinkNetwork,
+    items: tuple[SequenceItem, ...],
+    cursor: _ReplayCursor,
+) -> OccurrenceRef:
+    values = tuple(_replay_item(before, after, item, cursor) for item in items)
+    if len(values) == 1:
+        return values[0]
+
+    last: OccurrenceRef | None = None
+    for start, end in zip(values, values[1:]):
+        edge = cursor.consume()
+        link = after.link(edge.ref)
+        if edge.start is not start or edge.end is not end:
+            raise SequenceMaterializationError(
+                "created edge evidence does not match sequence adjacency"
+            )
+        if link.start is not start or link.end is not end:
+            raise SequenceMaterializationError(
+                "after network link does not match sequence adjacency"
+            )
+        last = edge.ref
+    assert last is not None
+    return last
+
+
+def _replay_item(
+    before: LinkNetwork,
+    after: LinkNetwork,
+    item: SequenceItem,
+    cursor: _ReplayCursor,
+) -> OccurrenceRef:
+    if isinstance(item, SequenceAtom):
+        before.link(item.value)
+        after.link(item.value)
+        return item.value
+    return _replay_items(before, after, item.items, cursor)

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -24,21 +24,19 @@ P7  exact multistep Run                        #253/#254
 P8  separately T-admitted proof rule           #255/#256
 P9  integrated source→proof→Run checker        #257/#262
 Docs current MTS surface                       #261/#263
+Anum sequence → апамять materialization        #242/#264
 ```
 
-Текущий Gate-P release blocker:
+После merge #264 semantic candidate #242 считается завершённым Gate-P evidence. Текущий следующий release blocker:
 
 ```text
-#242  Anum sequence → апамять materialization
+#124  persistent L4/backend contract
 ```
-
-В этой ветке #242 получает executable candidate; после его merge следующая крупная зависимость — persistent L4 #124.
 
 Остаток release chain:
 
 ```text
-#242 sequence materialization
-→ #124 persistent L4/backend
+#124 persistent L4/backend
 → historical compatibility classification
 → atomic production cutover / old semantic-path deletion
 → versioned integrated conformance corpus
@@ -338,6 +336,8 @@ CP = Cursor ⟼ Position
 PQ = Position ⟼ Q
 ```
 
+#242 после merge #264 больше не является открытым semantic gap: sequence materialization имеет executable contract, tests и replay boundary. Он остаётся candidate частью будущей Foundation v2 до общего acceptance.
+
 ---
 
 # 11. Materialization identity policy
@@ -403,7 +403,7 @@ Read-only `find_links` отдельно доказывает отсутстви�
 
 # 13. Persistent L4 gap #124
 
-После #242 остаётся доказать те же свойства на persistent backend:
+Текущий следующий Gate-P blocker — доказать те же свойства на persistent backend:
 
 ```text
 multiplicity

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -4,263 +4,178 @@
 
 Главный epic: #237.
 
-Цель Gate P — собрать **один** link-only production/reference semantic path, удалить конкурирующие старые semantic paths при cutover и только затем опубликовать следующую accepted версию МТС для downstream consumers, прежде всего `aprover`.
+Цель Gate P — собрать **один** link-only production/reference semantic path и только затем опубликовать следующую accepted версию МТС для `aprover` и других downstream consumers.
 
 ---
 
-# 1. Текущее состояние
+# 1. Текущая лестница Gate P
 
-Foundation v2 уже прошла основные semantic gates:
+Завершённые semantic/docs gates:
 
 ```text
-P0  production semantic surface audit
-P1  exact-occurrence binary-link substrate
-P2  link-only K / D / G / T / I / A state
-P3  canonical source front-end
-P4  unified relation interpreter/replay
-P5  persistent scoped D + `:`
-P6  local representative `=`
-P7  exact multistep Run
-P8  separately T-admitted proof rule
-P9  integrated source → Rule → equality → proof → Run replay
+P0  production semantic surface audit          #238/#239
+P1  exact-occurrence binary-link substrate     #240/#241
+P2  explicit K / D / G / T / I / A             #243/#244
+P3  canonical source front-end                 #245/#246
+P4  relation interpreter/replay                #247/#248
+P5  persistent scoped D + `:`                  #249/#250
+P6  local representative `=`                   #251/#252
+P7  exact multistep Run                        #253/#254
+P8  separately T-admitted proof rule           #255/#256
+P9  integrated source→proof→Run checker        #257/#262
+Docs current MTS surface                       #261/#263
 ```
 
-Ключевые завершённые issues/PRs:
+Текущий Gate-P release blocker:
 
 ```text
-#238/#239  production semantic surface audit
-#240/#241  exact-occurrence substrate
-#243/#244  Foundation-v2 state / apamemory roles
-#245/#246  source front-end
-#247/#248  interpreter/replay
-#249/#250  scoped D + `:`
-#251/#252  local `=`
-#253/#254  exact Run
-#255/#256  first T-admitted proof rule
-#257/#262  integrated proof/checker conformance
+#242  Anum sequence → апамять materialization
 ```
 
-Сейчас semantic proof/checker core считается **готовым к release-hardening**, но Foundation v2 ещё не принята.
+В этой ветке #242 получает executable candidate; после его merge следующая крупная зависимость — persistent L4 #124.
 
-Оставшиеся крупные blockers:
+Остаток release chain:
 
 ```text
-#261  current documentation refresh
-#242  Anum sequence → апамять executable materialization
-#124  persistent L4/backend contract
-historical compatibility classification
-atomic production cutover / legacy semantic-path deletion
-versioned integrated conformance corpus
-explicit Foundation-v2 acceptance
-published next MTS version
-aprover repin
+#242 sequence materialization
+→ #124 persistent L4/backend
+→ historical compatibility classification
+→ atomic production cutover / old semantic-path deletion
+→ versioned integrated conformance corpus
+→ explicit Foundation-v2 acceptance
+→ published next MTS version
+→ aprover repin
 ```
 
 ---
 
 # 2. Базовый substrate
 
-Единственный primitive semantic shape:
+Примитив:
 
 ```text
 Link(start, end)
 ```
 
-При этом identity находится не в паре полюсов, а в exact occurrence.
+Identity принадлежит exact occurrence, а не паре полюсов:
 
 ```text
 P1 = A ⟼ B
 P2 = A ⟼ B
-
 P1 ≠ P2
 ```
 
-Substrate обязан поддерживать:
+Допускаются:
 
-- duplicate pairs;
-- multiple self-cycles;
-- arbitrary finite cycles;
-- sharing;
-- exact root selection;
-- portable topology snapshot без объявления snapshot slot универсальной identity.
+```text
+duplicate pairs
+self-cycles
+mutual cycles
+sharing
+```
 
-Не принимаются как semantic identity:
+Не являются semantic identity:
 
 ```text
 graph isomorphism
 pair interning
-physical memory address
-persistent backend handle
 AST path
 source spelling
+snapshot slot
+physical backend address
 ```
 
-Production-facing implementation: `core/exact_link_network.py`.
+`core/exact_link_network.py` теперь также поддерживает **additive persistent evolution**: новое immutable state может сохранять те же exact refs старых occurrences и append-ить новые occurrences без изменения `before`.
 
 ---
 
-# 3. Bootstrap R/O/C/L/U
+# 3. Explicit state и source
 
-Foundation v2 использует небольшой набор distinguished exact occurrences:
-
-```text
-R / O / C / L / U
-```
-
-Их назначение bootstrap-уровня определяется exact selection, а не глобальным shape classifier.
-
-Например две связи:
+Foundation v2 выражает обычными связями:
 
 ```text
-R = R ⟼ R
-X = X ⟼ X
+K  context
+D  scoped dictionary
+G  grammar admission
+T  theory admission
+I  interpreter
+A  actual act
 ```
 
-остаются различными exact occurrences.
+Source path:
 
-Поэтому нельзя восстанавливать semantic role только из self-closed shape.
+```text
+UTF-8
+→ canonical content C
+→ exact source occurrence S
+→ selected segmentation
+→ scoped D
+→ G/T admission
+→ exact form
+```
+
+Token/AST class не является semantic authority.
 
 ---
 
-# 4. Context K
+# 4. Trusted replay
 
-Persistent context выражается обычными связями:
+Основное разделение:
+
+```text
+untrusted search / ranking / execution planning
+             ↓ selected exact evidence
+trusted deterministic replay
+             ↓
+accept / reject
+```
+
+Replay:
+
+- не ищет candidate;
+- не выбирает rule;
+- не materialize-ит отсутствующие links;
+- не доверяет shape equality;
+- не зависит от legacy parser/proof checker.
+
+---
+
+# 5. Persistent K и D
+
+Context:
 
 ```text
 P = parent ⟼ current
 K = K ⟼ P
 ```
 
-`K` — exact snapshot.
-
-Текущий focus:
-
-```text
-↑ = current(K)
-```
-
-не требует скрытого global current или `ContextFrame` stack.
-
-Переход:
-
-```text
-K_before → K_after
-```
-
-должен иметь explicit evidence в actual act.
-
----
-
-# 5. Source pipeline
-
-Foundation v2 source path:
-
-```text
-raw UTF-8
-→ canonical byte carriers
-→ canonical astring content C
-→ exact source occurrence S
-→ selected exact segmentation
-→ scoped D resolution
-→ explicit G/T admission
-→ exact semantic form(s)
-```
-
-Главная граница:
-
-```text
-source occurrence != canonical content != semantic form != theory admission
-```
-
-Trusted replay не обязан доверять tokenizer-у, longest-match или AST class.
-
-Production-facing implementation: `core/foundation_v2_source.py`.
-
----
-
-# 6. Persistent scoped dictionary D
-
-Canonical D topology:
+Dictionary:
 
 ```text
 D = D ⟼ (parentScope ⟼ localHistory)
 ```
 
-Definition:
+Definition effect:
 
 ```text
 Entry      = sourceContent ⟼ form
 Occurrence = D_before ⟼ Entry
 H_after    = H_before ⟼ Occurrence
-D_after    = D_after ⟼ (sameParentScope ⟼ H_after)
+D_after    = D_after ⟼ (sameParent ⟼ H_after)
 ```
 
-Свойства:
-
-- old scope не мутирует;
-- local mapping может shadow parent;
-- local miss использует parent;
-- duplicate same mapping может сохраняться как provenance;
-- conflicting local resolution не разрешается «last write wins» молча.
+Старые `K`/`D` не мутируют.
 
 ---
 
-# 7. `:` как explicit effect
+# 6. `:` и `=`
 
-`:` — persistent dictionary effect.
+`:` — explicit persistent dictionary effect.
 
-Он не является:
-
-```text
-equality
-host assignment
-theorem assertion
-```
-
-Executor/materializer может создать требуемые exact links.
-
-Trusted replay только проверяет уже предъявленный transition:
+`=` — local one-hop representative constraint:
 
 ```text
-D_before
-→ exact definition occurrence
-→ H_after
-→ D_after
-```
-
-без мутации проверяемой сети.
-
----
-
-# 8. Relation resolution
-
-Самозамкнутый один полюс формы является структурой, а не opcode.
-
-```text
-F = F ⟼ X
-```
-
-или:
-
-```text
-F = X ⟼ F
-```
-
-Operation возникает при selected form + exact binding from `K`.
-
-Trusted replay проверяет exact result и новый `K`, но не materialize-ит их.
-
-Production-facing implementation: `core/foundation_v2_interpreter.py`.
-
----
-
-# 9. Local `=`
-
-Foundation v2 equality candidate:
-
-```text
-Pair    = member ⟼ representative
-Binding = K ⟼ Pair
+K ⟼ (member ⟼ representative)
 ```
 
 ```text
@@ -268,334 +183,275 @@ Equal_K(a,b)
 ⇔ rep_K(a) is rep_K(b)
 ```
 
-Только local exact representative и только один hop.
-
 Не встроены:
 
 ```text
-global structural equality
-transitive alias closure
-substitution
+global substitution
 congruence
+transitive alias closure
 recursive decomposition
 union-find semantics
 ```
 
-Это решение предотвращает collapse различений exact-occurrence сети.
-
 ---
 
-# 10. Actual act A
+# 7. Actual acts и Run
 
-Foundation v2 различает:
+`I` и конкретный `A` различаются.
 
-```text
-I — interpreter / capability
-A — actual occurrence конкретного действия
-```
-
-Actual act содержит role-addressed exact evidence, например:
-
-```text
-source
-form
-D
-G
-T
-K_before
-binding
-result
-K_after
-```
-
-Roles также представлены ordinary link occurrences, а не enum field внутри `Link`.
-
----
-
-# 11. Exact Run
-
-Многошаговый artifact:
+Последовательность acts:
 
 ```text
 Run_0     = R
 Run_(i+1) = Run_i ⟼ A_i
 ```
 
-Continuity:
+Exact continuity:
 
 ```text
 A_i.after is A_(i+1).before
 ```
 
-Exact identity обязательна: shape-equivalent `K_copy` не подходит.
-
-Run не создаёт:
-
-```text
-K0 → Kn shortcut
-logical transitivity
-theorem closure
-```
-
-Он фиксирует exact order/provenance actual acts.
-
-Production-facing implementation: `core/foundation_v2_run.py`.
+Run фиксирует order/provenance, но не создаёт логическую транзитивность.
 
 ---
 
-# 12. Separately admitted proof rule
+# 8. Proof rule и integrated checker
 
-Первый proof-rule candidate специально вынесен за пределы `=`.
-
-Premise:
-
-```text
-Equal_K(L,R) = true
-```
-
-Links:
-
-```text
-L = ls ⟼ le
-R = rs ⟼ re
-```
-
-Admission:
+Первый proof-rule candidate существует только через admission:
 
 ```text
 T ⟼ Rule
 ```
 
-One-step conclusions:
+и одношагово decomposes истинное local equality завершённых links.
 
-```text
-C_start = ls ⟼ rs
-C_end   = le ⟼ re
-```
-
-Claims не materialize-ят equality bindings и nested relations не decomposed автоматически.
-
-Production-facing implementation: `core/foundation_v2_proof.py`.
-
-Подробнее: [Foundation v2 Proof replay](Foundation%20v2%20Proof%20replay.md).
-
----
-
-# 13. Integrated checker P9
-
-Первый целостный trusted artifact:
+Integrated P9 artifact:
 
 ```text
 source `decompose`
-        ↓
-canonical C / exact S
-        ↓
-selected segmentation
-        ↓
-scoped D
-        ↓
-exact Rule + G/T source admission
-        ↓
-true local equality A_eq in exact K
-        ↓
-exact direct T ⟼ Rule
-        ↓
-one-step A_rule
-        ↓
-exact Run[A_eq, A_rule]
-        ↓
-read-only integrated replay
+→ scoped D / G / T
+→ exact Rule
+→ true equality A_eq in exact K
+→ direct T ⟼ Rule
+→ A_rule
+→ Run[A_eq, A_rule]
+→ read-only trusted replay
 ```
 
-Integrated checker требует сквозное exact тождество:
+Production-facing modules:
 
 ```text
-source-selected Rule is proof Rule
-source T is proof T
-premise K is proof K is Run K
-Run acts are exactly (A_eq, A_rule)
+core/foundation_v2_proof.py
+core/foundation_v2_checker.py
 ```
-
-Он не:
-
-- tokenizes source;
-- ищет proof;
-- ранжирует rules;
-- выводит equality по shape;
-- выбирает T;
-- materialize-ит claims;
-- вызывает legacy proof checker.
-
-Production-facing implementation: `core/foundation_v2_checker.py`.
-
-Research record: [P9 integrated proof conformance](../research/Foundation%20v2%20P9%20integrated%20proof%20conformance.md).
 
 ---
 
-# 14. Апамять как прикладной смысл Gate P
+# 9. Апамять как controller
 
-Foundation v2 становится особенно наглядной, если смотреть на неё как на теорию **контроллера сетей связей**.
-
-Апамять предоставляет две принципиально разные группы действий:
+Foundation v2 operationally разделяет:
 
 ```text
 READ SIDE
-find
-select
-enumerate
-resolve
-replay
+read / find / enumerate / resolve / replay
 
 EFFECT SIDE
-materialize
-define
-delete
-persist
+materialize / define / delete / persist transition
 ```
 
-Их нельзя смешивать.
-
-В одной exact network могут существовать:
+Главный инвариант:
 
 ```text
-application data
-source carrier
-K contexts
-D histories
-G/T admissions
-actual acts
-proof claims
-Runs
+find / replay != materialize
 ```
 
-Поиск может использовать эффективные индексы, кэши, эвристики и backend-specific handles. Но trusted semantics принимает только exact evidence network.
+Индексы и эвристики могут быть backend-specific и недоверенными; semantic acceptance определяется exact evidence.
 
 Подробнее: [Апамять и управление сетью связей](Апамять%20и%20управление%20сетью%20связей.md).
 
 ---
 
-# 15. Ачисло и materialization gap #242
+# 10. #242 — sequence materialization
 
-Recursive Anum пока является structural description, а не готовым universal materializer arbitrary exact network.
+Исторический Anum raw/source carrier может хранить элементы будущей связи **несвязанными**.
 
-Нужен explicit executable bridge:
+Например:
 
 ```text
-Anum/source sequence
-→ selected structural interpretation
-→ materialization plan
-→ exact links before/after
-→ replayable effect evidence
+carrier(∞ a b)
 ```
 
-Особенно важны:
+не обязан содержать:
 
-- nested structures;
-- exact occurrence multiplicity;
-- sharing policy;
-- cycles;
-- duplicate pair policy;
-- source provenance;
-- round-trip boundary;
-- отсутствие скрытых writes во время decode.
+```text
+a ⟼ b
+```
 
-Это следующий semantic release blocker #242 после docs gate #261.
+Foundation-v2 candidate определяет sequence effect:
+
+```text
+∞ A B C
+→ create new exact A⟼B
+→ create new exact B⟼C
+```
+
+Root `∞` — sentinel и не участвует в adjacency.
+
+Nested group:
+
+```text
+[A B]
+→ X = A ⟼ B
+→ return exact X as one outer value
+```
+
+Поэтому:
+
+```text
+∞ [A B] C
+→ X = A ⟼ B
+→ Y = X ⟼ C
+```
+
+Singleton:
+
+```text
+[A] → exact A
+```
+
+без нового link.
+
+Полный пример:
+
+```text
+∞[window][cursor][position][[[x][int]][point]]
+```
+
+даёт nested-first candidate relations:
+
+```text
+XI = X ⟼ I
+Q  = XI ⟼ Point
+WC = Window ⟼ Cursor
+CP = Cursor ⟼ Position
+PQ = Position ⟼ Q
+```
 
 ---
 
-# 16. Persistent L4 gap #124
+# 11. Materialization identity policy
 
-In-memory `OccurrenceRef` не должен превращаться в universal persistent identity.
+#242 не использует historical `AnumMemory.intern_link`.
 
-Persistent backend contract обязан отделить:
+Каждая adjacency materialization создаёт **новый exact occurrence**:
 
 ```text
-semantic exact occurrence identity
-portable snapshot/local identity
-backend physical address/handle
+old = A ⟼ B
+new = A ⟼ B
+old ≠ new
 ```
 
-и доказать сохранение:
+Если executor хочет reuse, это должно быть отдельным explicit planning decision; pair equality сама по себе reuse не разрешает.
 
-- multiplicity;
-- cycles;
-- sharing;
-- root selection;
-- read/find no-mutation guarantees;
-- explicit materialization;
-- portable replay evidence.
+Persistent before/after lineage:
 
-Только после этого production cutover может зависеть от реального persistent storage.
+```text
+before
+→ explicit effect
+→ after
+```
+
+сохраняет exact identity старых refs и immutable old links.
+
+Independent snapshot reload по-прежнему создаёт fresh runtime identity scope.
 
 ---
 
-# 17. Historical compatibility boundary
+# 12. Sequence replay boundary
 
-Accepted v0.2–v0.5 path содержит:
+Production-facing candidate:
 
 ```text
-mtc_parser.py
-mtc_ast.py
-mtc_interpreter.py
-ContextFrame
-TokenKind
+core/foundation_v2_materialization.py
+```
+
+Machine contract:
+
+```text
+contracts/mts-anum-sequence-materialization-v0.7.json
+```
+
+Trusted replay проверяет:
+
+```text
+exact root
+base identity preserved
+old links unchanged
+exact created count/order
+nested adjacency poles
+exact result
+no extra links
+before/after snapshots unchanged during replay
+```
+
+Read-only `find_links` отдельно доказывает отсутствие hidden materialization.
+
+Подробнее: [Ачисла и сериализация](Ачисла%20и%20сериализация.md).
+
+---
+
+# 13. Persistent L4 gap #124
+
+После #242 остаётся доказать те же свойства на persistent backend:
+
+```text
+multiplicity
+cycles
+sharing
+persistent state transitions
+read-only find/replay
+explicit materialization
+portable evidence
+backend address != semantic identity
+```
+
+In-memory same-lineage `OccurrenceRef` не должен превращаться в universal persistent identity.
+
+---
+
+# 14. Historical compatibility
+
+Accepted v0.2–v0.5 остаются reproducible historical contracts.
+
+В частности:
+
+```text
+mtc_parser / typed AST / ContextFrame
 historical root program
-bundle semantics
-old proof contracts
+recursive Anum v0.2
+historical AnumMemory pair interning
 ```
 
-Git сохраняет историю; поэтому Gate P не должен оставлять после cutover два равноправных semantic cores.
+не удаляются задним числом.
 
-Для каждого legacy consumer должно быть принято одно решение:
-
-```text
-migrate
-preserve as historical-only artifact
-or remove from production path
-```
-
-Временный adapter не должен становиться новой постоянной semantics.
+Но production cutover не должен оставить два равноправных semantic cores. Каждый legacy consumer должен быть migrated, preserved as historical-only, либо removed from production path.
 
 ---
 
-# 18. Acceptance gate
+# 15. Acceptance criterion
 
-Foundation v2 может стать следующей accepted версией только после одного интегрированного решения:
+Следующая версия МТС принимается только как одна интегрированная система:
 
 ```text
-exact-occurrence substrate
-+ source/D/G/T
-+ K/A
+exact occurrence network
++ source/D/G/T/K/A
 + relation/:/=
 + proof/Run/checker
-+ Anum materialization
++ sequence materialization
 + persistent L4
-+ compatibility cutover
-+ versioned conformance corpus
++ cutover
++ versioned conformance
 ```
 
-После этого:
-
-1. публикуется новый versioned MTS contract;
-2. candidate-маркировки снимаются;
-3. старый production semantic path удаляется/архивируется согласно решению;
-4. downstream consumers pin-ятся на новый contract;
-5. `aprover` получает право на repin.
-
-До этого момента закрытые Gate-P issues являются **evidence направления**, но не отдельными accepted версиями МТС.
-
----
-
-# 19. Канонический принцип Gate P
-
-```text
-одна сеть связей
-+ exact occurrence identity
-+ explicit state/evidence
-+ untrusted discovery
-+ deterministic trusted replay
-+ explicit materialization
-+ one production semantic path
-```
-
-Если новый механизм требует скрытого metadata-object, второго semantic core или доверия к поисковой эвристике, он должен считаться архитектурным подозрением и проходить отдельный gate.
+До explicit acceptance все Foundation-v2 contracts остаются candidate evidence, а `aprover` не repin-ится.

--- a/docs/specs/Ачисла и сериализация.md
+++ b/docs/specs/Ачисла и сериализация.md
@@ -1,251 +1,181 @@
 # Ачисла и сериализация
 
-Статус: актуальное, нормативное для контейнера и raw-слоя `*.anum`. Root boundary, storage-neutral raw carrier, denotation handoff, direct `0/1` pair subset и recursive root-denotation согласованы с МТС v0.2. Relative denotation остаётся вне принятой семантики; общий integration gate — #89.
+Статус: **актуальный обзор Anum**, объединяющий historical accepted L3 v0.2–v0.5 и Foundation-v2 sequence-materialization candidate #242.
 
-Уровень: **L3 — сериализация**.
+> Старые raw/boundary/pair/recursive contracts остаются принятыми для своей версии. Foundation v2 не переписывает их задним числом, а добавляет более общий operational boundary: **source sequence и target network — разные вещи; materialization является явным effect**.
 
-Граница L2/L3/L4 задаётся [Reference model МТС v0.2](Reference%20model%20МТС%20v0.2.md).
+Связанные документы:
 
-Machine contracts:
+- [Основания МТС](../theory/Основания%20МТС.md)
+- [Foundation v2 Gate P](Foundation%20v2%20Gate%20P.md)
+- [Апамять и управление сетью связей](Апамять%20и%20управление%20сетью%20связей.md)
 
-- [`contracts/anum-raw-carrier-v0.2.json`](../../contracts/anum-raw-carrier-v0.2.json);
-- [`contracts/anum-boundary-projection-v0.2.json`](../../contracts/anum-boundary-projection-v0.2.json);
-- [`contracts/anum-denotation-v0.2.json`](../../contracts/anum-denotation-v0.2.json);
-- [`contracts/anum-pair-denotation-v0.2.json`](../../contracts/anum-pair-denotation-v0.2.json);
-- [`contracts/anum-recursive-denotation-v0.2.json`](../../contracts/anum-recursive-denotation-v0.2.json).
+---
 
-## 1. Ачисло и raw carrier
+# 1. Что такое ачисло в текущей картине
 
-Ачисло хранится/передаётся как raw-последовательность базовых абитов:
+Исторический базовый алфавит ачисла:
 
 ```text
 [ ] 1 0
 ```
 
-Raw carrier и его denotation различаются:
+Raw carrier — последовательность этих абитов.
+
+Но важнейшая граница:
 
 ```text
-raw(A) != den(A)
+raw/source carrier != denotation != materialized target network
 ```
 
-Raw parser отвечает только за чтение четырёх абитов. Он не выполняет materialization, не выбирает context и не применяет обычную балансировку программных скобок. Поэтому `][`, `[[`, `]]`, `[]` являются допустимыми raw carriers.
+Ачисло может переносить элементы будущих отношений в последовательном виде, не содержа самих target relations.
 
-### 1.1. Structural raw carrier
+Именно поэтому запись связи и её создание должны быть разделены.
 
-Помимо текста raw carrier имеет storage-neutral структурное описание, сохраняющее последовательностную форму и **не являющееся denotation**.
+---
 
-Для raw-последовательности `x0 x1 ... xn`:
+# 2. Исторический raw layer остаётся accepted
+
+Для v0.2–v0.5 продолжают действовать contracts:
+
+- [`anum-raw-carrier-v0.2`](../../contracts/anum-raw-carrier-v0.2.json)
+- [`anum-boundary-projection-v0.2`](../../contracts/anum-boundary-projection-v0.2.json)
+- [`anum-denotation-v0.2`](../../contracts/anum-denotation-v0.2.json)
+- [`anum-pair-denotation-v0.2`](../../contracts/anum-pair-denotation-v0.2.json)
+- [`anum-recursive-denotation-v0.2`](../../contracts/anum-recursive-denotation-v0.2.json)
+
+Raw parser читает только четыре абита и не materialize-ит связи.
+
+```text
+parse(raw)
+```
+
+не означает:
+
+```text
+create(den(raw))
+```
+
+Это historical правило полностью согласуется с Foundation v2.
+
+---
+
+# 3. Structural raw carrier
+
+Raw sequence может иметь storage-neutral structural carrier:
 
 ```text
 c0 = RootRole
-c1 = Link(c0, AbitRole(x0))
-c2 = Link(c1, AbitRole(x1))
+c1 = c0 ⟼ AbitRole(x0)
+c2 = c1 ⟼ AbitRole(x1)
 ...
-rawRoot = cn
+cn = c(n-1) ⟼ AbitRole(xn)
 ```
 
-Например:
+Этот carrier хранит **последовательность source**, а не target relations.
+
+Например carrier условной последовательности:
 
 ```text
-raw(01) = Link(Link(RootRole, AbitRole(0)), AbitRole(1))
-den(01) = Link(protocol:0, protocol:1)
+∞ a b
 ```
 
-Это разные типы и контракты. Raw-роли:
+может содержать:
 
 ```text
-root
-abit:[
-abit:]
-abit:1
-abit:0
+S1 = ∞ ⟼ a
+S2 = S1 ⟼ b
 ```
 
-не являются `protocol:0/1` denotation anchors.
-
-Локальный номер carrier-node — только позиция внутри переносимого description, не глобальный идентификатор узла МТС и не persistent `LinkId`. Это согласуется с остенсивным чтением #98: transport representation не вводит внешнюю онтологическую identity.
-
-`core/anum_raw_carrier.py` получает уже разобранный `AnumForm`; он не знает `ProjectionContext`, quote, root projection или L4 memory.
-
-## 2. Канонический pipeline L3
+и при этом **не содержать**:
 
 ```text
-parse_raw_quaternary
-→ raw carrier description
-→ validate_anum(context)
-→ project_anum(context)
-→ contextual denotation subset
-→ canonical inverse, если denotation поддерживается
+a ⟼ b
 ```
 
-Это разные операции.
+Это принципиальный инвариант.
 
-`parse_raw_quaternary` не знает семантики. Structural raw carrier сохраняет последовательность. `validate_anum` не меняет raw. `project_anum` всегда получает явный `ProjectionContext`. Denotation layer выдаёт storage-neutral `AnumDenotation` и не обращается к L4-памяти.
+---
 
-Контексты:
+# 4. Почему source carrier нельзя считать result network
+
+Пусть нужно узнать, существует ли:
 
 ```text
-root
-quote
-relative
+a ⟼ b
 ```
 
-Контекст не выводится скрыто из raw carrier.
+Если сама загрузка source `∞ab` создаёт `a⟼b`, то последующий поиск всегда найдёт связь и перестанет отличать факт от описания.
 
-## 3. Формат `*.anum`
-
-Контейнер поддерживает:
+Поэтому правильная архитектура:
 
 ```text
-# anum-format: quaternary
-# anum-format: string
+source
+  ↓
+decode / resolve
+  ↓
+structural description
+  ↓
+explicit materialization plan
+  ↓
+materialization effect
+  ↓
+target network
 ```
 
-Без заголовка используется `quaternary`.
-
-### Quaternary
-
-Значащие символы — только `[ ] 1 0`. Пробелы и переводы строк игнорируются, `#` начинает комментарий до конца строки. Другой значащий символ — синтаксическая ошибка.
-
-### String
-
-String mode хранит имена, не дополнительные абиты:
+А read-only путь:
 
 ```text
-name
-→ AnumDictionary entry
-→ quaternary raw carrier
+source
+  ↓
+decode / resolve
+  ↓
+find / compare / replay
 ```
 
-Имя не преобразуется в UTF-8 автоматически. Неизвестное или повторно определённое имя — ошибка.
+не меняет network state.
 
-## 4. UTF-8 payload — отдельный codec
+---
 
-`converters/text_to_anum.py` и `converters/anum_to_text.py` кодируют байты UTF-8, например:
+# 5. Historical root boundary projection
+
+Accepted v0.2 root boundary:
 
 ```text
-hello
-→ [01101000][01100101][01101100][01101100][01101111]
+[  → ♀∞
+]  → ∞♂
+[] → 1
+][ → 0
 ```
 
-Это payload codec, а не dictionary resolution и не structural denotation.
+`[[` и `]]` остаются special boundary forms без protocol value в этой historical линии.
 
-## 5. Incremental decoder
+Эта orientation сохраняется как accepted versioned behavior и не изменяется sequence-materialization gate #242.
 
-`IncrementalQuaternaryDecoder` принимает произвольные chunks. Границы chunks могут проходить между абитами и внутри комментария.
+---
 
-Инвариант:
+# 6. Historical direct pair subset
+
+Принятый v0.2 subset:
 
 ```text
-batch parse == incremental parse
+0  → Anchor(protocol:0)
+1  → Anchor(protocol:1)
+00 → 0 ⟼ 0
+01 → 0 ⟼ 1
+10 → 1 ⟼ 0
+11 → 1 ⟼ 1
 ```
 
-включая абсолютные offsets токенов.
+Он даёт storage-neutral structural denotation пары.
 
-Raw decoder не объявляет последовательность завершённой по балансу `[ ]`: structural/context semantics принадлежат последующим слоям.
+Этот contract полезен и остаётся accepted, но он не покрывает весь исходный замысел последовательностного ачисла.
 
-## 6. Deterministic raw serialization
+---
 
-`serialize_quaternary_anum` выдаёт canonical compact raw body. Для raw-слоя:
+# 7. Historical recursive root denotation
 
-```text
-parse(serialize(parse(A)))
-```
-
-сохраняет последовательность абитов.
-
-Это transport round-trip. Structural inverse serialization существует только для принятых denoting subsets.
-
-## 7. Цитирование и context isolation
-
-Цитирование реализовано реальными абитами:
-
-```text
-quote(A) := [ A ]
-```
-
-В `quote` context снимается ровно один внешний уровень:
-
-```text
-project(quote²(A), quote) = quote(A)
-project(quote(A), quote)  = A
-```
-
-Если quote-context получает raw payload без внешней оболочки, payload сохраняется. Root structural grammar в quote context **не запускается**.
-
-Structural raw carrier при этом вообще не снимает оболочку: `[A]` для него всегда последовательность raw-абитов. Снятие уровня относится только к явному quote context.
-
-Relative context в v0.2 сохраняет raw и не имеет принятой structural denotation.
-
-## 8. Граница L2/L3 и root boundary projection
-
-Совпадение glyph `[` и `]` с квадратной формой L2 не означает тождества.
-
-Корневая L2-система содержит:
-
-```text
-([) : (♀∞)
-(]) : (∞♂)
-(⟼) : (♀∞ ⟼ ∞♂)
-(↛) : (∞♂ ⟼ ♀∞)
-[1] : (⟼)
-[0] : (↛)
-```
-
-Отсюда в **root context** принят boundary subset:
-
-```text
-[  -> ♀∞
-]  -> ∞♂
-[] -> 1
-][ -> 0
-```
-
-Старая experimental orientation issue #61 `[] -> 0`, `][ -> 1` больше не является активной семантикой.
-
-`[[` и `]]` остаются валидными raw carriers и root `boundary-form` без `protocol_value`. Эти четыре special boundary forms имеют приоритет перед recursive grammar.
-
-## 9. Минимальный direct pair subset
-
-Исходные read-only заметки фиксируют:
-
-1. ачисло неявно начинается от `∞`;
-2. raw `(∞ ⟼ a) ⟼ b` не содержит `a ⟼ b`, но десериализация описывает `a ⟼ b`.
-
-Поэтому принят базовый subset:
-
-```text
-0  -> Anchor(protocol:0)
-1  -> Anchor(protocol:1)
-00 -> 0 ⟼ 0
-01 -> 0 ⟼ 1
-10 -> 1 ⟼ 0
-11 -> 1 ⟼ 1
-```
-
-Boundary aliases дают те же anchor denotations:
-
-```text
-][ -> den(0)
-[] -> den(1)
-```
-
-Canonical inverse не обязан сохранять исходный alias:
-
-```text
-den(][) -> 0
-den([]) -> 1
-```
-
-Этот pair-contract остаётся базовым слоем; вложенная композиция принадлежит recursive contract.
-
-## 10. Recursive root denotation
-
-Исходные мысли МТС требуют скобки при последовательном обходе сложной связи, чтобы не потерять структуру, и отдельно фиксируют схлопывание нескольких открывающих скобок сразу после акорня — «аксиому начала».
-
-В v0.2 это формализовано **только для root context**.
-
-После виртуального восстановления схлопнутых root-openings grammar:
+Accepted recursive v0.2 grammar:
 
 ```text
 Atom  := 0 | 1
@@ -254,129 +184,491 @@ Pair  := Value Value
 Root  := Atom | Pair
 ```
 
-Смысл:
+и:
 
 ```text
-D(0) = protocol:0
-D(1) = protocol:1
 D(A B) = Link(D(A), D(B))
 ```
 
-Примеры canonical root encoding:
+описывает occurrence-tree structure.
+
+Она сохраняет разные structural occurrences одинаковых поддеревьев и имеет canonical inverse на своей области.
+
+Но Foundation v2 уточняет её границу:
 
 ```text
-Link(0,1)                    -> 01
-Link(Link(0,1),1)            -> [01]1
-Link(0,Link(1,0))            -> 0[10]
-Link(Link(0,1),Link(1,0))    -> [01][10]
-Link(Link(Link(0,1),1),0)    -> [01]1]0
+recursive Anum
+= root-relative structural description
+
+not
+
+universal exact identity arbitrary shared/cyclic aset
 ```
 
-Последний пример показывает root-opening collapse. Expanded form:
+Sharing и произвольные cycles требуют exact occurrence network.
+
+---
+
+# 8. Почему pair-only grammar недостаточна
+
+Исходный замысел последовательностного ачисла допускает:
 
 ```text
-[[01]1]0
+∞ A B C D
 ```
 
-имеет две ведущие `[`. В canonical physical root raw они схлопываются в одну:
+как описание последовательности будущих отношений:
 
 ```text
-[01]1]0
+A ⟼ B
+B ⟼ C
+C ⟼ D
 ```
 
-### 10.1. Восстановление root-opening collapse
+Это не то же самое, что рекурсивно прочитать весь source как единственную бинарную `Pair`-структуру.
 
-Decoder не угадывает число потерянных `[`. Для root candidate, начинающегося с `[`, вычисляется:
+Поэтому Foundation v2 не заменяет recursive v0.2 contract, а вводит **отдельный sequence-materialization mode**.
+
+---
+
+# 9. Foundation-v2 sequence semantics #242
+
+Machine contract candidate:
+
+[`contracts/mts-anum-sequence-materialization-v0.7.json`](../../contracts/mts-anum-sequence-materialization-v0.7.json)
+
+Вход этого слоя — уже выбранное root-relative nested sequence description над exact existing occurrences.
+
+Он **не парсит `[`/`]` как host PUSH/POP opcodes**.
+
+Raw source parsing и выбор структурной интерпретации находятся раньше.
+
+## 9.1. Top-level sequence
 
 ```text
-balance = count('[') - count(']')
+∞ A B
 ```
 
-Если balance отрицателен, перед parsing виртуально добавляется ровно `-balance` открывающих скобок. После разбора действует обязательный veto:
+materialize-ит один новый exact occurrence:
 
 ```text
-encode(decoded)
-→ root-opening collapse
-→ должно быть byte-for-byte равно исходному canonical raw
+X = A ⟼ B
 ```
-
-Если равенства нет, carrier не принимается recursive grammar и остаётся typed `RAW`.
-
-Например expanded spelling `[[01]1]0` не является canonical root raw: его canonical form — `[01]1]0`.
-
-### 10.2. Occurrence identity
-
-Recursive denotation строит occurrence tree и переводит его в topological `AnumDenotation`. Два одинаковых поддерева в разных местах получают два разных description-local node positions. Structural interning внутри L3 не выполняется.
 
 ```text
-[01][01]
+∞ A B C
 ```
 
-содержит два occurrence узла `01`, хотя их формы равны. Это не вводит глобальную node identity и согласуется с #98. Физический L4 backend позднее может канонизировать одинаковые пары при `realize`, но это уже другой уровень.
-
-Canonical inverse recursive subset не принимает explicit shared-node graph, unused nodes или внешние anchors: он сериализует именно occurrence-tree description.
-
-### 10.3. Challenge/veto
-
-Executable conformance проверяет:
-
-- nested-left / nested-right / nested-both;
-- глубокий left-root opening collapse;
-- malformed и noncanonical spellings;
-- special boundary precedence;
-- quote/relative isolation;
-- exhaustive binary occurrence trees над `0/1` до глубины 3: отсутствие collision canonical raw и двусторонний encode/decode round-trip.
-
-Recursive grammar не является context-free значением скобок: в `quote` и `relative` contexts она отключена.
-
-## 11. Граница L3/L4
-
-L3 не реализует память.
+materialize-ит:
 
 ```text
-load(A) не создаёт den(A)
-find(A) не создаёт den(A)
-realize(A) может явно материализовать den(A)
-interpret(F) не выполняет realize(F)
+X = A ⟼ B
+Y = B ⟼ C
 ```
 
-`core/anum_raw_carrier.py`, `core/anum_pair_denotation.py` и `core/anum_recursive_denotation.py` не читают и не мутируют L4 memory.
+и result sequence равен exact `Y` — последней построенной relation occurrence.
 
-## 12. Актуальные модули
+`∞` является root/sentinel контекста и не участвует в adjacency:
 
 ```text
-core/anum_model.py                 typed protocol data
-core/anum_parser.py                raw parser + incremental decoder + raw serialization
-core/anum_raw_carrier.py           storage-neutral structural raw(A)
-core/anum_protocol.py              validate/project/quote/unquote/dictionary
-core/anum_denotation.py            storage-neutral structural denotation handoff
-core/anum_pair_denotation.py       direct 0/1 pair base subset
-core/anum_recursive_denotation.py  recursive root occurrence-tree subset + inverse
-core/anum_memory.py                L4 test-double
-
-contracts/anum-raw-carrier-v0.2.json
-contracts/anum-raw-carrier-conformance-v0.2.json
-contracts/anum-boundary-projection-v0.2.json
-contracts/anum-denotation-v0.2.json
-contracts/anum-denotation-conformance-v0.2.json
-contracts/anum-pair-denotation-v0.2.json
-contracts/anum-pair-denotation-conformance-v0.2.json
-contracts/anum-recursive-denotation-v0.2.json
-contracts/anum-recursive-denotation-conformance-v0.2.json
+∞ ⟼ A
 ```
 
-Один raw parser остаётся в `core/anum_parser.py`, один contextual projection path — в `core/anum_protocol.py`. Recursive denotation потребляет их результаты и не создаёт второй parser/projection path.
+не создаётся sequence semantics автоматически.
 
-## 13. CLI
+---
 
-```bash
-python -m converters.anum_cli parse file.anum
-python -m converters.anum_cli validate file.anum --context root
-python -m converters.anum_cli project file.anum --context root
-python -m converters.anum_cli project file.anum --context quote
-python -m converters.anum_cli normalize file.anum
-python -m converters.anum_cli quote file.anum
-python -m converters.anum_cli unquote quoted.anum
+# 10. Singleton nested value
+
+Вложенная группа из одного значения ничего не materialize-ит:
+
+```text
+[A]
+→ exact A
 ```
 
-L3 CLI не содержит `realize`: materialization относится к L4.
+Это позволяет конструкции вроде:
+
+```text
+[window]
+[cursor]
+[position]
+```
+
+передавать существующие exact values во внешнюю последовательность без лишних target links.
+
+---
+
+# 11. Nested sequence возвращает одну exact relation
+
+Для:
+
+```text
+[A B]
+```
+
+создаётся:
+
+```text
+X = A ⟼ B
+```
+
+и вложенный context возвращает exact `X` как один элемент внешней последовательности.
+
+Поэтому:
+
+```text
+∞ [A B] C
+```
+
+даёт:
+
+```text
+X = A ⟼ B
+Y = X ⟼ C
+```
+
+а не внешнее продолжение через внутренний `B`.
+
+Nested result сохраняет структуру вложенности без AST-node identity.
+
+---
+
+# 12. Более длинная вложенная последовательность
+
+Для группы:
+
+```text
+[A B C]
+```
+
+строятся:
+
+```text
+X = A ⟼ B
+Y = B ⟼ C
+```
+
+а наружу возвращается exact `Y`.
+
+Правило:
+
+```text
+singleton → contained exact value
+multi-item → last created adjacency occurrence
+```
+
+---
+
+# 13. Полный пример
+
+Исходный мотивирующий source:
+
+```text
+∞[window][cursor][position][[[x][int]][point]]
+```
+
+Пусть singleton groups разрешены в exact values:
+
+```text
+W  = [window]
+C  = [cursor]
+P  = [position]
+X  = [x]
+I  = [int]
+PT = [point]
+```
+
+Внутри:
+
+```text
+XI = X ⟼ I
+Q  = XI ⟼ PT
+```
+
+Внешняя sequence materialization:
+
+```text
+WC = W ⟼ C
+CP = C ⟼ P
+PQ = P ⟼ Q
+```
+
+Детерминированный nested-first порядок новых exact occurrences:
+
+```text
+XI
+Q
+WC
+CP
+PQ
+```
+
+Наглядно:
+
+```text
+W ─────▶ C ─────▶ P
+                  │
+                  ▼
+                  Q
+                 / \
+                /   \
+              XI    PT
+             /  \
+            X    I
+```
+
+`PQ` является result всего top-level sequence.
+
+---
+
+# 14. Materialization создаёт новые occurrences, а не интернирует пары
+
+Foundation v2 exact identity требует:
+
+```text
+P1 = A ⟼ B
+P2 = A ⟼ B
+P1 ≠ P2
+```
+
+Поэтому sequence effect #242 принимает правило:
+
+> **каждая adjacency, которую materialize-ит sequence effect, создаёт новый exact occurrence.**
+
+Если `A⟼B` уже существует, новый effect всё равно может создать ещё один exact occurrence той же пары.
+
+Старый `core/anum_memory.py::intern_link` относится к historical v0.2 test-double semantics и **не используется Foundation-v2 materializer-ом**.
+
+Если будущий executor хочет переиспользовать существующую relation, он должен сделать это отдельным explicit planning decision, а не скрытым pair interning.
+
+---
+
+# 15. Persistent before/after identity lineage
+
+Materialization не мутирует immutable `before` network.
+
+```text
+before
+  ↓ explicit effect
+ after
+```
+
+В рамках одного runtime lineage:
+
+- все старые `OccurrenceRef` сохраняются теми же exact objects;
+- старые links не изменяются;
+- новые occurrences append-ятся;
+- duplicate pairs разрешены;
+- root сохраняется.
+
+Это реализовано через additive evolution exact network.
+
+Но independent snapshot reload создаёт новый runtime identity scope.
+
+Поэтому:
+
+```text
+same slot after reload
+!=
+same universal semantic occurrence
+```
+
+Snapshot slot остаётся transport-local identity.
+
+---
+
+# 16. Find остаётся read-only
+
+Foundation-v2 helper:
+
+```text
+find_links(network, start=?, end=?)
+```
+
+только перечисляет exact existing occurrences.
+
+Если pair отсутствует:
+
+```text
+find_links(A,B) -> ()
+```
+
+и network snapshot не меняется.
+
+Только:
+
+```text
+materialize_sequence(...)
+```
+
+создаёт `after` state.
+
+---
+
+# 17. Trusted replay materialization effect
+
+`materialize_sequence` создаёт candidate `after` и exact evidence.
+
+Затем:
+
+```text
+replay_sequence_materialization(before, evidence)
+```
+
+повторно проверяет:
+
+1. exact root sequence;
+2. неизменность всех base occurrences;
+3. exact same identity старых refs в before/after lineage;
+4. отсутствие изменения старых links;
+5. точное число новых occurrences;
+6. deterministic nested-first order новых relations;
+7. правильные exact start/end каждой adjacency;
+8. правильный exact result;
+9. отсутствие extra materialization;
+10. неизменность before/after во время replay.
+
+Replay ничего не создаёт.
+
+---
+
+# 18. Почему host nesting допустим, но не является ontology
+
+Текущий Python API использует checker handles:
+
+```text
+SequenceAtom
+SequenceGroup
+SequenceDescription
+```
+
+Это не semantic classes МТС.
+
+Они представляют **уже выбранную structural interpretation** для conformance/replay.
+
+Идентичность значений находится в exact `OccurrenceRef`, а не в Python-object `SequenceGroup` и не в исходном символе `[`.
+
+В дальнейшем source front-end может выдавать эквивалентное exact evidence другим способом без изменения sequence semantics.
+
+---
+
+# 19. Round-trip boundary
+
+Есть два разных round-trip.
+
+### Structural/source round-trip
+
+Historical recursive contracts могут проверять:
+
+```text
+encode(decode(raw)) = canonical raw
+```
+
+на своей occurrence-tree области.
+
+### Network snapshot round-trip
+
+Foundation-v2 exact network:
+
+```text
+after.snapshot()
+→ serialize / load
+→ same topology, multiplicity, sharing, root
+```
+
+но загрузка создаёт fresh runtime occurrence scope.
+
+Поэтому structural round-trip и exact runtime identity — разные свойства.
+
+---
+
+# 20. Compatibility с v0.2
+
+#242 не отменяет:
+
+```text
+boundary projection v0.2
+pair denotation v0.2
+recursive denotation v0.2
+quote/relative isolation v0.2
+```
+
+Он также не наследует historical L4 pair interning.
+
+Граница:
+
+```text
+v0.2 recursive denotation
+= accepted structural occurrence-tree contract
+
+Foundation-v2 sequence materialization
+= candidate explicit effect over exact-occurrence network
+```
+
+Оба отвечают на разные вопросы и сохраняются до production cutover.
+
+---
+
+# 21. Актуальные модули
+
+Historical L3:
+
+```text
+core/anum_model.py
+core/anum_parser.py
+core/anum_raw_carrier.py
+core/anum_protocol.py
+core/anum_denotation.py
+core/anum_pair_denotation.py
+core/anum_recursive_denotation.py
+```
+
+Historical v0.2 L4 test double:
+
+```text
+core/anum_memory.py
+```
+
+Foundation v2:
+
+```text
+core/exact_link_network.py
+core/foundation_v2_materialization.py
+```
+
+Machine contract candidate:
+
+```text
+contracts/mts-anum-sequence-materialization-v0.7.json
+```
+
+---
+
+# 22. Что остаётся после #242
+
+Sequence semantics закрывает conceptual gap:
+
+```text
+source sequence
+→ nested structural value
+→ explicit materialization
+→ exact before/after network
+```
+
+Но accepted Foundation v2 требует ещё persistent L4 #124.
+
+Следующий слой должен доказать, что те же свойства сохраняются на storage backend:
+
+```text
+multiplicity
+sharing
+cycles
+persistent history
+explicit effects
+read-only search/replay
+portable evidence
+backend address != semantic identity
+```
+
+Только после этого возможны production cutover, versioned integrated conformance и `aprover` repin.

--- a/tests/test_mts_anum_sequence_materialization.py
+++ b/tests/test_mts_anum_sequence_materialization.py
@@ -287,7 +287,7 @@ def test_replay_rejects_extra_after_occurrence() -> None:
         )
 
 
-def test_replay_rejects_changed_base_topology_from_independent_reload() -> None:
+def test_replay_rejects_independent_reload_as_fresh_identity_lineage() -> None:
     before, root, refs = _base_network(("a", "b"))
     evidence = materialize_sequence(
         before,
@@ -295,7 +295,9 @@ def test_replay_rejects_changed_base_topology_from_independent_reload() -> None:
     )
     reloaded = LinkNetwork.from_snapshot(evidence.after.snapshot())
 
-    with pytest.raises(SequenceMaterializationError, match="preserve exact base"):
+    assert reloaded.snapshot() == evidence.after.snapshot()
+    assert reloaded.root is not before.root
+    with pytest.raises(SequenceMaterializationError, match="changed the exact root"):
         replay_sequence_materialization(
             before,
             replace(evidence, after=reloaded),

--- a/tests/test_mts_anum_sequence_materialization.py
+++ b/tests/test_mts_anum_sequence_materialization.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetwork, LinkNetworkBuilder, LinkNetworkError
+from core.foundation_v2_materialization import (
+    MaterializedEdge,
+    SequenceAtom,
+    SequenceDescription,
+    SequenceGroup,
+    SequenceMaterializationError,
+    find_links,
+    materialize_sequence,
+    replay_sequence_materialization,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts/mts-anum-sequence-materialization-v0.7.json"
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def _base_network(names: tuple[str, ...]):
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    refs = {name: builder.reserve() for name in names}
+    builder.define(root, root, root)
+    for ref in refs.values():
+        builder.define(ref, ref, ref)
+    return builder.freeze(root), root, refs
+
+
+def _atom(ref):
+    return SequenceAtom(ref)
+
+
+def _group(*items):
+    return SequenceGroup(tuple(items))
+
+
+def _description(root, *items):
+    return SequenceDescription(root=root, items=tuple(items))
+
+
+def test_contract_is_candidate_and_does_not_authorize_aprover_repin() -> None:
+    contract = _contract()
+    assert contract["schema"] == "mts-anum-sequence-materialization/v0.7"
+    assert contract["status"] == "gate-p-candidate"
+    assert contract["accepted"] is False
+    assert contract["issue"] == 242
+    assert contract["aproverRepinAllowed"] is False
+    assert contract["effectBoundary"]["pairInterning"] is False
+
+
+def test_evolution_preserves_base_exact_identity_and_keeps_before_immutable() -> None:
+    before, root, refs = _base_network(("a", "b"))
+    before_snapshot = before.snapshot()
+    evolution = before.evolve()
+    created = evolution.reserve()
+    evolution.define(created, refs["a"], refs["b"])
+    after = evolution.freeze()
+
+    assert before.snapshot() == before_snapshot
+    assert after.root is root
+    assert after.refs[: len(before.refs)] == before.refs
+    assert all(
+        after.refs[index] is ref for index, ref in enumerate(before.refs)
+    )
+    assert after.link(refs["a"]) is before.link(refs["a"])
+    assert after.link(created).start is refs["a"]
+    assert after.link(created).end is refs["b"]
+    with pytest.raises(LinkNetworkError, match="slot is out of range"):
+        before.link(created)
+
+
+def test_evolution_allows_duplicate_pair_occurrences_without_interning() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    a = builder.reserve()
+    b = builder.reserve()
+    old = builder.reserve()
+    builder.define(root, root, root)
+    builder.define(a, a, a)
+    builder.define(b, b, b)
+    builder.define(old, a, b)
+    before = builder.freeze(root)
+
+    evidence = materialize_sequence(before, _description(root, _atom(a), _atom(b)))
+    new = evidence.result
+
+    assert new is not old
+    assert evidence.after.link(new) == evidence.after.link(old)
+    assert find_links(evidence.after, start=a, end=b) == (old, new)
+
+
+def test_source_carrier_for_infinity_ab_does_not_contain_target_before_effect() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    a = builder.reserve()
+    b = builder.reserve()
+    source_a = builder.reserve()
+    source_b = builder.reserve()
+    builder.define(root, root, root)
+    builder.define(a, a, a)
+    builder.define(b, b, b)
+    builder.define(source_a, root, a)
+    builder.define(source_b, source_a, b)
+    before = builder.freeze(root)
+    description = _description(root, _atom(a), _atom(b))
+
+    snapshot = before.snapshot()
+    assert find_links(before, start=a, end=b) == ()
+    assert before.snapshot() == snapshot
+
+    evidence = materialize_sequence(before, description)
+
+    assert before.snapshot() == snapshot
+    assert find_links(before, start=a, end=b) == ()
+    assert find_links(evidence.after, start=a, end=b) == (evidence.result,)
+    assert evidence.after.link(evidence.result).start is a
+    assert evidence.after.link(evidence.result).end is b
+
+
+def test_infinity_abc_creates_adjacent_relations_and_returns_last_edge() -> None:
+    before, root, refs = _base_network(("a", "b", "c"))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _atom(refs["a"]), _atom(refs["b"]), _atom(refs["c"])),
+    )
+
+    assert len(evidence.created) == 2
+    ab, bc = evidence.created
+    assert (ab.start, ab.end) == (refs["a"], refs["b"])
+    assert (bc.start, bc.end) == (refs["b"], refs["c"])
+    assert evidence.result is bc.ref
+    assert replay_sequence_materialization(before, evidence) is bc.ref
+
+
+def test_nested_ab_is_one_outer_value_in_infinity_group_ab_c() -> None:
+    before, root, refs = _base_network(("a", "b", "c"))
+    evidence = materialize_sequence(
+        before,
+        _description(
+            root,
+            _group(_atom(refs["a"]), _atom(refs["b"])),
+            _atom(refs["c"]),
+        ),
+    )
+
+    assert len(evidence.created) == 2
+    inner, outer = evidence.created
+    assert (inner.start, inner.end) == (refs["a"], refs["b"])
+    assert outer.start is inner.ref
+    assert outer.end is refs["c"]
+    assert evidence.result is outer.ref
+
+
+def test_singleton_group_returns_exact_item_without_materialization() -> None:
+    before, root, refs = _base_network(("x",))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _group(_atom(refs["x"]))),
+    )
+
+    assert evidence.created == ()
+    assert evidence.result is refs["x"]
+    assert evidence.after.snapshot() == before.snapshot()
+    assert evidence.after.refs[refs["x"].slot] is refs["x"]
+
+
+def test_full_window_cursor_position_nested_example() -> None:
+    before, root, refs = _base_network(
+        ("window", "cursor", "position", "x", "int", "point")
+    )
+    description = _description(
+        root,
+        _group(_atom(refs["window"])),
+        _group(_atom(refs["cursor"])),
+        _group(_atom(refs["position"])),
+        _group(
+            _group(
+                _group(_atom(refs["x"])),
+                _group(_atom(refs["int"])),
+            ),
+            _group(_atom(refs["point"])),
+        ),
+    )
+    evidence = materialize_sequence(before, description)
+
+    assert len(evidence.created) == 5
+    xi, q, window_cursor, cursor_position, position_q = evidence.created
+
+    assert (xi.start, xi.end) == (refs["x"], refs["int"])
+    assert q.start is xi.ref
+    assert q.end is refs["point"]
+    assert (window_cursor.start, window_cursor.end) == (
+        refs["window"],
+        refs["cursor"],
+    )
+    assert (cursor_position.start, cursor_position.end) == (
+        refs["cursor"],
+        refs["position"],
+    )
+    assert position_q.start is refs["position"]
+    assert position_q.end is q.ref
+    assert evidence.result is position_q.ref
+    assert replay_sequence_materialization(before, evidence) is position_q.ref
+
+
+def test_find_is_read_only_for_present_and_absent_pairs() -> None:
+    before, _, refs = _base_network(("a", "b"))
+    snapshot = before.snapshot()
+
+    assert find_links(before, start=refs["a"]) == (refs["a"],)
+    assert find_links(before, start=refs["a"], end=refs["b"]) == ()
+    assert before.snapshot() == snapshot
+
+
+def test_wrong_root_and_foreign_atom_reject() -> None:
+    before, root, refs = _base_network(("a", "b"))
+    other, other_root, other_refs = _base_network(("x",))
+
+    with pytest.raises(SequenceMaterializationError, match="exact distinguished"):
+        materialize_sequence(
+            before,
+            _description(refs["a"], _atom(refs["a"]), _atom(refs["b"])),
+        )
+
+    assert other.root is other_root
+    with pytest.raises(SequenceMaterializationError, match="before network"):
+        materialize_sequence(
+            before,
+            _description(root, _atom(refs["a"]), _atom(other_refs["x"])),
+        )
+
+
+def test_empty_top_level_and_nested_sequences_reject() -> None:
+    before, root, _ = _base_network(("a",))
+    with pytest.raises(SequenceMaterializationError, match="top-level"):
+        SequenceDescription(root=root, items=())
+    with pytest.raises(SequenceMaterializationError, match="nested"):
+        SequenceGroup(items=())
+    assert before.root is root
+
+
+def test_replay_rejects_forged_edge_poles_and_result() -> None:
+    before, root, refs = _base_network(("a", "b", "c"))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _atom(refs["a"]), _atom(refs["b"])),
+    )
+    edge = evidence.created[0]
+
+    forged_edge = replace(edge, end=refs["c"])
+    with pytest.raises(SequenceMaterializationError, match="adjacency"):
+        replay_sequence_materialization(
+            before,
+            replace(evidence, created=(forged_edge,)),
+        )
+
+    with pytest.raises(SequenceMaterializationError, match="result"):
+        replay_sequence_materialization(before, replace(evidence, result=refs["a"]))
+
+
+def test_replay_rejects_extra_after_occurrence() -> None:
+    before, root, refs = _base_network(("a", "b"))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _atom(refs["a"]), _atom(refs["b"])),
+    )
+    evolution = evidence.after.evolve()
+    extra = evolution.reserve()
+    evolution.define(extra, refs["a"], refs["a"])
+    too_large_after = evolution.freeze()
+
+    with pytest.raises(SequenceMaterializationError, match="cardinality"):
+        replay_sequence_materialization(
+            before,
+            replace(evidence, after=too_large_after),
+        )
+
+
+def test_replay_rejects_changed_base_topology_from_independent_reload() -> None:
+    before, root, refs = _base_network(("a", "b"))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _atom(refs["a"]), _atom(refs["b"])),
+    )
+    reloaded = LinkNetwork.from_snapshot(evidence.after.snapshot())
+
+    with pytest.raises(SequenceMaterializationError, match="preserve exact base"):
+        replay_sequence_materialization(
+            before,
+            replace(evidence, after=reloaded),
+        )
+
+
+def test_snapshot_roundtrip_preserves_topology_but_creates_fresh_identity() -> None:
+    before, root, refs = _base_network(("a", "b"))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _atom(refs["a"]), _atom(refs["b"])),
+    )
+    restored = LinkNetwork.from_snapshot(evidence.after.snapshot())
+
+    assert restored.snapshot() == evidence.after.snapshot()
+    assert restored.refs[evidence.result.slot] is not evidence.result
+    assert restored.refs[evidence.result.slot] != evidence.result
+
+
+def test_old_v02_memory_interning_is_not_used_by_foundation_v2_module() -> None:
+    source = (ROOT / "core/foundation_v2_materialization.py").read_text(encoding="utf-8")
+    assert "anum_memory" not in source
+    assert "intern_link" not in source
+    assert "mtc_parser" not in source
+    assert "mtc_ast" not in source
+    assert _contract()["compatibility"]["historicalAnumMemoryPairInterningInherited"] is False
+
+
+def test_materialized_edge_has_no_hidden_semantic_tags() -> None:
+    before, root, refs = _base_network(("a", "b"))
+    evidence = materialize_sequence(
+        before,
+        _description(root, _atom(refs["a"]), _atom(refs["b"])),
+    )
+    edge = evidence.created[0]
+
+    assert isinstance(edge, MaterializedEdge)
+    assert set(edge.__dataclass_fields__) == {"ref", "start", "end"}


### PR DESCRIPTION
Closes #242 after explicit decision if CI/evidence is accepted. Parent: #237. Depends on the merged Foundation-v2 exact-occurrence/state/source/replay stack and docs refresh #263.

## Sequence semantics

This PR formalizes the historical sequence intuition without turning brackets into host opcodes:

```text
∞ A B C
→ new exact A⟼B
→ new exact B⟼C
```

`∞` is a root/sentinel and is not an adjacency operand.

Nested groups return one exact value to the outer sequence:

```text
[A]   → exact A, no new relation
[A B] → X = A⟼B, return exact X

∞ [A B] C
→ X = A⟼B
→ Y = X⟼C
```

The full `∞[window][cursor][position][[[x][int]][point]]` vector creates `XI`, `Q`, `W⟼C`, `C⟼P`, `P⟼Q` in deterministic nested-first order.

## Exact materialization boundary

`LinkNetwork.evolve()` creates a new immutable state in the same runtime identity lineage:
- the `before` state is untouched;
- existing exact refs are preserved by object identity;
- existing links are immutable;
- new occurrences are appended;
- duplicate pole pairs are allowed.

Every sequence adjacency creates a **new exact occurrence**. Foundation v2 deliberately does not reuse historical `AnumMemory.intern_link` pair-interning semantics. Any reuse policy must be an explicit planner decision, not a hidden consequence of equal poles.

Independent snapshot reload still creates a fresh runtime identity scope; snapshot slots are not universal semantic IDs.

## Read vs effect

`find_links(...)` is read-only and never creates a missing pair.
`materialize_sequence(...)` is the explicit effect constructor.
`replay_sequence_materialization(...)` is read-only trusted verification of before/after lineage, exact created order/poles/result and absence of extra changes.

## Compatibility

Historical v0.2 boundary/pair/recursive Anum contracts remain accepted and unchanged. The new sequence mode does not replace the recursive occurrence-tree grammar and does not inherit old L4 pair interning.

## Documentation

Updates the main `README.md`, `Foundation v2 Gate P.md` and `Ачисла и сериализация.md` in the same PR so the main MTS documentation stays synchronized with the executable gate.

Machine contract: `contracts/mts-anum-sequence-materialization-v0.7.json`.

After this gate the next major release blocker is persistent L4 #124, not another parallel Anum semantics path.