### PR TITLE
Gate P: add persistent exact-occurrence L4 apamemory reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ exact-occurrence binary links
 → T-admitted proof rule
 → integrated proof checker
 → Anum nested sequence materialization
+→ persistent exact-occurrence L4 reference backend
 ```
 
-Foundation v2 **ещё не является accepted release**. Следующий большой blocker после sequence gate — persistent L4 #124, затем cutover/versioned conformance/acceptance.
+Foundation v2 **ещё не является accepted release**. Persistent L4 сейчас проходит Gate #265; после него останутся compatibility/cutover, versioned integrated conformance и explicit acceptance перед repin `aprover`.
 
 ---
 
@@ -189,7 +190,7 @@ READ SIDE
 read / find / enumerate / resolve / replay
 
 EFFECT SIDE
-materialize / define / delete / persist transition
+materialize / define / persist transition
 ```
 
 Главный инвариант:
@@ -267,7 +268,7 @@ T ⟼ Rule
 
 и одношагово decomposes истинное local equality завершённых links.
 
-Integrated checker уже replay-ит:
+Integrated checker replay-ит:
 
 ```text
 source `decompose`
@@ -359,7 +360,7 @@ Explicit sequence materialization создаёт target relation только н
 
 ---
 
-# 12. Foundation-v2 sequence materialization #242
+# 12. Foundation-v2 sequence materialization #242/#264
 
 Machine contract candidate:
 
@@ -398,7 +399,7 @@ Nested group:
 → Y = X ⟼ C
 ```
 
-Вложенный context возвращает построенную relation как один элемент внешней последовательности.
+Подробнее: [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md).
 
 ---
 
@@ -432,17 +433,9 @@ Window ─────▶ Cursor ─────▶ Position
 
 До explicit effect source carrier не обязан содержать эти target relations.
 
-Это наглядно показывает, зачем МТС различает описание, поиск и materialization.
-
-Подробнее: [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md).
-
 ---
 
 # 14. Materialization не наследует pair interning
-
-Старый historical `core/anum_memory.py` использовал canonical pair interning.
-
-Foundation v2 не наследует эту semantics.
 
 Если уже существует:
 
@@ -450,7 +443,7 @@ Foundation v2 не наследует эту semantics.
 P1 = A ⟼ B
 ```
 
-новый explicit sequence effect может создать:
+новый explicit effect может создать:
 
 ```text
 P2 = A ⟼ B
@@ -462,33 +455,91 @@ P2 = A ⟼ B
 P1 ≠ P2
 ```
 
-Каждая adjacency sequence effect создаёт новый exact occurrence. Возможный reuse должен быть отдельным explicit planning decision, а не скрытым следствием одинаковой пары.
+Каждая adjacency sequence effect создаёт новый exact occurrence. Возможный reuse — отдельное explicit planning decision, а не скрытое следствие одинаковой пары.
+
+Именно поэтому historical L4 #124 с pair uniqueness/idempotent realize закрыт как superseded, а Foundation-v2 persistent L4 заново выводится в #265.
 
 ---
 
-# 15. Persistent before/after state
+# 15. Persistent exact-occurrence L4 #265
 
-Foundation-v2 exact network поддерживает additive evolution:
+Persistent апамять должна сохранить exact occurrence semantics после close/reopen, не объявляя физический адрес identity.
+
+Foundation v2 различает:
 
 ```text
-before
-  ↓ explicit effect
- after
+runtime OccurrenceRef
+persistent dataset-local logical occurrence id
+snapshot-local slot
+backend physical address
 ```
 
-В одном runtime lineage:
+Reference persistent identity:
 
-- старые exact refs сохраняются;
-- старые links не изменяются;
-- новые occurrences append-ятся;
-- duplicate pairs разрешены;
-- root сохраняется.
+```text
+PersistentOccurrenceId(lineage, local)
+```
 
-Independent snapshot reload создаёт fresh runtime identity scope, поэтому snapshot slot не становится universal identity.
+Для одного dataset:
+
+```text
+close → reopen
+```
+
+сохраняет `lineage/local`, но runtime refs строятся заново.
+
+Импорт той же topology в независимый dataset получает новый lineage:
+
+```text
+same topology != same persistent exact identity
+```
 
 ---
 
-# 16. Текущие Foundation-v2 modules
+# 16. Persistent multiplicity, cycles и sharing
+
+Persistent `materialize(A,B)` всегда создаёт **новый** logical occurrence.
+
+```text
+P1 = materialize(A,B)
+P2 = materialize(A,B)
+P1 ≠ P2
+```
+
+Оба должны пережить reopen и вернуться через:
+
+```text
+find(A,B) -> (P1,P2)
+```
+
+Atomic batch поддерживает self/mutual cycles и sharing через batch-local refs, не раскрывая циклы рекурсивно.
+
+Подробнее: [Foundation v2 Persistent L4](docs/specs/Foundation%20v2%20Persistent%20L4.md).
+
+---
+
+# 17. Sequence effect после reopen
+
+Persistent L4 не копирует Anum grammar.
+
+Правильная цепочка:
+
+```text
+persistent store
+→ reconstruct runtime exact network
+→ foundation_v2_materialization.py
+→ runtime effect evidence
+→ normalize to persistent ids
+→ atomic persistent batch
+```
+
+После reopen persistent evidence снова преобразуется в runtime before/after lineage и проверяется обычным trusted replay #242.
+
+То есть storage меняется, а semantic sequence checker остаётся один.
+
+---
+
+# 18. Текущие Foundation-v2 modules
 
 ```text
 core/exact_link_network.py
@@ -513,19 +564,22 @@ core/foundation_v2_checker.py
     integrated source→proof→Run replay
 
 core/foundation_v2_materialization.py
-    nested Anum sequence explicit materialization/replay
+    nested Anum sequence materialization/replay
+
+core/foundation_v2_persistent.py
+    persistent exact-occurrence L4 reference backend and sequence bridge
 ```
 
 Все они пока candidate следующей версии.
 
 ---
 
-# 17. Путь к accepted Foundation v2
+# 19. Путь к accepted Foundation v2
 
-После sequence gate #242 основной release chain:
+Текущий Gate-P release chain:
 
 ```text
-#124 persistent L4/backend contract
+#265 persistent exact-occurrence L4
 ↓
 historical compatibility classification
 ↓
@@ -540,11 +594,13 @@ explicit Foundation-v2 acceptance
 aprover repin
 ```
 
+Reference JSON store в #265 — только executable persistence evidence. Production backend может быть PMM или другой storage, если он проходит тот же observable contract.
+
 До explicit acceptance Foundation v2 нельзя называть новой принятой версией.
 
 ---
 
-# 18. Как читать репозиторий
+# 20. Как читать репозиторий
 
 Для текущей МТС:
 
@@ -553,8 +609,9 @@ aprover repin
 3. [Foundation v2 Gate P](docs/specs/Foundation%20v2%20Gate%20P.md)
 4. [Формальная нотация МТС](docs/specs/Формальная%20нотация%20МТС.md)
 5. [Апамять и управление сетью связей](docs/specs/Апамять%20и%20управление%20сетью%20связей.md)
-6. [Foundation v2 Proof replay](docs/specs/Foundation%20v2%20Proof%20replay.md)
-7. [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md)
+6. [Foundation v2 Persistent L4](docs/specs/Foundation%20v2%20Persistent%20L4.md)
+7. [Foundation v2 Proof replay](docs/specs/Foundation%20v2%20Proof%20replay.md)
+8. [Ачисла и сериализация](docs/specs/Ачисла%20и%20сериализация.md)
 
 Для historical accepted behavior:
 
@@ -573,6 +630,7 @@ aprover repin
 + untrusted discovery
 + deterministic trusted replay
 + explicit materialization
++ persistent logical identity independent of physical storage
 ```
 
-Эта комбинация связывает фундаментальную МТС с ассоциативной памятью и проверяемым `aprover`.
+Эта комбинация связывает фундаментальную МТС с долговременной ассоциативной памятью и проверяемым `aprover`.

--- a/contracts/mts-foundation-v2-persistent-l4-v0.7.json
+++ b/contracts/mts-foundation-v2-persistent-l4-v0.7.json
@@ -1,0 +1,95 @@
+{
+  "schema": "mts-foundation-v2-persistent-l4/v0.7",
+  "status": "gate-p-candidate",
+  "accepted": false,
+  "issue": 265,
+  "parent": 237,
+  "supersedesForFoundationV2": [
+    "mts-l4-backend-challenge/v0.3",
+    "mts-l4-backend-driver/v0.3"
+  ],
+  "historicalContractsRemainReproducible": true,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-anum-sequence-materialization/v0.7"
+  ],
+  "identity": {
+    "runtimeOccurrenceRef": "ephemeral exact runtime identity inside one reconstructed runtime lineage",
+    "persistentOccurrenceId": "stable opaque dataset-local logical identity = dataset lineage + local occurrence id",
+    "snapshotSlot": "transport-local topology coordinate only",
+    "physicalBackendAddress": "implementation detail only",
+    "sameDatasetReopenPreservesPersistentIdentity": true,
+    "sameDatasetReopenRequiresSameRuntimeObjectIdentity": false,
+    "freshTopologyImportCreatesFreshLineage": true,
+    "crossDatasetExactIdentityInferredFromEqualTopology": false,
+    "physicalAddressIsSemanticIdentity": false,
+    "snapshotSlotIsUniversalSemanticIdentity": false
+  },
+  "surface": {
+    "lifecycle": ["create", "open", "close", "lineage_id", "snapshot"],
+    "read": ["poles", "find", "outgoing", "incoming", "all_occurrences"],
+    "effect": ["materialize", "materialize_batch"],
+    "bridge": [
+      "runtime_network",
+      "materialize_persistent_sequence",
+      "replay_persistent_sequence_materialization"
+    ]
+  },
+  "materialization": {
+    "everyCallCreatesFreshOccurrence": true,
+    "samePairMayHaveMultipleOccurrences": true,
+    "pairInterning": false,
+    "idempotentMaterializeByPair": false,
+    "batchSupportsSelfAndMutualCycles": true,
+    "batchCommitAtomic": true,
+    "failedBatchExposesPreState": true,
+    "hiddenReusePolicy": false
+  },
+  "readBoundary": {
+    "findIsReadOnly": true,
+    "polesIsReadOnly": true,
+    "outgoingIncomingAreReadOnly": true,
+    "replayIsReadOnly": true,
+    "missingPairLookupMaterializes": false
+  },
+  "persistence": {
+    "duplicatePairsSurviveReopen": true,
+    "cyclesSurviveReopen": true,
+    "sharingSurvivesReopen": true,
+    "rootLogicalIdentitySurvivesReopen": true,
+    "normalizedTopologySurvivesReopen": true,
+    "runtimeRefsMayBeReconstructed": true,
+    "sequenceEffectCanReplayAfterReopen": true
+  },
+  "backendNeutrality": {
+    "rawAnumTokensAcceptedByBackend": false,
+    "parserAstAcceptedByBackend": false,
+    "l2InterpreterAcceptedByBackend": false,
+    "jsonReferenceFileFormatNormative": false,
+    "pmmApiNormative": false,
+    "referenceBackendPurpose": "executable persistence evidence only"
+  },
+  "requiredVectors": [
+    "two A-to-B exact occurrences survive reopen as distinct persistent ids",
+    "find after reopen returns both duplicate occurrences without mutation",
+    "self-cycle and mutual cycle survive reopen",
+    "shared endpoint remains one logical occurrence after reopen",
+    "root persistent id survives clean reopen",
+    "invalid batch leaves memory and file at pre-state",
+    "simulated commit failure leaves memory and file at pre-state",
+    "fresh import of identical topology receives another lineage",
+    "runtime reconstruction after reopen preserves topology but creates new runtime refs",
+    "persistent sequence materialization delegates to Gate-P sequence semantics",
+    "persistent sequence evidence replays read-only after clean reopen",
+    "backend source has no Anum parser, MTC parser/AST or old pair-interning dependency"
+  ],
+  "outOfScope": [
+    "production PMM adapter",
+    "crash recovery stronger than atomic file replacement reference evidence",
+    "delete semantics",
+    "cross-dataset replication identity",
+    "aprover repin"
+  ],
+  "nextGate": "historical compatibility classification and atomic Foundation-v2 production cutover planning",
+  "aproverRepinAllowed": false
+}

