### PR TITLE
Убрать ложное схлопывание второго скобочного уровня

### DIFF
--- a/tests/test_anum_protocol_projection.py
+++ b/tests/test_anum_protocol_projection.py
@@ -346,43 +346,6 @@ def test_second_envelope_literal_formula_and_recursive_reencoding_are_distinct_c
     assert network.link(recursive_second) != network.link(literal_second)
 
 
-def test_structural_nesting_alone_does_not_raise_description_level() -> None:
-    kernel = build_root_kernel()
-    root = kernel.refs.root
-    a = kernel.refs.unlinked
-    b = kernel.refs.linked
-    before = kernel.network
-
-    structural_twice = materialize_sequence(
-        before,
-        SequenceDescription(
-            root=root,
-            items=(
-                SequenceGroup(
-                    (
-                        SequenceGroup((SequenceAtom(a), SequenceAtom(b))),
-                    )
-                ),
-            ),
-        ),
-    )
-
-    assert len(structural_twice.created) == 1
-    x = structural_twice.created[0].ref
-    assert structural_twice.result is x
-    assert structural_twice.after.link(x).start is a
-    assert structural_twice.after.link(x).end is b
-    assert find_links(structural_twice.after, start=root, end=x) == ()
-
-    builder = structural_twice.after.evolve()
-    carrier_x = builder.reserve()
-    builder.define(carrier_x, root, x)
-    encoded = builder.freeze()
-    assert encoded.link(carrier_x).start is root
-    assert encoded.link(carrier_x).end is x
-    assert carrier_x is not x
-
-
 def test_mixed_ab_group_ab_preserves_duplicate_exact_pair_occurrences() -> None:
     kernel = build_root_kernel()
     root = kernel.refs.root


### PR DESCRIPTION
После исправления left-fold в #312 и exact fork в #314 стало видно, что один тест из #311 закрепляет неподтверждённое и противоречащее пользовательским формулам ограничение: `SequenceGroup(SequenceGroup(a,b))` объявлялся семантически тем же результатом, что один `SequenceGroup(a,b)`.

Для семейства `[[ab]]ab` пользовательская формула требует сохранения дополнительного уровня carrier перед внешней левой свёрткой. Поэтому утверждение «structural nesting alone does not raise description level» нельзя оставлять как veto, пока правило скобочной глубины не выведено.

Этот PR **только удаляет ложное отрицательное требование**. Он не меняет production `SequenceGroup`, не вводит depth/tag/opcode, не выбирает между competing envelope semantics и не меняет #314/#315.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_anum_protocol_projection.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - tests/test_anum_protocol_projection.py
must_not_touch:
  - core/**
  - contracts/**
  - docs/**
expected_effects:
  - remove unsupported requirement that second structural nesting must collapse
  - preserve corrected left-fold semantics
  - preserve mixed ab[ab] exact-occurrence challenge
  - preserve second-envelope fork from #314
  - introduce no new bracket semantics
```