### PR TITLE
Привязать Foundation v2 proof replay к точной выбранной цели

### DIFF
--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from .exact_link_network import Link, LinkNetwork, LinkNetworkBuilder, OccurrenceRef
 from .foundation_v2_checker import (
     IntegratedProofEvidence,
+    ProofGoalEvidence,
     replay_integrated_proof,
 )
 from .foundation_v2_interpreter import (
@@ -79,6 +80,7 @@ __all__ = [
     "PersistentSequenceDescription",
     "PersistentSequenceGroup",
     "PersistentSequenceMaterialization",
+    "ProofGoalEvidence",
     "RelationStepEvidence",
     "RunEvidence",
     "SequenceAtom",

--- a/core/foundation_v2_checker.py
+++ b/core/foundation_v2_checker.py
@@ -29,12 +29,25 @@ class IntegratedCheckerError(ValueError):
 
 
 @dataclass(frozen=True)
+class ProofGoalEvidence:
+    """Transport selection of the exact claim occurrences the proof must establish.
+
+    This dataclass is not a new MTS ontological type or a claim-kind tag.  The
+    semantic content remains the two already-existing exact link occurrences.
+    """
+
+    start_claim: OccurrenceRef
+    end_claim: OccurrenceRef
+
+
+@dataclass(frozen=True)
 class IntegratedProofEvidence:
     """One selected exact Foundation-v2 proof artifact."""
 
     source: SourceFrontEndEvidence
     rule_application: DecomposeEqualityEvidence
     run: RunEvidence
+    goal: ProofGoalEvidence
 
 
 def replay_integrated_proof(
@@ -42,7 +55,13 @@ def replay_integrated_proof(
     evidence: IntegratedProofEvidence,
     byte_refs: Mapping[int, OccurrenceRef],
 ) -> tuple[OccurrenceRef, OccurrenceRef]:
-    """Replay one source-selected rule proof without search or materialization."""
+    """Replay one source-selected rule proof for one exact selected goal.
+
+    Search is outside the trusted boundary.  Success means that trusted replay
+    produces the same exact claim occurrences, in the same roles, that were
+    selected as the goal.  Same-shape or same-pole substitute occurrences do
+    not satisfy the goal.
+    """
 
     before_snapshot = network.snapshot()
     try:
@@ -81,6 +100,8 @@ def replay_integrated_proof(
         except ProofRuleReplayError as exc:
             raise IntegratedCheckerError("invalid admitted proof-rule application") from exc
 
+        _verify_exact_goal(evidence.goal, claims)
+
         expected_acts = (premise.act, evidence.rule_application.act)
         if evidence.run.initial_context is not context:
             raise IntegratedCheckerError("run starts from another exact K")
@@ -99,3 +120,13 @@ def replay_integrated_proof(
     finally:
         if network.snapshot() != before_snapshot:
             raise IntegratedCheckerError("integrated proof replay mutated the network")
+
+
+def _verify_exact_goal(
+    goal: ProofGoalEvidence,
+    claims: tuple[OccurrenceRef, OccurrenceRef],
+) -> None:
+    if claims[0] is not goal.start_claim or claims[1] is not goal.end_claim:
+        raise IntegratedCheckerError(
+            "replayed proof does not establish the exact selected goal"
+        )

--- a/tests/test_mts_foundation_v2_checker.py
+++ b/tests/test_mts_foundation_v2_checker.py
@@ -9,6 +9,7 @@ from core.exact_link_network import LinkNetworkBuilder
 from core.foundation_v2_checker import (
     IntegratedCheckerError,
     IntegratedProofEvidence,
+    ProofGoalEvidence,
     replay_integrated_proof,
 )
 from core.foundation_v2_interpreter import EqualityEvaluationEvidence, EqualityRoleRefs
@@ -158,7 +159,13 @@ def _fixture():
         terminal_context=context,
         steps=(eq_step, proof_step),
     )
-    evidence = IntegratedProofEvidence(source=source, rule_application=proof, run=run)
+    goal = ProofGoalEvidence(start_claim=start_claim, end_claim=end_claim)
+    evidence = IntegratedProofEvidence(
+        source=source,
+        rule_application=proof,
+        run=run,
+        goal=goal,
+    )
     return builder, root, byte_refs, evidence, rule, theory, context
 
 
@@ -168,10 +175,46 @@ def test_integrated_source_to_rule_to_run_replays_read_only() -> None:
     before = network.snapshot()
 
     assert replay_integrated_proof(network, evidence, byte_refs) == (
-        evidence.rule_application.start_claim,
-        evidence.rule_application.end_claim,
+        evidence.goal.start_claim,
+        evidence.goal.end_claim,
     )
     assert network.snapshot() == before
+
+
+def test_swapped_exact_goal_rejects() -> None:
+    builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    forged = replace(
+        evidence,
+        goal=ProofGoalEvidence(
+            start_claim=evidence.goal.end_claim,
+            end_claim=evidence.goal.start_claim,
+        ),
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(IntegratedCheckerError, match="exact selected goal"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_same_shape_different_occurrence_does_not_satisfy_exact_goal() -> None:
+    builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    network = builder.freeze(root)
+    original = network.link(evidence.goal.start_claim)
+
+    evolution = network.evolve()
+    duplicate = evolution.reserve()
+    evolution.define(duplicate, original.start, original.end)
+    evolved = evolution.freeze()
+
+    assert duplicate is not evidence.goal.start_claim
+    assert evolved.link(duplicate) == evolved.link(evidence.goal.start_claim)
+
+    forged = replace(
+        evidence,
+        goal=replace(evidence.goal, start_claim=duplicate),
+    )
+    with pytest.raises(IntegratedCheckerError, match="exact selected goal"):
+        replay_integrated_proof(evolved, forged, byte_refs)
 
 
 def test_valid_source_selecting_another_exact_rule_rejects_cross_layer() -> None:


### PR DESCRIPTION
Продвигает #122, но не закрывает его.

Текущий Foundation v2 уже умеет воспроизводить:

```text
истинное локальное равенство
→ T ⟼ Rule
→ одношаговую декомпозицию полюсов
→ точный Run
```

Этот PR добавляет недостающую границу суждения: trusted checker должен установить **именно заранее выбранную точную цель**, а не просто получить корректные утверждения той же формы.

`ProofGoalEvidence` — только транспорт двух уже существующих `OccurrenceRef`, не новый онтологический тип и не `goalKind`.

Критерий успеха:

```text
replayed_start is selected_start
replayed_end   is selected_end
```

Отдельно проверяется, что другое точное вхождение с теми же полюсами цель не удовлетворяет.

Новых правил вывода, contracts и файлов нет.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_checker.py
  - core/foundation_v2.py
  - tests/test_mts_foundation_v2_checker.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 180
must_touch:
  - core/foundation_v2_checker.py
  - tests/test_mts_foundation_v2_checker.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - trusted checker validates an explicit exact selected proof goal
  - same-shape different occurrence cannot satisfy the goal
  - no new inference rule is introduced
  - proof replay remains read-only
```

Метрика: 3 существующих файла, 0 новых файлов, +81/−5 строк.