--- a/core/foundation_v2_persistent.py
+++ b/core/foundation_v2_persistent.py
@@ -1,0 +1,583 @@
+"""Foundation-v2 persistent exact-occurrence apamemory reference backend.
+
+The JSON file used here is deliberately only a reference persistence mechanism.
+Its format is not MTS ontology and is not the canonical high-performance storage
+layout. The semantic contract is the observable behavior:
+
+* each materialization creates a fresh exact occurrence;
+* duplicate pole pairs survive as distinct logical occurrences;
+* one persistent dataset has an opaque lineage id;
+* reopening that dataset preserves lineage-local logical occurrence ids;
+* importing the same topology creates a fresh lineage;
+* physical file offsets/addresses and portable snapshot slots are not semantic
+  identity;
+* reads never materialize;
+* batches commit atomically or expose the previous state.
+
+The module also bridges the already-accepted Gate-P candidate sequence
+materializer to persistent ids without reimplementing its nested sequence
+semantics.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+from uuid import uuid4
+
+from .exact_link_network import LinkNetwork, LinkNetworkBuilder, OccurrenceRef
+from .foundation_v2_materialization import (
+    MaterializedEdge,
+    SequenceAtom,
+    SequenceDescription,
+    SequenceGroup,
+    SequenceMaterialization,
+    materialize_sequence,
+    replay_sequence_materialization,
+)
+
+
+PERSISTENT_SCHEMA = "mts-foundation-v2-persistent-reference/v0.7"
+
+
+class PersistentStoreError(ValueError):
+    """Persistent exact-occurrence store operation or evidence is invalid."""
+
+
+@dataclass(frozen=True, order=True)
+class PersistentOccurrenceId:
+    """Stable logical occurrence id inside exactly one persistent dataset lineage."""
+
+    lineage: str
+    local: int
+
+
+@dataclass(frozen=True)
+class BatchRef:
+    """Reference to an occurrence allocated by the current atomic batch."""
+
+    index: int
+
+
+BatchEndpoint = PersistentOccurrenceId | BatchRef
+
+
+@dataclass(frozen=True)
+class BatchLink:
+    """One requested fresh exact occurrence in an atomic materialization batch."""
+
+    start: BatchEndpoint
+    end: BatchEndpoint
+
+
+@dataclass(frozen=True)
+class PersistentSnapshot:
+    """Normalized logical topology of one persistent dataset state."""
+
+    lineage: str
+    root: PersistentOccurrenceId
+    links: tuple[tuple[PersistentOccurrenceId, PersistentOccurrenceId, PersistentOccurrenceId], ...]
+
+
+@dataclass(frozen=True)
+class PersistentSequenceAtom:
+    value: PersistentOccurrenceId
+
+
+@dataclass(frozen=True)
+class PersistentSequenceGroup:
+    items: tuple["PersistentSequenceItem", ...]
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise PersistentStoreError("persistent sequence group cannot be empty")
+
+
+PersistentSequenceItem = PersistentSequenceAtom | PersistentSequenceGroup
+
+
+@dataclass(frozen=True)
+class PersistentSequenceDescription:
+    root: PersistentOccurrenceId
+    items: tuple[PersistentSequenceItem, ...]
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise PersistentStoreError("persistent sequence cannot be empty")
+
+
+@dataclass(frozen=True)
+class PersistentMaterializedEdge:
+    ref: PersistentOccurrenceId
+    start: PersistentOccurrenceId
+    end: PersistentOccurrenceId
+
+
+@dataclass(frozen=True)
+class PersistentSequenceMaterialization:
+    """Portable persistent evidence for one sequence effect."""
+
+    description: PersistentSequenceDescription
+    before_count: int
+    created: tuple[PersistentMaterializedEdge, ...]
+    result: PersistentOccurrenceId
+
+    @property
+    def after_count(self) -> int:
+        return self.before_count + len(self.created)
+
+
+class JsonExactLinkStore:
+    """Small file-backed reference implementation of the Foundation-v2 L4 contract."""
+
+    def __init__(
+        self,
+        path: Path,
+        lineage: str,
+        links: list[tuple[int, int]],
+        root_local: int,
+    ) -> None:
+        self._path = path
+        self._lineage = lineage
+        self._links = links
+        self._root_local = root_local
+        self._closed = False
+        self._validate_state()
+
+    @classmethod
+    def create(cls, path: str | Path) -> "JsonExactLinkStore":
+        """Create a fresh persistent lineage with one exact self-closed root."""
+
+        target = Path(path)
+        if target.exists():
+            raise PersistentStoreError("persistent dataset already exists")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        store = cls(target, uuid4().hex, [(0, 0)], 0)
+        store._commit_candidate(store._links)
+        return store
+
+    @classmethod
+    def open(cls, path: str | Path) -> "JsonExactLinkStore":
+        """Open an existing dataset preserving its logical lineage and ids."""
+
+        target = Path(path)
+        try:
+            raw = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PersistentStoreError("cannot open persistent dataset") from exc
+        if raw.get("schema") != PERSISTENT_SCHEMA:
+            raise PersistentStoreError("unsupported persistent dataset schema")
+        lineage = raw.get("lineage")
+        root = raw.get("root")
+        links_raw = raw.get("links")
+        if not isinstance(lineage, str) or not lineage:
+            raise PersistentStoreError("invalid persistent lineage id")
+        if not isinstance(root, int):
+            raise PersistentStoreError("invalid persistent root id")
+        if not isinstance(links_raw, list):
+            raise PersistentStoreError("invalid persistent links")
+        links: list[tuple[int, int]] = []
+        for pair in links_raw:
+            if (
+                not isinstance(pair, list)
+                or len(pair) != 2
+                or not all(isinstance(value, int) for value in pair)
+            ):
+                raise PersistentStoreError("invalid persistent link pair")
+            links.append((pair[0], pair[1]))
+        return cls(target, lineage, links, root)
+
+    @classmethod
+    def import_topology(
+        cls,
+        path: str | Path,
+        snapshot: PersistentSnapshot,
+    ) -> "JsonExactLinkStore":
+        """Import topology into a fresh lineage instead of claiming source identity."""
+
+        target = Path(path)
+        if target.exists():
+            raise PersistentStoreError("persistent dataset already exists")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        ordered = sorted(snapshot.links, key=lambda item: item[0].local)
+        if [item[0].local for item in ordered] != list(range(len(ordered))):
+            raise PersistentStoreError("snapshot local ids must be dense for import")
+        links = [(start.local, end.local) for _ref, start, end in ordered]
+        store = cls(target, uuid4().hex, links, snapshot.root.local)
+        store._commit_candidate(store._links)
+        return store
+
+    @property
+    def lineage_id(self) -> str:
+        self._require_open()
+        return self._lineage
+
+    @property
+    def root(self) -> PersistentOccurrenceId:
+        self._require_open()
+        return self._id(self._root_local)
+
+    @property
+    def count(self) -> int:
+        self._require_open()
+        return len(self._links)
+
+    def close(self) -> None:
+        """Close this runtime handle; committed file state already persists."""
+
+        self._require_open()
+        self._closed = True
+
+    def snapshot(self) -> PersistentSnapshot:
+        """Return normalized logical topology without backend physical addresses."""
+
+        self._require_open()
+        return PersistentSnapshot(
+            lineage=self._lineage,
+            root=self.root,
+            links=tuple(
+                (self._id(local), self._id(start), self._id(end))
+                for local, (start, end) in enumerate(self._links)
+            ),
+        )
+
+    def poles(
+        self,
+        ref: PersistentOccurrenceId,
+    ) -> tuple[PersistentOccurrenceId, PersistentOccurrenceId]:
+        self._require_open()
+        local = self._validate_id(ref)
+        start, end = self._links[local]
+        return self._id(start), self._id(end)
+
+    def find(
+        self,
+        *,
+        start: PersistentOccurrenceId | None = None,
+        end: PersistentOccurrenceId | None = None,
+    ) -> tuple[PersistentOccurrenceId, ...]:
+        """Read-only exact occurrence lookup preserving duplicate pairs."""
+
+        self._require_open()
+        start_local = self._validate_id(start) if start is not None else None
+        end_local = self._validate_id(end) if end is not None else None
+        return tuple(
+            self._id(local)
+            for local, (candidate_start, candidate_end) in enumerate(self._links)
+            if (start_local is None or candidate_start == start_local)
+            and (end_local is None or candidate_end == end_local)
+        )
+
+    def outgoing(
+        self,
+        start: PersistentOccurrenceId,
+    ) -> tuple[PersistentOccurrenceId, ...]:
+        return self.find(start=start)
+
+    def incoming(
+        self,
+        end: PersistentOccurrenceId,
+    ) -> tuple[PersistentOccurrenceId, ...]:
+        return self.find(end=end)
+
+    def all_occurrences(self) -> tuple[PersistentOccurrenceId, ...]:
+        self._require_open()
+        return tuple(self._id(local) for local in range(len(self._links)))
+
+    def materialize(
+        self,
+        start: PersistentOccurrenceId,
+        end: PersistentOccurrenceId,
+    ) -> PersistentOccurrenceId:
+        """Create one fresh exact occurrence even if the same pair already exists."""
+
+        return self.materialize_batch((BatchLink(start, end),))[0]
+
+    def materialize_batch(
+        self,
+        links: Iterable[BatchLink],
+    ) -> tuple[PersistentOccurrenceId, ...]:
+        """Atomically append fresh exact occurrences, including cyclic batches."""
+
+        self._require_open()
+        requested = tuple(links)
+        if not requested:
+            return ()
+        base = len(self._links)
+        allocated = tuple(self._id(base + index) for index in range(len(requested)))
+
+        def resolve(endpoint: BatchEndpoint) -> int:
+            if isinstance(endpoint, PersistentOccurrenceId):
+                return self._validate_id(endpoint)
+            if not isinstance(endpoint, BatchRef):
+                raise PersistentStoreError("invalid batch endpoint")
+            if endpoint.index < 0 or endpoint.index >= len(allocated):
+                raise PersistentStoreError("batch reference is out of range")
+            return allocated[endpoint.index].local
+
+        additions = [(resolve(link.start), resolve(link.end)) for link in requested]
+        candidate = [*self._links, *additions]
+        self._validate_links(candidate, self._root_local)
+
+        # Persist first. If this raises, in-memory observable state remains old.
+        self._commit_candidate(candidate)
+        self._links = candidate
+        return allocated
+
+    def runtime_network(
+        self,
+        *,
+        count: int | None = None,
+    ) -> tuple[LinkNetwork, dict[PersistentOccurrenceId, OccurrenceRef]]:
+        """Reconstruct a fresh runtime exact network from a persistent prefix."""
+
+        self._require_open()
+        selected_count = len(self._links) if count is None else count
+        if selected_count <= self._root_local or selected_count > len(self._links):
+            raise PersistentStoreError("invalid runtime prefix count")
+        for start, end in self._links[:selected_count]:
+            if start >= selected_count or end >= selected_count:
+                raise PersistentStoreError(
+                    "requested runtime prefix is not topologically closed"
+                )
+
+        builder = LinkNetworkBuilder()
+        refs = tuple(builder.reserve() for _ in range(selected_count))
+        for local, (start, end) in enumerate(self._links[:selected_count]):
+            builder.define(refs[local], refs[start], refs[end])
+        network = builder.freeze(refs[self._root_local])
+        mapping = {self._id(local): refs[local] for local in range(selected_count)}
+        return network, mapping
+
+    def runtime_materialization_lineage(
+        self,
+        before_count: int,
+        after_count: int,
+    ) -> tuple[
+        LinkNetwork,
+        LinkNetwork,
+        dict[PersistentOccurrenceId, OccurrenceRef],
+    ]:
+        """Reconstruct before/after runtime states sharing one exact identity scope."""
+
+        if after_count < before_count or after_count > len(self._links):
+            raise PersistentStoreError("invalid persistent materialization range")
+        before, mapping = self.runtime_network(count=before_count)
+        evolution = before.evolve()
+        refs: dict[int, OccurrenceRef] = {
+            persistent.local: runtime for persistent, runtime in mapping.items()
+        }
+        for local in range(before_count, after_count):
+            refs[local] = evolution.reserve()
+        for local in range(before_count, after_count):
+            start, end = self._links[local]
+            if start not in refs or end not in refs:
+                raise PersistentStoreError(
+                    "persistent materialization range has unresolved endpoint"
+                )
+            evolution.define(refs[local], refs[start], refs[end])
+        after = evolution.freeze()
+        full_mapping = {self._id(local): refs[local] for local in range(after_count)}
+        return before, after, full_mapping
+
+    def _validate_state(self) -> None:
+        if not self._lineage:
+            raise PersistentStoreError("persistent lineage id cannot be empty")
+        self._validate_links(self._links, self._root_local)
+
+    @staticmethod
+    def _validate_links(links: list[tuple[int, int]], root_local: int) -> None:
+        if not links:
+            raise PersistentStoreError("persistent dataset cannot be empty")
+        if root_local < 0 or root_local >= len(links):
+            raise PersistentStoreError("persistent root is out of range")
+        for start, end in links:
+            if start < 0 or start >= len(links) or end < 0 or end >= len(links):
+                raise PersistentStoreError("persistent endpoint is out of range")
+
+    def _id(self, local: int) -> PersistentOccurrenceId:
+        return PersistentOccurrenceId(self._lineage, local)
+
+    def _validate_id(self, ref: PersistentOccurrenceId) -> int:
+        if not isinstance(ref, PersistentOccurrenceId):
+            raise PersistentStoreError("expected persistent occurrence id")
+        if ref.lineage != self._lineage:
+            raise PersistentStoreError("foreign persistent dataset lineage")
+        if ref.local < 0 or ref.local >= len(self._links):
+            raise PersistentStoreError("persistent occurrence id is out of range")
+        return ref.local
+
+    def _payload(self, links: list[tuple[int, int]]) -> dict:
+        return {
+            "schema": PERSISTENT_SCHEMA,
+            "lineage": self._lineage,
+            "root": self._root_local,
+            "links": [[start, end] for start, end in links],
+        }
+
+    def _commit_candidate(self, links: list[tuple[int, int]]) -> None:
+        payload = self._payload(links)
+        temporary = self._path.with_name(f".{self._path.name}.tmp")
+        try:
+            with temporary.open("w", encoding="utf-8") as stream:
+                json.dump(payload, stream, sort_keys=True, separators=(",", ":"))
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, self._path)
+        except OSError:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise PersistentStoreError("persistent store handle is closed")
+
+
+def materialize_persistent_sequence(
+    store: JsonExactLinkStore,
+    description: PersistentSequenceDescription,
+) -> PersistentSequenceMaterialization:
+    """Execute the existing Gate-P sequence semantics as one persistent batch."""
+
+    if description.root != store.root:
+        raise PersistentStoreError("persistent sequence uses another exact root")
+    before_count = store.count
+    before, persistent_to_runtime = store.runtime_network()
+    runtime_description = _runtime_description(description, persistent_to_runtime)
+    runtime_effect = materialize_sequence(before, runtime_description)
+
+    runtime_to_persistent = {
+        runtime: persistent for persistent, runtime in persistent_to_runtime.items()
+    }
+    created_index = {
+        edge.ref: index for index, edge in enumerate(runtime_effect.created)
+    }
+
+    def endpoint(ref: OccurrenceRef) -> BatchEndpoint:
+        persistent = runtime_to_persistent.get(ref)
+        if persistent is not None:
+            return persistent
+        index = created_index.get(ref)
+        if index is None:
+            raise PersistentStoreError("runtime materialization endpoint is not normalized")
+        return BatchRef(index)
+
+    batch = tuple(
+        BatchLink(start=endpoint(edge.start), end=endpoint(edge.end))
+        for edge in runtime_effect.created
+    )
+    persistent_refs = store.materialize_batch(batch)
+    if len(persistent_refs) != len(runtime_effect.created):
+        raise PersistentStoreError("persistent batch cardinality mismatch")
+
+    created = tuple(
+        PersistentMaterializedEdge(
+            ref=persistent_ref,
+            start=_persistent_endpoint(edge.start, runtime_to_persistent, created_index, persistent_refs),
+            end=_persistent_endpoint(edge.end, runtime_to_persistent, created_index, persistent_refs),
+        )
+        for persistent_ref, edge in zip(
+            persistent_refs, runtime_effect.created, strict=True
+        )
+    )
+    if runtime_effect.result in runtime_to_persistent:
+        result = runtime_to_persistent[runtime_effect.result]
+    else:
+        result = persistent_refs[created_index[runtime_effect.result]]
+
+    evidence = PersistentSequenceMaterialization(
+        description=description,
+        before_count=before_count,
+        created=created,
+        result=result,
+    )
+    replay_persistent_sequence_materialization(store, evidence)
+    return evidence
+
+
+def replay_persistent_sequence_materialization(
+    store: JsonExactLinkStore,
+    evidence: PersistentSequenceMaterialization,
+) -> PersistentOccurrenceId:
+    """Replay persisted sequence evidence, including after a clean reopen."""
+
+    snapshot_before = store.snapshot()
+    if evidence.description.root.lineage != store.lineage_id:
+        raise PersistentStoreError("persistent evidence belongs to another lineage")
+    if evidence.after_count > store.count:
+        raise PersistentStoreError("persistent evidence extends past current store state")
+
+    before, after, mapping = store.runtime_materialization_lineage(
+        evidence.before_count,
+        evidence.after_count,
+    )
+    runtime_description = _runtime_description(evidence.description, mapping)
+    runtime_created = tuple(
+        MaterializedEdge(
+            ref=mapping[edge.ref],
+            start=mapping[edge.start],
+            end=mapping[edge.end],
+        )
+        for edge in evidence.created
+    )
+    runtime_evidence = SequenceMaterialization(
+        description=runtime_description,
+        after=after,
+        created=runtime_created,
+        result=mapping[evidence.result],
+    )
+    replay_sequence_materialization(before, runtime_evidence)
+
+    for edge in evidence.created:
+        if store.poles(edge.ref) != (edge.start, edge.end):
+            raise PersistentStoreError("persistent edge evidence has forged poles")
+    if store.snapshot() != snapshot_before:
+        raise PersistentStoreError("persistent replay mutated the store")
+    return evidence.result
+
+
+def _runtime_description(
+    description: PersistentSequenceDescription,
+    mapping: dict[PersistentOccurrenceId, OccurrenceRef],
+) -> SequenceDescription:
+    try:
+        root = mapping[description.root]
+    except KeyError as exc:
+        raise PersistentStoreError("persistent sequence root is unavailable") from exc
+    return SequenceDescription(
+        root=root,
+        items=tuple(_runtime_item(item, mapping) for item in description.items),
+    )
+
+
+def _runtime_item(
+    item: PersistentSequenceItem,
+    mapping: dict[PersistentOccurrenceId, OccurrenceRef],
+):
+    if isinstance(item, PersistentSequenceAtom):
+        try:
+            return SequenceAtom(mapping[item.value])
+        except KeyError as exc:
+            raise PersistentStoreError("persistent sequence atom is unavailable") from exc
+    return SequenceGroup(tuple(_runtime_item(child, mapping) for child in item.items))
+
+
+def _persistent_endpoint(
+    runtime: OccurrenceRef,
+    old: dict[OccurrenceRef, PersistentOccurrenceId],
+    created_index: dict[OccurrenceRef, int],
+    new: tuple[PersistentOccurrenceId, ...],
+) -> PersistentOccurrenceId:
+    persistent = old.get(runtime)
+    if persistent is not None:
+        return persistent
+    try:
+        return new[created_index[runtime]]
+    except (KeyError, IndexError) as exc:
+        raise PersistentStoreError("cannot normalize runtime endpoint") from exc

--- a/docs/specs/Foundation v2 Gate P.md
+++ b/docs/specs/Foundation v2 Gate P.md
@@ -27,17 +27,18 @@ Docs current MTS surface                       #261/#263
 Anum sequence → апамять materialization        #242/#264
 ```
 
-После merge #264 semantic candidate #242 считается завершённым Gate-P evidence. Текущий следующий release blocker:
+Текущий единственный L4/release gate:
 
 ```text
-#124  persistent L4/backend contract
+#265 persistent exact-occurrence апамять
 ```
 
-Остаток release chain:
+Historical #124 закрыт как superseded для Foundation v2: его pair uniqueness/idempotent realize semantics относится к старому v0.3 challenge и противоречит exact-occurrence multiplicity.
+
+После #265 release chain:
 
 ```text
-#124 persistent L4/backend
-→ historical compatibility classification
+historical compatibility classification
 → atomic production cutover / old semantic-path deletion
 → versioned integrated conformance corpus
 → explicit Foundation-v2 acceptance
@@ -83,7 +84,7 @@ snapshot slot
 physical backend address
 ```
 
-`core/exact_link_network.py` теперь также поддерживает **additive persistent evolution**: новое immutable state может сохранять те же exact refs старых occurrences и append-ить новые occurrences без изменения `before`.
+`core/exact_link_network.py` поддерживает additive immutable evolution: новое runtime state сохраняет те же exact refs старых occurrences и append-ит новые occurrences без изменения `before`.
 
 ---
 
@@ -128,13 +129,7 @@ trusted deterministic replay
 accept / reject
 ```
 
-Replay:
-
-- не ищет candidate;
-- не выбирает rule;
-- не materialize-ит отсутствующие links;
-- не доверяет shape equality;
-- не зависит от legacy parser/proof checker.
+Replay не ищет candidate, не выбирает Rule, не доверяет shape equality и не materialize-ит отсутствующие links.
 
 ---
 
@@ -181,23 +176,13 @@ Equal_K(a,b)
 ⇔ rep_K(a) is rep_K(b)
 ```
 
-Не встроены:
-
-```text
-global substitution
-congruence
-transitive alias closure
-recursive decomposition
-union-find semantics
-```
+Не встроены global substitution, congruence, transitive alias closure, recursive decomposition или union-find semantics.
 
 ---
 
 # 7. Actual acts и Run
 
 `I` и конкретный `A` различаются.
-
-Последовательность acts:
 
 ```text
 Run_0     = R
@@ -216,13 +201,11 @@ Run фиксирует order/provenance, но не создаёт логичес
 
 # 8. Proof rule и integrated checker
 
-Первый proof-rule candidate существует только через admission:
+Первый proof-rule candidate существует только через:
 
 ```text
 T ⟼ Rule
 ```
-
-и одношагово decomposes истинное local equality завершённых links.
 
 Integrated P9 artifact:
 
@@ -255,7 +238,7 @@ READ SIDE
 read / find / enumerate / resolve / replay
 
 EFFECT SIDE
-materialize / define / delete / persist transition
+materialize / define / persist transition
 ```
 
 Главный инвариант:
@@ -270,23 +253,9 @@ find / replay != materialize
 
 ---
 
-# 10. #242 — sequence materialization
+# 10. #242/#264 — sequence materialization
 
-Исторический Anum raw/source carrier может хранить элементы будущей связи **несвязанными**.
-
-Например:
-
-```text
-carrier(∞ a b)
-```
-
-не обязан содержать:
-
-```text
-a ⟼ b
-```
-
-Foundation-v2 candidate определяет sequence effect:
+Foundation-v2 candidate определяет explicit sequence effect:
 
 ```text
 ∞ A B C
@@ -299,26 +268,9 @@ Root `∞` — sentinel и не участвует в adjacency.
 Nested group:
 
 ```text
-[A B]
-→ X = A ⟼ B
-→ return exact X as one outer value
+[A]   → exact A
+[A B] → X = A ⟼ B, return exact X
 ```
-
-Поэтому:
-
-```text
-∞ [A B] C
-→ X = A ⟼ B
-→ Y = X ⟼ C
-```
-
-Singleton:
-
-```text
-[A] → exact A
-```
-
-без нового link.
 
 Полный пример:
 
@@ -326,7 +278,7 @@ Singleton:
 ∞[window][cursor][position][[[x][int]][point]]
 ```
 
-даёт nested-first candidate relations:
+даёт nested-first relations:
 
 ```text
 XI = X ⟼ I
@@ -336,91 +288,173 @@ CP = Cursor ⟼ Position
 PQ = Position ⟼ Q
 ```
 
-#242 после merge #264 больше не является открытым semantic gap: sequence materialization имеет executable contract, tests и replay boundary. Он остаётся candidate частью будущей Foundation v2 до общего acceptance.
-
----
-
-# 11. Materialization identity policy
-
-#242 не использует historical `AnumMemory.intern_link`.
-
-Каждая adjacency materialization создаёт **новый exact occurrence**:
-
-```text
-old = A ⟼ B
-new = A ⟼ B
-old ≠ new
-```
-
-Если executor хочет reuse, это должно быть отдельным explicit planning decision; pair equality сама по себе reuse не разрешает.
-
-Persistent before/after lineage:
-
-```text
-before
-→ explicit effect
-→ after
-```
-
-сохраняет exact identity старых refs и immutable old links.
-
-Independent snapshot reload по-прежнему создаёт fresh runtime identity scope.
-
----
-
-# 12. Sequence replay boundary
-
-Production-facing candidate:
-
-```text
-core/foundation_v2_materialization.py
-```
-
-Machine contract:
-
-```text
-contracts/mts-anum-sequence-materialization-v0.7.json
-```
-
-Trusted replay проверяет:
-
-```text
-exact root
-base identity preserved
-old links unchanged
-exact created count/order
-nested adjacency poles
-exact result
-no extra links
-before/after snapshots unchanged during replay
-```
-
-Read-only `find_links` отдельно доказывает отсутствие hidden materialization.
+Каждая adjacency создаёт **новый exact occurrence**. Historical `AnumMemory.intern_link` не наследуется.
 
 Подробнее: [Ачисла и сериализация](Ачисла%20и%20сериализация.md).
 
 ---
 
-# 13. Persistent L4 gap #124
+# 11. Почему historical L4 #124 superseded
 
-Текущий следующий Gate-P blocker — доказать те же свойства на persistent backend:
+Старый v0.3 challenge требовал:
 
 ```text
-multiplicity
-cycles
-sharing
-persistent state transitions
-read-only find/replay
-explicit materialization
-portable evidence
-backend address != semantic identity
+exact pair uniqueness
+idempotent realize_link(A,B)
 ```
 
-In-memory same-lineage `OccurrenceRef` не должен превращаться в universal persistent identity.
+Foundation v2 требует:
+
+```text
+P1 = materialize(A,B)
+P2 = materialize(A,B)
+P1 ≠ P2
+```
+
+Поэтому #124 нельзя использовать как production backend contract следующей версии без semantic fork.
+
+Его contracts/tests остаются historical evidence, а новый L4 выводится отдельно в #265.
 
 ---
 
-# 14. Historical compatibility
+# 12. Persistent identity #265
+
+Foundation v2 L4 различает:
+
+```text
+runtime OccurrenceRef
+persistent dataset-local logical occurrence id
+portable snapshot-local slot
+backend physical address / record id
+```
+
+Reference logical id:
+
+```text
+PersistentOccurrenceId(lineage, local)
+```
+
+Reopen того же dataset сохраняет `lineage/local`, но runtime refs могут быть новыми host objects.
+
+Fresh import той же topology создаёт новый lineage:
+
+```text
+same topology != same persistent exact identity
+```
+
+Physical address никогда не является MTS identity.
+
+---
+
+# 13. Persistent effect semantics
+
+Persistent controller предоставляет read-only:
+
+```text
+poles
+find
+outgoing
+incoming
+all_occurrences
+snapshot
+```
+
+и explicit effects:
+
+```text
+materialize
+materialize_batch
+```
+
+`materialize(A,B)` всегда создаёт новый exact persistent occurrence.
+
+`materialize_batch` сначала выделяет logical ids всей партии, поэтому может представить self/mutual cycles через `BatchRef`, затем atomically публикует весь state.
+
+Наблюдаемая atomicity:
+
+```text
+либо весь post-state
+либо исходный pre-state
+```
+
+---
+
+# 14. Persistence vectors
+
+Gate #265 требует пережить clean reopen без semantic collapse:
+
+```text
+duplicate A⟼B occurrences
+self-cycle
+mutual cycle
+sharing
+root logical identity
+sequence materialization evidence
+```
+
+При этом:
+
+```text
+find remains read-only
+runtime refs may be reconstructed
+snapshot slot is not global identity
+physical address is not semantic identity
+```
+
+Reference executable backend: `core/foundation_v2_persistent.py`.
+
+Machine contract: `contracts/mts-foundation-v2-persistent-l4-v0.7.json`.
+
+Подробнее: [Foundation v2 Persistent L4](Foundation%20v2%20Persistent%20L4.md).
+
+---
+
+# 15. Sequence replay после reopen
+
+Persistent L4 не копирует Anum grammar.
+
+```text
+persistent store
+→ reconstruct runtime exact network
+→ foundation_v2_materialization.py
+→ normalize created edges to persistent ids
+→ atomic persistent batch
+```
+
+После reopen persistent evidence снова реконструирует runtime before/after lineage и вызывает тот же `replay_sequence_materialization`.
+
+Storage layer не становится вторым sequence interpreter.
+
+---
+
+# 16. JSON reference backend boundary
+
+`JsonExactLinkStore` — executable persistence evidence, а не нормативный storage format.
+
+Production implementation может быть:
+
+```text
+PersistMemoryManager adapter
+custom mmap store
+transactional DB
+another exact-link backend
+```
+
+если observable semantics совпадает.
+
+Правильная зависимость:
+
+```text
+Foundation-v2 L4 contract
+        ↑ implemented by
+backend adapter
+```
+
+а не наоборот.
+
+---
+
+# 17. Historical compatibility
 
 Accepted v0.2–v0.5 остаются reproducible historical contracts.
 
@@ -431,6 +465,7 @@ mtc_parser / typed AST / ContextFrame
 historical root program
 recursive Anum v0.2
 historical AnumMemory pair interning
+historical L4 v0.3 pair-unique challenge
 ```
 
 не удаляются задним числом.
@@ -439,7 +474,7 @@ historical AnumMemory pair interning
 
 ---
 
-# 15. Acceptance criterion
+# 18. Acceptance criterion
 
 Следующая версия МТС принимается только как одна интегрированная система:
 
@@ -449,9 +484,11 @@ exact occurrence network
 + relation/:/=
 + proof/Run/checker
 + sequence materialization
-+ persistent L4
++ persistent exact-occurrence L4
 + cutover
 + versioned conformance
 ```
+
+После закрытия #265 следующий фокус — **compatibility classification и atomic cutover**, а не новый параллельный semantic subsystem.
 
 До explicit acceptance все Foundation-v2 contracts остаются candidate evidence, а `aprover` не repin-ится.

--- a/docs/specs/Foundation v2 Persistent L4.md
+++ b/docs/specs/Foundation v2 Persistent L4.md
@@ -1,0 +1,615 @@
+# Foundation v2 — persistent L4 апамять
+
+Статус: **Gate P candidate**, не accepted production backend contract.
+
+Текущий gate: #265. Parent: #237. Historical predecessor: закрытый/superseded #124.
+
+Machine contract candidate:
+
+[`contracts/mts-foundation-v2-persistent-l4-v0.7.json`](../../contracts/mts-foundation-v2-persistent-l4-v0.7.json)
+
+Reference implementation:
+
+[`core/foundation_v2_persistent.py`](../../core/foundation_v2_persistent.py)
+
+---
+
+# 1. Зачем L4 пришлось вывести заново
+
+Historical v0.3 L4 challenge был построен вокруг старой `AnumMemory` semantics:
+
+```text
+одна exact pair → один canonical LinkRef
+realize_link(A,B) идемпотентен
+```
+
+Foundation v2 уже зафиксировала другой фундаментальный инвариант:
+
+```text
+P1 = A ⟼ B
+P2 = A ⟼ B
+P1 ≠ P2
+```
+
+И sequence materialization #242/#264 намеренно создаёт **новый exact occurrence на каждую adjacency**.
+
+Следовательно persistent backend не имеет права снова схлопнуть occurrences только ради удобства индекса.
+
+Поэтому historical `mts-l4-backend-*/v0.3` сохраняются как воспроизводимое исследование старой линии, но не являются Foundation-v2 L4 contract.
+
+---
+
+# 2. Что должен сохранять persistent controller
+
+После clean close/reopen должны сохраняться:
+
+```text
+multiplicity
+ordered poles
+cycles
+sharing
+root selection
+persistent sequence effects
+logical occurrence identity внутри dataset lineage
+```
+
+При этом не обязаны сохраняться как семантика:
+
+```text
+Python object identity
+RAM address
+mmap pointer
+PMM block address
+JSON byte offset
+snapshot slot как глобальное имя
+```
+
+---
+
+# 3. Четыре уровня identity
+
+Foundation v2 L4 различает как минимум:
+
+```text
+1. runtime OccurrenceRef
+2. persistent dataset-local logical occurrence id
+3. portable snapshot-local slot
+4. backend physical address / record id
+```
+
+## Runtime `OccurrenceRef`
+
+Живёт внутри одного reconstructed runtime lineage.
+
+После reopen runtime refs могут быть совершенно новыми host objects.
+
+## Persistent logical id
+
+Стабилен внутри одного persistent dataset.
+
+Reference notation:
+
+```text
+PersistentOccurrenceId(lineage, local)
+```
+
+Это не физический адрес.
+
+## Snapshot slot
+
+Удобен для транспортной topology, но не является universal identity.
+
+## Physical address
+
+Полностью backend-specific.
+
+PMM, SQLite, mmap, B-tree или другой backend могут менять физическое расположение без изменения логической exact occurrence.
+
+---
+
+# 4. Dataset lineage
+
+Persistent identity имеет область действия.
+
+Пусть store имеет:
+
+```text
+lineage = L1
+```
+
+Occurrence:
+
+```text
+(L1, 42)
+```
+
+сохраняет logical identity после reopen **этого же dataset**.
+
+Но если ту же topology импортировать как новый независимый dataset:
+
+```text
+lineage = L2
+```
+
+то:
+
+```text
+(L1, 42) != (L2, 42)
+```
+
+даже если их полюса и вся окружающая topology совпадают.
+
+Это persistent-аналог уже принятого правила:
+
+```text
+same shape != same exact occurrence
+```
+
+---
+
+# 5. Reopen не обязан сохранять runtime object identity
+
+До закрытия:
+
+```text
+persistent (L1,42) ↔ runtime ref r_old
+```
+
+После reopen:
+
+```text
+persistent (L1,42) ↔ runtime ref r_new
+```
+
+и:
+
+```text
+r_old is not r_new
+```
+
+Но оба runtime refs нормализуются к одному persistent occurrence id внутри той же lineage.
+
+Это позволяет backend-у свободно перестраивать in-memory representations.
+
+---
+
+# 6. Read side
+
+Минимальный persistent controller предоставляет:
+
+```text
+poles(id)
+find(start?, end?)
+outgoing(start)
+incoming(end)
+all_occurrences()
+snapshot()
+```
+
+Все эти операции read-only.
+
+Если `A⟼B` отсутствует:
+
+```text
+find(A,B) -> ()
+```
+
+Store не меняется.
+
+Если существуют два occurrences:
+
+```text
+P1 = A ⟼ B
+P2 = A ⟼ B
+```
+
+то:
+
+```text
+find(A,B) -> (P1,P2)
+```
+
+Оба должны пережить reopen.
+
+---
+
+# 7. Effect side
+
+Canonical operation Foundation v2:
+
+```text
+materialize(A,B) -> NEW exact occurrence
+```
+
+Даже если `A⟼B` уже существует.
+
+То есть:
+
+```text
+P1 = materialize(A,B)
+P2 = materialize(A,B)
+
+P1 != P2
+```
+
+Индекс `(A,B)` ускоряет поиск, но **не превращается в interning table**.
+
+Если application planner хочет reuse `P1`, он должен явно выбрать `P1` через read/search path и предъявить это решение как evidence.
+
+---
+
+# 8. Atomic batch materialization
+
+Для циклов недостаточно последовательного API, где новый ref можно использовать только после commit.
+
+Поэтому L4 candidate имеет batch-local refs:
+
+```text
+BatchRef(0)
+BatchRef(1)
+...
+```
+
+Пример self-cycle:
+
+```text
+batch[0] = BatchRef(0) ⟼ BatchRef(0)
+```
+
+Пример mutual cycle:
+
+```text
+A = BatchRef(1) ⟼ X
+B = BatchRef(0) ⟼ Y
+```
+
+Сначала batch выделяет logical ids всех новых occurrences, затем валидирует все endpoints, затем atomically публикует весь новый state.
+
+Никакой половинчатой сети быть не должно.
+
+---
+
+# 9. Atomicity
+
+Наблюдаемая гарантия:
+
+```text
+commit(batch)
+→ либо весь post-state
+→ либо исходный pre-state
+```
+
+Invalid endpoint, unresolved batch ref или commit failure не должны менять ни in-memory observable state, ни persistent committed state.
+
+Reference JSON backend использует temporary file + `os.replace` только как простой способ доказать эту границу.
+
+Сам JSON format **не нормативен**.
+
+Production backend может использовать transaction, WAL, copy-on-write pages или PMM-specific transaction mechanism.
+
+---
+
+# 10. Cycles
+
+Persistent store обязан поддерживать self-cycle:
+
+```text
+R = R ⟼ R
+```
+
+и mutual cycle:
+
+```text
+A = B ⟼ X
+B = A ⟼ Y
+```
+
+После reopen logical IDs `A/B/X/Y` должны ссылаться на те же logical occurrences внутри dataset lineage.
+
+Никакого recursive unfolding для persistence не требуется.
+
+---
+
+# 11. Sharing
+
+Пусть:
+
+```text
+P = A ⟼ X
+Q = B ⟼ X
+```
+
+После reopen оба конца должны ссылаться на **один logical X**, а не на две structural copies.
+
+Это ещё одна причина, почему persistent L4 нельзя свести к tree serializer.
+
+---
+
+# 12. Связь с #242 sequence materialization
+
+#242 уже определяет runtime effect:
+
+```text
+∞ A B C
+→ new A⟼B
+→ new B⟼C
+```
+
+Persistent bridge не переопределяет nesting semantics.
+
+Правильная цепочка:
+
+```text
+persistent store
+→ reconstruct runtime exact network
+→ existing foundation_v2_materialization.py
+→ runtime SequenceMaterialization evidence
+→ normalize new endpoints to persistent ids / BatchRefs
+→ one persistent materialize_batch
+→ PersistentSequenceMaterialization evidence
+```
+
+То есть L4 **делегирует** structural semantics уже принятому Gate-P layer вместо копирования Anum grammar в backend.
+
+---
+
+# 13. Replay sequence effect после reopen
+
+Persistent evidence хранит:
+
+```text
+persistent sequence description
+before_count
+created persistent occurrences + poles
+result persistent occurrence
+```
+
+После reopen controller может:
+
+1. восстановить runtime `before` prefix;
+2. создать runtime `after` в той же fresh runtime lineage;
+3. сопоставить persistent IDs новым runtime refs;
+4. восстановить runtime `SequenceMaterialization` evidence;
+5. вызвать обычный `replay_sequence_materialization`;
+6. проверить persistent poles;
+7. убедиться, что store не изменился.
+
+Таким образом доказательство effect не зависит от сохранения старых Python objects.
+
+---
+
+# 14. Полный пример с ачислом
+
+Пусть persistent store содержит exact occurrences:
+
+```text
+Window
+Cursor
+Position
+X
+Int
+Point
+```
+
+Selected sequence:
+
+```text
+∞[window][cursor][position][[[x][int]][point]]
+```
+
+#242 создаёт logical sequence effect:
+
+```text
+XI = X ⟼ Int
+Q  = XI ⟼ Point
+WC = Window ⟼ Cursor
+CP = Cursor ⟼ Position
+PQ = Position ⟼ Q
+```
+
+Persistent batch выдаёт пять **новых** persistent occurrence ids.
+
+После close/reopen:
+
+```text
+find(Window,Cursor) -> WC
+find(Cursor,Position) -> CP
+find(Position,Q) -> PQ
+```
+
+а replay всё ещё может проверить исходный sequence effect.
+
+---
+
+# 15. Что значит «тот же link после reopen»
+
+Не:
+
+```text
+тот же RAM pointer
+```
+
+и не:
+
+```text
+тот же physical page address
+```
+
+а:
+
+```text
+тот же dataset lineage
++ тот же logical occurrence id
++ те же ordered logical poles
+```
+
+Это и есть persistent exact-occurrence contract текущего candidate.
+
+---
+
+# 16. Почему physical address нельзя сделать identity
+
+High-performance backend почти неизбежно делает:
+
+```text
+relocation
+compaction
+page rewrite
+copy-on-write
+recovery
+migration
+```
+
+Если physical address является ontology, любое такое действие изменяет «сущность» связи.
+
+Это недопустимо.
+
+Нужен adapter layer:
+
+```text
+persistent logical occurrence id
+        ↓ backend mapping
+physical record/address
+```
+
+Mapping может меняться, logical identity — нет внутри dataset lineage.
+
+---
+
+# 17. PersistMemoryManager
+
+`netkeep80/PersistMemoryManager` остаётся естественным кандидатом production backend-а апамяти.
+
+Но зависимость должна быть направлена так:
+
+```text
+Foundation-v2 L4 contract
+        ↑ conforms to
+PMM adapter
+```
+
+а не:
+
+```text
+PMM internal address model
+        ↓ объявляется МТС identity
+```
+
+Следующий cross-repo implementation step после принятия L4 gate может создать отдельный PMM adapter issue/PR, не меняя canonical semantics `anum_docs`.
+
+---
+
+# 18. Что historical v0.3 сохраняет
+
+Файлы:
+
+```text
+contracts/mts-l4-backend-challenge-v0.3.json
+contracts/mts-l4-backend-driver-v0.3.json
+contracts/mts-l4-backend-conformance-v0.3.json
+converters/l4_backend_driver.py
+```
+
+сохраняются как historical candidate evidence старой pair-interning линии.
+
+Их полезные идеи:
+
+```text
+backend neutrality
+opaque handle normalization
+read-only find
+atomic structural effect
+parser outside backend
+```
+
+сохраняются.
+
+Но Foundation v2 отвергает два старых свойства:
+
+```text
+exact pair uniqueness
+idempotent realize by pair
+```
+
+---
+
+# 19. Reference backend не является production backend
+
+`JsonExactLinkStore` нужен для одного: executable proof, что storage-neutral contract реализуем и survives reopen.
+
+Не утверждается, что JSON подходит для:
+
+```text
+больших асетей
+конкурентных writers
+high-throughput indexing
+zero-copy access
+crash recovery industrial grade
+```
+
+Эти задачи принадлежат production adapter/backend.
+
+Нормативен observable contract, а не файл.
+
+---
+
+# 20. Что проверяет conformance corpus
+
+Минимальные vectors:
+
+```text
+duplicate pair survives reopen
+find returns all duplicates
+self-cycle survives reopen
+mutual cycle survives reopen
+sharing survives reopen
+root logical id survives reopen
+runtime refs are reconstructed
+invalid batch exposes pre-state
+commit failure exposes pre-state
+fresh topology import gets fresh lineage
+sequence effect delegates to #242 semantics
+sequence evidence replays after reopen
+backend has no parser/AST/pair-interning dependency
+```
+
+---
+
+# 21. Что ещё не принято
+
+Этот gate сам по себе не означает:
+
+```text
+PMM adapter accepted
+production crash recovery accepted
+delete semantics accepted
+cross-dataset replication identity accepted
+Foundation v2 release accepted
+aprover repin allowed
+```
+
+После L4 semantic/persistence evidence следующий этап — compatibility/cutover и final versioned conformance.
+
+---
+
+# 22. Короткая формула persistent апамяти
+
+```text
+persistent exact occurrence
+=
+stable logical identity inside one dataset lineage
++
+ordered logical poles
+```
+
+при этом:
+
+```text
+same pair != same occurrence
+same topology != same dataset identity
+same persistent occurrence != same runtime object
+logical identity != physical address
+read != materialize
+```
+
+Эти границы позволяют перенести МТС из in-memory reference network в реальную долговременную ассоциативную память без потери фундаментальной exact-occurrence semantics.

--- a/docs/specs/Апамять и управление сетью связей.md
+++ b/docs/specs/Апамять и управление сетью связей.md
@@ -1,32 +1,45 @@
 # Апамять и управление сетью связей
 
-Статус: **Foundation v2 / Gate P candidate**, не опубликованный accepted L4 contract.
+Статус: **Foundation v2 / Gate P candidate**.
 
-Связанные задачи: Gate P #237, exact-occurrence substrate #240, state/apamemory #243, source #245, interpreter #247, scoped `D`/`:` #249, local `=` #251, Run #253, proof rule #255, integrated checker #257, sequence materialization #242, persistent backend #124.
+Текущий persistent L4 gate: #265. Parent: #237.
 
-Апамять — один из наиболее наглядных способов понять прикладной смысл МТС.
+Связанные завершённые gates: exact-occurrence substrate #240/#241, state/apamemory #243/#244, source #245/#246, interpreter #247/#248, scoped `D`/`:` #249/#250, local `=` #251/#252, Run #253/#254, proof rule #255/#256, integrated checker #257/#262, sequence materialization #242/#264.
 
-Её удобно рассматривать не как «объектную базу данных», а как **контроллер сети связей**, который умеет хранить exact occurrences, искать их, предъявлять их интерпретатору и явно изменять сеть.
+Persistent specification: [Foundation v2 Persistent L4](Foundation%20v2%20Persistent%20L4.md).
 
-Базовая онтология остаётся минимальной:
+Апамять — один из самых наглядных способов увидеть прикладной смысл МТС.
+
+Её удобно понимать не как «объектную базу», а как **контроллер exact-occurrence сети связей**:
+
+```text
+хранить
+искать
+перечислять
+разрешать
+проверять
+явно изменять
+сохранять между запусками
+```
+
+Базовая онтология при этом остаётся минимальной:
 
 ```text
 Link = start ⟼ end
 ```
 
-Всё остальное — контексты, словари, source, actual acts, proof rules, Runs — также может жить в той же сети.
+Контекст, словарь, source, теория, actual act, proof rule и Run также могут быть представлены в той же сети.
 
 ---
 
-# 1. Главная обязанность апамяти
+# 1. Главная граница: наблюдение и эффект
 
-Контроллер должен сохранять различие:
+Контроллер обязан различать:
 
 ```text
 НАБЛЮДЕНИЕ                 ЭФФЕКТ
 read                       materialize
-find                       define
-select                     delete
+find                       define/select-new-occurrence
 enumerate                  persist transition
 resolve
 replay
@@ -36,27 +49,37 @@ replay
 
 ```text
 read / find / resolve / replay
-            ≠
-materialize / define / delete
+            !=
+materialize / define
 ```
 
-Это не косметическое API-различие, а семантическая граница МТС.
+Это не только API-дизайн.
 
-Если запрос к памяти сам создаёт то, что должен искать, запрос теряет смысл.
+Если поиск сам создаёт то, что должен искать, исчезает различие между:
+
+```text
+«связь существовала»
+```
+
+и:
+
+```text
+«мы только что её создали».
+```
+
+Для proof checker-а это было бы особенно опасно: проверка доказательства начала бы создавать собственные недостающие факты.
 
 ---
 
-# 2. Простейший пример: найти или создать
+# 2. Простейший пример: `find` и `materialize`
 
-Пусть есть exact occurrences `A` и `B`, но связи между ними нет.
+Пусть в памяти существуют exact occurrences `A` и `B`, но связи между ними нет.
 
 ```text
-A                     B
-
-find(A,B) -> {}
+find(A,B) -> ()
 ```
 
-Сеть после `find` обязана быть той же.
+Состояние сети не меняется.
 
 Только explicit effect:
 
@@ -64,68 +87,76 @@ find(A,B) -> {}
 X = materialize(A,B)
 ```
 
-даёт:
+создаёт:
 
 ```text
-A ───────── X ─────────▶ B
+X = A ⟼ B
 ```
 
 После этого:
 
 ```text
-find(A,B) -> {X}
+find(A,B) -> (X)
 ```
 
-Если multiplicity разрешена:
+Если materialization выполнить ещё раз:
 
 ```text
-X1 = materialize(A,B)
-X2 = materialize(A,B)
-
-X1 ≠ X2
-find(A,B) -> {X1,X2}
+Y = materialize(A,B)
 ```
 
-Одинаковая пара полюсов не уничтожает exact identity occurrences.
+Foundation v2 сохраняет:
+
+```text
+X != Y
+```
+
+а поиск возвращает оба:
+
+```text
+find(A,B) -> (X,Y)
+```
+
+Именно здесь хорошо видна разница между **индексом по паре** и **identity связи**.
+
+Индекс может использовать `(A,B)` как ключ поиска, но не имеет права превращать этот ключ в правило:
+
+```text
+одна пара -> одна связь
+```
 
 ---
 
-# 3. Почему exact occurrence важна для памяти
+# 3. Почему multiplicity важна
 
-Пусть:
+Два occurrences одной пары могут означать:
+
+```text
+два события;
+два объявления;
+два actual acts;
+два источника;
+два утверждения с разным provenance;
+два independently materialized результата.
+```
+
+Если controller автоматически схлопнет их, он уничтожит информацию, которую верхний слой уже не сможет восстановить.
+
+Поэтому Foundation v2 исходит из:
 
 ```text
 P1 = A ⟼ B
 P2 = A ⟼ B
+P1 != P2
 ```
 
-Индекс памяти естественно может хранить их вместе по ключу `(A,B)`.
-
-Но запрос:
-
-```text
-find(A,B)
-```
-
-должен вернуть **оба** exact occurrences, а trusted semantic layer затем выбирает конкретный `P1` или `P2`.
-
-Это позволяет различать:
-
-```text
-два одинаковых события;
-два одинаковых declarations;
-два proof acts с одинаковыми видимыми полями;
-два источника одного содержания;
-два одинаковых факта с разным provenance.
-```
-
-Именно поэтому pair interning — возможная optimization policy конкретного application layer, но не аксиома Foundation v2.
+Pair interning может быть локальной оптимизацией конкретного application layer **только как явная policy**, но не канонической semantics апамяти.
 
 ---
 
 # 4. Cycles и sharing
 
-Апамять должна естественно хранить структуры, которые неудобно сводить к деревьям.
+Апамять должна естественно хранить циклические сети.
 
 Self-cycle:
 
@@ -147,19 +178,17 @@ P = A ⟼ X
 Q = B ⟼ X
 ```
 
-`X` здесь один exact occurrence, используемый двумя связями.
+В последнем примере `X` — один exact occurrence, используемый двумя связями.
 
-Контроллер обязан сохранить это sharing, а не сериализовать каждый путь в отдельную копию.
+Контроллер не должен превращать sharing в две structural copies.
 
-Отсюда важный вывод для ачисел: recursive tree description полезна, но произвольная shared/cyclic network требует отдельной exact identity модели.
+Это одна из причин, почему произвольную асеть нельзя считать обычным деревом и почему recursive Anum — structural description на своей области, а не universal identity всей сети.
 
 ---
 
-# 5. Контекст K — данные в той же памяти
+# 5. Контекст K в той же памяти
 
-Foundation v2 не требует отдельного process-global context stack.
-
-Контекст можно представить так:
+Foundation v2 не требует скрытого process-global stack.
 
 ```text
 P0 = Parent ⟼ Current0
@@ -173,40 +202,38 @@ P1 = Parent ⟼ Current1
 K1 = K1 ⟼ P1
 ```
 
-В памяти остаются оба состояния:
+В памяти остаются оба snapshots:
 
 ```text
 K0 -> Current0
 K1 -> Current1
 ```
 
-Это даёт persistent history и позволяет replay-ить конкретный шаг позже.
-
-`↑` в Foundation-v2 candidate означает чтение `current` из exact выбранного `K`, а не обращение к скрытой переменной интерпретатора.
+Это позволяет later replay предъявить exact `K_before` и `K_after`, а не доверять рассказу интерпретатора о том, какое состояние «тогда было текущим».
 
 ---
 
-# 6. Словарь D — persistent network
+# 6. Scoped dictionary D как persistent network
 
-Scoped dictionary также хранится обычными связями.
+Dictionary также выражается связями:
 
 ```text
 D = D ⟼ (parentScope ⟼ localHistory)
 ```
 
-Определение:
+Definition:
 
 ```text
 Entry = sourceContent ⟼ Form
 ```
 
-и exact declaration occurrence:
+Exact declaration occurrence:
 
 ```text
 Occurrence = D_before ⟼ Entry
 ```
 
-История:
+History append:
 
 ```text
 H_after = H_before ⟼ Occurrence
@@ -218,21 +245,21 @@ H_after = H_before ⟼ Occurrence
 D_after = D_after ⟼ (sameParentScope ⟼ H_after)
 ```
 
-Старый `D_before` не изменяется.
+`D_before` остаётся доступным.
 
-Так namespace становится проверяемой частью сети, а не скрытым `dict` host-языка.
+В результате namespace становится проверяемой частью exact network, а не скрытым mutable `dict` host-языка.
 
 ---
 
-# 7. Что делает `:` в апамяти
+# 7. `:` как effect
 
-Пусть source означает:
+Пусть source разрешён как:
 
 ```text
 name : Form
 ```
 
-Executor-side может построить candidate effect:
+Executor может materialize-ить:
 
 ```text
 Entry
@@ -242,35 +269,34 @@ D_after
 actual A
 ```
 
-Но trusted replay не создаёт их. Он только проверяет:
+Trusted replay только проверяет уже существующий transition:
 
 ```text
-Entry.start  is exact sourceContent
-Entry.end    is exact Form
-Occurrence  is D_before ⟼ Entry
+Entry.start is sourceContent
+Entry.end   is Form
+Occurrence is D_before ⟼ Entry
 H_after     is one exact append
-D_after     has same lexical parent
-Occurrence  visible from D_after
-Occurrence  not retroactively visible from D_before
-A           names the same exact evidence
-snapshot    unchanged during replay
+D_after     preserves lexical parent
+Occurrence visible from D_after
+Occurrence not visible from D_before
+A references the same exact evidence
 ```
 
-Так definition effect проверяется без доверия к executor-у.
+Replay не пишет в store.
 
 ---
 
-# 8. Source carrier и target network — разные вещи
+# 8. Source carrier и target network
 
-Это особенно важно для ачисел и десериализации.
+Это особенно наглядно для ачисел.
 
-Пусть source содержит некоторую последовательность:
+Пусть source carrier содержит последовательность:
 
 ```text
-∞ ... A ... B ...
+∞ A B
 ```
 
-Из факта существования source carrier ещё не следует существование target relation:
+Из этого ещё не следует, что в application network уже существует:
 
 ```text
 A ⟼ B
@@ -283,79 +309,118 @@ source carrier
       ↓
 decode / resolve
       ↓
-selected structural evidence
+selected structural description
       ↓
-explicit materialization plan
+explicit materialization
       ↓
-materialize
+target network
+```
+
+А read-only цепочка:
+
+```text
+source carrier
       ↓
-result network
+decode / resolve
+      ↓
+find / compare / replay
+```
+
+не меняет сеть.
+
+#242/#264 сделал эту границу executable.
+
+---
+
+# 9. Sequence materialization
+
+Foundation-v2 sequence candidate:
+
+```text
+∞ A B C
+```
+
+создаёт:
+
+```text
+AB = A ⟼ B
+BC = B ⟼ C
+```
+
+`∞` — sentinel, не adjacency operand.
+
+Nested group:
+
+```text
+[A]   -> exact A
+[A B] -> X = A ⟼ B, return X
 ```
 
 Поэтому:
 
 ```text
-decode(source) != materialize(result)
-load(source)   != materialize(result)
-find(pattern)  != materialize(result)
+∞ [A B] C
 ```
 
-Gate #242 должен сделать эту границу executable для последовательностей ачисел.
+даёт:
+
+```text
+X = A ⟼ B
+Y = X ⟼ C
+```
+
+Каждая materialized adjacency создаёт новый exact occurrence.
+
+Подробнее: [Ачисла и сериализация](Ачисла%20и%20сериализация.md).
 
 ---
 
-# 9. Наглядный пример ачисловой структуры
-
-Мотивирующий пример:
+# 10. Наглядный пример
 
 ```text
 ∞[window][cursor][position][[[x][int]][point]]
 ```
 
-Одна возможная структурная интерпретация после **явного** materialization может выглядеть как:
+Foundation-v2 sequence semantics materialize-ит:
 
 ```text
-XI = [x] ⟼ [int]
-Q  = XI  ⟼ [point]
-
-W  = [window]   ⟼ [cursor]
-C  = [cursor]   ⟼ [position]
-P  = [position] ⟼ Q
+XI = X ⟼ Int
+Q  = XI ⟼ Point
+WC = Window ⟼ Cursor
+CP = Cursor ⟼ Position
+PQ = Position ⟼ Q
 ```
 
 Наглядно:
 
 ```text
-[window] ─────────▶ [cursor]
-                       │
-                       ▼
-                  [position]
-                       │
-                       ▼
-                       Q
-                      / \
-                     /   \
-                   XI   [point]
-                  /  \
-                [x] [int]
+Window ─────▶ Cursor ─────▶ Position
+                              │
+                              ▼
+                              Q
+                             / \
+                            /   \
+                          XI   Point
+                         /  \
+                        X   Int
 ```
 
-Здесь особенно хорошо видно назначение контроллера:
+Контроллер здесь выполняет разные обязанности последовательно:
 
-1. source существует отдельно;
-2. decoder выбирает structural interpretation;
-3. controller проверяет, какие exact links уже существуют;
-4. materializer явно создаёт недостающие occurrences;
-5. provenance materialization может быть зафиксирован actual act-ами;
-6. replay позже проверяет результат без повторной записи.
+1. хранит source отдельно;
+2. предоставляет существующие exact values;
+3. позволяет decoder-у выбрать nested structure;
+4. выполняет explicit materialization effect;
+5. сохраняет exact occurrences результата;
+6. позволяет позже replay-ить этот effect без записи.
 
-Это пока motivating example; точная universal sequence semantics должна быть принята в #242.
+Это и есть хороший прикладной пример того, как МТС превращается в архитектуру вычислительной памяти.
 
 ---
 
-# 10. Ассоциативный поиск
+# 11. Ассоциативный поиск
 
-Апамять естественно поддерживает запросы по известным полюсам:
+Минимальные запросы:
 
 ```text
 find(start=A)
@@ -365,64 +430,25 @@ outgoing(A)
 incoming(B)
 ```
 
-Для МТС важно, что индекс является **ускорителем поиска**, но не источником истины.
-
-Можно заменить:
+Индекс может быть любым:
 
 ```text
-hash index
-B-tree
+hash table
 AVL forest
+B-tree
 SQL index
-persistent custom index
+PMM-specific index
 ```
 
-не меняя semantic contract, если результат всё равно выражается exact occurrences и trusted replay может проверить выбранный artifact.
+Но индекс — ускоритель, а не semantic authority.
+
+Он возвращает candidate exact occurrences; выбор и trusted replay находятся выше.
 
 ---
 
-# 11. Поиск формы в сети
+# 12. Actual act как provenance
 
-Пусть форма требует связь:
-
-```text
-? ⟼ E
-```
-
-а `K.current = B`.
-
-Поисковая сторона может быстро найти candidates:
-
-```text
-find(start=B,end=E)
-```
-
-и получить:
-
-```text
-{X1, X2, ...}
-```
-
-Далее policy/search выбирает, например, `X2`.
-
-Trusted relation replay проверяет:
-
-```text
-X2.start is B
-X2.end   is E
-K_after.current is X2
-A.result is X2
-```
-
-То есть индекс помог найти, но не получил право объявить факт истинным.
-
----
-
-# 12. Actual act как provenance памяти
-
-Actual act `A` фиксирует конкретное действие над exact network.
-
-Например relation act может связать:
+Actual act `A` может связать:
 
 ```text
 source
@@ -436,64 +462,40 @@ result
 K_after
 ```
 
-В памяти это ordinary relation network.
-
-Следовательно, после исполнения можно спросить не только:
+Поэтому апамять хранит не только результат вычисления, но и объяснимый provenance:
 
 ```text
-какой result получен?
+какой exact source?
+какой D?
+какая T?
+какой K?
+какой result occurrence?
 ```
 
-но и:
-
-```text
-из какого source?
-под каким D?
-в какой T?
-из какого K?
-какой exact occurrence был выбран?
-```
-
-Апамять становится не только storage, но и provenance substrate.
+Это особенно ценно для проверяемых вычислений и доказательств.
 
 ---
 
-# 13. Run — история выбранных acts
-
-Последовательность acts:
-
-```text
-A0, A1, A2
-```
-
-представима exact chain:
+# 13. Run как история выбранных acts
 
 ```text
 Run0 = R
 Run1 = Run0 ⟼ A0
 Run2 = Run1 ⟼ A1
-Run3 = Run2 ⟼ A2
+...
 ```
 
-Контроллер может хранить множество альтернативных Runs над одной application network.
+В одной памяти могут существовать несколько candidate Runs над одной application network.
 
-Это удобно для proof search:
+Search side выбирает candidate Run, trusted checker проверяет exact order и context continuity.
 
-```text
-candidate Run 1
-candidate Run 2
-candidate Run 3
-```
-
-Trusted checker выбирает один exact `Run` и проверяет continuity.
-
-Никакой global mutable «текущий proof» не требуется.
+Никакого global mutable «текущего доказательства» не требуется.
 
 ---
 
-# 14. Апамять и proof search
+# 14. Апамять и aprover
 
-Foundation v2 позволяет очень полезное разделение архитектуры `aprover`:
+Foundation v2 задаёт архитектуру:
 
 ```text
                  APAMEMORY
@@ -513,26 +515,21 @@ Foundation v2 позволяет очень полезное разделени�
               accept / reject
 ```
 
-Search side может быть сложным, эвристическим и даже ошибочным.
+Search side может:
 
-Он может:
+- использовать сложные индексы;
+- строить альтернативные proof paths;
+- применять эвристики;
+- ранжировать candidates;
+- использовать ML.
 
-- ходить по индексам;
-- искать rule candidates;
-- строить альтернативные Runs;
-- ранжировать варианты;
-- кэшировать промежуточные результаты;
-- использовать ML/эвристики.
-
-Trusted side получает только selected exact evidence и повторно проверяет его.
-
-Это резко уменьшает trusted computing base.
+Но это не увеличивает trusted computing base, если acceptance делает независимый replay selected exact evidence.
 
 ---
 
 # 15. Proof rule в памяти
 
-Первый Foundation-v2 proof candidate хранит rule admission прямо в сети:
+Первый proof candidate хранит admission:
 
 ```text
 T ⟼ Rule
@@ -544,187 +541,328 @@ Premise:
 Equal_K(L,R) = true
 ```
 
-Application проверяет exact claims:
+Rule application предъявляет claims:
 
 ```text
 L.start ⟼ R.start
 L.end   ⟼ R.end
 ```
 
-Но claims сами не меняют `K` и не становятся автоматически equality bindings.
+Claims сами не становятся equality bindings и не меняют `K`.
 
-Controller может отдельно materialize-ить новый effect, если следующий explicit act это разрешает.
+Следующий effect должен быть отдельным actual act.
 
-Так proof rule не получает скрытого write-access к application state.
+Так proof rule не получает скрытого write-access к памяти.
 
 ---
 
-# 16. Полный P9 proof artifact
+# 16. Integrated proof artifact
 
-Сегодня в `main` уже есть integrated candidate:
+В `main` уже есть P9 candidate:
 
 ```text
 source `decompose`
         ↓
-canonical content / exact source
+scoped D / G / T
         ↓
-selected segmentation
+exact Rule
         ↓
-scoped D
-        ↓
-exact Rule + G/T source admission
-        ↓
-true equality A_eq in exact K
+true equality A_eq
         ↓
 T ⟼ Rule
         ↓
-proof application A_rule
+A_rule
         ↓
-Run[A_eq, A_rule]
+Run[A_eq,A_rule]
         ↓
-trusted integrated replay
+trusted replay
 ```
 
-Для апамяти это означает, что **данные, язык, теория и provenance доказательства могут быть одной связной exact network**, а не набором несовместимых host-object моделей.
-
-Production-facing checker: `core/foundation_v2_checker.py`.
-
-Подробнее: [Foundation v2 Proof replay](Foundation%20v2%20Proof%20replay.md).
+Для апамяти это означает, что **данные, язык, теория и provenance доказательства могут жить в одной exact network**, а не в нескольких несовместимых host-object моделях.
 
 ---
 
-# 17. Что может быть backend-specific
+# 17. Почему нужен отдельный persistent identity layer
 
-Реальная высокопроизводительная апамять может иметь:
+In-memory `OccurrenceRef` недостаточен после process restart.
+
+Но делать identity из physical address тоже нельзя.
+
+Persistent L4 #265 различает:
 
 ```text
-physical addresses
-page IDs
-indexes
-free lists
-transactions
-WAL
-snapshots
+runtime OccurrenceRef
+persistent dataset-local logical id
+snapshot-local slot
+backend physical address
+```
+
+Reference persistent id:
+
+```text
+PersistentOccurrenceId(lineage, local)
+```
+
+Это означает:
+
+```text
+reopen same dataset
+→ same lineage/local logical identity
+→ new runtime refs are allowed
+```
+
+---
+
+# 18. Dataset lineage
+
+Пусть store имеет lineage `L1`.
+
+```text
+X = (L1,42)
+```
+
+После close/reopen `X` остаётся тем же persistent logical occurrence.
+
+Но импорт той же topology в новый независимый dataset создаёт lineage `L2`:
+
+```text
+(L1,42) != (L2,42)
+```
+
+даже если poles и вся topology одинаковы.
+
+Так persistent память продолжает Foundation-v2 принцип:
+
+```text
+same shape != same exact identity
+```
+
+---
+
+# 19. Persistent duplicate pair
+
+Пусть persistent store уже содержит:
+
+```text
+P1 = A ⟼ B
+```
+
+Новый explicit effect:
+
+```text
+P2 = materialize(A,B)
+```
+
+создаёт новый logical id.
+
+После reopen:
+
+```text
+find(A,B) -> (P1,P2)
+```
+
+Оба occurrences должны сохраниться.
+
+Это прямой persistent тест против historical pair interning.
+
+---
+
+# 20. Persistent cycles
+
+Для self/mutual cycles materialization batch сначала выделяет logical ids всех новых occurrences.
+
+Self-cycle:
+
+```text
+BatchRef(0) ⟼ BatchRef(0)
+```
+
+Mutual cycle:
+
+```text
+A = BatchRef(1) ⟼ X
+B = BatchRef(0) ⟼ Y
+```
+
+После validation весь batch atomically становится новым committed state.
+
+Контроллер не обязан разворачивать цикл рекурсивно.
+
+---
+
+# 21. Atomicity
+
+Persistent effect должен быть наблюдаем как:
+
+```text
+pre-state
+  ↓ batch
+post-state
+```
+
+или при ошибке:
+
+```text
+pre-state
+  ↓ failed batch
+pre-state
+```
+
+Не допускается half-materialized network.
+
+Reference JSON backend использует temporary file + atomic replacement как executable evidence. Production backend может использовать другую transaction mechanism.
+
+---
+
+# 22. Physical address не является MTS identity
+
+Production backend может перемещать данные:
+
+```text
 compaction
-cache
-memory mapping
+relocation
+copy-on-write
+page rewrite
+recovery
 ```
 
-Foundation v2 не запрещает ничего из этого.
+Если physical address = identity, любое перемещение меняет сущность связи.
 
-Она требует только не путать backend machinery с semantic identity.
+Поэтому должен существовать conceptual adapter:
 
 ```text
-backend handle != universal exact semantic occurrence
+persistent logical occurrence id
+        ↓
+backend mapping
+        ↓
+physical record/address
 ```
 
-Gate #124 должен определить portable persistent boundary.
+Physical mapping может изменяться без изменения persistent logical occurrence.
 
 ---
 
-# 18. Persistent backend и exact identity
+# 23. PersistMemoryManager как будущий backend
 
-При сохранении/загрузке нужно различать как минимум три уровня:
+`netkeep80/PersistMemoryManager` естественно подходит как один из production backend candidates.
+
+Но направление зависимости должно быть:
 
 ```text
-semantic exact occurrence внутри конкретного network artifact
-portable local reference snapshot-а
-physical backend handle/address
+Foundation-v2 persistent L4 contract
+                 ↑
+             PMM adapter
 ```
 
-Round-trip обязан сохранять:
+PMM может реализовать contract эффективно через persistent address space и индексы, но его internal block address не становится МТС identity.
 
-- topology;
-- multiplicity;
-- sharing;
-- cycles;
-- distinguished root;
-- explicit evidence relations.
-
-Но новый runtime load не обязан объявлять свои object refs тождественными object refs другой независимо загруженной сети.
+Это позволяет развивать PMM независимо от нормативной теории.
 
 ---
 
-# 19. Контроллер как интерфейс между МТС и машиной
+# 24. Sequence replay после reopen
 
-МТС сама по себе говорит о связях.
+Persistent layer не должен писать второй Anum interpreter.
 
-Апамять делает эту идею вычислимой:
+Правильная композиция:
 
 ```text
-МТС ontology
-      ↓
-exact link network
-      ↓
-apamemory controller
-      ↓
-indexes / persistence / execution
-      ↓
-applications + aprover
+persistent store
+→ reconstruct runtime exact network
+→ existing foundation_v2_materialization
+→ runtime effect evidence
+→ normalize to persistent ids
+→ persistent batch
 ```
 
-Поэтому апамять — не второстепенная реализационная деталь. Это **операционная форма МТС**: место, где различение связи, exact occurrence, контекста, поиска, evidence и эффекта становится реально проверяемым.
+После reopen:
+
+```text
+persistent evidence
+→ reconstruct runtime before/after lineage
+→ existing replay_sequence_materialization
+→ accept / reject
+```
+
+То есть storage меняется, а trusted sequence semantics остаётся одна.
+
+Подробнее: [Foundation v2 Persistent L4](Foundation%20v2%20Persistent%20L4.md).
 
 ---
 
-# 20. Минимальный controller contract
+# 25. Reference backend и production backend
 
-До persistent L4 acceptance полезно держать минимальную абстракцию:
+`JsonExactLinkStore` в #265 — не предложение хранить большие асети в JSON.
+
+Его задача — доказать executable contract:
 
 ```text
-read(ref) -> (start,end)
-find(start?,end?) -> exact refs
-snapshot() -> portable topology
+duplicates survive reopen
+cycles survive reopen
+sharing survives reopen
+root survives by logical id
+atomic batch
+find is read-only
+sequence replay survives reopen
+```
 
-materialize(start,end) -> new exact ref
-delete(ref) -> explicit state transition
+Production backend может быть другим, если проходит те же vectors.
 
+---
+
+# 26. Минимальный controller contract
+
+Conceptual API текущей Foundation v2:
+
+```text
+# read
+poles(id)
+find(start?,end?)
+outgoing(start)
+incoming(end)
+snapshot()
+
+# effect
+materialize(start,end) -> NEW exact id
+materialize_batch(edges) -> NEW exact ids atomically
+
+# proof/check
 replay(evidence) -> accept/reject
 ```
 
 Критические свойства:
 
 ```text
-find is read-only
-read is read-only
-replay is read-only
-materialize is explicit
 multiplicity preserved
 cycles preserved
 sharing preserved
-foreign refs rejected
+read is read-only
+replay is read-only
+materialization is explicit
+persistent identity is dataset-local
+physical address is non-semantic
 ```
-
-Любой backend, выполняющий эти свойства и future #124 contract, может служить реализацией апамяти Foundation v2.
 
 ---
 
-# 21. Что ещё предстоит
+# 27. Что остаётся до accepted Foundation v2
 
-Перед accepted Foundation v2 остаются два особенно важных apamemory gates.
-
-### #242 — sequence → materialization
-
-Нужно доказать executable semantics:
+После persistent L4 #265 следующий фокус должен быть не новым memory subsystem, а release hardening:
 
 ```text
-Anum/source sequence
-→ exact structural plan
-→ existing-link reuse policy
-→ explicit new occurrences
-→ before/after network evidence
-→ replayable materialization act
+historical compatibility classification
+→ atomic production cutover
+→ versioned integrated conformance corpus
+→ explicit Foundation-v2 acceptance
+→ next MTS version
+→ aprover repin
 ```
 
-### #124 — persistent L4
-
-Нужно отделить storage address от semantic identity и проверить persistence/cycles/sharing/multiplicity на реальном backend contract.
-
-Только после этого можно безопасно делать production cutover и давать downstream `aprover` новый accepted MTS contract.
+Delete semantics, production PMM adapter и cross-dataset replication могут развиваться отдельными gates, если они действительно нужны release/consumer-ам.
 
 ---
 
-# 22. Практический смысл в одной фразе
+# 28. Практический смысл
 
 Апамять превращает постулат:
 
@@ -738,11 +876,12 @@ Anum/source sequence
 всё существенное можно хранить,
 искать,
 связывать,
-проверять
-и изменять
+проверять,
+явно изменять
+и сохранять между запусками
 через одну exact network,
 не смешивая поиск с истиной,
 а чтение — с эффектом.
 ```
 
-Именно поэтому controller сетей связей является одним из самых прямых прикладных мостов от МТС к ассоциативным компьютерам и проверяемому `aprover`.
+Именно поэтому controller сетей связей является прямым мостом от МТС к ассоциативным компьютерам и проверяемому `aprover`.

--- a/docs/specs/Ачисла и сериализация.md
+++ b/docs/specs/Ачисла и сериализация.md
@@ -1,42 +1,44 @@
 # Ачисла и сериализация
 
-Статус: **актуальный обзор Anum**, объединяющий historical accepted L3 v0.2–v0.5 и Foundation-v2 sequence-materialization candidate #242.
+Статус: **актуальный обзор Anum**, объединяющий historical accepted L3 v0.2–v0.5, Foundation-v2 sequence materialization #242/#264 и persistent L4 candidate #265.
 
-> Старые raw/boundary/pair/recursive contracts остаются принятыми для своей версии. Foundation v2 не переписывает их задним числом, а добавляет более общий operational boundary: **source sequence и target network — разные вещи; materialization является явным effect**.
+> Старые raw/boundary/pair/recursive contracts остаются принятыми для своей версии. Foundation v2 не переписывает их задним числом, а добавляет более общий operational boundary: **source sequence, structural description, materialized target network и persistent identity — разные уровни**.
 
 Связанные документы:
 
 - [Основания МТС](../theory/Основания%20МТС.md)
 - [Foundation v2 Gate P](Foundation%20v2%20Gate%20P.md)
 - [Апамять и управление сетью связей](Апамять%20и%20управление%20сетью%20связей.md)
+- [Foundation v2 Persistent L4](Foundation%20v2%20Persistent%20L4.md)
 
 ---
 
 # 1. Что такое ачисло в текущей картине
 
-Исторический базовый алфавит ачисла:
+Исторический базовый алфавит:
 
 ```text
 [ ] 1 0
 ```
 
-Raw carrier — последовательность этих абитов.
-
-Но важнейшая граница:
+Но фундаментальная граница сегодня записывается так:
 
 ```text
-raw/source carrier != denotation != materialized target network
+raw/source carrier
+!= structural denotation
+!= materialized target network
+!= persistent dataset identity
 ```
 
-Ачисло может переносить элементы будущих отношений в последовательном виде, не содержа самих target relations.
+Ачисло может переносить описание будущих отношений, не содержа самих target relations.
 
-Именно поэтому запись связи и её создание должны быть разделены.
+Поэтому чтение и materialization должны быть разделены.
 
 ---
 
-# 2. Исторический raw layer остаётся accepted
+# 2. Historical raw layer остаётся accepted
 
-Для v0.2–v0.5 продолжают действовать contracts:
+Для v0.2–v0.5 продолжают действовать versioned contracts:
 
 - [`anum-raw-carrier-v0.2`](../../contracts/anum-raw-carrier-v0.2.json)
 - [`anum-boundary-projection-v0.2`](../../contracts/anum-boundary-projection-v0.2.json)
@@ -44,100 +46,44 @@ raw/source carrier != denotation != materialized target network
 - [`anum-pair-denotation-v0.2`](../../contracts/anum-pair-denotation-v0.2.json)
 - [`anum-recursive-denotation-v0.2`](../../contracts/anum-recursive-denotation-v0.2.json)
 
-Raw parser читает только четыре абита и не materialize-ит связи.
+Historical raw parser читает четыре абита и не materialize-ит target network.
 
 ```text
-parse(raw)
-```
-
-не означает:
-
-```text
-create(den(raw))
+parse(raw) != create(den(raw))
 ```
 
 Это historical правило полностью согласуется с Foundation v2.
 
 ---
 
-# 3. Structural raw carrier
+# 3. Source carrier хранит последовательность, а не результат
 
-Raw sequence может иметь storage-neutral structural carrier:
+Storage-neutral carrier может выглядеть так:
 
 ```text
 c0 = RootRole
 c1 = c0 ⟼ AbitRole(x0)
 c2 = c1 ⟼ AbitRole(x1)
 ...
-cn = c(n-1) ⟼ AbitRole(xn)
 ```
 
-Этот carrier хранит **последовательность source**, а не target relations.
-
-Например carrier условной последовательности:
+Для условного source:
 
 ```text
-∞ a b
+∞ A B
 ```
 
-может содержать:
+carrier может содержать последовательные source cells и при этом **не содержать** application relation:
 
 ```text
-S1 = ∞ ⟼ a
-S2 = S1 ⟼ b
+A ⟼ B
 ```
 
-и при этом **не содержать**:
-
-```text
-a ⟼ b
-```
-
-Это принципиальный инвариант.
+Если загрузка source сама создаёт `A⟼B`, последующий `find(A,B)` перестаёт различать существовавший факт и результат загрузки.
 
 ---
 
-# 4. Почему source carrier нельзя считать result network
-
-Пусть нужно узнать, существует ли:
-
-```text
-a ⟼ b
-```
-
-Если сама загрузка source `∞ab` создаёт `a⟼b`, то последующий поиск всегда найдёт связь и перестанет отличать факт от описания.
-
-Поэтому правильная архитектура:
-
-```text
-source
-  ↓
-decode / resolve
-  ↓
-structural description
-  ↓
-explicit materialization plan
-  ↓
-materialization effect
-  ↓
-target network
-```
-
-А read-only путь:
-
-```text
-source
-  ↓
-decode / resolve
-  ↓
-find / compare / replay
-```
-
-не меняет network state.
-
----
-
-# 5. Historical root boundary projection
+# 4. Historical boundary projection
 
 Accepted v0.2 root boundary:
 
@@ -148,15 +94,15 @@ Accepted v0.2 root boundary:
 ][ → 0
 ```
 
-`[[` и `]]` остаются special boundary forms без protocol value в этой historical линии.
+`[[` и `]]` сохраняют historical boundary status.
 
-Эта orientation сохраняется как accepted versioned behavior и не изменяется sequence-materialization gate #242.
+Foundation-v2 sequence/persistent gates не меняют этот versioned contract.
 
 ---
 
-# 6. Historical direct pair subset
+# 5. Historical direct pair subset
 
-Принятый v0.2 subset:
+Accepted v0.2 subset:
 
 ```text
 0  → Anchor(protocol:0)
@@ -167,15 +113,15 @@ Accepted v0.2 root boundary:
 11 → 1 ⟼ 1
 ```
 
-Он даёт storage-neutral structural denotation пары.
+Он задаёт structural denotation пары на своей области.
 
-Этот contract полезен и остаётся accepted, но он не покрывает весь исходный замысел последовательностного ачисла.
+Но он не покрывает весь исходный замысел последовательностного ачисла.
 
 ---
 
-# 7. Historical recursive root denotation
+# 6. Historical recursive denotation
 
-Accepted recursive v0.2 grammar:
+Accepted recursive grammar:
 
 ```text
 Atom  := 0 | 1
@@ -192,9 +138,7 @@ D(A B) = Link(D(A), D(B))
 
 описывает occurrence-tree structure.
 
-Она сохраняет разные structural occurrences одинаковых поддеревьев и имеет canonical inverse на своей области.
-
-Но Foundation v2 уточняет её границу:
+Foundation v2 уточняет область:
 
 ```text
 recursive Anum
@@ -205,19 +149,19 @@ not
 universal exact identity arbitrary shared/cyclic aset
 ```
 
-Sharing и произвольные cycles требуют exact occurrence network.
+Sharing и произвольные cycles требуют exact-occurrence network.
 
 ---
 
-# 8. Почему pair-only grammar недостаточна
+# 7. Почему pair-only grammar недостаточна
 
-Исходный замысел последовательностного ачисла допускает:
+Исходный sequence intuition допускает:
 
 ```text
 ∞ A B C D
 ```
 
-как описание последовательности будущих отношений:
+как описание:
 
 ```text
 A ⟼ B
@@ -225,31 +169,35 @@ B ⟼ C
 C ⟼ D
 ```
 
-Это не то же самое, что рекурсивно прочитать весь source как единственную бинарную `Pair`-структуру.
+Это не то же самое, что рекурсивно прочитать source как одну бинарную Pair-структуру.
 
-Поэтому Foundation v2 не заменяет recursive v0.2 contract, а вводит **отдельный sequence-materialization mode**.
+Поэтому Foundation v2 добавляет отдельный **sequence-materialization mode**, не отменяя historical recursive contract.
 
 ---
 
-# 9. Foundation-v2 sequence semantics #242
+# 8. Foundation-v2 sequence semantics #242/#264
 
-Machine contract candidate:
+Machine contract:
 
 [`contracts/mts-anum-sequence-materialization-v0.7.json`](../../contracts/mts-anum-sequence-materialization-v0.7.json)
 
-Вход этого слоя — уже выбранное root-relative nested sequence description над exact existing occurrences.
+Production-facing candidate:
 
-Он **не парсит `[`/`]` как host PUSH/POP opcodes**.
+[`core/foundation_v2_materialization.py`](../../core/foundation_v2_materialization.py)
 
-Raw source parsing и выбор структурной интерпретации находятся раньше.
+Вход — уже выбранное root-relative nested sequence description над exact existing occurrences.
 
-## 9.1. Top-level sequence
+Этот слой **не делает `[`/`]` host PUSH/POP opcodes**. Raw parsing и выбор structural interpretation находятся раньше.
+
+---
+
+# 9. Top-level sequence
 
 ```text
 ∞ A B
 ```
 
-materialize-ит один новый exact occurrence:
+materialize-ит новый exact occurrence:
 
 ```text
 X = A ⟼ B
@@ -266,54 +214,35 @@ X = A ⟼ B
 Y = B ⟼ C
 ```
 
-и result sequence равен exact `Y` — последней построенной relation occurrence.
+Result sequence — exact `Y`, последняя построенная adjacency.
 
-`∞` является root/sentinel контекста и не участвует в adjacency:
+`∞` — root/sentinel и не участвует в adjacency:
 
 ```text
 ∞ ⟼ A
 ```
 
-не создаётся sequence semantics автоматически.
+не создаётся автоматически.
 
 ---
 
-# 10. Singleton nested value
+# 10. Nested values
 
-Вложенная группа из одного значения ничего не materialize-ит:
-
-```text
-[A]
-→ exact A
-```
-
-Это позволяет конструкции вроде:
+Singleton group:
 
 ```text
-[window]
-[cursor]
-[position]
+[A] → exact A
 ```
 
-передавать существующие exact values во внешнюю последовательность без лишних target links.
+без нового target link.
 
----
-
-# 11. Nested sequence возвращает одну exact relation
-
-Для:
+Двухэлементная группа:
 
 ```text
 [A B]
+→ X = A ⟼ B
+→ return exact X
 ```
-
-создаётся:
-
-```text
-X = A ⟼ B
-```
-
-и вложенный context возвращает exact `X` как один элемент внешней последовательности.
 
 Поэтому:
 
@@ -328,15 +257,9 @@ X = A ⟼ B
 Y = X ⟼ C
 ```
 
-а не внешнее продолжение через внутренний `B`.
+Вложенный результат становится одним exact значением внешней sequence.
 
-Nested result сохраняет структуру вложенности без AST-node identity.
-
----
-
-# 12. Более длинная вложенная последовательность
-
-Для группы:
+Для:
 
 ```text
 [A B C]
@@ -349,9 +272,9 @@ X = A ⟼ B
 Y = B ⟼ C
 ```
 
-а наружу возвращается exact `Y`.
+и наружу возвращается `Y`.
 
-Правило:
+Короткое правило:
 
 ```text
 singleton → contained exact value
@@ -360,9 +283,7 @@ multi-item → last created adjacency occurrence
 
 ---
 
-# 13. Полный пример
-
-Исходный мотивирующий source:
+# 11. Полный пример
 
 ```text
 ∞[window][cursor][position][[[x][int]][point]]
@@ -371,37 +292,17 @@ multi-item → last created adjacency occurrence
 Пусть singleton groups разрешены в exact values:
 
 ```text
-W  = [window]
-C  = [cursor]
-P  = [position]
-X  = [x]
-I  = [int]
-PT = [point]
+W, C, P, X, I, PT
 ```
 
-Внутри:
+Nested-first materialization:
 
 ```text
 XI = X ⟼ I
 Q  = XI ⟼ PT
-```
-
-Внешняя sequence materialization:
-
-```text
 WC = W ⟼ C
 CP = C ⟼ P
 PQ = P ⟼ Q
-```
-
-Детерминированный nested-first порядок новых exact occurrences:
-
-```text
-XI
-Q
-WC
-CP
-PQ
 ```
 
 Наглядно:
@@ -418,124 +319,99 @@ W ─────▶ C ─────▶ P
             X    I
 ```
 
-`PQ` является result всего top-level sequence.
+`PQ` — result top-level sequence.
 
 ---
 
-# 14. Materialization создаёт новые occurrences, а не интернирует пары
+# 12. Каждая adjacency создаёт новый exact occurrence
 
-Foundation v2 exact identity требует:
+Foundation v2 требует:
 
 ```text
 P1 = A ⟼ B
 P2 = A ⟼ B
-P1 ≠ P2
+P1 != P2
 ```
 
-Поэтому sequence effect #242 принимает правило:
+Поэтому sequence effect создаёт **новый exact occurrence на каждую adjacency**.
 
-> **каждая adjacency, которую materialize-ит sequence effect, создаёт новый exact occurrence.**
+Historical `core/anum_memory.py::intern_link` не используется Foundation-v2 materializer-ом.
 
-Если `A⟼B` уже существует, новый effect всё равно может создать ещё один exact occurrence той же пары.
-
-Старый `core/anum_memory.py::intern_link` относится к historical v0.2 test-double semantics и **не используется Foundation-v2 materializer-ом**.
-
-Если будущий executor хочет переиспользовать существующую relation, он должен сделать это отдельным explicit planning decision, а не скрытым pair interning.
+Если planner хочет reuse существующего `P1`, он должен сначала явно найти/выбрать `P1`; одинаковые poles сами по себе reuse не разрешают.
 
 ---
 
-# 15. Persistent before/after identity lineage
+# 13. Runtime before/after lineage
 
-Materialization не мутирует immutable `before` network.
+Materialization не мутирует immutable `before`:
 
 ```text
 before
   ↓ explicit effect
- after
+after
 ```
 
-В рамках одного runtime lineage:
+В одном runtime lineage:
 
-- все старые `OccurrenceRef` сохраняются теми же exact objects;
-- старые links не изменяются;
+- старые `OccurrenceRef` сохраняются exact;
+- старые links неизменны;
 - новые occurrences append-ятся;
 - duplicate pairs разрешены;
 - root сохраняется.
 
-Это реализовано через additive evolution exact network.
-
-Но independent snapshot reload создаёт новый runtime identity scope.
-
-Поэтому:
+Independent snapshot reload создаёт fresh runtime identity scope.
 
 ```text
-same slot after reload
-!=
-same universal semantic occurrence
+same snapshot slot after independent reload
+!= same universal runtime occurrence
 ```
-
-Snapshot slot остаётся transport-local identity.
 
 ---
 
-# 16. Find остаётся read-only
-
-Foundation-v2 helper:
+# 14. Find остаётся read-only
 
 ```text
-find_links(network, start=?, end=?)
+find_links(network,start=?,end=?)
 ```
 
-только перечисляет exact existing occurrences.
+перечисляет существующие exact occurrences и не materialize-ит missing pair.
 
-Если pair отсутствует:
-
-```text
-find_links(A,B) -> ()
-```
-
-и network snapshot не меняется.
-
-Только:
+Только explicit:
 
 ```text
 materialize_sequence(...)
 ```
 
-создаёт `after` state.
+создаёт новое `after` state.
 
 ---
 
-# 17. Trusted replay materialization effect
-
-`materialize_sequence` создаёт candidate `after` и exact evidence.
-
-Затем:
+# 15. Trusted replay sequence effect
 
 ```text
-replay_sequence_materialization(before, evidence)
+replay_sequence_materialization(before,evidence)
 ```
 
-повторно проверяет:
+проверяет:
 
-1. exact root sequence;
-2. неизменность всех base occurrences;
-3. exact same identity старых refs в before/after lineage;
-4. отсутствие изменения старых links;
-5. точное число новых occurrences;
-6. deterministic nested-first order новых relations;
-7. правильные exact start/end каждой adjacency;
-8. правильный exact result;
-9. отсутствие extra materialization;
-10. неизменность before/after во время replay.
+```text
+exact root
+base refs preserved
+old links unchanged
+exact created count/order
+nested adjacency poles
+exact result
+no extra materialization
+before/after unchanged during replay
+```
 
 Replay ничего не создаёт.
 
 ---
 
-# 18. Почему host nesting допустим, но не является ontology
+# 16. Host nesting не является ontology
 
-Текущий Python API использует checker handles:
+Python handles:
 
 ```text
 SequenceAtom
@@ -543,58 +419,197 @@ SequenceGroup
 SequenceDescription
 ```
 
-Это не semantic classes МТС.
+представляют выбранную structural interpretation для checker-а.
 
-Они представляют **уже выбранную structural interpretation** для conformance/replay.
-
-Идентичность значений находится в exact `OccurrenceRef`, а не в Python-object `SequenceGroup` и не в исходном символе `[`.
-
-В дальнейшем source front-end может выдавать эквивалентное exact evidence другим способом без изменения sequence semantics.
+Semantic identity находится в exact `OccurrenceRef`, а не в Python class/object и не в glyph `[`.
 
 ---
 
-# 19. Round-trip boundary
+# 17. Structural round-trip и network identity — разные свойства
 
-Есть два разных round-trip.
-
-### Structural/source round-trip
-
-Historical recursive contracts могут проверять:
+Historical structural round-trip может проверять:
 
 ```text
 encode(decode(raw)) = canonical raw
 ```
 
-на своей occurrence-tree области.
+на occurrence-tree области.
 
-### Network snapshot round-trip
-
-Foundation-v2 exact network:
+Network snapshot round-trip проверяет:
 
 ```text
-after.snapshot()
-→ serialize / load
+serialize/load
 → same topology, multiplicity, sharing, root
 ```
 
-но загрузка создаёт fresh runtime occurrence scope.
+но independent load создаёт fresh runtime scope.
 
-Поэтому structural round-trip и exact runtime identity — разные свойства.
+Следовательно structural equivalence и exact runtime identity нельзя смешивать.
 
 ---
 
-# 20. Compatibility с v0.2
+# 18. Persistent L4 #265
 
-#242 не отменяет:
+После #242 следующий вопрос: что значит exact occurrence **после process restart**?
+
+Historical #124 использовал старую pair-unique/idempotent-realize semantics и закрыт как superseded для Foundation v2.
+
+Новый Gate #265 различает:
 
 ```text
-boundary projection v0.2
-pair denotation v0.2
-recursive denotation v0.2
-quote/relative isolation v0.2
+runtime OccurrenceRef
+persistent dataset-local logical occurrence id
+snapshot-local slot
+backend physical address
 ```
 
-Он также не наследует historical L4 pair interning.
+Reference persistent id:
+
+```text
+PersistentOccurrenceId(lineage, local)
+```
+
+Reopen того же dataset сохраняет `lineage/local`, но runtime refs могут быть реконструированы заново.
+
+Fresh import той же topology получает новый lineage.
+
+Подробнее: [Foundation v2 Persistent L4](Foundation%20v2%20Persistent%20L4.md).
+
+---
+
+# 19. Persistent sequence materialization
+
+Persistent layer не реализует вторую Anum grammar.
+
+Правильная композиция:
+
+```text
+persistent store
+→ reconstruct runtime exact network
+→ existing foundation_v2_materialization
+→ runtime SequenceMaterialization evidence
+→ normalize endpoints to persistent IDs / BatchRefs
+→ atomic persistent materialization
+```
+
+Persistent evidence хранит:
+
+```text
+sequence description in persistent ids
+before_count
+created persistent occurrences + poles
+result persistent occurrence
+```
+
+После clean reopen оно снова может быть replayed через тот же runtime sequence checker.
+
+---
+
+# 20. Полный persistent пример
+
+Пусть persistent store уже содержит exact logical occurrences:
+
+```text
+Window
+Cursor
+Position
+X
+Int
+Point
+```
+
+Для:
+
+```text
+∞[window][cursor][position][[[x][int]][point]]
+```
+
+persistent batch создаёт пять новых logical occurrence IDs:
+
+```text
+XI
+Q
+WC
+CP
+PQ
+```
+
+После close/reopen:
+
+```text
+find(Window,Cursor) -> WC
+find(Cursor,Position) -> CP
+find(Position,Q) -> PQ
+```
+
+и stored sequence evidence всё ещё replay-ится read-only.
+
+---
+
+# 21. Persistent multiplicity и cycles
+
+Если до effect уже существует:
+
+```text
+Old = A ⟼ B
+```
+
+новая materialization создаёт:
+
+```text
+New = A ⟼ B
+Old != New
+```
+
+Оба persistent IDs переживают reopen.
+
+Atomic batch поддерживает:
+
+```text
+self-cycle
+mutual cycle
+sharing
+```
+
+через batch-local references, выделяя IDs всей партии до commit.
+
+---
+
+# 22. Physical storage не определяет identity
+
+Persistent logical identity не равна:
+
+```text
+file offset
+mmap pointer
+PMM block address
+DB row physical location
+```
+
+Production backend может делать relocation/compaction/recovery, не меняя logical occurrence.
+
+Правильная граница:
+
+```text
+persistent logical ID
+        ↓ backend mapping
+physical storage handle
+```
+
+---
+
+# 23. Compatibility с historical v0.2–v0.5
+
+Foundation-v2 sequence/persistent gates не отменяют historical:
+
+```text
+boundary projection
+pair denotation
+recursive denotation
+quote/relative isolation
+```
+
+Но они **не наследуют** historical L4 pair interning.
 
 Граница:
 
@@ -603,14 +618,15 @@ v0.2 recursive denotation
 = accepted structural occurrence-tree contract
 
 Foundation-v2 sequence materialization
-= candidate explicit effect over exact-occurrence network
-```
+= explicit exact runtime effect
 
-Оба отвечают на разные вопросы и сохраняются до production cutover.
+Foundation-v2 persistent L4
+= dataset-lineage persistent identity/effect contract
+```
 
 ---
 
-# 21. Актуальные модули
+# 24. Актуальные модули
 
 Historical L3:
 
@@ -635,40 +651,31 @@ Foundation v2:
 ```text
 core/exact_link_network.py
 core/foundation_v2_materialization.py
+core/foundation_v2_persistent.py
 ```
 
-Machine contract candidate:
+Machine contracts:
 
 ```text
 contracts/mts-anum-sequence-materialization-v0.7.json
+contracts/mts-foundation-v2-persistent-l4-v0.7.json
 ```
 
 ---
 
-# 22. Что остаётся после #242
+# 25. Что остаётся после persistent L4
 
-Sequence semantics закрывает conceptual gap:
+После #265 следующий этап уже не должен изобретать третий Anum или memory path.
 
-```text
-source sequence
-→ nested structural value
-→ explicit materialization
-→ exact before/after network
-```
-
-Но accepted Foundation v2 требует ещё persistent L4 #124.
-
-Следующий слой должен доказать, что те же свойства сохраняются на storage backend:
+Release hardening:
 
 ```text
-multiplicity
-sharing
-cycles
-persistent history
-explicit effects
-read-only search/replay
-portable evidence
-backend address != semantic identity
+historical compatibility classification
+→ atomic production cutover
+→ versioned integrated conformance
+→ explicit Foundation-v2 acceptance
+→ next MTS version
+→ aprover repin
 ```
 
-Только после этого возможны production cutover, versioned integrated conformance и `aprover` repin.
+Production PMM adapter может стать отдельным backend implementation gate, но должен подчиняться этому L4 contract, а не определять его.

--- a/tests/test_mts_foundation_v2_persistent.py
+++ b/tests/test_mts_foundation_v2_persistent.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.foundation_v2_persistent import (
+    BatchLink,
+    BatchRef,
+    JsonExactLinkStore,
+    PERSISTENT_SCHEMA,
+    PersistentSequenceAtom,
+    PersistentSequenceDescription,
+    PersistentSequenceGroup,
+    PersistentStoreError,
+    materialize_persistent_sequence,
+    replay_persistent_sequence_materialization,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts/mts-foundation-v2-persistent-l4-v0.7.json"
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def _self_occurrences(store: JsonExactLinkStore, count: int):
+    return store.materialize_batch(
+        tuple(BatchLink(BatchRef(index), BatchRef(index)) for index in range(count))
+    )
+
+
+def _local_topology(store: JsonExactLinkStore):
+    snapshot = store.snapshot()
+    return (
+        snapshot.root.local,
+        tuple((ref.local, start.local, end.local) for ref, start, end in snapshot.links),
+    )
+
+
+def _atom(ref):
+    return PersistentSequenceAtom(ref)
+
+
+def _group(*items):
+    return PersistentSequenceGroup(tuple(items))
+
+
+def test_contract_is_candidate_and_supersedes_pair_interning_for_foundation_v2() -> None:
+    contract = _contract()
+    assert contract["schema"] == "mts-foundation-v2-persistent-l4/v0.7"
+    assert contract["status"] == "gate-p-candidate"
+    assert contract["accepted"] is False
+    assert contract["issue"] == 265
+    assert contract["materialization"]["pairInterning"] is False
+    assert contract["materialization"]["idempotentMaterializeByPair"] is False
+    assert contract["aproverRepinAllowed"] is False
+
+
+def test_duplicate_pair_occurrences_survive_clean_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "store.json"
+    store = JsonExactLinkStore.create(path)
+    a, b = _self_occurrences(store, 2)
+    first = store.materialize(a, b)
+    second = store.materialize(a, b)
+    lineage = store.lineage_id
+
+    assert first is not second
+    assert first != second
+    assert store.find(start=a, end=b) == (first, second)
+    store.close()
+
+    reopened = JsonExactLinkStore.open(path)
+    assert reopened.lineage_id == lineage
+    assert reopened.find(start=a, end=b) == (first, second)
+    assert reopened.poles(first) == (a, b)
+    assert reopened.poles(second) == (a, b)
+
+
+def test_find_is_read_only_before_and_after_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "store.json"
+    store = JsonExactLinkStore.create(path)
+    a, b = _self_occurrences(store, 2)
+    snapshot = store.snapshot()
+    file_before = path.read_bytes()
+
+    assert store.find(start=a, end=b) == ()
+    assert store.snapshot() == snapshot
+    assert path.read_bytes() == file_before
+    store.close()
+
+    reopened = JsonExactLinkStore.open(path)
+    reopened_snapshot = reopened.snapshot()
+    reopened_file = path.read_bytes()
+    assert reopened.find(start=a, end=b) == ()
+    assert reopened.snapshot() == reopened_snapshot
+    assert path.read_bytes() == reopened_file
+
+
+def test_self_and_mutual_cycles_survive_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "cycles.json"
+    store = JsonExactLinkStore.create(path)
+    self_cycle = store.materialize_batch((BatchLink(BatchRef(0), BatchRef(0)),))[0]
+    left, right = store.materialize_batch(
+        (
+            BatchLink(BatchRef(1), BatchRef(1)),
+            BatchLink(BatchRef(0), BatchRef(0)),
+        )
+    )
+    # Replace the previous two independent self-cycles with an explicit mutual
+    # cycle in another atomic batch so forward references are exercised.
+    mutual_left, mutual_right = store.materialize_batch(
+        (
+            BatchLink(BatchRef(1), BatchRef(1)),
+            BatchLink(BatchRef(0), BatchRef(0)),
+        )
+    )
+    # The two edges above are self-cycles by construction; add a true cross-cycle.
+    cross_left, cross_right = store.materialize_batch(
+        (
+            BatchLink(BatchRef(1), BatchRef(1)),
+            BatchLink(BatchRef(0), BatchRef(0)),
+        )
+    )
+    # A BatchRef can target any newly allocated occurrence. Make an actual
+    # left->right / right->left cycle with the occurrences themselves as poles.
+    cycle_a, cycle_b = store.materialize_batch(
+        (
+            BatchLink(BatchRef(1), BatchRef(1)),
+            BatchLink(BatchRef(0), BatchRef(0)),
+        )
+    )
+
+    # Sanity for reference values that must survive reopen.
+    assert store.poles(self_cycle) == (self_cycle, self_cycle)
+    assert store.poles(left) == (right, right)
+    assert store.poles(right) == (left, left)
+    assert store.poles(mutual_left) == (mutual_right, mutual_right)
+    assert store.poles(mutual_right) == (mutual_left, mutual_left)
+    assert store.poles(cross_left) == (cross_right, cross_right)
+    assert store.poles(cross_right) == (cross_left, cross_left)
+    assert store.poles(cycle_a) == (cycle_b, cycle_b)
+    assert store.poles(cycle_b) == (cycle_a, cycle_a)
+    store.close()
+
+    reopened = JsonExactLinkStore.open(path)
+    assert reopened.poles(self_cycle) == (self_cycle, self_cycle)
+    assert reopened.poles(cycle_a) == (cycle_b, cycle_b)
+    assert reopened.poles(cycle_b) == (cycle_a, cycle_a)
+
+
+def test_shared_endpoint_remains_shared_after_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "sharing.json"
+    store = JsonExactLinkStore.create(path)
+    a, b, shared = _self_occurrences(store, 3)
+    first = store.materialize(a, shared)
+    second = store.materialize(b, shared)
+    store.close()
+
+    reopened = JsonExactLinkStore.open(path)
+    assert reopened.poles(first) == (a, shared)
+    assert reopened.poles(second) == (b, shared)
+    assert reopened.incoming(shared) == (first, second, shared)
+
+
+def test_root_logical_identity_survives_reopen_but_runtime_ref_is_reconstructed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "root.json"
+    store = JsonExactLinkStore.create(path)
+    root = store.root
+    runtime_before, mapping_before = store.runtime_network()
+    runtime_root_before = mapping_before[root]
+    store.close()
+
+    reopened = JsonExactLinkStore.open(path)
+    assert reopened.root == root
+    runtime_after, mapping_after = reopened.runtime_network()
+    assert runtime_after.snapshot() == runtime_before.snapshot()
+    assert mapping_after[root] is not runtime_root_before
+    assert mapping_after[root] != runtime_root_before
+
+
+def test_invalid_batch_is_atomic_in_memory_and_on_disk(tmp_path: Path) -> None:
+    path = tmp_path / "atomic-invalid.json"
+    store = JsonExactLinkStore.create(path)
+    before_snapshot = store.snapshot()
+    before_file = path.read_bytes()
+
+    with pytest.raises(PersistentStoreError, match="out of range"):
+        store.materialize_batch((BatchLink(BatchRef(1), BatchRef(0)),))
+
+    assert store.snapshot() == before_snapshot
+    assert path.read_bytes() == before_file
+
+
+def test_simulated_commit_failure_exposes_pre_state_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "atomic-commit.json"
+    store = JsonExactLinkStore.create(path)
+    a, b = _self_occurrences(store, 2)
+    before_snapshot = store.snapshot()
+    before_file = path.read_bytes()
+
+    def fail(_links):
+        raise OSError("simulated commit failure")
+
+    monkeypatch.setattr(store, "_commit_candidate", fail)
+    with pytest.raises(OSError, match="simulated"):
+        store.materialize(a, b)
+
+    assert store.snapshot() == before_snapshot
+    assert path.read_bytes() == before_file
+
+
+def test_fresh_import_of_same_topology_creates_another_lineage(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.json"
+    imported_path = tmp_path / "imported.json"
+    source = JsonExactLinkStore.create(source_path)
+    a, b = _self_occurrences(source, 2)
+    source.materialize(a, b)
+    snapshot = source.snapshot()
+
+    imported = JsonExactLinkStore.import_topology(imported_path, snapshot)
+
+    assert imported.lineage_id != source.lineage_id
+    assert _local_topology(imported) == _local_topology(source)
+    assert imported.root.local == source.root.local
+    assert imported.root != source.root
+
+
+def test_backend_file_has_logical_ids_only_not_runtime_objects(tmp_path: Path) -> None:
+    path = tmp_path / "wire.json"
+    store = JsonExactLinkStore.create(path)
+    a, b = _self_occurrences(store, 2)
+    store.materialize(a, b)
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["schema"] == PERSISTENT_SCHEMA
+    assert set(raw) == {"schema", "lineage", "root", "links"}
+    assert all(isinstance(value, int) for pair in raw["links"] for value in pair)
+    assert "OccurrenceRef" not in path.read_text(encoding="utf-8")
+
+
+def test_persistent_sequence_materialization_replays_after_clean_reopen(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sequence.json"
+    store = JsonExactLinkStore.create(path)
+    window, cursor, position, x, integer, point = _self_occurrences(store, 6)
+    description = PersistentSequenceDescription(
+        root=store.root,
+        items=(
+            _group(_atom(window)),
+            _group(_atom(cursor)),
+            _group(_atom(position)),
+            _group(
+                _group(_group(_atom(x)), _group(_atom(integer))),
+                _group(_atom(point)),
+            ),
+        ),
+    )
+
+    evidence = materialize_persistent_sequence(store, description)
+    assert len(evidence.created) == 5
+    xi, q, window_cursor, cursor_position, position_q = evidence.created
+    assert (xi.start, xi.end) == (x, integer)
+    assert q.start == xi.ref
+    assert q.end == point
+    assert (window_cursor.start, window_cursor.end) == (window, cursor)
+    assert (cursor_position.start, cursor_position.end) == (cursor, position)
+    assert (position_q.start, position_q.end) == (position, q.ref)
+    assert evidence.result == position_q.ref
+
+    snapshot_after = store.snapshot()
+    assert replay_persistent_sequence_materialization(store, evidence) == evidence.result
+    assert store.snapshot() == snapshot_after
+    store.close()
+
+    reopened = JsonExactLinkStore.open(path)
+    reopened_snapshot = reopened.snapshot()
+    assert replay_persistent_sequence_materialization(reopened, evidence) == evidence.result
+    assert reopened.snapshot() == reopened_snapshot
+
+
+def test_sequence_bridge_preserves_duplicate_pair_policy(tmp_path: Path) -> None:
+    path = tmp_path / "sequence-duplicate.json"
+    store = JsonExactLinkStore.create(path)
+    a, b = _self_occurrences(store, 2)
+    old = store.materialize(a, b)
+    description = PersistentSequenceDescription(
+        root=store.root,
+        items=(_atom(a), _atom(b)),
+    )
+
+    evidence = materialize_persistent_sequence(store, description)
+    assert evidence.result != old
+    assert store.find(start=a, end=b) == (old, evidence.result)
+
+
+def test_closed_handle_rejects_observation(tmp_path: Path) -> None:
+    path = tmp_path / "closed.json"
+    store = JsonExactLinkStore.create(path)
+    store.close()
+    with pytest.raises(PersistentStoreError, match="closed"):
+        _ = store.root
+
+
+def test_backend_does_not_import_legacy_parser_or_pair_interning() -> None:
+    source = (ROOT / "core/foundation_v2_persistent.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "anum_memory",
+        "intern_link",
+        "anum_parser",
+        "mtc_parser",
+        "mtc_ast",
+        "mtc_interpreter",
+    ):
+        assert forbidden not in source
+    contract = _contract()
+    assert contract["backendNeutrality"]["jsonReferenceFileFormatNormative"] is False
+    assert contract["backendNeutrality"]["pmmApiNormative"] is False

--- a/tests/test_mts_foundation_v2_persistent.py
+++ b/tests/test_mts_foundation_v2_persistent.py
@@ -103,53 +103,24 @@ def test_find_is_read_only_before_and_after_reopen(tmp_path: Path) -> None:
 def test_self_and_mutual_cycles_survive_reopen(tmp_path: Path) -> None:
     path = tmp_path / "cycles.json"
     store = JsonExactLinkStore.create(path)
+    x, y = _self_occurrences(store, 2)
     self_cycle = store.materialize_batch((BatchLink(BatchRef(0), BatchRef(0)),))[0]
-    left, right = store.materialize_batch(
-        (
-            BatchLink(BatchRef(1), BatchRef(1)),
-            BatchLink(BatchRef(0), BatchRef(0)),
-        )
-    )
-    # Replace the previous two independent self-cycles with an explicit mutual
-    # cycle in another atomic batch so forward references are exercised.
-    mutual_left, mutual_right = store.materialize_batch(
-        (
-            BatchLink(BatchRef(1), BatchRef(1)),
-            BatchLink(BatchRef(0), BatchRef(0)),
-        )
-    )
-    # The two edges above are self-cycles by construction; add a true cross-cycle.
-    cross_left, cross_right = store.materialize_batch(
-        (
-            BatchLink(BatchRef(1), BatchRef(1)),
-            BatchLink(BatchRef(0), BatchRef(0)),
-        )
-    )
-    # A BatchRef can target any newly allocated occurrence. Make an actual
-    # left->right / right->left cycle with the occurrences themselves as poles.
     cycle_a, cycle_b = store.materialize_batch(
         (
-            BatchLink(BatchRef(1), BatchRef(1)),
-            BatchLink(BatchRef(0), BatchRef(0)),
+            BatchLink(BatchRef(1), x),
+            BatchLink(BatchRef(0), y),
         )
     )
 
-    # Sanity for reference values that must survive reopen.
     assert store.poles(self_cycle) == (self_cycle, self_cycle)
-    assert store.poles(left) == (right, right)
-    assert store.poles(right) == (left, left)
-    assert store.poles(mutual_left) == (mutual_right, mutual_right)
-    assert store.poles(mutual_right) == (mutual_left, mutual_left)
-    assert store.poles(cross_left) == (cross_right, cross_right)
-    assert store.poles(cross_right) == (cross_left, cross_left)
-    assert store.poles(cycle_a) == (cycle_b, cycle_b)
-    assert store.poles(cycle_b) == (cycle_a, cycle_a)
+    assert store.poles(cycle_a) == (cycle_b, x)
+    assert store.poles(cycle_b) == (cycle_a, y)
     store.close()
 
     reopened = JsonExactLinkStore.open(path)
     assert reopened.poles(self_cycle) == (self_cycle, self_cycle)
-    assert reopened.poles(cycle_a) == (cycle_b, cycle_b)
-    assert reopened.poles(cycle_b) == (cycle_a, cycle_a)
+    assert reopened.poles(cycle_a) == (cycle_b, x)
+    assert reopened.poles(cycle_b) == (cycle_a, y)
 
 
 def test_shared_endpoint_remains_shared_after_reopen(tmp_path: Path) -> None:
@@ -163,7 +134,7 @@ def test_shared_endpoint_remains_shared_after_reopen(tmp_path: Path) -> None:
     reopened = JsonExactLinkStore.open(path)
     assert reopened.poles(first) == (a, shared)
     assert reopened.poles(second) == (b, shared)
-    assert reopened.incoming(shared) == (first, second, shared)
+    assert reopened.incoming(shared) == (shared, first, second)
 
 
 def test_root_logical_identity_survives_reopen_but_runtime_ref_is_reconstructed(

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -28,6 +28,7 @@ ACTIVE_SPECS = {
     "Пучки значений МТС v0.2.md",
     "Foundation v2 Gate P.md",
     "Foundation v2 Proof replay.md",
+    "Foundation v2 Persistent L4.md",
     "Апамять и управление сетью связей.md",
 }
 ACTIVE_MARKDOWN = (


### PR DESCRIPTION
Closes #265 after explicit decision if CI/evidence is accepted. Parent: #237. Supersedes historical #124 only for Foundation-v2 release work; old v0.3 L4 contracts remain reproducible history.

## Why L4 is re-derived

Historical v0.3 required exact-pair uniqueness and idempotent `realize_link(A,B)`. Foundation v2 now requires exact occurrence multiplicity and #242/#264 creates a fresh occurrence for every explicit sequence adjacency. This PR therefore does not adapt old pair interning into the new path.

## Persistent identity

The candidate distinguishes:

```text
runtime OccurrenceRef
persistent dataset-local logical occurrence id
snapshot-local slot
backend physical address / record id
```

Reference logical identity is `PersistentOccurrenceId(lineage, local)`. Reopening the same dataset preserves lineage/local identity while runtime refs may be reconstructed. Importing identical topology into a fresh dataset creates a fresh lineage. Physical addresses are never MTS identity.

## Reference backend

`core/foundation_v2_persistent.py` adds a deliberately small file-backed `JsonExactLinkStore` as executable persistence evidence, not a normative storage format.

It provides read-only `poles/find/outgoing/incoming/snapshot`, explicit fresh-occurrence `materialize`, and atomic `materialize_batch` with batch-local forward/self references for cycles.

Every materialization creates a new exact occurrence; duplicate pairs survive clean reopen.

## Sequence bridge

Persistent L4 delegates structural semantics to the already merged `foundation_v2_materialization.py` instead of implementing another Anum grammar:

```text
persistent store
→ reconstruct runtime exact network
→ existing sequence materializer
→ normalize new endpoints to persistent ids / BatchRefs
→ atomic persistent batch
```

Persistent sequence evidence can be replayed read-only after clean reopen.

## Conformance

Vectors cover duplicate pairs, read-only find, self/mutual cycles, sharing, root identity, reconstructed runtime refs, invalid batch atomicity, simulated commit failure, fresh-lineage topology import, sequence replay after reopen and no legacy parser/pair-interning dependency.

Machine contract: `contracts/mts-foundation-v2-persistent-l4-v0.7.json`.

## Documentation

Updated in the same PR:
- README;
- `Foundation v2 Gate P.md`;
- `Апамять и управление сетью связей.md`;
- `Ачисла и сериализация.md`;
- new active spec `Foundation v2 Persistent L4.md`.

The docs explicitly mark #124 as historical/superseded and #265 as the current persistent L4 gate.

After this gate the next work is compatibility classification and atomic production cutover planning, then versioned integrated conformance/acceptance. No `aprover` repin yet.