### PR TITLE
Cutover C2/C3: add exact Foundation-v2 root and public entry surface

### DIFF
--- a/contracts/mts-foundation-v2-consumer-matrix-v0.7.json
+++ b/contracts/mts-foundation-v2-consumer-matrix-v0.7.json
@@ -2,9 +2,9 @@
   "schema": "mts-foundation-v2-consumer-matrix/v0.7",
   "status": "gate-p-cutover-consumer-audit",
   "accepted": false,
-  "issue": 272,
+  "issue": 274,
   "parent": 271,
-  "baseMainCommit": "38488fdcbce999a54726f56ad01ac358d28a9e1a",
+  "baseMainCommit": "884ce13d5528ac35d7e95c257711b9b4d7087e17",
   "allowedActions": [
     "MIGRATE_TO_FOUNDATION_V2",
     "HISTORICAL_REPLAY_ONLY",
@@ -15,21 +15,21 @@
   "rows": [
     {
       "path": "core/root_library.py",
-      "role": "historical ten-formula root loader currently used as a root-facing entry surface",
-      "action": "MIGRATE_TO_FOUNDATION_V2",
+      "role": "historical ten-formula root loader; no longer owner of the new live Foundation-v2 root",
+      "action": "HISTORICAL_REPLAY_ONLY",
       "expectedCoreImports": ["core.mtc_ast", "core.mtc_definitions", "core.mtc_parser"],
-      "replacementOwner": "C3 distinguished exact R/O/C/L/U bootstrap",
-      "precondition": "A live Foundation-v2 root/bootstrap entrypoint exists and no live consumer needs typed root AST identity.",
+      "replacementOwner": "core/foundation_v2_root.py",
+      "precondition": "The exact R/O/C/L/U production root entrypoint and its contract are green.",
       "postCutover": "Historical root loading may remain only as explicitly version-scoped replay tooling or be deleted if tag/Git replay is sufficient."
     },
     {
       "path": "core/validate_root.py",
-      "role": "historical typed ten-formula root validator",
-      "action": "MIGRATE_TO_FOUNDATION_V2",
+      "role": "historical typed ten-formula root validator; not the Foundation-v2 root validator",
+      "action": "HISTORICAL_REPLAY_ONLY",
       "expectedCoreImports": ["core.mtc_ast", "core.mtc_definitions", "core.root_library"],
-      "replacementOwner": "C3 Foundation-v2 bootstrap/conformance validator",
-      "precondition": "The five-link bootstrap and ostensive invariants have executable release-candidate validation.",
-      "postCutover": "Historical ten-formula validation must not be the new live root authority."
+      "replacementOwner": "core/foundation_v2_root.py::validate_root_kernel + Foundation-v2 root conformance",
+      "precondition": "The five-link bootstrap, arbitrary allocation-order and ostensive invariants have executable validation.",
+      "postCutover": "Historical ten-formula validation must not be a new live root authority."
     },
     {
       "path": "core/proof_checker.py",
@@ -132,6 +132,8 @@
   },
   "trustedFoundationV2Modules": [
     "core/exact_link_network.py",
+    "core/foundation_v2_root.py",
+    "core/foundation_v2.py",
     "core/foundation_v2_state.py",
     "core/foundation_v2_source.py",
     "core/foundation_v2_interpreter.py",
@@ -149,6 +151,7 @@
     "core.mtc_opening_path",
     "core.proof_checker",
     "core.root_library",
+    "core.validate_root",
     "core.reference_model",
     "core.anum_memory"
   ],

--- a/contracts/mts-foundation-v2-cutover-manifest-v0.7.json
+++ b/contracts/mts-foundation-v2-cutover-manifest-v0.7.json
@@ -2,26 +2,40 @@
   "schema": "mts-foundation-v2-cutover-manifest/v0.7",
   "status": "gate-p-cutover-manifest",
   "accepted": false,
-  "issue": 272,
+  "issue": 274,
   "parent": 271,
   "umbrella": 237,
-  "baseMainCommit": "38488fdcbce999a54726f56ad01ac358d28a9e1a",
+  "baseMainCommit": "884ce13d5528ac35d7e95c257711b9b4d7087e17",
   "cutoverPerformed": false,
   "foundationV2Accepted": false,
   "downstreamRepinAllowed": false,
-  "purpose": "Freeze the exact current Foundation-v2 release-candidate owners before migrating any historical live consumer or deleting any superseded semantic path.",
+  "purpose": "Freeze the exact current Foundation-v2 release-candidate owners while cutover migrates historical live consumers without introducing a second semantic runtime.",
   "owners": {
+    "publicEntrySurface": {
+      "modules": ["core/foundation_v2.py"],
+      "contracts": ["contracts/mts-foundation-v2-root-v0.7.json"],
+      "schemas": ["mts-foundation-v2-root/v0.7"],
+      "compatibilityMode": false,
+      "legacyDispatcher": false
+    },
     "exactOccurrenceSubstrate": {
       "modules": ["core/exact_link_network.py"],
       "contracts": ["contracts/mts-exact-occurrence-link-network-v0.7.json"],
       "schemas": ["mts-exact-occurrence-link-network/v0.7"]
     },
     "rootBootstrapEvidence": {
-      "modules": [],
-      "contracts": ["contracts/mts-semantic-root-kernel-challenge-v0.7.json"],
-      "schemas": ["mts-semantic-root-kernel-challenge/v0.7"],
+      "modules": ["core/foundation_v2_root.py"],
+      "contracts": [
+        "contracts/mts-foundation-v2-root-v0.7.json",
+        "contracts/mts-semantic-root-kernel-challenge-v0.7.json"
+      ],
+      "schemas": [
+        "mts-foundation-v2-root/v0.7",
+        "mts-semantic-root-kernel-challenge/v0.7"
+      ],
       "readerFacingOwners": ["README.md", "docs/theory/Основания МТС.md", "docs/theory/Система аксиом МТС.md"],
-      "liveProductionEntrypointReady": false,
+      "liveProductionEntrypointReady": true,
+      "implementedByIssue": 274,
       "cutoverPhase": "C3",
       "requiredOstensiveForms": ["∞", "♂e = S = S ⟼ e", "b♀ = E = b ⟼ E", "b ⟼ e"]
     },
@@ -105,5 +119,5 @@
     "legacyContextFrameMayBackFoundationV2K": false,
     "legacyPairInterningMayBackFoundationV2Materialization": false
   },
-  "next": "complete the exact consumer matrix, then begin C2/C3 public-entry/root cutover only after #272 decision"
+  "next": "continue C4/C5/C6 consumer isolation and migration; no deletion, acceptance or downstream repin until the later atomic cutover/release gates"
 }

--- a/contracts/mts-foundation-v2-root-v0.7.json
+++ b/contracts/mts-foundation-v2-root-v0.7.json
@@ -1,0 +1,72 @@
+{
+  "schema": "mts-foundation-v2-root/v0.7",
+  "status": "gate-p-production-root-candidate",
+  "accepted": false,
+  "issue": 274,
+  "parent": 271,
+  "umbrella": 237,
+  "dependsOn": [
+    "mts-exact-occurrence-link-network/v0.7",
+    "mts-semantic-root-kernel-challenge/v0.7"
+  ],
+  "ostensivePrimary": {
+    "root": "∞",
+    "startSelfClosed": "♂e = S = S ⟼ e",
+    "endSelfClosed": "b♀ = E = b ⟼ E",
+    "complete": "b ⟼ e"
+  },
+  "kernel": {
+    "R": "R = R ⟼ R",
+    "O": "O = O ⟼ R",
+    "C": "C = R ⟼ C",
+    "L": "L = O ⟼ C",
+    "U": "U = C ⟼ O",
+    "exactOccurrenceCount": 5,
+    "networkRoot": "exact R",
+    "pairInterning": false,
+    "semanticTagsOnLink": false
+  },
+  "rootVocabulary": {
+    "∞": "exact R",
+    "[": "exact O",
+    "]": "exact C",
+    "1": "exact L",
+    "0": "exact U",
+    "glyphSpellingRecognizesKernelRole": false,
+    "mappingAppliesAfterExactKernelConstruction": true,
+    "rootAbitsIdenticalToFormalMaleFemaleGlyphOccurrences": false
+  },
+  "identity": {
+    "rootRecognizedBySelfClosedShapeSearch": false,
+    "rootRecognizedByGraphIsomorphism": false,
+    "suppliedExactRefsAndTopologyRequired": true,
+    "anotherSelfClosedOccurrenceIsRoot": false,
+    "samePoleDuplicateIsSameOccurrence": false,
+    "freshBuildCreatesFreshRuntimeIdentityScope": true
+  },
+  "implementation": {
+    "rootModule": "core/foundation_v2_root.py",
+    "publicEntrySurface": "core/foundation_v2.py",
+    "substrate": "core/exact_link_network.py",
+    "historicalRootLibraryDependency": false,
+    "historicalRootValidatorDependency": false,
+    "legacyParserDependency": false,
+    "legacyAstDependency": false,
+    "referenceModelDependency": false,
+    "contextFrameDependency": false,
+    "compatibilityMode": false
+  },
+  "historicalBoundary": {
+    "tenFormulaRootProgramModified": false,
+    "historicalAcceptedContractsModified": false,
+    "rootLibraryDeleted": false,
+    "validateRootDeleted": false,
+    "historicalReplayStillSeparate": true
+  },
+  "releaseBoundary": {
+    "cutoverComplete": false,
+    "foundationV2Accepted": false,
+    "aproverRepinAllowed": false,
+    "next": "migrate/isolate remaining source/interpreter/proof/L4 consumers, then atomic deletion and integrated release conformance"
+  }
+}

--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -1,0 +1,106 @@
+"""One public Python entry surface for the Foundation-v2 production candidate.
+
+This module is deliberately a thin facade over the already-tested Foundation-v2
+implementation modules.  It adds no semantic dispatch and no compatibility mode.
+In particular there is no legacy parser, AST, ContextFrame or pair-interning path
+behind this API.
+
+The facade is implementation API only; Python classes/functions are not new MTS
+ontological types.
+"""
+from __future__ import annotations
+
+from .exact_link_network import Link, LinkNetwork, LinkNetworkBuilder, OccurrenceRef
+from .foundation_v2_checker import (
+    IntegratedProofEvidence,
+    replay_integrated_proof,
+)
+from .foundation_v2_interpreter import (
+    ColonEffectEvidence,
+    EqualityEvaluationEvidence,
+    RelationStepEvidence,
+    replay_colon_effect,
+    replay_equality_evaluation,
+    replay_relation_step,
+)
+from .foundation_v2_materialization import (
+    SequenceAtom,
+    SequenceDescription,
+    SequenceGroup,
+    SequenceMaterialization,
+    find_links,
+    materialize_sequence,
+    replay_sequence_materialization,
+)
+from .foundation_v2_persistent import (
+    JsonExactLinkStore,
+    PersistentOccurrenceId,
+    PersistentSequenceAtom,
+    PersistentSequenceDescription,
+    PersistentSequenceGroup,
+    PersistentSequenceMaterialization,
+    materialize_persistent_sequence,
+    replay_persistent_sequence_materialization,
+)
+from .foundation_v2_proof import (
+    DecomposeEqualityEvidence,
+    replay_decompose_equal_relations,
+)
+from .foundation_v2_root import (
+    FoundationRootKernel,
+    FoundationRootRefs,
+    build_root_kernel,
+    root_role_refs,
+    root_vocabulary,
+    validate_root_kernel,
+)
+from .foundation_v2_run import RunEvidence, replay_run
+from .foundation_v2_source import (
+    SourceFrontEndBuilder,
+    SourceFrontEndEvidence,
+    replay_source_front_end,
+)
+
+
+__all__ = [
+    "ColonEffectEvidence",
+    "DecomposeEqualityEvidence",
+    "EqualityEvaluationEvidence",
+    "FoundationRootKernel",
+    "FoundationRootRefs",
+    "IntegratedProofEvidence",
+    "JsonExactLinkStore",
+    "Link",
+    "LinkNetwork",
+    "LinkNetworkBuilder",
+    "OccurrenceRef",
+    "PersistentOccurrenceId",
+    "PersistentSequenceAtom",
+    "PersistentSequenceDescription",
+    "PersistentSequenceGroup",
+    "PersistentSequenceMaterialization",
+    "RelationStepEvidence",
+    "RunEvidence",
+    "SequenceAtom",
+    "SequenceDescription",
+    "SequenceGroup",
+    "SequenceMaterialization",
+    "SourceFrontEndBuilder",
+    "SourceFrontEndEvidence",
+    "build_root_kernel",
+    "find_links",
+    "materialize_persistent_sequence",
+    "materialize_sequence",
+    "replay_colon_effect",
+    "replay_decompose_equal_relations",
+    "replay_equality_evaluation",
+    "replay_integrated_proof",
+    "replay_persistent_sequence_materialization",
+    "replay_relation_step",
+    "replay_run",
+    "replay_sequence_materialization",
+    "replay_source_front_end",
+    "root_role_refs",
+    "root_vocabulary",
+    "validate_root_kernel",
+]

--- a/core/foundation_v2_root.py
+++ b/core/foundation_v2_root.py
@@ -1,7 +1,7 @@
 """Foundation-v2 production-facing exact root/bootstrap.
 
 This module constructs the distinguished five-link root directly in the exact-
-occurrence substrate.  It deliberately does *not* parse the historical ten-
+occurrence substrate. It deliberately does *not* parse the historical ten-
 formula root program and does not use token, AST, ContextFrame, graph-isomorphism
 or pair-interning identity.
 
@@ -14,7 +14,7 @@ The ontological/ostensive reading precedes this implementation carrier::
     U   == C ⟼ O
 
 ``[ ] 1 0`` are the root Anum/bootstrap vocabulary mapped to already-distinguished
-exact occurrences.  The glyph mapping does not recognize or create semantic
+exact occurrences. The glyph mapping does not recognize or create semantic
 roles; topology and the explicitly supplied refs exist first.
 """
 from __future__ import annotations
@@ -23,7 +23,12 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Mapping
 
-from .exact_link_network import LinkNetwork, LinkNetworkBuilder, LinkNetworkError, OccurrenceRef
+from .exact_link_network import (
+    LinkNetwork,
+    LinkNetworkBuilder,
+    LinkNetworkError,
+    OccurrenceRef,
+)
 
 
 class FoundationRootError(ValueError):
@@ -34,14 +39,14 @@ class FoundationRootError(ValueError):
 class FoundationRootRefs:
     """Host handles for the five distinguished exact bootstrap occurrences.
 
-    Field names are API handles, not semantic tags stored on links.  The semantic
+    Field names are API handles, not semantic tags stored on links. The semantic
     structure is verified from the exact ordered poles in :class:`LinkNetwork`.
     """
 
-    root: OccurrenceRef      # R = ∞
-    opening: OccurrenceRef   # O = O ⟼ R  == ♂∞
-    closing: OccurrenceRef   # C = R ⟼ C  == ∞♀
-    linked: OccurrenceRef    # L = O ⟼ C
+    root: OccurrenceRef  # R = ∞
+    opening: OccurrenceRef  # O = O ⟼ R  == ♂∞
+    closing: OccurrenceRef  # C = R ⟼ C  == ∞♀
+    linked: OccurrenceRef  # L = O ⟼ C
     unlinked: OccurrenceRef  # U = C ⟼ O
 
     def as_tuple(self) -> tuple[OccurrenceRef, ...]:
@@ -59,7 +64,7 @@ class FoundationRootKernel:
 def build_root_kernel() -> FoundationRootKernel:
     """Construct one fresh exact ``R/O/C/L/U`` bootstrap network.
 
-    Every call creates a fresh runtime identity scope.  Equal topology from two
+    Every call creates a fresh runtime identity scope. Equal topology from two
     calls therefore does not imply cross-network exact occurrence identity.
     """
 
@@ -91,11 +96,11 @@ def build_root_kernel() -> FoundationRootKernel:
 
 
 def validate_root_kernel(kernel: FoundationRootKernel) -> None:
-    """Validate the supplied exact refs without shape-searching for a root.
+    """Validate supplied exact refs without shape-searching for a root.
 
-    Validation starts from the explicitly distinguished refs.  It does not scan a
-    larger graph for "something self-closed" and call that root, and it does not
-    infer identity by isomorphism.
+    Validation starts from explicitly distinguished refs. It does not scan a
+    graph for "something self-closed" and call that root, does not infer identity
+    by isomorphism, and does not depend on runtime slot/allocation order.
     """
 
     if not isinstance(kernel, FoundationRootKernel):
@@ -103,15 +108,12 @@ def validate_root_kernel(kernel: FoundationRootKernel) -> None:
 
     network = kernel.network
     refs = kernel.refs
-    ordered = refs.as_tuple()
-    if len(set(ordered)) != 5:
+    if len(set(refs.as_tuple())) != 5:
         raise FoundationRootError("root bootstrap refs must be five distinct occurrences")
     if len(network.refs) != 5:
         raise FoundationRootError("root bootstrap network must contain exactly five occurrences")
     if network.root is not refs.root:
         raise FoundationRootError("distinguished network root is not exact R")
-    if tuple(network.refs) != ordered:
-        raise FoundationRootError("bootstrap occurrence order differs from R/O/C/L/U allocation")
 
     expected = (
         (refs.root, refs.root, refs.root),
@@ -124,15 +126,19 @@ def validate_root_kernel(kernel: FoundationRootKernel) -> None:
         for ref, start, end in expected:
             actual = network.link(ref)
             if actual.start is not start or actual.end is not end:
-                raise FoundationRootError("exact root/bootstrap topology does not match R/O/C/L/U")
+                raise FoundationRootError(
+                    "exact root/bootstrap topology does not match R/O/C/L/U"
+                )
     except LinkNetworkError as exc:
-        raise FoundationRootError("root/bootstrap contains a foreign or invalid exact ref") from exc
+        raise FoundationRootError(
+            "root/bootstrap contains a foreign or invalid exact ref"
+        ) from exc
 
 
 def root_vocabulary(kernel: FoundationRootKernel) -> Mapping[str, OccurrenceRef]:
-    """Return the explicit root protocol vocabulary over already-built exact refs.
+    """Return explicit root protocol vocabulary over already-built exact refs.
 
-    The returned glyphs are transport/source vocabulary.  They are not consulted
+    The returned glyphs are transport/source vocabulary. They are not consulted
     by :func:`validate_root_kernel`, so spelling cannot manufacture R/O/C/L/U.
     """
 

--- a/core/foundation_v2_root.py
+++ b/core/foundation_v2_root.py
@@ -1,0 +1,165 @@
+"""Foundation-v2 production-facing exact root/bootstrap.
+
+This module constructs the distinguished five-link root directly in the exact-
+occurrence substrate.  It deliberately does *not* parse the historical ten-
+formula root program and does not use token, AST, ContextFrame, graph-isomorphism
+or pair-interning identity.
+
+The ontological/ostensive reading precedes this implementation carrier::
+
+    ∞
+    ♂∞  == O = O ⟼ R
+    ∞♀  == C = R ⟼ C
+    L   == O ⟼ C
+    U   == C ⟼ O
+
+``[ ] 1 0`` are the root Anum/bootstrap vocabulary mapped to already-distinguished
+exact occurrences.  The glyph mapping does not recognize or create semantic
+roles; topology and the explicitly supplied refs exist first.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+from .exact_link_network import LinkNetwork, LinkNetworkBuilder, LinkNetworkError, OccurrenceRef
+
+
+class FoundationRootError(ValueError):
+    """The supplied five exact refs do not form the Foundation-v2 root kernel."""
+
+
+@dataclass(frozen=True)
+class FoundationRootRefs:
+    """Host handles for the five distinguished exact bootstrap occurrences.
+
+    Field names are API handles, not semantic tags stored on links.  The semantic
+    structure is verified from the exact ordered poles in :class:`LinkNetwork`.
+    """
+
+    root: OccurrenceRef      # R = ∞
+    opening: OccurrenceRef   # O = O ⟼ R  == ♂∞
+    closing: OccurrenceRef   # C = R ⟼ C  == ∞♀
+    linked: OccurrenceRef    # L = O ⟼ C
+    unlinked: OccurrenceRef  # U = C ⟼ O
+
+    def as_tuple(self) -> tuple[OccurrenceRef, ...]:
+        return (self.root, self.opening, self.closing, self.linked, self.unlinked)
+
+
+@dataclass(frozen=True)
+class FoundationRootKernel:
+    """One exact five-occurrence bootstrap network and its distinguished refs."""
+
+    network: LinkNetwork
+    refs: FoundationRootRefs
+
+
+def build_root_kernel() -> FoundationRootKernel:
+    """Construct one fresh exact ``R/O/C/L/U`` bootstrap network.
+
+    Every call creates a fresh runtime identity scope.  Equal topology from two
+    calls therefore does not imply cross-network exact occurrence identity.
+    """
+
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    opening = builder.reserve()
+    closing = builder.reserve()
+    linked = builder.reserve()
+    unlinked = builder.reserve()
+
+    builder.define(root, root, root)
+    builder.define(opening, opening, root)
+    builder.define(closing, root, closing)
+    builder.define(linked, opening, closing)
+    builder.define(unlinked, closing, opening)
+
+    kernel = FoundationRootKernel(
+        network=builder.freeze(root),
+        refs=FoundationRootRefs(
+            root=root,
+            opening=opening,
+            closing=closing,
+            linked=linked,
+            unlinked=unlinked,
+        ),
+    )
+    validate_root_kernel(kernel)
+    return kernel
+
+
+def validate_root_kernel(kernel: FoundationRootKernel) -> None:
+    """Validate the supplied exact refs without shape-searching for a root.
+
+    Validation starts from the explicitly distinguished refs.  It does not scan a
+    larger graph for "something self-closed" and call that root, and it does not
+    infer identity by isomorphism.
+    """
+
+    if not isinstance(kernel, FoundationRootKernel):
+        raise FoundationRootError("expected FoundationRootKernel")
+
+    network = kernel.network
+    refs = kernel.refs
+    ordered = refs.as_tuple()
+    if len(set(ordered)) != 5:
+        raise FoundationRootError("root bootstrap refs must be five distinct occurrences")
+    if len(network.refs) != 5:
+        raise FoundationRootError("root bootstrap network must contain exactly five occurrences")
+    if network.root is not refs.root:
+        raise FoundationRootError("distinguished network root is not exact R")
+    if tuple(network.refs) != ordered:
+        raise FoundationRootError("bootstrap occurrence order differs from R/O/C/L/U allocation")
+
+    expected = (
+        (refs.root, refs.root, refs.root),
+        (refs.opening, refs.opening, refs.root),
+        (refs.closing, refs.root, refs.closing),
+        (refs.linked, refs.opening, refs.closing),
+        (refs.unlinked, refs.closing, refs.opening),
+    )
+    try:
+        for ref, start, end in expected:
+            actual = network.link(ref)
+            if actual.start is not start or actual.end is not end:
+                raise FoundationRootError("exact root/bootstrap topology does not match R/O/C/L/U")
+    except LinkNetworkError as exc:
+        raise FoundationRootError("root/bootstrap contains a foreign or invalid exact ref") from exc
+
+
+def root_vocabulary(kernel: FoundationRootKernel) -> Mapping[str, OccurrenceRef]:
+    """Return the explicit root protocol vocabulary over already-built exact refs.
+
+    The returned glyphs are transport/source vocabulary.  They are not consulted
+    by :func:`validate_root_kernel`, so spelling cannot manufacture R/O/C/L/U.
+    """
+
+    validate_root_kernel(kernel)
+    refs = kernel.refs
+    return MappingProxyType(
+        {
+            "∞": refs.root,
+            "[": refs.opening,
+            "]": refs.closing,
+            "1": refs.linked,
+            "0": refs.unlinked,
+        }
+    )
+
+
+def root_role_refs(kernel: FoundationRootKernel) -> Mapping[str, OccurrenceRef]:
+    """Expose conventional R/O/C/L/U labels as non-semantic API/debug handles."""
+
+    validate_root_kernel(kernel)
+    refs = kernel.refs
+    return MappingProxyType(
+        {
+            "R": refs.root,
+            "O": refs.opening,
+            "C": refs.closing,
+            "L": refs.linked,
+            "U": refs.unlinked,
+        }
+    )

--- a/tests/test_mts_foundation_v2_cutover_manifest.py
+++ b/tests/test_mts_foundation_v2_cutover_manifest.py
@@ -15,6 +15,7 @@ ALLOWED_ACTIONS = {
     "NON_SEMANTIC_TOOLING",
 }
 EXPECTED_OWNER_KEYS = {
+    "publicEntrySurface",
     "exactOccurrenceSubstrate",
     "rootBootstrapEvidence",
     "state",
@@ -64,10 +65,10 @@ def test_manifest_freezes_nonaccepting_release_candidate() -> None:
     assert manifest["schema"] == "mts-foundation-v2-cutover-manifest/v0.7"
     assert manifest["status"] == "gate-p-cutover-manifest"
     assert manifest["accepted"] is False
-    assert manifest["issue"] == 272
+    assert manifest["issue"] == 274
     assert manifest["parent"] == 271
     assert manifest["umbrella"] == 237
-    assert manifest["baseMainCommit"] == "38488fdcbce999a54726f56ad01ac358d28a9e1a"
+    assert manifest["baseMainCommit"] == "884ce13d5528ac35d7e95c257711b9b4d7087e17"
     assert manifest["cutoverPerformed"] is False
     assert manifest["foundationV2Accepted"] is False
     assert manifest["downstreamRepinAllowed"] is False
@@ -93,10 +94,13 @@ def test_every_frozen_owner_path_and_contract_exists_with_exact_schema() -> None
             assert read(contract_path)["schema"] == schema, (name, path, schema)
 
 
-def test_manifest_keeps_root_bootstrap_honest_and_ostensive() -> None:
-    root = read(MANIFEST)["owners"]["rootBootstrapEvidence"]
-    assert root["liveProductionEntrypointReady"] is False
+def test_manifest_promotes_exact_root_without_legacy_dispatch() -> None:
+    manifest = read(MANIFEST)
+    root = manifest["owners"]["rootBootstrapEvidence"]
+    assert root["liveProductionEntrypointReady"] is True
+    assert root["implementedByIssue"] == 274
     assert root["cutoverPhase"] == "C3"
+    assert root["modules"] == ["core/foundation_v2_root.py"]
     assert root["requiredOstensiveForms"] == [
         "∞",
         "♂e = S = S ⟼ e",
@@ -104,13 +108,20 @@ def test_manifest_keeps_root_bootstrap_honest_and_ostensive() -> None:
         "b ⟼ e",
     ]
     assert "core/root_library.py" not in root["modules"]
+    assert "core/validate_root.py" not in root["modules"]
 
-    guard = read(MANIFEST)["owners"]["ostensiveRegressionGuard"]
+    public = manifest["owners"]["publicEntrySurface"]
+    assert public["modules"] == ["core/foundation_v2.py"]
+    assert public["contracts"] == ["contracts/mts-foundation-v2-root-v0.7.json"]
+    assert public["compatibilityMode"] is False
+    assert public["legacyDispatcher"] is False
+
+    guard = manifest["owners"]["ostensiveRegressionGuard"]
     assert guard["decisionIssue"] == 267
     assert guard["mergedPr"] == 268
     assert guard["releaseVeto"] is True
 
-    compatibility = read(MANIFEST)["owners"]["compatibilityClassification"]
+    compatibility = manifest["owners"]["compatibilityClassification"]
     assert compatibility["decisionIssue"] == 269
     assert compatibility["mergedPr"] == 270
 
@@ -120,8 +131,9 @@ def test_consumer_matrix_is_total_and_has_no_unknown_action() -> None:
     assert matrix["schema"] == "mts-foundation-v2-consumer-matrix/v0.7"
     assert matrix["status"] == "gate-p-cutover-consumer-audit"
     assert matrix["accepted"] is False
-    assert matrix["issue"] == 272
+    assert matrix["issue"] == 274
     assert matrix["parent"] == 271
+    assert matrix["baseMainCommit"] == "884ce13d5528ac35d7e95c257711b9b4d7087e17"
     assert set(matrix["allowedActions"]) == ALLOWED_ACTIONS
     assert matrix["unknownAllowed"] is False
     assert matrix["cutoverPerformed"] is False
@@ -170,6 +182,8 @@ def test_foundation_v2_trusted_modules_do_not_import_historical_semantics() -> N
     matrix = read(MATRIX)
     forbidden = set(matrix["forbiddenHistoricalImportsInTrustedFoundationV2"])
 
+    assert "core/foundation_v2_root.py" in matrix["trustedFoundationV2Modules"]
+    assert "core/foundation_v2.py" in matrix["trustedFoundationV2Modules"]
     for path in matrix["trustedFoundationV2Modules"]:
         imports = set(core_imports(path))
         overlap = imports & forbidden
@@ -196,12 +210,21 @@ def test_delete_with_owner_rows_have_a_real_acceptance_precondition() -> None:
         assert "delete" in row["postCutover"].lower(), row["path"]
 
 
-def test_root_and_new_proof_roles_are_not_left_on_historical_live_authority() -> None:
+def test_historical_root_and_proof_are_no_longer_new_live_authorities() -> None:
     by_path = {row["path"]: row for row in read(MATRIX)["rows"]}
-    assert by_path["core/root_library.py"]["action"] == "MIGRATE_TO_FOUNDATION_V2"
-    assert by_path["core/validate_root.py"]["action"] == "MIGRATE_TO_FOUNDATION_V2"
-    assert by_path["core/proof_checker.py"]["action"] == "HISTORICAL_REPLAY_ONLY"
-    assert by_path["core/proof_checker.py"]["replacementOwner"] == (
+
+    root = by_path["core/root_library.py"]
+    validator = by_path["core/validate_root.py"]
+    proof = by_path["core/proof_checker.py"]
+
+    assert root["action"] == "HISTORICAL_REPLAY_ONLY"
+    assert root["replacementOwner"] == "core/foundation_v2_root.py"
+    assert validator["action"] == "HISTORICAL_REPLAY_ONLY"
+    assert validator["replacementOwner"].startswith(
+        "core/foundation_v2_root.py::validate_root_kernel"
+    )
+    assert proof["action"] == "HISTORICAL_REPLAY_ONLY"
+    assert proof["replacementOwner"] == (
         "core/foundation_v2_checker.py for new production proofs"
     )
 
@@ -227,4 +250,4 @@ def test_manifest_does_not_authorize_cutover_or_acceptance_by_itself() -> None:
         "legacyContextFrameMayBackFoundationV2K": False,
         "legacyPairInterningMayBackFoundationV2Materialization": False,
     }
-    assert "C2/C3" in manifest["next"]
+    assert "C4/C5/C6" in manifest["next"]

--- a/tests/test_mts_foundation_v2_root.py
+++ b/tests/test_mts_foundation_v2_root.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2 import build_root_kernel as public_build_root_kernel
+from core.foundation_v2_root import (
+    FoundationRootKernel,
+    FoundationRootRefs,
+    build_root_kernel,
+    root_role_refs,
+    root_vocabulary,
+    validate_root_kernel,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts" / "mts-foundation-v2-root-v0.7.json"
+ROOT_FIXTURE = ROOT / "tests" / "mtc_formulas.mtc"
+ROOT_FORMULAS_SHA256 = "1ccfb6fa0ae3c744dffcdefefcf2d5d96108573f4b04fdd8ac45a2e15a98ee3a"
+OLD_MODULE_NAMES = {
+    "core.mtc_parser",
+    "core.mtc_ast",
+    "core.mtc_interpreter",
+    "core.mtc_definitions",
+    "core.mtc_opening_path",
+    "core.proof_checker",
+    "core.root_library",
+    "core.validate_root",
+    "core.reference_model",
+    "core.anum_memory",
+}
+
+
+def read_contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def core_imports(path: Path) -> set[str]:
+    rel = path.relative_to(ROOT).as_posix()
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "core" or alias.name.startswith("core."):
+                    imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level == 0 and (module == "core" or module.startswith("core.")):
+                imports.add(module)
+            elif node.level == 1 and rel.startswith("core/") and module:
+                imports.add(f"core.{module}")
+    return imports
+
+
+def root_formula_text() -> str:
+    return "\n".join(
+        line.strip()
+        for line in ROOT_FIXTURE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ) + "\n"
+
+
+def test_contract_is_candidate_not_release_permission() -> None:
+    contract = read_contract()
+    assert contract["schema"] == "mts-foundation-v2-root/v0.7"
+    assert contract["status"] == "gate-p-production-root-candidate"
+    assert contract["accepted"] is False
+    assert contract["issue"] == 274
+    assert contract["parent"] == 271
+    assert contract["umbrella"] == 237
+    assert contract["releaseBoundary"]["cutoverComplete"] is False
+    assert contract["releaseBoundary"]["foundationV2Accepted"] is False
+    assert contract["releaseBoundary"]["aproverRepinAllowed"] is False
+
+
+def test_exact_five_link_root_topology() -> None:
+    kernel = build_root_kernel()
+    network = kernel.network
+    refs = kernel.refs
+
+    assert len(network.refs) == 5
+    assert len(set(refs.as_tuple())) == 5
+    assert network.root is refs.root
+
+    root = network.link(refs.root)
+    opening = network.link(refs.opening)
+    closing = network.link(refs.closing)
+    linked = network.link(refs.linked)
+    unlinked = network.link(refs.unlinked)
+
+    assert (root.start, root.end) == (refs.root, refs.root)
+    assert (opening.start, opening.end) == (refs.opening, refs.root)
+    assert (closing.start, closing.end) == (refs.root, refs.closing)
+    assert (linked.start, linked.end) == (refs.opening, refs.closing)
+    assert (unlinked.start, unlinked.end) == (refs.closing, refs.opening)
+    validate_root_kernel(kernel)
+
+
+def test_root_vocabulary_maps_only_root_abits_after_kernel_exists() -> None:
+    kernel = build_root_kernel()
+    refs = kernel.refs
+    vocabulary = root_vocabulary(kernel)
+
+    assert dict(vocabulary) == {
+        "∞": refs.root,
+        "[": refs.opening,
+        "]": refs.closing,
+        "1": refs.linked,
+        "0": refs.unlinked,
+    }
+    assert "♂" not in vocabulary
+    assert "♀" not in vocabulary
+    with pytest.raises(TypeError):
+        vocabulary["∞"] = refs.opening  # type: ignore[index]
+
+    roles = root_role_refs(kernel)
+    assert dict(roles) == {
+        "R": refs.root,
+        "O": refs.opening,
+        "C": refs.closing,
+        "L": refs.linked,
+        "U": refs.unlinked,
+    }
+
+
+def test_validation_is_independent_of_allocation_slot_order() -> None:
+    builder = LinkNetworkBuilder()
+    unlinked = builder.reserve()  # slot 0
+    closing = builder.reserve()   # slot 1
+    root = builder.reserve()      # slot 2
+    linked = builder.reserve()    # slot 3
+    opening = builder.reserve()   # slot 4
+
+    builder.define(root, root, root)
+    builder.define(opening, opening, root)
+    builder.define(closing, root, closing)
+    builder.define(linked, opening, closing)
+    builder.define(unlinked, closing, opening)
+
+    kernel = FoundationRootKernel(
+        network=builder.freeze(root),
+        refs=FoundationRootRefs(
+            root=root,
+            opening=opening,
+            closing=closing,
+            linked=linked,
+            unlinked=unlinked,
+        ),
+    )
+    assert kernel.refs.root.slot == 2
+    assert kernel.refs.opening.slot == 4
+    validate_root_kernel(kernel)
+    assert root_vocabulary(kernel)["∞"] is root
+    assert root_role_refs(kernel)["O"] is opening
+
+
+def test_equal_topology_in_two_builds_does_not_create_cross_network_identity() -> None:
+    first = build_root_kernel()
+    second = build_root_kernel()
+
+    assert first.network.snapshot().links == second.network.snapshot().links
+    assert first.refs.root != second.refs.root
+    assert first.refs.opening != second.refs.opening
+    assert first.refs.linked != second.refs.linked
+
+
+def test_another_self_closed_occurrence_is_not_root() -> None:
+    kernel = build_root_kernel()
+    evolution = kernel.network.evolve()
+    other = evolution.reserve()
+    evolution.define(other, other, other)
+    after = evolution.freeze()
+
+    assert after.root is kernel.refs.root
+    assert other is not after.root
+    assert after.link(other).start is other
+    assert after.link(other).end is other
+
+
+def test_duplicate_same_pole_occurrence_remains_distinct() -> None:
+    kernel = build_root_kernel()
+    evolution = kernel.network.evolve()
+    duplicate = evolution.reserve()
+    evolution.define(duplicate, kernel.refs.opening, kernel.refs.closing)
+    after = evolution.freeze()
+
+    assert duplicate is not kernel.refs.linked
+    assert after.link(duplicate) == after.link(kernel.refs.linked)
+
+
+def test_public_facade_uses_the_same_root_builder() -> None:
+    kernel = public_build_root_kernel()
+    validate_root_kernel(kernel)
+    assert root_vocabulary(kernel)["∞"] is kernel.network.root
+
+
+def test_root_and_public_modules_have_no_historical_semantic_imports() -> None:
+    for name in ("foundation_v2_root.py", "foundation_v2.py"):
+        imports = core_imports(ROOT / "core" / name)
+        assert not (imports & OLD_MODULE_NAMES), (name, sorted(imports & OLD_MODULE_NAMES))
+
+    root_source = (ROOT / "core" / "foundation_v2_root.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "parse_formula",
+        "ContextFrame",
+        "DefinitionEnvironment",
+        "TokenKind",
+        "carrier_isomorphic",
+        "intern_link",
+    ):
+        # Mentions in the module-level explanatory veto are acceptable; executable
+        # imports/calls are covered structurally above. Ensure no function call form.
+        assert f"{forbidden}(" not in root_source
+
+
+def test_contract_preserves_ostensive_orientation_and_vocabulary_distinction() -> None:
+    contract = read_contract()
+    assert contract["ostensivePrimary"] == {
+        "root": "∞",
+        "startSelfClosed": "♂e = S = S ⟼ e",
+        "endSelfClosed": "b♀ = E = b ⟼ E",
+        "complete": "b ⟼ e",
+    }
+    assert contract["rootVocabulary"]["glyphSpellingRecognizesKernelRole"] is False
+    assert contract["rootVocabulary"]["mappingAppliesAfterExactKernelConstruction"] is True
+    assert contract["rootVocabulary"]["rootAbitsIdenticalToFormalMaleFemaleGlyphOccurrences"] is False
+
+
+def test_historical_ten_formula_root_fixture_is_unchanged() -> None:
+    text = root_formula_text()
+    assert len(text.splitlines()) == 10
+    assert hashlib.sha256(text.encode("utf-8")).hexdigest() == ROOT_FORMULAS_SHA256


### PR DESCRIPTION
Closes #274 after green CI and explicit decision. Parent: #271, umbrella #237.

## Production exact root

Adds `core/foundation_v2_root.py`, which constructs the distinguished five-link bootstrap directly over `core/exact_link_network.py`:

```text
R = R ⟼ R      # ∞
O = O ⟼ R      # ♂∞
C = R ⟼ C      # ∞♀
L = O ⟼ C
U = C ⟼ O
```

No historical ten-formula parsing, typed AST, ContextFrame, `reference_model.py`, pair interning or graph-isomorphism recognition is involved.

Validation requires the explicitly supplied exact R/O/C/L/U refs and exact topology. It is deliberately independent of runtime slot/allocation order; conformance builds a valid kernel with allocation order `U,C,R,L,O` and requires it to validate.

A second exact self-cycle is not root by shape, and a duplicate O⟼C occurrence is not exact L.

## Root vocabulary after topology

The root protocol vocabulary is applied only after the exact kernel exists:

```text
∞ -> exact R
[ -> exact O
] -> exact C
1 -> exact L
0 -> exact U
```

Glyph spelling does not recognize semantic role. The root vocabulary also deliberately contains no `♂/♀` keys: root abits and later formal ostensive signs remain distinct source layers.

The primary semantic reading remains:

```text
∞
♂e = S = S ⟼ e
b♀ = E = b ⟼ E
b ⟼ e
```

## One public candidate surface

Adds `core/foundation_v2.py`, a thin public implementation facade over the already-tested Foundation-v2 modules: exact network/root, source replay, relation/colon/equality, Run/proof/integrated checker, sequence materialization and persistent exact-occurrence L4.

It has no legacy/new dispatcher and no compatibility parameters.

## Contract

Adds non-accepting `contracts/mts-foundation-v2-root-v0.7.json` with:

```text
accepted=false
cutoverComplete=false
foundationV2Accepted=false
aproverRepinAllowed=false
```

It pins exact root topology, ostensive orientation, root vocabulary ordering and the no-isomorphism/no-pair-interning identity boundary.

## Cutover state update

C0/C1 artifacts are advanced in the same PR:
- manifest now marks `liveProductionEntrypointReady=true` and freezes `core/foundation_v2.py` as public candidate surface;
- `root_library.py` and `validate_root.py` become `HISTORICAL_REPLAY_ONLY` rather than owners of the new live root;
- trusted import audit now includes the new root and public facade and still forbids all old semantic dependencies.

Historical files are not deleted yet; C7 owns atomic deletion after remaining consumers are isolated/migrated.

## Conformance

New tests cover exact topology/distinctness, allocation-order independence, fresh identity scopes, extra self-cycle, duplicate same-pole occurrence, immutable root vocabulary, public facade imports, ostensive orientation, historical root fixture hash and non-acceptance boundaries.

No historical accepted contract content is modified and no downstream repin is allowed by this PR.