### PR TITLE
Cutover C0/C1: freeze candidate owners and historical consumer matrix

### DIFF
--- a/contracts/mts-foundation-v2-consumer-matrix-v0.7.json
+++ b/contracts/mts-foundation-v2-consumer-matrix-v0.7.json
@@ -1,0 +1,156 @@
+{
+  "schema": "mts-foundation-v2-consumer-matrix/v0.7",
+  "status": "gate-p-cutover-consumer-audit",
+  "accepted": false,
+  "issue": 272,
+  "parent": 271,
+  "baseMainCommit": "38488fdcbce999a54726f56ad01ac358d28a9e1a",
+  "allowedActions": [
+    "MIGRATE_TO_FOUNDATION_V2",
+    "HISTORICAL_REPLAY_ONLY",
+    "DELETE_WITH_OWNER",
+    "NON_SEMANTIC_TOOLING"
+  ],
+  "unknownAllowed": false,
+  "rows": [
+    {
+      "path": "core/root_library.py",
+      "role": "historical ten-formula root loader currently used as a root-facing entry surface",
+      "action": "MIGRATE_TO_FOUNDATION_V2",
+      "expectedCoreImports": ["core.mtc_ast", "core.mtc_definitions", "core.mtc_parser"],
+      "replacementOwner": "C3 distinguished exact R/O/C/L/U bootstrap",
+      "precondition": "A live Foundation-v2 root/bootstrap entrypoint exists and no live consumer needs typed root AST identity.",
+      "postCutover": "Historical root loading may remain only as explicitly version-scoped replay tooling or be deleted if tag/Git replay is sufficient."
+    },
+    {
+      "path": "core/validate_root.py",
+      "role": "historical typed ten-formula root validator",
+      "action": "MIGRATE_TO_FOUNDATION_V2",
+      "expectedCoreImports": ["core.mtc_ast", "core.mtc_definitions", "core.root_library"],
+      "replacementOwner": "C3 Foundation-v2 bootstrap/conformance validator",
+      "precondition": "The five-link bootstrap and ostensive invariants have executable release-candidate validation.",
+      "postCutover": "Historical ten-formula validation must not be the new live root authority."
+    },
+    {
+      "path": "core/proof_checker.py",
+      "role": "accepted historical v0.2-v0.4 proof replay island",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.mtc_ast", "core.mtc_definitions", "core.mtc_interpreter", "core.mtc_opening_path", "core.mtc_parser"],
+      "replacementOwner": "core/foundation_v2_checker.py for new production proofs",
+      "precondition": "New production proof entrypoints consume only the Foundation-v2 integrated checker.",
+      "postCutover": "No Foundation-v2 proof validity may dispatch to this historical checker. C5 may later delete the historical runtime if Git/tag replay is selected."
+    },
+    {
+      "path": "core/mtc_opening_path.py",
+      "role": "historical v0.4 DefinitionOpeningPath replay over typed AST and DefinitionEnvironment",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.mtc_ast", "core.mtc_definitions"],
+      "replacementOwner": "No live Foundation-v2 opening primitive; persistent scoped D and explicit T-admitted rules own new behavior.",
+      "precondition": "No new-production proof/source path imports DefinitionOpeningPath replay.",
+      "postCutover": "Historical-only dependency of old proof versions or removable with that replay island."
+    },
+    {
+      "path": "core/mtc_parser.py",
+      "role": "historical tokenizer/precedence parser and typed-AST constructor with semantic-looking TokenKind dispatch",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.mtc_ast"],
+      "replacementOwner": "core/foundation_v2_source.py",
+      "precondition": "All new live semantic consumers use canonical source occurrence + selected segmentation + D/G/T evidence.",
+      "postCutover": "May remain only inside the historical replay island; any reusable editor parser must be split into NON_SEMANTIC_TOOLING explicitly."
+    },
+    {
+      "path": "core/mtc_ast.py",
+      "role": "historical typed syntax/formatting structure whose classes currently carry semantic-looking distinctions",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": [],
+      "replacementOwner": "exact source/form occurrences and Foundation-v2 evidence",
+      "precondition": "No trusted/new-production semantic module uses AST class or AST path as identity.",
+      "postCutover": "Historical replay only unless a separately isolated NON_SEMANTIC_TOOLING formatting layer is retained."
+    },
+    {
+      "path": "core/mtc_interpreter.py",
+      "role": "historical ContextFrame/MemoryView AST-driven read-only interpreter",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.mtc_ast"],
+      "replacementOwner": "core/foundation_v2_interpreter.py",
+      "precondition": "Every new live interpretation entrypoint supplies exact K/D/G/T/A evidence.",
+      "postCutover": "No Foundation-v2 validity path may call ContextFrame, resolve_context_pronoun, projection lookup or interpret_constraints. C5 may delete the island with historical runtime replay."
+    },
+    {
+      "path": "core/mtc_definitions.py",
+      "role": "historical host lexical DefinitionEnvironment and definition opening",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.mtc_ast"],
+      "replacementOwner": "core/foundation_v2_state.py + core/foundation_v2_interpreter.py persistent scoped D/colon",
+      "precondition": "All new source/definition consumers use exact persistent D history/evidence.",
+      "postCutover": "No new live dictionary semantics may use host DefinitionEnvironment."
+    },
+    {
+      "path": "core/reference_model.py",
+      "role": "historical live machine-readable operator/reference authority tied to typed AST and ContextFrame concepts",
+      "action": "DELETE_WITH_OWNER",
+      "expectedCoreImports": [],
+      "replacementOwner": "future accepted Foundation-v2 contract after C8/C9",
+      "precondition": "A new accepted versioned Foundation-v2 contract exists and all live consumers have repointed.",
+      "postCutover": "Delete from live semantic authority; immutable historical JSON contracts/Git retain the previous release record."
+    },
+    {
+      "path": "core/anum_memory.py",
+      "role": "historical v0.2 in-memory L4 with exact ordered-pair interning and idempotent intern/realize behavior",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.anum_denotation", "core.anum_raw_carrier"],
+      "replacementOwner": "core/foundation_v2_persistent.py + core/foundation_v2_materialization.py",
+      "precondition": "Every new live L4/materialization consumer accepts exact occurrence multiplicity and persistent logical identity.",
+      "postCutover": "No Foundation-v2 materialization or persistence path may use pair interning as semantic identity."
+    },
+    {
+      "path": "converters/l4_backend_driver.py",
+      "role": "historical v0.3 language-neutral backend driver delegating to pair-interning AnumMemory",
+      "action": "HISTORICAL_REPLAY_ONLY",
+      "expectedCoreImports": ["core.anum_denotation", "core.anum_memory", "core.anum_model", "core.anum_parser", "core.anum_recursive_denotation"],
+      "replacementOwner": "Foundation-v2 persistent exact-occurrence backend/conformance boundary",
+      "precondition": "C6/C8 provide one exact-occurrence persistent driver/release corpus if an external backend driver remains required.",
+      "postCutover": "Historical backend conformance only; not a new live L4 authority."
+    },
+    {
+      "path": "core/semantic_carrier.py",
+      "role": "finite graph/topology engineering utility with explicit non-equality warning",
+      "action": "NON_SEMANTIC_TOOLING",
+      "expectedCoreImports": [],
+      "replacementOwner": "core/exact_link_network.py for live exact-occurrence semantics",
+      "precondition": "No trusted Foundation-v2 module imports CarrierGraph/LinkNode as semantic identity.",
+      "postCutover": "May remain only as structural tooling/research utility."
+    }
+  ],
+  "verifiedHistoricalDependencyIsland": {
+    "core/root_library.py": ["core.mtc_ast", "core.mtc_definitions", "core.mtc_parser"],
+    "core/validate_root.py": ["core.mtc_ast", "core.mtc_definitions", "core.root_library"],
+    "core/proof_checker.py": ["core.mtc_ast", "core.mtc_definitions", "core.mtc_interpreter", "core.mtc_opening_path", "core.mtc_parser"],
+    "core/mtc_opening_path.py": ["core.mtc_ast", "core.mtc_definitions"],
+    "converters/l4_backend_driver.py": ["core.anum_denotation", "core.anum_memory", "core.anum_model", "core.anum_parser", "core.anum_recursive_denotation"]
+  },
+  "trustedFoundationV2Modules": [
+    "core/exact_link_network.py",
+    "core/foundation_v2_state.py",
+    "core/foundation_v2_source.py",
+    "core/foundation_v2_interpreter.py",
+    "core/foundation_v2_run.py",
+    "core/foundation_v2_proof.py",
+    "core/foundation_v2_checker.py",
+    "core/foundation_v2_materialization.py",
+    "core/foundation_v2_persistent.py"
+  ],
+  "forbiddenHistoricalImportsInTrustedFoundationV2": [
+    "core.mtc_parser",
+    "core.mtc_ast",
+    "core.mtc_interpreter",
+    "core.mtc_definitions",
+    "core.mtc_opening_path",
+    "core.proof_checker",
+    "core.root_library",
+    "core.reference_model",
+    "core.anum_memory"
+  ],
+  "cutoverPerformed": false,
+  "downstreamRepinAllowed": false
+}

