### PR TITLE
Восстанавливать схлопнутые начальные O по exact identity

### DIFF
--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -33,6 +33,7 @@ from .foundation_v2_materialization import (
     find_links,
     materialize_sequence,
     replay_resolved_sequence_grouping,
+    replay_root_opening_restoration,
     replay_sequence_materialization,
 )
 from .foundation_v2_persistent import (
@@ -103,6 +104,7 @@ __all__ = [
     "replay_persistent_sequence_materialization",
     "replay_relation_step",
     "replay_resolved_sequence_grouping",
+    "replay_root_opening_restoration",
     "replay_run",
     "replay_sequence_materialization",
     "replay_source_front_end",

--- a/core/foundation_v2_materialization.py
+++ b/core/foundation_v2_materialization.py
@@ -2,10 +2,12 @@
 
 The source/Anum front-end and this module are deliberately separate. Raw glyphs,
 tokens and parser nodes are not semantic identity here. After source replay has
-selected an ordered tuple of exact forms, ``replay_resolved_sequence_grouping``
-may interpret two explicitly selected exact occurrences as open/close delimiters
-for sequence-deserialization mode. Delimiter meaning is therefore contextual;
-the link shape alone never makes an occurrence a bracket command.
+selected an ordered tuple of exact forms, an explicitly selected root-opening
+restoration may first expand collapsed leading-open usage. Then
+``replay_resolved_sequence_grouping`` may interpret two explicitly selected
+exact occurrences as open/close delimiters for sequence-deserialization mode.
+Delimiter meaning is contextual; the link shape alone never makes an occurrence
+a bracket command.
 
 The resulting nested sequence description has arbitrary exact existing link
 occurrences as leaves. A leaf may itself be a complete non-self-closed relation;
@@ -106,6 +108,55 @@ class SequenceMaterialization:
     result: OccurrenceRef
 
 
+def replay_root_opening_restoration(
+    network: LinkNetwork,
+    forms: tuple[OccurrenceRef, ...],
+    *,
+    open_form: OccurrenceRef,
+    close_form: OccurrenceRef,
+) -> tuple[OccurrenceRef, ...]:
+    """Restore root-collapsed leading opens over exact resolved forms.
+
+    This is the exact-occurrence analogue of the historical Anum beginning rule.
+    Restoration is eligible only when the represented carrier already begins
+    with the exact selected ``open_form``. If exact closes outnumber exact opens,
+    the deficit is prepended as repeated *uses of the same open occurrence*.
+    No link is created and no group is interpreted here.
+
+    Same-shape occurrences do not contribute to the balance unless they are the
+    exact selected delimiter refs. A caller must run grouping separately, so a
+    malformed restored sequence still fails closed at the next trusted layer.
+    """
+
+    before = network.snapshot()
+    try:
+        _validate_resolved_grouping_inputs(
+            network,
+            forms,
+            open_form=open_form,
+            close_form=close_form,
+        )
+        if forms[0] is not open_form:
+            return forms
+
+        balance = sum(
+            1 if form is open_form else -1 if form is close_form else 0
+            for form in forms
+        )
+        if balance >= 0:
+            return forms
+        return (open_form,) * (-balance) + forms
+    except LinkNetworkError as exc:
+        raise SequenceMaterializationError(
+            "resolved sequence contains a foreign exact occurrence"
+        ) from exc
+    finally:
+        if network.snapshot() != before:
+            raise SequenceMaterializationError(
+                "root opening restoration mutated the network"
+            )
+
+
 def replay_resolved_sequence_grouping(
     network: LinkNetwork,
     forms: tuple[OccurrenceRef, ...],
@@ -119,22 +170,19 @@ def replay_resolved_sequence_grouping(
     sequence-deserialization mode. Only those exact occurrences delimit groups;
     another occurrence with the same poles is an ordinary sequence value.
 
-    This function does not define the raw-carrier/root-opening-collapse mapping.
-    It starts after source/D replay has already produced exact forms in order.
+    This function starts after source/D replay. If root-opening collapse belongs
+    to the selected carrier protocol, call ``replay_root_opening_restoration``
+    explicitly before grouping; grouping itself never guesses missing opens.
     """
 
     before = network.snapshot()
     try:
-        network.link(open_form)
-        network.link(close_form)
-        if open_form is close_form:
-            raise SequenceMaterializationError(
-                "open and close sequence delimiters must be exact-distinct"
-            )
-        if not forms:
-            raise SequenceMaterializationError("resolved sequence cannot be empty")
-        for form in forms:
-            network.link(form)
+        _validate_resolved_grouping_inputs(
+            network,
+            forms,
+            open_form=open_form,
+            close_form=close_form,
+        )
 
         items, position = _group_resolved_forms(
             forms,
@@ -249,6 +297,25 @@ def replay_sequence_materialization(
             raise SequenceMaterializationError("replay mutated the before network")
         if evidence.after.snapshot() != after_snapshot:
             raise SequenceMaterializationError("replay mutated the after network")
+
+
+def _validate_resolved_grouping_inputs(
+    network: LinkNetwork,
+    forms: tuple[OccurrenceRef, ...],
+    *,
+    open_form: OccurrenceRef,
+    close_form: OccurrenceRef,
+) -> None:
+    network.link(open_form)
+    network.link(close_form)
+    if open_form is close_form:
+        raise SequenceMaterializationError(
+            "open and close sequence delimiters must be exact-distinct"
+        )
+    if not forms:
+        raise SequenceMaterializationError("resolved sequence cannot be empty")
+    for form in forms:
+        network.link(form)
 
 
 def _group_resolved_forms(

--- a/tests/test_mts_foundation_v2_source.py
+++ b/tests/test_mts_foundation_v2_source.py
@@ -12,6 +12,7 @@ from core.foundation_v2_materialization import (
     SequenceGroup,
     materialize_sequence,
     replay_resolved_sequence_grouping,
+    replay_root_opening_restoration,
 )
 from core.foundation_v2_root import build_root_kernel
 from core.foundation_v2_source import (
@@ -256,6 +257,69 @@ def test_source_root_brackets_drive_nested_sequence_deserialization() -> None:
     assert network.snapshot() == before
 
 
+def test_root_opening_restoration_reuses_exact_opening_occurrence() -> None:
+    kernel = build_root_kernel()
+    builder = kernel.network.evolve()
+    opening = kernel.refs.opening
+    closing = kernel.refs.closing
+    a = _anchor(builder)
+    b = _anchor(builder)
+    c = _anchor(builder)
+    d = _anchor(builder)
+    same_poles_as_opening = builder.reserve()
+    builder.define(same_poles_as_opening, opening, kernel.refs.root)
+    network = builder.freeze()
+
+    before = network.snapshot()
+    collapsed = (opening, a, b, closing, c, closing, d)
+    restored = replay_root_opening_restoration(
+        network,
+        collapsed,
+        open_form=opening,
+        close_form=closing,
+    )
+    assert restored == (opening, opening, a, b, closing, c, closing, d)
+    assert restored[0] is opening and restored[1] is opening
+    assert network.snapshot() == before
+
+    description = replay_resolved_sequence_grouping(
+        network,
+        restored,
+        open_form=opening,
+        close_form=closing,
+    )
+    assert description == SequenceDescription(
+        root=kernel.refs.root,
+        items=(
+            SequenceGroup(
+                (
+                    SequenceGroup((SequenceAtom(a), SequenceAtom(b))),
+                    SequenceAtom(c),
+                )
+            ),
+            SequenceAtom(d),
+        ),
+    )
+
+    balanced = (opening, a, b, closing, c)
+    assert replay_root_opening_restoration(
+        network,
+        balanced,
+        open_form=opening,
+        close_form=closing,
+    ) == balanced
+
+    assert network.link(same_poles_as_opening) == network.link(opening)
+    shape_duplicate_carrier = (same_poles_as_opening, a, closing)
+    assert replay_root_opening_restoration(
+        network,
+        shape_duplicate_carrier,
+        open_form=opening,
+        close_form=closing,
+    ) == shape_duplicate_carrier
+    assert network.snapshot() == before
+
+
 def test_ambiguous_segmentations_are_both_replayable_without_longest_match() -> None:
     builder, root, byte_refs, front_end, grammar, theory = _base_fixture()
     form_a = _anchor(builder)
@@ -364,7 +428,10 @@ def test_forged_grammar_or_theory_admission_is_rejected() -> None:
     form = _anchor(builder)
     source = front_end.source_occurrence(b"x")
     dictionary, occurrences = _dictionary_with(
-        builder, root, front_end, ((b"x", form),)
+        builder,
+        root,
+        front_end,
+        ((b"x", form),),
     )
     evidence = front_end.build_selected_evidence(
         source,


### PR DESCRIPTION
Продвигает #123 и связывает новую Foundation-v2 последовательностную десериализацию с исторической «аксиомой начала» без зависимости от старого raw decoder.

Историческая граница:

```text
expanded:  [[01]1]0
canonical: [01]1]0
```

Новый read-only replay работает уже после source/D resolution над exact forms:

```text
(O, A, B, C, D, C, E)
→ (O, O, A, B, C, D, C, E)
```

если:
- первый form **is exact O**;
- exact C встречается больше раз, чем exact O.

Недостающие открытия — не новые связи, а повторные употребления **того же exact O** как виртуальной начальной границы.

Отдельно проверяется:
- balanced forms остаются без изменений;
- связь с теми же полюсами, что O, но другим exact occurrence, не получает право на восстановление;
- восстановление read-only;
- grouping выполняется отдельным уже существующим replay и по-прежнему отвечает за структурную корректность.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_materialization.py
  - core/foundation_v2.py
  - tests/test_mts_foundation_v2_source.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 220
must_touch:
  - core/foundation_v2_materialization.py
  - tests/test_mts_foundation_v2_source.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - collapsed leading root openings can be restored over exact resolved forms
  - restoration reuses the distinguished exact O rather than creating occurrences
  - same-shape non-O occurrences do not participate in the beginning rule
  - restoration remains separate from grouping and materialization
```

Метрика: 3 существующих файла, 0 новых файлов, +153/−17 строк.