### PR TITLE
Разложить примеры Anum на pass / deserialize / encode

### DIFF
--- a/tests/test_anum_protocol_projection.py
+++ b/tests/test_anum_protocol_projection.py
@@ -405,6 +405,105 @@ def test_grouping_preserves_depth_that_generic_materializer_does_not_encode() ->
     ) == ()
 
 
+def test_user_examples_decompose_into_pass_deserialize_encode_and_left_fold() -> None:
+    kernel = build_root_kernel()
+    builder = kernel.network.evolve()
+    root = kernel.refs.root
+    a = kernel.refs.unlinked
+    b = kernel.refs.linked
+
+    carrier_a = builder.reserve()
+    carrier_ab = builder.reserve()
+    builder.define(carrier_a, root, a)
+    builder.define(carrier_ab, carrier_a, b)
+    before = builder.freeze()
+
+    empty = materialize_sequence(before, SequenceDescription(root=root, items=()))
+    singleton = materialize_sequence(
+        before,
+        SequenceDescription(root=root, items=(SequenceAtom(a),)),
+    )
+    assert empty.result is root and empty.created == ()
+    assert singleton.result is a and singleton.created == ()
+
+    # P: pass an already-existing exact carrier as one value, with no effect.
+    passed = materialize_sequence(
+        before,
+        SequenceDescription(root=root, items=(SequenceAtom(carrier_ab),)),
+    )
+    assert passed.result is carrier_ab
+    assert passed.created == ()
+
+    # D: deserialize ab by the corrected left fold, without R as an operand.
+    deserialized = materialize_sequence(
+        before,
+        SequenceDescription(
+            root=root,
+            items=(SequenceAtom(a), SequenceAtom(b)),
+        ),
+    )
+    x = deserialized.result
+    assert len(deserialized.created) == 1
+    assert (deserialized.created[0].start, deserialized.created[0].end) == (a, b)
+
+    # E: encode one selected exact value as a carrier R⟼value.  This is an
+    # explicit link effect, not an intrinsic bracket opcode.
+    encoded_builder = deserialized.after.evolve()
+    carrier_x = encoded_builder.reserve()
+    carrier_carrier_ab = encoded_builder.reserve()
+    encoded_builder.define(carrier_x, root, x)
+    encoded_builder.define(carrier_carrier_ab, root, carrier_ab)
+    encoded = encoded_builder.freeze()
+
+    # User families:
+    #   [ab]   -> E(D(ab)) = C_X
+    #   [[ab]] -> E(P(C_ab)) = C(C_ab)
+    assert encoded.link(carrier_x).start is root
+    assert encoded.link(carrier_x).end is x
+    assert encoded.link(carrier_carrier_ab).start is root
+    assert encoded.link(carrier_carrier_ab).end is carrier_ab
+    assert carrier_x is not carrier_carrier_ab
+
+    # ab[ab] -> D(a,b,D(a,b)); inner and outer a⟼b are exact-distinct.
+    mixed = materialize_sequence(
+        before,
+        SequenceDescription(
+            root=root,
+            items=(
+                SequenceAtom(a),
+                SequenceAtom(b),
+                SequenceGroup((SequenceAtom(a), SequenceAtom(b))),
+            ),
+        ),
+    )
+    inner_ab, outer_ab, mixed_result = mixed.created
+    assert (inner_ab.start, inner_ab.end) == (a, b)
+    assert (outer_ab.start, outer_ab.end) == (a, b)
+    assert inner_ab.ref is not outer_ab.ref
+    assert mixed_result.start is outer_ab.ref
+    assert mixed_result.end is inner_ab.ref
+    assert mixed.result is mixed_result.ref
+
+    # [[ab]]ab -> D(E(P(C_ab)),a,b), using the literal second-level candidate.
+    outer = materialize_sequence(
+        encoded,
+        SequenceDescription(
+            root=root,
+            items=(
+                SequenceAtom(carrier_carrier_ab),
+                SequenceAtom(a),
+                SequenceAtom(b),
+            ),
+        ),
+    )
+    first, full = outer.created
+    assert first.start is carrier_carrier_ab
+    assert first.end is a
+    assert full.start is first.ref
+    assert full.end is b
+    assert outer.result is full.ref
+
+
 def test_mixed_ab_group_ab_preserves_duplicate_exact_pair_occurrences() -> None:
     kernel = build_root_kernel()
     root = kernel.refs.root


### PR DESCRIPTION
Продолжает #123 после #314–#317.

Executable challenge проверяет, что пользовательские примеры можно выразить без intrinsic bracket opcodes и без новой ontology через три уже понятных вида действий:

```text
P(v)   = передать существующее exact значение без эффекта
D(seq) = материализовать sequence left-fold без R как operand
E(v)   = явно построить carrier одного значения R ⟼ v
```

Получается:

```text
ab       -> D(a,b)
[ab]     -> E(D(a,b))
[[ab]]   -> E(P(C_ab))
ab[ab]   -> D(a,b,D(a,b))
[[ab]]ab -> D(E(P(C_ab)),a,b)
```

где `C_ab=(R⟼a)⟼b` — уже существующий carrier исходного `ab`.

Challenge также фиксирует `D(ε)=R`, `D(a)=a` и exact-distinct внутренний/внешний `a⟼b` в `ab[ab]`.

Это **не** вводит production `P/D/E` opcodes или enum: названия используются только как аналитическая декомпозиция уже существующих exact-link эффектов. Выбор конкретной композиции должен в дальнейшем быть засвидетельствован actual act + K/D/G/T, как показано в #315.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_anum_protocol_projection.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 120
must_touch:
  - tests/test_anum_protocol_projection.py
must_not_touch:
  - core/**
  - contracts/**
  - docs/**
expected_effects:
  - reproduce user examples by exact pass deserialize encode composition
  - preserve corrected left-fold semantics
  - keep carrier and denotation exact-distinct
  - introduce no intrinsic bracket opcode or hidden depth state
```