--- a/contracts/mts-foundation-v2-consumer-matrix-v0.7.json
+++ b/contracts/mts-foundation-v2-consumer-matrix-v0.7.json
@@ -53,7 +53,7 @@
       "path": "core/mtc_parser.py",
       "role": "historical tokenizer/precedence parser and typed-AST constructor with semantic-looking TokenKind dispatch",
       "action": "HISTORICAL_REPLAY_ONLY",
-      "expectedCoreImports": ["core.mtc_ast"],
+      "expectedCoreImports": ["core.mtc_ast", "core.reference_model"],
       "replacementOwner": "core/foundation_v2_source.py",
       "precondition": "All new live semantic consumers use canonical source occurrence + selected segmentation + D/G/T evidence.",
       "postCutover": "May remain only inside the historical replay island; any reusable editor parser must be split into NON_SEMANTIC_TOOLING explicitly."
@@ -127,6 +127,7 @@
     "core/validate_root.py": ["core.mtc_ast", "core.mtc_definitions", "core.root_library"],
     "core/proof_checker.py": ["core.mtc_ast", "core.mtc_definitions", "core.mtc_interpreter", "core.mtc_opening_path", "core.mtc_parser"],
     "core/mtc_opening_path.py": ["core.mtc_ast", "core.mtc_definitions"],
