### PR TITLE
Зафиксировать дейктическую границу актуальности Foundation v2

### DIFF
--- a/tests/test_mts_foundation_v2_state.py
+++ b/tests/test_mts_foundation_v2_state.py
@@ -138,6 +138,32 @@ def test_gate_r_header_keeps_two_actual_acts_occurrence_distinct() -> None:
     assert act_header(network, act_two) == (interpreter, role_dictionary, after_context)
 
 
+def test_exact_current_act_is_selected_by_explicit_context_not_global_now() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    interpreter = _anchor(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    transition_parent = _anchor(builder)
+    result = _anchor(builder)
+    after_context = define_context(builder, transition_parent, result)
+
+    act_one = define_act_header(builder, interpreter, role_dictionary, after_context)
+    act_two = define_act_header(builder, interpreter, role_dictionary, after_context)
+
+    deictic_parent = _anchor(builder)
+    context_one = define_context(builder, deictic_parent, act_one)
+    context_two = define_context(builder, deictic_parent, act_two)
+    network = builder.freeze(root)
+
+    before = network.snapshot()
+    assert act_one is not act_two
+    assert act_header(network, act_one) == act_header(network, act_two)
+    assert current_of_context(network, context_one) is act_one
+    assert current_of_context(network, context_two) is act_two
+    assert context_one is not context_two
+    assert network.snapshot() == before
+
+
 def test_role_addressed_act_fields_are_additive_link_data() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)


### PR DESCRIPTION
Продвигает исследование #170, не меняя нормативную семантику.

Добавляет один executable boundary в существующий `tests/test_mts_foundation_v2_state.py`:

```text
A1 ≠ A2                     exact occurrence
header(A1) = header(A2)     одинаковое структурное содержание
current(K1) is A1
current(K2) is A2
```

Это показывает, что Foundation v2 уже умеет выражать **локальную текущесть** реляционно через явно выбранный `K`, без глобального `Actual(A)` и без скрытого clock/now.

Одновременно PR не делает более сильного вывода: наличие точного `A` и ссылки `K.current=A` ещё не объявляется объяснением фундаментального «происходит». Поэтому processual branch #229 остаётся отдельным вопросом.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_mts_foundation_v2_state.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 80
must_touch:
  - tests/test_mts_foundation_v2_state.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - two structurally identical actual-act records remain exact-distinct
  - explicit K can select either act as current
  - no global actuality flag or clock is introduced
  - the test does not claim relational currentness solves processual actuality
```

Метрика: 1 существующий файл, 0 новых файлов, +26 строк.