### PR TITLE
Связать D-разрешение существующей связи с десериализатором ачисел

### DIFF
--- a/tests/test_mts_foundation_v2_source.py
+++ b/tests/test_mts_foundation_v2_source.py
@@ -284,7 +284,7 @@ def test_occurrence_not_visible_from_selected_dictionary_is_rejected() -> None:
     network = builder.freeze(root)
 
     with pytest.raises(SourceReplayError, match="scoped dictionary evidence"):
-        replay_source_front_end(network, forged, byte_refs)
+        replay_source_front_end(network, evidence, byte_refs)
 
 
 def test_forged_grammar_or_theory_admission_is_rejected() -> None:

--- a/tests/test_mts_foundation_v2_source.py
+++ b/tests/test_mts_foundation_v2_source.py
@@ -6,6 +6,11 @@ from pathlib import Path
 import pytest
 
 from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_materialization import (
+    SequenceAtom,
+    SequenceDescription,
+    materialize_sequence,
+)
 from core.foundation_v2_source import (
     SegmentSpec,
     SourceFrontEndBuilder,
@@ -133,6 +138,52 @@ def test_same_bytes_can_resolve_differently_under_explicit_dictionaries() -> Non
     assert evidence_one.source is evidence_two.source
 
 
+def test_dictionary_resolved_exact_link_is_direct_sequence_value() -> None:
+    builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
+    a = _anchor(builder)
+    b = _anchor(builder)
+    prefix = _anchor(builder)
+    existing = builder.reserve()
+    builder.define(existing, a, b)
+
+    raw = b"existing"
+    source = front_end.source_occurrence(raw)
+    dictionary, occurrences = _dictionary_with(
+        builder,
+        root,
+        front_end,
+        ((raw, existing),),
+    )
+    evidence = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, len(raw), existing, occurrences[0]),),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze(root)
+
+    before = network.snapshot()
+    resolved = replay_source_front_end(network, evidence, byte_refs)
+    assert resolved == (existing,)
+    assert network.snapshot() == before
+
+    materialized = materialize_sequence(
+        network,
+        SequenceDescription(
+            root=root,
+            items=(SequenceAtom(prefix), SequenceAtom(resolved[0])),
+        ),
+    )
+
+    assert len(materialized.created) == 1
+    outer = materialized.created[0]
+    assert outer.start is prefix
+    assert outer.end is existing
+    assert materialized.after.link(existing) is network.link(existing)
+    assert network.snapshot() == before
+
+
 def test_ambiguous_segmentations_are_both_replayable_without_longest_match() -> None:
     builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form_a = _anchor(builder)
@@ -233,7 +284,7 @@ def test_occurrence_not_visible_from_selected_dictionary_is_rejected() -> None:
     network = builder.freeze(root)
 
     with pytest.raises(SourceReplayError, match="scoped dictionary evidence"):
-        replay_source_front_end(network, evidence, byte_refs)
+        replay_source_front_end(network, forged, byte_refs)
 
 
 def test_forged_grammar_or_theory_admission_is_rejected() -> None:


### PR DESCRIPTION
Продвигает #123 после #301/#302.

Проверяет существующий Foundation-v2 конвейер без нового механизма ссылок:

```text
source slice
→ explicit D resolution
→ exact existing link occurrence
→ SequenceAtom(existing)
→ outer sequence materialization
```

Тест создаёт уже существующую полную связь `existing=A⟼B`, разрешает исходную запись через scoped `D` **ровно в это exact occurrence**, а затем использует результат `replay_source_front_end(...)` непосредственно как значение последовательностной десериализации.

Проверяется:
- D возвращает тот же `existing` по identity;
- sequence не копирует и не реконструирует его;
- внешний результат указывает на `existing` как на значение;
- source replay и before-network остаются read-only.

Это не доказывает, что отдельный raw reference syntax никогда не понадобится, но показывает: на resolved semantic layer уже существующего `K/D` достаточно, чтобы передавать произвольные связи в десериализатор.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_mts_foundation_v2_source.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 90
must_touch:
  - tests/test_mts_foundation_v2_source.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - scoped D can resolve source directly to an existing exact link
  - the resolved exact link can be consumed as a sequence value without reconstruction
  - exact occurrence identity is preserved across source-to-sequence composition
  - no bracket navigation or new reference syntax is introduced
```

Метрика: 1 существующий файл, 0 новых файлов, +51 строка.