+    "core/mtc_parser.py": ["core.mtc_ast", "core.reference_model"],
     "converters/l4_backend_driver.py": ["core.anum_denotation", "core.anum_memory", "core.anum_model", "core.anum_parser", "core.anum_recursive_denotation"]
   },
   "trustedFoundationV2Modules": [

--- a/contracts/mts-foundation-v2-cutover-manifest-v0.7.json
+++ b/contracts/mts-foundation-v2-cutover-manifest-v0.7.json
@@ -1,0 +1,109 @@
+{
+  "schema": "mts-foundation-v2-cutover-manifest/v0.7",
+  "status": "gate-p-cutover-manifest",
+  "accepted": false,
+  "issue": 272,
+  "parent": 271,
+  "umbrella": 237,
+  "baseMainCommit": "38488fdcbce999a54726f56ad01ac358d28a9e1a",
+  "cutoverPerformed": false,
+  "foundationV2Accepted": false,
+  "downstreamRepinAllowed": false,
+  "purpose": "Freeze the exact current Foundation-v2 release-candidate owners before migrating any historical live consumer or deleting any superseded semantic path.",
+  "owners": {
+    "exactOccurrenceSubstrate": {
+      "modules": ["core/exact_link_network.py"],
+      "contracts": ["contracts/mts-exact-occurrence-link-network-v0.7.json"],
+      "schemas": ["mts-exact-occurrence-link-network/v0.7"]
+    },
+    "rootBootstrapEvidence": {
+      "modules": [],
+      "contracts": ["contracts/mts-semantic-root-kernel-challenge-v0.7.json"],
+      "schemas": ["mts-semantic-root-kernel-challenge/v0.7"],
+      "readerFacingOwners": ["README.md", "docs/theory/Основания МТС.md", "docs/theory/Система аксиом МТС.md"],
+      "liveProductionEntrypointReady": false,
+      "cutoverPhase": "C3",
+      "requiredOstensiveForms": ["∞", "♂e = S = S ⟼ e", "b♀ = E = b ⟼ E", "b ⟼ e"]
+    },
+    "state": {
+      "modules": ["core/foundation_v2_state.py"],
+      "contracts": ["contracts/mts-foundation-v2-state-v0.7.json"],
+      "schemas": ["mts-foundation-v2-state/v0.7"]
+    },
+    "sourceFrontEnd": {
+      "modules": ["core/foundation_v2_source.py"],
+      "contracts": ["contracts/mts-foundation-v2-source-v0.7.json"],
+      "schemas": ["mts-foundation-v2-source/v0.7"]
+    },
+    "interpreterReplay": {
+      "modules": ["core/foundation_v2_interpreter.py"],
+      "contracts": [
+        "contracts/mts-foundation-v2-interpreter-replay-v0.7.json",
+        "contracts/mts-foundation-v2-colon-v0.7.json",
+        "contracts/mts-foundation-v2-equality-v0.7.json"
+      ],
+      "schemas": [
+        "mts-foundation-v2-interpreter-replay/v0.7",
+        "mts-foundation-v2-colon/v0.7",
+        "mts-foundation-v2-equality/v0.7"
+      ]
+    },
+    "run": {
+      "modules": ["core/foundation_v2_run.py"],
+      "contracts": ["contracts/mts-foundation-v2-run-v0.7.json"],
+      "schemas": ["mts-foundation-v2-run/v0.7"]
+    },
+    "proofAndIntegratedChecker": {
+      "modules": ["core/foundation_v2_proof.py", "core/foundation_v2_checker.py"],
+      "contracts": [
+        "contracts/mts-foundation-v2-proof-rule-v0.7.json",
+        "contracts/mts-foundation-v2-integrated-proof-v0.7.json"
+      ],
+      "schemas": [
+        "mts-foundation-v2-proof-rule/v0.7",
+        "mts-foundation-v2-integrated-proof/v0.7"
+      ]
+    },
+    "recursiveAnumPreservedDomain": {
+      "modules": ["core/anum_recursive_denotation.py"],
+      "contracts": ["contracts/anum-recursive-denotation-v0.2.json"],
+      "schemas": ["anum-recursive-denotation/v0.2"],
+      "historicalAcceptedContract": true,
+      "boundedPreservationOnly": true
+    },
+    "sequenceMaterialization": {
+      "modules": ["core/foundation_v2_materialization.py"],
+      "contracts": ["contracts/mts-anum-sequence-materialization-v0.7.json"],
+      "schemas": ["mts-anum-sequence-materialization/v0.7"]
+    },
+    "persistentL4": {
+      "modules": ["core/foundation_v2_persistent.py"],
+      "contracts": ["contracts/mts-foundation-v2-persistent-l4-v0.7.json"],
+      "schemas": ["mts-foundation-v2-persistent-l4/v0.7"]
+    },
+    "compatibilityClassification": {
+      "modules": [],
+      "contracts": ["contracts/mts-foundation-v2-compatibility-classification-v0.7.json"],
+      "schemas": ["mts-foundation-v2-compatibility-classification/v0.7"],
+      "decisionIssue": 269,
+      "mergedPr": 270
+    },
+    "ostensiveRegressionGuard": {
+      "modules": [],
+      "contracts": [],
+      "schemas": [],
+      "tests": ["tests/test_mts_ostensive_docs_contract.py"],
+      "decisionIssue": 267,
+      "mergedPr": 268,
+      "releaseVeto": true
+    }
+  },
+  "forbiddenReleaseInterpretations": {
+    "candidateEvidenceMeansAcceptedRelease": false,
+    "historicalReplayMeansSecondLiveRuntime": false,
+    "machineLinkCarrierReplacesOstensiveNotation": false,
+    "legacyContextFrameMayBackFoundationV2K": false,
+    "legacyPairInterningMayBackFoundationV2Materialization": false
+  },
+  "next": "complete the exact consumer matrix, then begin C2/C3 public-entry/root cutover only after #272 decision"
+}

--- a/tests/test_mts_foundation_v2_cutover_manifest.py
+++ b/tests/test_mts_foundation_v2_cutover_manifest.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "contracts" / "mts-foundation-v2-cutover-manifest-v0.7.json"
+MATRIX = ROOT / "contracts" / "mts-foundation-v2-consumer-matrix-v0.7.json"
+ALLOWED_ACTIONS = {
+    "MIGRATE_TO_FOUNDATION_V2",
+    "HISTORICAL_REPLAY_ONLY",
+    "DELETE_WITH_OWNER",
+    "NON_SEMANTIC_TOOLING",
+}
+EXPECTED_OWNER_KEYS = {
+    "exactOccurrenceSubstrate",
+    "rootBootstrapEvidence",
+    "state",
+    "sourceFrontEnd",
+    "interpreterReplay",
+    "run",
+    "proofAndIntegratedChecker",
+    "recursiveAnumPreservedDomain",
+    "sequenceMaterialization",
+    "persistentL4",
+    "compatibilityClassification",
+    "ostensiveRegressionGuard",
+}
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _module_name(path: str) -> str:
+    return path.removesuffix(".py").replace("/", ".")
+
+
+def core_imports(path: str) -> tuple[str, ...]:
+    source_path = ROOT / path
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=path)
+    result: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "core" or alias.name.startswith("core."):
+                    result.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level == 0:
+                if module == "core" or module.startswith("core."):
+                    result.add(module)
+            elif node.level == 1 and path.startswith("core/") and module:
+                result.add(f"core.{module}")
+
+    return tuple(sorted(result))
+
+
+def test_manifest_freezes_nonaccepting_release_candidate() -> None:
+    manifest = read(MANIFEST)
+    assert manifest["schema"] == "mts-foundation-v2-cutover-manifest/v0.7"
+    assert manifest["status"] == "gate-p-cutover-manifest"
+    assert manifest["accepted"] is False
+    assert manifest["issue"] == 272
+    assert manifest["parent"] == 271
+    assert manifest["umbrella"] == 237
+    assert manifest["baseMainCommit"] == "38488fdcbce999a54726f56ad01ac358d28a9e1a"
+    assert manifest["cutoverPerformed"] is False
+    assert manifest["foundationV2Accepted"] is False
+    assert manifest["downstreamRepinAllowed"] is False
+    assert set(manifest["owners"]) == EXPECTED_OWNER_KEYS
+
+
+def test_every_frozen_owner_path_and_contract_exists_with_exact_schema() -> None:
+    manifest = read(MANIFEST)
+    for name, owner in manifest["owners"].items():
+        for path in owner.get("modules", []):
+            assert (ROOT / path).is_file(), (name, path)
+        for path in owner.get("readerFacingOwners", []):
+            assert (ROOT / path).is_file(), (name, path)
+        for path in owner.get("tests", []):
+            assert (ROOT / path).is_file(), (name, path)
+
+        contracts = owner.get("contracts", [])
+        schemas = owner.get("schemas", [])
+        assert len(contracts) == len(schemas), name
+        for path, schema in zip(contracts, schemas, strict=True):
+            contract_path = ROOT / path
+            assert contract_path.is_file(), (name, path)
+            assert read(contract_path)["schema"] == schema, (name, path, schema)
+
+
+def test_manifest_keeps_root_bootstrap_honest_and_ostensive() -> None:
+    root = read(MANIFEST)["owners"]["rootBootstrapEvidence"]
+    assert root["liveProductionEntrypointReady"] is False
+    assert root["cutoverPhase"] == "C3"
+    assert root["requiredOstensiveForms"] == [
+        "∞",
+        "♂e = S = S ⟼ e",
+        "b♀ = E = b ⟼ E",
+        "b ⟼ e",
+    ]
+    assert "core/root_library.py" not in root["modules"]
+
+    guard = read(MANIFEST)["owners"]["ostensiveRegressionGuard"]
+    assert guard["decisionIssue"] == 267
+    assert guard["mergedPr"] == 268
+    assert guard["releaseVeto"] is True
+
+    compatibility = read(MANIFEST)["owners"]["compatibilityClassification"]
+    assert compatibility["decisionIssue"] == 269
+    assert compatibility["mergedPr"] == 270
+
+
+def test_consumer_matrix_is_total_and_has_no_unknown_action() -> None:
+    matrix = read(MATRIX)
+    assert matrix["schema"] == "mts-foundation-v2-consumer-matrix/v0.7"
+    assert matrix["status"] == "gate-p-cutover-consumer-audit"
+    assert matrix["accepted"] is False
+    assert matrix["issue"] == 272
+    assert matrix["parent"] == 271
+    assert set(matrix["allowedActions"]) == ALLOWED_ACTIONS
+    assert matrix["unknownAllowed"] is False
+    assert matrix["cutoverPerformed"] is False
+    assert matrix["downstreamRepinAllowed"] is False
+
+    paths: set[str] = set()
+    for row in matrix["rows"]:
+        assert row["path"] not in paths, row["path"]
+        paths.add(row["path"])
+        assert row["action"] in ALLOWED_ACTIONS, row["path"]
+        assert row["role"], row["path"]
+        assert row["replacementOwner"], row["path"]
+        assert row["precondition"], row["path"]
+        assert row["postCutover"], row["path"]
+        assert (ROOT / row["path"]).is_file(), row["path"]
+
+    required = {
+        "core/root_library.py",
+        "core/validate_root.py",
+        "core/proof_checker.py",
+        "core/mtc_opening_path.py",
+        "core/mtc_parser.py",
+        "core/mtc_ast.py",
+        "core/mtc_interpreter.py",
+        "core/mtc_definitions.py",
+        "core/reference_model.py",
+        "core/anum_memory.py",
+        "converters/l4_backend_driver.py",
+        "core/semantic_carrier.py",
+    }
+    assert paths == required
+
+
+def test_matrix_pins_actual_direct_core_imports() -> None:
+    matrix = read(MATRIX)
+    for row in matrix["rows"]:
+        expected = tuple(sorted(row["expectedCoreImports"]))
+        assert core_imports(row["path"]) == expected, row["path"]
+
+    pinned = matrix["verifiedHistoricalDependencyIsland"]
+    for path, expected in pinned.items():
+        assert core_imports(path) == tuple(sorted(expected)), path
+
+
+def test_foundation_v2_trusted_modules_do_not_import_historical_semantics() -> None:
+    matrix = read(MATRIX)
+    forbidden = set(matrix["forbiddenHistoricalImportsInTrustedFoundationV2"])
+
+    for path in matrix["trustedFoundationV2Modules"]:
+        imports = set(core_imports(path))
+        overlap = imports & forbidden
+        assert not overlap, (path, sorted(overlap))
+
+
+def test_nonsemantic_tooling_is_not_a_trusted_foundation_dependency() -> None:
+    matrix = read(MATRIX)
+    tooling_modules = {
+        _module_name(row["path"])
+        for row in matrix["rows"]
+        if row["action"] == "NON_SEMANTIC_TOOLING" and row["path"].startswith("core/")
+    }
+    assert tooling_modules
+    for path in matrix["trustedFoundationV2Modules"]:
+        assert not (set(core_imports(path)) & tooling_modules), path
+
+
+def test_delete_with_owner_rows_have_a_real_acceptance_precondition() -> None:
+    rows = [row for row in read(MATRIX)["rows"] if row["action"] == "DELETE_WITH_OWNER"]
+    assert {row["path"] for row in rows} == {"core/reference_model.py"}
+    for row in rows:
+        assert "accepted" in row["precondition"].lower(), row["path"]
+        assert "delete" in row["postCutover"].lower(), row["path"]
+
+
+def test_root_and_new_proof_roles_are_not_left_on_historical_live_authority() -> None:
+    by_path = {row["path"]: row for row in read(MATRIX)["rows"]}
+    assert by_path["core/root_library.py"]["action"] == "MIGRATE_TO_FOUNDATION_V2"
+    assert by_path["core/validate_root.py"]["action"] == "MIGRATE_TO_FOUNDATION_V2"
+    assert by_path["core/proof_checker.py"]["action"] == "HISTORICAL_REPLAY_ONLY"
+    assert by_path["core/proof_checker.py"]["replacementOwner"] == (
+        "core/foundation_v2_checker.py for new production proofs"
+    )
+
+
+def test_historical_l4_pair_interning_fact_is_still_real_until_c6_updates_matrix() -> None:
+    source = (ROOT / "core" / "anum_memory.py").read_text(encoding="utf-8")
+    assert "self._exact: dict[tuple[LinkRef, LinkRef], LinkRef]" in source
+    assert "def intern_link(" in source
+    assert "existing = self._exact.get((start, end))" in source
+    assert "return existing" in source
+
+    driver = (ROOT / "converters" / "l4_backend_driver.py").read_text(encoding="utf-8")
+    assert "from core.anum_memory import" in driver
+    assert "AnumMemory" in driver
+
+
+def test_manifest_does_not_authorize_cutover_or_acceptance_by_itself() -> None:
+    manifest = read(MANIFEST)
+    assert manifest["forbiddenReleaseInterpretations"] == {
+        "candidateEvidenceMeansAcceptedRelease": False,
+        "historicalReplayMeansSecondLiveRuntime": False,
+        "machineLinkCarrierReplacesOstensiveNotation": False,
+        "legacyContextFrameMayBackFoundationV2K": False,
+        "legacyPairInterningMayBackFoundationV2Materialization": False,
+    }
+    assert "C2/C3" in manifest["next"]


