### PR TITLE
Обновить repo-guard pin для UTF-8 путей

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@4e8df8af30e76053ec70ec7e0074e67e9ed3b037
+        uses: netkeep80/repo-guard@2543721de5f0ef50af0bd4ab9bbea5b47cdb8092
         with:
           mode: check-pr
           enforcement: blocking


### PR DESCRIPTION
Fixes #292.

Меняет только immutable SHA внешнего Action:

```text
4e8df8af30e76053ec70ec7e0074e67e9ed3b037
→
2543721de5f0ef50af0bd4ab9bbea5b47cdb8092
```

Новый SHA — merge `repo-guard#120`, где исправлена выдача UTF-8 путей из `git diff` и добавлена end-to-end регрессия для кириллического `must_touch`.

Политика `anum_docs` не меняется.