### PR TITLE
Уточнить связи как значения последовательностной десериализации

### DIFF
--- a/core/foundation_v2_materialization.py
+++ b/core/foundation_v2_materialization.py
@@ -2,10 +2,20 @@
 
 The source/Anum front-end and this module are deliberately separate. Brackets,
 tokens and parser nodes are not interpreted here. The trusted input is an
-already-selected nested sequence description whose leaves are exact existing
-occurrences. Materialization is an explicit persistent effect: the immutable
-``before`` network is preserved and an ``after`` state in the same runtime
-identity lineage is produced with newly appended exact link occurrences.
+already-selected nested sequence description whose leaves are arbitrary exact
+existing link occurrences. A leaf may itself be a complete non-self-closed
+relation; it is not required to be an "atomic" value in the MTS ontology.
+
+A nested group is a host-side handle for a nested invocation of the same
+sequence-deserialization semantics. Its exact result is returned as one value
+to the surrounding sequence. Therefore the resolved semantic value domain is
+closed over links:
+
+``ExactLink | NestedSequence -> ExactLink``.
+
+Materialization is an explicit persistent effect: the immutable ``before``
+network is preserved and an ``after`` state in the same runtime identity lineage
+is produced with newly appended exact link occurrences.
 
 Sequence semantics:
 
@@ -33,14 +43,22 @@ class SequenceMaterializationError(ValueError):
 
 @dataclass(frozen=True)
 class SequenceAtom:
-    """One already-resolved exact occurrence used as a sequence value."""
+    """One already-resolved exact link occurrence used as a sequence value.
+
+    ``Atom`` is only transport terminology. ``value`` may itself denote any
+    existing relation occurrence, including a complete ``A⟼B`` link.
+    """
 
     value: OccurrenceRef
 
 
 @dataclass(frozen=True)
 class SequenceGroup:
-    """One nested sequence; host nesting is a checker handle, not semantic ID."""
+    """Nested sequence invocation returning one exact link to the outer level.
+
+    Host nesting is a checker handle, not semantic identity and not a second
+    kind of MTS entity.
+    """
 
     items: tuple["SequenceItem", ...]
 

--- a/tests/test_mts_anum_sequence_materialization.py
+++ b/tests/test_mts_anum_sequence_materialization.py
@@ -70,9 +70,7 @@ def test_evolution_preserves_base_exact_identity_and_keeps_before_immutable() ->
     assert before.snapshot() == before_snapshot
     assert after.root is root
     assert after.refs[: len(before.refs)] == before.refs
-    assert all(
-        after.refs[index] is ref for index, ref in enumerate(before.refs)
-    )
+    assert all(after.refs[index] is ref for index, ref in enumerate(before.refs))
     assert after.link(refs["a"]) is before.link(refs["a"])
     assert after.link(created).start is refs["a"]
     assert after.link(created).end is refs["b"]
@@ -160,6 +158,41 @@ def test_nested_ab_is_one_outer_value_in_infinity_group_ab_c() -> None:
     assert outer.start is inner.ref
     assert outer.end is refs["c"]
     assert evidence.result is outer.ref
+
+
+def test_existing_relation_and_nested_result_are_peer_sequence_values() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    a = builder.reserve()
+    b = builder.reserve()
+    c = builder.reserve()
+    d = builder.reserve()
+    existing = builder.reserve()
+    builder.define(root, root, root)
+    for ref in (a, b, c, d):
+        builder.define(ref, ref, ref)
+    builder.define(existing, a, b)
+    before = builder.freeze(root)
+
+    before_snapshot = before.snapshot()
+    evidence = materialize_sequence(
+        before,
+        _description(
+            root,
+            _atom(existing),
+            _group(_atom(c), _atom(d)),
+        ),
+    )
+
+    assert before.snapshot() == before_snapshot
+    assert len(evidence.created) == 2
+    nested_result, outer = evidence.created
+    assert evidence.after.link(existing) is before.link(existing)
+    assert (nested_result.start, nested_result.end) == (c, d)
+    assert outer.start is existing
+    assert outer.end is nested_result.ref
+    assert evidence.result is outer.ref
+    assert replay_sequence_materialization(before, evidence) is outer.ref
 
 
 def test_singleton_group_returns_exact_item_without_materialization() -> None:


### PR DESCRIPTION
Продвигает понимание #123 и уточняет уже реализованную sequence semantics #242 после концептуальной поправки.

PR #300 закрыт без merge: bracket-only path `[`→start / `]`→end оказался слишком узкой трактовкой.

Вместо этого фиксируется более общий resolved semantic layer:

```text
ResolvedValue := ExactLink | NestedSequence

deserialize_value(ExactLink)
    → тот же ExactLink

deserialize_value(NestedSequence)
    → вложенная sequence-deserialization
    → ExactLink
```

`SequenceAtom(ref)` теперь явно документирован как transport произвольной уже существующей exact link occurrence, включая полную `A⟼B`, а не как новый «атомарный» сорт сущего.

`SequenceGroup(...)` явно документирован как вложенный запуск той же sequence semantics, возвращающий одну exact-связь внешнему уровню.

Добавлен regression:

```text
existing = A ⟼ B          # уже существует до эффекта
nested   = [C D] → CD     # вложенный результат
outer    = existing ⟼ CD  # оба результата — равноправные link-values
```

Сырой carrier `[ ] 1 0` и вопрос, как relative syntax ссылается на exact links, этим PR не определяются.

```repo-guard-yaml
change_type: test
scope:
  - core/foundation_v2_materialization.py
  - tests/test_mts_anum_sequence_materialization.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 120
must_touch:
  - core/foundation_v2_materialization.py
  - tests/test_mts_anum_sequence_materialization.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - arbitrary existing exact links are valid sequence values
  - nested sequence deserialization returns an exact link to the outer level
  - existing links and nested results are composable as peer values
  - no new relative bracket-path semantics is introduced
```

Метрика: 2 существующих файла, 0 новых файлов, +60/−9 строк.