### PR TITLE
Добавить bracket-only relative Anum поверх точного K

### DIFF
--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -48,6 +48,7 @@ from .foundation_v2_proof import (
     DecomposeEqualityEvidence,
     replay_decompose_equal_relations,
 )
+from .foundation_v2_relative import RelativeAnumError, replay_relative_bracket_path
 from .foundation_v2_root import (
     FoundationRootKernel,
     FoundationRootRefs,
@@ -84,6 +85,7 @@ __all__ = [
     "ProofGoalEvidence",
     "ProofJudgmentEvidence",
     "RelationStepEvidence",
+    "RelativeAnumError",
     "RunEvidence",
     "SequenceAtom",
     "SequenceDescription",
@@ -101,6 +103,7 @@ __all__ = [
     "replay_integrated_proof",
     "replay_persistent_sequence_materialization",
     "replay_relation_step",
+    "replay_relative_bracket_path",
     "replay_run",
     "replay_sequence_materialization",
     "replay_source_front_end",

--- a/core/foundation_v2_relative.py
+++ b/core/foundation_v2_relative.py
@@ -1,0 +1,55 @@
+"""Foundation-v2 bracket-only relative Anum reading over exact occurrences.
+
+The relative context is an already-existing exact ``K``.  Its current value is
+the initial focus.  After that selection, every ``[`` step follows the start
+pole of the current exact occurrence and every ``]`` step follows the end pole.
+Context ancestry is deliberately not part of path traversal.
+
+This is one explicit relative reading mode of a canonical bracket carrier, not
+an intrinsic opcode meaning of the root abits.  Root and quote readings are not
+implemented or changed here.  ``0`` and ``1`` remain undefined in this first
+relative subset and therefore fail closed.
+"""
+from __future__ import annotations
+
+from .exact_link_network import LinkNetwork, LinkNetworkError, OccurrenceRef
+from .foundation_v2_state import FoundationStateError, current_of_context
+
+
+class RelativeAnumError(ValueError):
+    """The selected relative context or bracket path is invalid."""
+
+
+def replay_relative_bracket_path(
+    network: LinkNetwork,
+    context: OccurrenceRef,
+    carrier: str,
+) -> OccurrenceRef:
+    """Read one finite bracket path relative to exact ``current(K)``.
+
+    ``""`` selects the exact focus itself.  ``[`` and ``]`` then traverse one
+    existing start/end pole per character.  No link is searched by shape,
+    created, deleted or interned.  A cyclic carrier remains finite because the
+    number of traversal steps is exactly the finite carrier length.
+    """
+
+    if not isinstance(carrier, str):
+        raise RelativeAnumError("relative bracket carrier must be text")
+
+    before = network.snapshot()
+    try:
+        cursor = current_of_context(network, context)
+        for position, abit in enumerate(carrier):
+            if abit not in "[]":
+                raise RelativeAnumError(
+                    "relative bracket subset accepts only '[' and ']' "
+                    f"(invalid character at position {position})"
+                )
+            link = network.link(cursor)
+            cursor = link.start if abit == "[" else link.end
+        return cursor
+    except (FoundationStateError, LinkNetworkError) as exc:
+        raise RelativeAnumError("invalid exact relative context or path") from exc
+    finally:
+        if network.snapshot() != before:
+            raise RelativeAnumError("relative path replay mutated the network")

--- a/tests/test_mts_foundation_v2_state.py
+++ b/tests/test_mts_foundation_v2_state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_relative import RelativeAnumError, replay_relative_bracket_path
 from core.foundation_v2_state import (
     FoundationStateError,
     act_header,
@@ -28,6 +29,12 @@ def _anchor(builder: LinkNetworkBuilder):
     return ref
 
 
+def _link(builder: LinkNetworkBuilder, start, end):
+    ref = builder.reserve()
+    builder.define(ref, start, end)
+    return ref
+
+
 def test_explicit_context_resolves_current_without_ambient_stack() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)
@@ -39,6 +46,89 @@ def test_explicit_context_resolves_current_without_ambient_stack() -> None:
     before = network.snapshot()
     assert parent_of_context(network, context) is parent
     assert current_of_context(network, context) is current
+    assert network.snapshot() == before
+
+
+def test_relative_bracket_path_traverses_exact_focus_start_and_end() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    ll, lr, rl, rr = (_anchor(builder) for _ in range(4))
+    left = _link(builder, ll, lr)
+    right = _link(builder, rl, rr)
+    focus = _link(builder, left, right)
+    context = define_context(builder, _anchor(builder), focus)
+    network = builder.freeze(root)
+
+    before = network.snapshot()
+    assert replay_relative_bracket_path(network, context, "") is focus
+    assert replay_relative_bracket_path(network, context, "[") is left
+    assert replay_relative_bracket_path(network, context, "]") is right
+    assert replay_relative_bracket_path(network, context, "[[") is ll
+    assert replay_relative_bracket_path(network, context, "[]") is lr
+    assert replay_relative_bracket_path(network, context, "][") is rl
+    assert replay_relative_bracket_path(network, context, "]]" ) is rr
+    assert network.snapshot() == before
+
+
+def test_relative_bracket_path_does_not_walk_context_parent_chain() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    parent_left = _anchor(builder)
+    parent_right = _anchor(builder)
+    parent_focus = _link(builder, parent_left, parent_right)
+    parent_context = define_context(builder, root, parent_focus)
+
+    focus_left = _anchor(builder)
+    focus_right = _anchor(builder)
+    focus = _link(builder, focus_left, focus_right)
+    context = define_context(builder, parent_context, focus)
+    network = builder.freeze(root)
+
+    assert parent_of_context(network, context) is parent_context
+    assert current_of_context(network, parent_context) is parent_focus
+    assert replay_relative_bracket_path(network, context, "[") is focus_left
+    assert replay_relative_bracket_path(network, context, "[") is not parent_focus
+
+
+def test_relative_bracket_path_preserves_exact_focus_identity() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    start = _anchor(builder)
+    end = _anchor(builder)
+    focus_one = _link(builder, start, end)
+    focus_two = _link(builder, start, end)
+    parent = _anchor(builder)
+    context_one = define_context(builder, parent, focus_one)
+    context_two = define_context(builder, parent, focus_two)
+    network = builder.freeze(root)
+
+    assert focus_one is not focus_two
+    assert network.link(focus_one) == network.link(focus_two)
+    assert replay_relative_bracket_path(network, context_one, "") is focus_one
+    assert replay_relative_bracket_path(network, context_two, "") is focus_two
+
+
+def test_relative_bracket_path_is_finite_on_self_closed_cycle() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, root, root)
+    network = builder.freeze(root)
+
+    before = network.snapshot()
+    assert replay_relative_bracket_path(network, context, "[[]]][[]]") is root
+    assert network.snapshot() == before
+
+
+def test_relative_bracket_subset_rejects_zero_one_and_noncanonical_text() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    context = define_context(builder, root, root)
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    for carrier in ("0", "1", "[0]", "[1]", "[ ]", "x"):
+        with pytest.raises(RelativeAnumError, match="only '\\[' and '\\]'"):
+            replay_relative_bracket_path(network, context, carrier)
     assert network.snapshot() == before
 
 


### PR DESCRIPTION
Закрыт без merge после концептуального уточнения пользователя.

Ошибка направления: PR преждевременно трактовал bracket-only relative carrier как навигационный path:

```text
[ → start(focus)
] → end(focus)
```

Это схлопывает адресацию и вложенную десериализацию.

Более общий инвариант МТС:

```text
Value := ExactLink | NestedAnum
NestedAnum deserialize → ExactLink
```

То есть листья разрешённой последовательности могут быть уже существующими точными связями, а вложенный запуск десериализации возвращает связь как один элемент внешнего уровня. Уже существующие `SequenceAtom(ref)` / `SequenceGroup(...)` и materialization semantics #242 ближе к этой модели, чем новый path traversal.

Сырой carrier остаётся `[ ] 1 0`; прямые exact links возникают на разрешённом semantic layer через явный словарь/контекст/evidence, а не как новый пятый символ.

Код из этого PR не является принятой Foundation-v2 semantics и в `main` не попадает.