### PR DESCRIPTION
Closes #272 after green CI and explicit decision. Parent: #271, umbrella #237.

## C0 — frozen release-candidate owners

Adds:

```text
contracts/mts-foundation-v2-cutover-manifest-v0.7.json
```

The manifest pins the current `main` base `38488fd...` and names exact module/contract/schema owners for:
- exact-occurrence substrate;
- root/bootstrap evidence;
- K/D/G/T/I/A state;
- source front-end;
- relation/`:`/`=` replay;
- Run;
- proof rule + integrated checker;
- preserved recursive Anum domain;
- Anum sequence materialization;
- persistent exact-occurrence L4;
- compatibility classification #269/#270;
- ostensive regression guard #267/#268.

It explicitly records:

```text
accepted = false
cutoverPerformed = false
foundationV2Accepted = false
downstreamRepinAllowed = false
```

The root entry is intentionally honest: current five-link/ostensive root has executable candidate evidence and reader-facing owners, but **no live production entrypoint yet**. That work is owned by C3 rather than being silently delegated to historical `root_library.py`.

## C1 — exact consumer matrix

Adds:

```text
contracts/mts-foundation-v2-consumer-matrix-v0.7.json
```

Every audited surface has exactly one action:

```text
MIGRATE_TO_FOUNDATION_V2
HISTORICAL_REPLAY_ONLY
DELETE_WITH_OWNER
NON_SEMANTIC_TOOLING
```

