### PR TITLE
Проверять вложенную структуру по точным формам скобок

### DIFF
--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -32,6 +32,7 @@ from .foundation_v2_materialization import (
     SequenceMaterialization,
     find_links,
     materialize_sequence,
+    replay_resolved_sequence_grouping,
     replay_sequence_materialization,
 )
 from .foundation_v2_persistent import (
@@ -101,6 +102,7 @@ __all__ = [
     "replay_integrated_proof",
     "replay_persistent_sequence_materialization",
     "replay_relation_step",
+    "replay_resolved_sequence_grouping",
     "replay_run",
     "replay_sequence_materialization",
     "replay_source_front_end",

--- a/core/foundation_v2_materialization.py
+++ b/core/foundation_v2_materialization.py
@@ -1,10 +1,15 @@
 """Foundation-v2 Anum sequence materialization over exact-occurrence networks.
 
-The source/Anum front-end and this module are deliberately separate. Brackets,
-tokens and parser nodes are not interpreted here. The trusted input is an
-already-selected nested sequence description whose leaves are arbitrary exact
-existing link occurrences. A leaf may itself be a complete non-self-closed
-relation; it is not required to be an "atomic" value in the MTS ontology.
+The source/Anum front-end and this module are deliberately separate. Raw glyphs,
+tokens and parser nodes are not semantic identity here. After source replay has
+selected an ordered tuple of exact forms, ``replay_resolved_sequence_grouping``
+may interpret two explicitly selected exact occurrences as open/close delimiters
+for sequence-deserialization mode. Delimiter meaning is therefore contextual;
+the link shape alone never makes an occurrence a bracket command.
+
+The resulting nested sequence description has arbitrary exact existing link
+occurrences as leaves. A leaf may itself be a complete non-self-closed relation;
+it is not required to be an "atomic" value in the MTS ontology.
 
 A nested group is a host-side handle for a nested invocation of the same
 sequence-deserialization semantics. Its exact result is returned as one value
@@ -101,6 +106,59 @@ class SequenceMaterialization:
     result: OccurrenceRef
 
 
+def replay_resolved_sequence_grouping(
+    network: LinkNetwork,
+    forms: tuple[OccurrenceRef, ...],
+    *,
+    open_form: OccurrenceRef,
+    close_form: OccurrenceRef,
+) -> SequenceDescription:
+    """Replay nested grouping over already-resolved exact forms without effects.
+
+    ``open_form`` and ``close_form`` are explicit role selections for this one
+    sequence-deserialization mode. Only those exact occurrences delimit groups;
+    another occurrence with the same poles is an ordinary sequence value.
+
+    This function does not define the raw-carrier/root-opening-collapse mapping.
+    It starts after source/D replay has already produced exact forms in order.
+    """
+
+    before = network.snapshot()
+    try:
+        network.link(open_form)
+        network.link(close_form)
+        if open_form is close_form:
+            raise SequenceMaterializationError(
+                "open and close sequence delimiters must be exact-distinct"
+            )
+        if not forms:
+            raise SequenceMaterializationError("resolved sequence cannot be empty")
+        for form in forms:
+            network.link(form)
+
+        items, position = _group_resolved_forms(
+            forms,
+            0,
+            open_form=open_form,
+            close_form=close_form,
+            inside_group=False,
+        )
+        if position != len(forms):
+            raise SequenceMaterializationError(
+                "resolved sequence grouping left unconsumed forms"
+            )
+        return SequenceDescription(root=network.root, items=items)
+    except LinkNetworkError as exc:
+        raise SequenceMaterializationError(
+            "resolved sequence contains a foreign exact occurrence"
+        ) from exc
+    finally:
+        if network.snapshot() != before:
+            raise SequenceMaterializationError(
+                "resolved sequence grouping mutated the network"
+            )
+
+
 def find_links(
     network: LinkNetwork,
     *,
@@ -191,6 +249,50 @@ def replay_sequence_materialization(
             raise SequenceMaterializationError("replay mutated the before network")
         if evidence.after.snapshot() != after_snapshot:
             raise SequenceMaterializationError("replay mutated the after network")
+
+
+def _group_resolved_forms(
+    forms: tuple[OccurrenceRef, ...],
+    position: int,
+    *,
+    open_form: OccurrenceRef,
+    close_form: OccurrenceRef,
+    inside_group: bool,
+) -> tuple[tuple[SequenceItem, ...], int]:
+    items: list[SequenceItem] = []
+
+    while position < len(forms):
+        form = forms[position]
+        if form is close_form:
+            if not inside_group:
+                raise SequenceMaterializationError(
+                    "unexpected close delimiter in resolved sequence"
+                )
+            if not items:
+                raise SequenceMaterializationError(
+                    "resolved sequence group cannot be empty"
+                )
+            return tuple(items), position + 1
+
+        if form is open_form:
+            nested, position = _group_resolved_forms(
+                forms,
+                position + 1,
+                open_form=open_form,
+                close_form=close_form,
+                inside_group=True,
+            )
+            items.append(SequenceGroup(nested))
+            continue
+
+        items.append(SequenceAtom(form))
+        position += 1
+
+    if inside_group:
+        raise SequenceMaterializationError(
+            "resolved sequence group is missing close delimiter"
+        )
+    return tuple(items), position
 
 
 def _require_description_root(

--- a/tests/test_mts_anum_sequence_materialization.py
+++ b/tests/test_mts_anum_sequence_materialization.py
@@ -15,6 +15,7 @@ from core.foundation_v2_materialization import (
     SequenceMaterializationError,
     find_links,
     materialize_sequence,
+    replay_resolved_sequence_grouping,
     replay_sequence_materialization,
 )
 
@@ -167,6 +168,96 @@ def test_same_carrier_can_be_passed_as_value_or_deserialized_to_target() -> None
     assert target_outer.end is target.ref
     assert deserialized_value.after.link(carrier) is before.link(carrier)
     assert before.snapshot() == before_snapshot
+
+
+def test_resolved_grouping_builds_nested_deserialization_without_effect() -> None:
+    before, _, refs = _base_network(("open", "close", "a", "b", "c"))
+    snapshot = before.snapshot()
+
+    description = replay_resolved_sequence_grouping(
+        before,
+        (
+            refs["open"],
+            refs["a"],
+            refs["b"],
+            refs["close"],
+            refs["c"],
+        ),
+        open_form=refs["open"],
+        close_form=refs["close"],
+    )
+
+    assert description == _description(
+        before.root,
+        _group(_atom(refs["a"]), _atom(refs["b"])),
+        _atom(refs["c"]),
+    )
+    assert before.snapshot() == snapshot
+
+    evidence = materialize_sequence(before, description)
+    assert len(evidence.created) == 2
+    nested, outer = evidence.created
+    assert (nested.start, nested.end) == (refs["a"], refs["b"])
+    assert outer.start is nested.ref
+    assert outer.end is refs["c"]
+
+
+def test_resolved_grouping_uses_exact_delimiter_identity_not_link_shape() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.reserve()
+    left = builder.reserve()
+    right = builder.reserve()
+    open_form = builder.reserve()
+    same_shape = builder.reserve()
+    close_form = builder.reserve()
+    value = builder.reserve()
+    builder.define(root, root, root)
+    builder.define(left, left, left)
+    builder.define(right, right, right)
+    builder.define(open_form, left, right)
+    builder.define(same_shape, left, right)
+    builder.define(close_form, close_form, close_form)
+    builder.define(value, value, value)
+    network = builder.freeze(root)
+
+    assert open_form is not same_shape
+    assert network.link(open_form) == network.link(same_shape)
+
+    description = replay_resolved_sequence_grouping(
+        network,
+        (same_shape, value),
+        open_form=open_form,
+        close_form=close_form,
+    )
+    assert description.items == (_atom(same_shape), _atom(value))
+
+
+def test_resolved_grouping_rejects_unbalanced_or_empty_groups() -> None:
+    before, _, refs = _base_network(("open", "close", "a"))
+
+    with pytest.raises(SequenceMaterializationError, match="unexpected close"):
+        replay_resolved_sequence_grouping(
+            before,
+            (refs["close"], refs["a"]),
+            open_form=refs["open"],
+            close_form=refs["close"],
+        )
+
+    with pytest.raises(SequenceMaterializationError, match="missing close"):
+        replay_resolved_sequence_grouping(
+            before,
+            (refs["open"], refs["a"]),
+            open_form=refs["open"],
+            close_form=refs["close"],
+        )
+
+    with pytest.raises(SequenceMaterializationError, match="cannot be empty"):
+        replay_resolved_sequence_grouping(
+            before,
+            (refs["open"], refs["close"]),
+            open_form=refs["open"],
+            close_form=refs["close"],
+        )
 
 
 def test_infinity_abc_creates_adjacent_relations_and_returns_last_edge() -> None:


### PR DESCRIPTION
Продвигает #123 после #301–#303.

Закрывает trusted-gap между плоским `source/D replay` и уже существующим `SequenceDescription`.

Добавлен read-only слой:

```text
exact forms в порядке source replay
+ явно выбранные exact open/close forms
→ вложенный SequenceDescription
```

`replay_resolved_sequence_grouping(...)`:
- не читает raw UTF-8 и не создаёт второй parser;
- не материализует связи;
- трактует open/close как роли только в явно выбранном режиме последовательностной десериализации;
- использует **exact identity** delimiter-вхождений;
- другая связь с теми же полюсами не становится скобкой автоматически;
- отвергает неожиданные закрытия, незакрытые и пустые группы.

После replay результат можно передать существующему `materialize_sequence`, поэтому:

```text
O A B C C
→ [A B] C
→ X=A⟼B
→ X⟼C
```

где первый/последний `O/C` в примере — роли точных вхождений, а не intrinsic opcodes.

**Не решается этим PR:** raw mapping, аксиома начала/root-opening collapse и quote/carrier-vs-denotation. Они остаются отдельной границей, чтобы не повторить ошибку #300.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_materialization.py
  - core/foundation_v2.py
  - tests/test_mts_anum_sequence_materialization.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 240
must_touch:
  - core/foundation_v2_materialization.py
  - tests/test_mts_anum_sequence_materialization.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - resolved exact bracket forms can be replayed into nested sequence structure
  - delimiter role is occurrence-local rather than shape-based
  - grouping replay is read-only and separate from materialization
  - malformed selected grouping fails closed
  - raw/root-opening semantics remain explicitly unresolved
```

Метрика: 3 существующих файла, 0 новых файлов, +201/−6 строк.