### PR TITLE
Включить repo-guard как blocking PR check

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,0 +1,36 @@
+name: repo-guard policy check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: ["**"]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  policy-check:
+    name: repo-guard blocking check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run repo-guard
+        id: repo_guard
+        uses: netkeep80/repo-guard@4e8df8af30e76053ec70ec7e0074e67e9ed3b037
+        with:
+          mode: check-pr
+          enforcement: blocking
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish repo-guard summary
+        if: always()
+        run: |
+          echo "repo-guard result: ${{ steps.repo_guard.outputs.result }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.repo_guard.outputs.summary }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Fixes #288.

Второй этап bootstrap: политика уже находится в `main`, теперь включается сам `repo-guard`.

- `netkeep80/repo-guard` pinned на immutable merge SHA `4e8df8af30e76053ec70ec7e0074e67e9ed3b037`;
- `mode: check-pr`;
- `enforcement: blocking`;
- `fetch-depth: 0` для точного base→head diff;
- права только read для contents/issues/pull-requests;
- результат публикуется в GitHub Step Summary.

Этот PR принципиально не меняет `repo-policy.json`: проверка должна использовать политику из base/main.