Important current facts pinned in the matrix:
- `root_library.py` and `validate_root.py` still depend on the historical typed root stack and must migrate for the new live root role;
- `proof_checker.py` is explicitly historical v0.2-v0.4 replay; new production proof validity belongs to `foundation_v2_checker.py`;
- `mtc_parser.py` depends on both typed AST and historical `reference_model.py`;
- `mtc_opening_path.py` / `DefinitionEnvironment` remain historical replay only;
- `core/anum_memory.py` still implements pair interning through `_exact[(start,end)]` and `intern_link()`;
- `converters/l4_backend_driver.py` delegates directly to that historical `AnumMemory`;
- `semantic_carrier.py` is classified only as non-semantic structural tooling.

## Executable audit

`tests/test_mts_foundation_v2_cutover_manifest.py` parses the **actual Python AST imports** and verifies the matrix against current source instead of trusting prose.

It also proves all trusted Foundation-v2 modules have zero imports from:

```text
mtc_parser
mtc_ast
mtc_interpreter
mtc_definitions
mtc_opening_path
proof_checker
root_library
reference_model
anum_memory
```

So a future dependency regression will fail CI immediately.

The test additionally pins the current pair-interning fact until C6 intentionally updates the matrix.

## Scope

No semantic implementation changes, no migration and no deletion in this PR. This gate only freezes the candidate and makes the next C2/C3 cutover steps non-guessable.