### PR TITLE
Связать source/D с вложенной десериализацией корневых скобок

### DIFF
--- a/tests/test_mts_foundation_v2_source.py
+++ b/tests/test_mts_foundation_v2_source.py
@@ -9,8 +9,11 @@ from core.exact_link_network import LinkNetworkBuilder
 from core.foundation_v2_materialization import (
     SequenceAtom,
     SequenceDescription,
+    SequenceGroup,
     materialize_sequence,
+    replay_resolved_sequence_grouping,
 )
+from core.foundation_v2_root import build_root_kernel
 from core.foundation_v2_source import (
     SegmentSpec,
     SourceFrontEndBuilder,
@@ -181,6 +184,75 @@ def test_dictionary_resolved_exact_link_is_direct_sequence_value() -> None:
     assert outer.start is prefix
     assert outer.end is existing
     assert materialized.after.link(existing) is network.link(existing)
+    assert network.snapshot() == before
+
+
+def test_source_root_brackets_drive_nested_sequence_deserialization() -> None:
+    kernel = build_root_kernel()
+    builder = kernel.network.evolve()
+    root = kernel.refs.root
+    opening = kernel.refs.opening
+    closing = kernel.refs.closing
+    byte_refs = _byte_vocabulary(builder)
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+    grammar = _anchor(builder)
+    theory = _anchor(builder)
+    a = _anchor(builder)
+    b = _anchor(builder)
+    c = _anchor(builder)
+
+    raw = b"[ab]c"
+    source = front_end.source_occurrence(raw)
+    dictionary, occurrences = _dictionary_with(
+        builder,
+        root,
+        front_end,
+        (
+            (b"[", opening),
+            (b"a", a),
+            (b"b", b),
+            (b"]", closing),
+            (b"c", c),
+        ),
+    )
+    evidence = front_end.build_selected_evidence(
+        source,
+        tuple(
+            SegmentSpec(index, index + 1, form, occurrences[index])
+            for index, form in enumerate((opening, a, b, closing, c))
+        ),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+    network = builder.freeze()
+
+    before = network.snapshot()
+    resolved = replay_source_front_end(network, evidence, byte_refs)
+    assert resolved == (opening, a, b, closing, c)
+
+    description = replay_resolved_sequence_grouping(
+        network,
+        resolved,
+        open_form=opening,
+        close_form=closing,
+    )
+    assert description == SequenceDescription(
+        root=root,
+        items=(
+            SequenceGroup((SequenceAtom(a), SequenceAtom(b))),
+            SequenceAtom(c),
+        ),
+    )
+    assert network.snapshot() == before
+
+    materialized = materialize_sequence(network, description)
+    assert len(materialized.created) == 2
+    nested, outer = materialized.created
+    assert (nested.start, nested.end) == (a, b)
+    assert outer.start is nested.ref
+    assert outer.end is c
+    assert materialized.result is outer.ref
     assert network.snapshot() == before
 
 


### PR DESCRIPTION
Продвигает #123 после #304 и проверяет полный путь без ручного построения `SequenceGroup`.

Сквозной вектор:

```text
bytes "[ab]c"
→ scoped D
→ exact forms (O, A, B, C, C₁)
→ replay_resolved_sequence_grouping
→ ([A B], C₁)
→ materialize_sequence
→ X = A ⟼ B
→ Y = X ⟼ C₁
```

Здесь `O` и `C` — **настоящие точные opening/closing связи пятисвязного Foundation-v2 root**:

```text
O = O ⟼ R = ♂∞
C = R ⟼ C = ∞♀
```

Важно:
- байты `[`/`]` не имеют встроенной исполнительной семантики;
- они сначала явно разрешаются через `D` в exact O/C;
- только выбранный sequence-deserialization mode использует эти exact occurrences как границы вложенного запуска;
- source replay и grouping replay read-only;
- target links возникают только в явном `materialize_sequence`.

PR не определяет аксиому начала/root-opening collapse для общего raw carrier и не решает quote/carrier-vs-denotation mapping.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_mts_foundation_v2_source.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - tests/test_mts_foundation_v2_source.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - source bytes can resolve through D to exact Foundation-v2 root bracket forms
  - resolved bracket forms drive trusted nested grouping
  - nested grouping feeds the existing materializer without host-authored groups
  - read-only source/grouping stages remain separated from explicit materialization
```

Метрика: 1 существующий файл, 0 новых файлов, +72 строки.