### PR TITLE
Сделать T K и Goal явным proof judgment Foundation v2

### DIFF
--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -14,6 +14,7 @@ from .exact_link_network import Link, LinkNetwork, LinkNetworkBuilder, Occurrenc
 from .foundation_v2_checker import (
     IntegratedProofEvidence,
     ProofGoalEvidence,
+    ProofJudgmentEvidence,
     replay_integrated_proof,
 )
 from .foundation_v2_interpreter import (
@@ -81,6 +82,7 @@ __all__ = [
     "PersistentSequenceGroup",
     "PersistentSequenceMaterialization",
     "ProofGoalEvidence",
+    "ProofJudgmentEvidence",
     "RelationStepEvidence",
     "RunEvidence",
     "SequenceAtom",

--- a/core/foundation_v2_checker.py
+++ b/core/foundation_v2_checker.py
@@ -32,7 +32,7 @@ class IntegratedCheckerError(ValueError):
 class ProofGoalEvidence:
     """Transport selection of the exact claim occurrences the proof must establish.
 
-    This dataclass is not a new MTS ontological type or a claim-kind tag.  The
+    This dataclass is not a new MTS ontological type or a claim-kind tag. The
     semantic content remains the two already-existing exact link occurrences.
     """
 
@@ -41,13 +41,27 @@ class ProofGoalEvidence:
 
 
 @dataclass(frozen=True)
+class ProofJudgmentEvidence:
+    """Transport selection of one exact Foundation-v2 proof judgment.
+
+    ``theory`` and ``context`` are already-existing exact occurrences. ``goal``
+    selects exact claim occurrences. The dataclass adds no Gamma-like global
+    premise store and no new semantic tag to primitive links.
+    """
+
+    theory: OccurrenceRef
+    context: OccurrenceRef
+    goal: ProofGoalEvidence
+
+
+@dataclass(frozen=True)
 class IntegratedProofEvidence:
-    """One selected exact Foundation-v2 proof artifact."""
+    """Evidence offered for one explicitly selected exact proof judgment."""
 
     source: SourceFrontEndEvidence
     rule_application: DecomposeEqualityEvidence
     run: RunEvidence
-    goal: ProofGoalEvidence
+    judgment: ProofJudgmentEvidence
 
 
 def replay_integrated_proof(
@@ -55,20 +69,28 @@ def replay_integrated_proof(
     evidence: IntegratedProofEvidence,
     byte_refs: Mapping[int, OccurrenceRef],
 ) -> tuple[OccurrenceRef, OccurrenceRef]:
-    """Replay one source-selected rule proof for one exact selected goal.
+    """Replay one source-selected rule proof for one exact selected judgment.
 
-    Search is outside the trusted boundary.  Success means that trusted replay
-    produces the same exact claim occurrences, in the same roles, that were
-    selected as the goal.  Same-shape or same-pole substitute occurrences do
-    not satisfy the goal.
+    Search is outside the trusted boundary. Success requires all nested evidence
+    to use the judgment's exact theory and context, and trusted replay must
+    produce the same exact goal-claim occurrences in the same roles. Same-shape
+    or same-pole substitutes do not satisfy the judgment.
     """
 
     before_snapshot = network.snapshot()
     try:
+        judgment = evidence.judgment
         rule = evidence.rule_application.rule
-        theory = evidence.rule_application.theory
         premise = evidence.rule_application.premise
-        context = premise.context
+
+        if evidence.rule_application.theory is not judgment.theory:
+            raise IntegratedCheckerError(
+                "proof application uses another exact theory than selected judgment"
+            )
+        if premise.context is not judgment.context:
+            raise IntegratedCheckerError(
+                "equality premise uses another exact context than selected judgment"
+            )
 
         try:
             selected_forms = replay_source_front_end(network, evidence.source, byte_refs)
@@ -78,9 +100,9 @@ def replay_integrated_proof(
             raise IntegratedCheckerError(
                 "source must select exactly the same exact Rule used by proof application"
             )
-        if evidence.source.theory is not theory:
+        if evidence.source.theory is not judgment.theory:
             raise IntegratedCheckerError(
-                "source admission and proof application use different exact theories"
+                "source admission uses another exact theory than selected judgment"
             )
 
         try:
@@ -90,9 +112,9 @@ def replay_integrated_proof(
         if not premise_result:
             raise IntegratedCheckerError("integrated proof equality premise is false")
 
-        if evidence.rule_application.before_context is not context:
+        if evidence.rule_application.before_context is not judgment.context:
             raise IntegratedCheckerError("proof application uses another exact K")
-        if evidence.rule_application.after_context is not context:
+        if evidence.rule_application.after_context is not judgment.context:
             raise IntegratedCheckerError("observational proof rule changed exact K")
 
         try:
@@ -100,12 +122,12 @@ def replay_integrated_proof(
         except ProofRuleReplayError as exc:
             raise IntegratedCheckerError("invalid admitted proof-rule application") from exc
 
-        _verify_exact_goal(evidence.goal, claims)
+        _verify_exact_goal(judgment.goal, claims)
 
         expected_acts = (premise.act, evidence.rule_application.act)
-        if evidence.run.initial_context is not context:
+        if evidence.run.initial_context is not judgment.context:
             raise IntegratedCheckerError("run starts from another exact K")
-        if evidence.run.terminal_context is not context:
+        if evidence.run.terminal_context is not judgment.context:
             raise IntegratedCheckerError("run terminates at another exact K")
         try:
             selected_acts = replay_run(network, evidence.run)

--- a/tests/test_mts_foundation_v2_checker.py
+++ b/tests/test_mts_foundation_v2_checker.py
@@ -10,6 +10,7 @@ from core.foundation_v2_checker import (
     IntegratedCheckerError,
     IntegratedProofEvidence,
     ProofGoalEvidence,
+    ProofJudgmentEvidence,
     replay_integrated_proof,
 )
 from core.foundation_v2_interpreter import EqualityEvaluationEvidence, EqualityRoleRefs
@@ -160,11 +161,12 @@ def _fixture():
         steps=(eq_step, proof_step),
     )
     goal = ProofGoalEvidence(start_claim=start_claim, end_claim=end_claim)
+    judgment = ProofJudgmentEvidence(theory=theory, context=context, goal=goal)
     evidence = IntegratedProofEvidence(
         source=source,
         rule_application=proof,
         run=run,
-        goal=goal,
+        judgment=judgment,
     )
     return builder, root, byte_refs, evidence, rule, theory, context
 
@@ -175,19 +177,23 @@ def test_integrated_source_to_rule_to_run_replays_read_only() -> None:
     before = network.snapshot()
 
     assert replay_integrated_proof(network, evidence, byte_refs) == (
-        evidence.goal.start_claim,
-        evidence.goal.end_claim,
+        evidence.judgment.goal.start_claim,
+        evidence.judgment.goal.end_claim,
     )
     assert network.snapshot() == before
 
 
 def test_swapped_exact_goal_rejects() -> None:
     builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    goal = evidence.judgment.goal
     forged = replace(
         evidence,
-        goal=ProofGoalEvidence(
-            start_claim=evidence.goal.end_claim,
-            end_claim=evidence.goal.start_claim,
+        judgment=replace(
+            evidence.judgment,
+            goal=ProofGoalEvidence(
+                start_claim=goal.end_claim,
+                end_claim=goal.start_claim,
+            ),
         ),
     )
     network = builder.freeze(root)
@@ -199,22 +205,54 @@ def test_swapped_exact_goal_rejects() -> None:
 def test_same_shape_different_occurrence_does_not_satisfy_exact_goal() -> None:
     builder, root, byte_refs, evidence, _, _, _ = _fixture()
     network = builder.freeze(root)
-    original = network.link(evidence.goal.start_claim)
+    goal = evidence.judgment.goal
+    original = network.link(goal.start_claim)
 
     evolution = network.evolve()
     duplicate = evolution.reserve()
     evolution.define(duplicate, original.start, original.end)
     evolved = evolution.freeze()
 
-    assert duplicate is not evidence.goal.start_claim
-    assert evolved.link(duplicate) == evolved.link(evidence.goal.start_claim)
+    assert duplicate is not goal.start_claim
+    assert evolved.link(duplicate) == evolved.link(goal.start_claim)
 
     forged = replace(
         evidence,
-        goal=replace(evidence.goal, start_claim=duplicate),
+        judgment=replace(
+            evidence.judgment,
+            goal=replace(goal, start_claim=duplicate),
+        ),
     )
     with pytest.raises(IntegratedCheckerError, match="exact selected goal"):
         replay_integrated_proof(evolved, forged, byte_refs)
+
+
+def test_selected_judgment_theory_must_be_exact() -> None:
+    builder, root, byte_refs, evidence, _, theory, _ = _fixture()
+    other_theory = _anchor(builder)
+    forged = replace(
+        evidence,
+        judgment=replace(evidence.judgment, theory=other_theory),
+    )
+    network = builder.freeze(root)
+
+    assert other_theory is not theory
+    with pytest.raises(IntegratedCheckerError, match="selected judgment"):
+        replay_integrated_proof(network, forged, byte_refs)
+
+
+def test_selected_judgment_context_must_be_exact() -> None:
+    builder, root, byte_refs, evidence, _, _, context = _fixture()
+    other_context = define_context(builder, _anchor(builder), _anchor(builder))
+    forged = replace(
+        evidence,
+        judgment=replace(evidence.judgment, context=other_context),
+    )
+    network = builder.freeze(root)
+
+    assert other_context is not context
+    with pytest.raises(IntegratedCheckerError, match="selected judgment"):
+        replay_integrated_proof(network, forged, byte_refs)
 
 
 def test_valid_source_selecting_another_exact_rule_rejects_cross_layer() -> None:
@@ -237,7 +275,7 @@ def test_valid_source_under_another_exact_theory_rejects_cross_layer() -> None:
     network = builder.freeze(root)
 
     assert other_theory is not theory
-    with pytest.raises(IntegratedCheckerError, match="different exact theories"):
+    with pytest.raises(IntegratedCheckerError, match="source admission"):
         replay_integrated_proof(network, forged, byte_refs)
 
 


### PR DESCRIPTION
Продвигает #122, не закрывая весь calculus.

После #296 точная цель уже проверяется по exact identity. Этот PR делает явным и окружение суждения:

```text
J = (T, K, Goal)
```

где `T`, `K` и утверждения цели — уже существующие точные вхождения связей. `ProofJudgmentEvidence` является транспортом, а не новой онтологией.

Trusted checker теперь требует:

```text
source.theory is J.T
rule_application.theory is J.T
premise.context is J.K
run.initial_context is J.K
run.terminal_context is J.K
replayed_claims are exactly J.Goal
```

Добавлены отрицательные проверки подмены выбранной теории и выбранного контекста. Новых inference rules, contracts и файлов нет.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_checker.py
  - core/foundation_v2.py
  - tests/test_mts_foundation_v2_checker.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 180
must_touch:
  - core/foundation_v2_checker.py
  - tests/test_mts_foundation_v2_checker.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - proof judgment explicitly selects exact T K and Goal
  - nested proof evidence cannot silently choose another theory or context
  - no new inference rule is introduced
  - trusted replay remains read-only
```

Метрика: 3 существующих файла, 0 новых файлов, +90/−28 строк.