### PR TITLE
Добавить trusted replay плоского чтения Anum

### DIFF
--- a/core/foundation_v2_interpreter.py
+++ b/core/foundation_v2_interpreter.py
@@ -7,6 +7,7 @@ it does not tokenize, parse, search, rank or materialize application links.
 The same engine currently replays:
 
 - one-pole relation resolution against exact K/current;
+- one flat selected Anum sequence reading against exact source/D/G/T evidence;
 - one persistent scoped-dictionary ``:`` effect;
 - one local exact-representative ``=`` evaluation.
 
@@ -74,6 +75,40 @@ class RelationStepEvidence:
     act: OccurrenceRef
     role_dictionary: OccurrenceRef
     roles: RelationStepRoleRefs
+
+
+@dataclass(frozen=True)
+class FlatSequenceReadingRoleRefs:
+    """Exact roles required to replay one selected flat Anum reading act."""
+
+    source: OccurrenceRef
+    source_selection: OccurrenceRef
+    form_sequence: OccurrenceRef
+    dictionary: OccurrenceRef
+    grammar: OccurrenceRef
+    theory: OccurrenceRef
+    before_context: OccurrenceRef
+    result: OccurrenceRef
+    after_context: OccurrenceRef
+
+
+@dataclass(frozen=True)
+class FlatSequenceReadingEvidence:
+    """Checker handle for one read-only flat sequence reading.
+
+    The selected source front-end fixes exact source/D/G/T evidence and the
+    ordered form sequence. ``result`` must already exist and must be exactly the
+    left-fold denotation of that flat sequence. Replay never creates it.
+    """
+
+    source_evidence: SourceFrontEndEvidence
+    interpreter: OccurrenceRef
+    before_context: OccurrenceRef
+    result: OccurrenceRef
+    after_context: OccurrenceRef
+    act: OccurrenceRef
+    role_dictionary: OccurrenceRef
+    roles: FlatSequenceReadingRoleRefs
 
 
 @dataclass(frozen=True)
@@ -183,6 +218,47 @@ def replay_relation_step(
     finally:
         if network.snapshot() != before_snapshot:
             raise InterpreterReplayError("interpreter replay mutated the network")
+
+
+def replay_flat_sequence_reading(
+    network: LinkNetwork,
+    evidence: FlatSequenceReadingEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+) -> OccurrenceRef:
+    """Replay one selected flat Anum sequence reading without effects.
+
+    This operation deliberately stops before O/C grouping. The source front-end
+    has already selected one exact flat form sequence under explicit D/G/T. The
+    result must be the exact existing left-fold denotation of those selected
+    forms: empty -> root, singleton -> the same occurrence, longer sequences ->
+    left-associated links. Search and creation remain outside replay.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        forms = _replay_source(network, evidence.source_evidence, byte_refs)
+        _verify_flat_sequence_result(network, forms, evidence.result)
+
+        try:
+            parent = parent_of_context(network, evidence.before_context)
+            current_of_context(network, evidence.before_context)
+            after_parent = parent_of_context(network, evidence.after_context)
+            after_current = current_of_context(network, evidence.after_context)
+        except FoundationStateError as exc:
+            raise InterpreterReplayError("invalid flat-reading context") from exc
+        if after_parent is not parent:
+            raise InterpreterReplayError("flat reading changed the explicit parent")
+        if after_current is not evidence.result:
+            raise InterpreterReplayError(
+                "flat-reading after-context current is not the exact result"
+            )
+
+        _verify_flat_sequence_act_header(network, evidence)
+        _verify_flat_sequence_act_fields(network, evidence)
+        return evidence.result
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise InterpreterReplayError("flat-reading replay mutated the network")
 
 
 def replay_colon_effect(
@@ -319,6 +395,36 @@ def _replay_source(
         raise InterpreterReplayError("invalid source-front-end evidence") from exc
 
 
+def _verify_flat_sequence_result(
+    network: LinkNetwork,
+    forms: tuple[OccurrenceRef, ...],
+    result: OccurrenceRef,
+) -> None:
+    if not forms:
+        if result is not network.root:
+            raise InterpreterReplayError("empty flat sequence result is not exact root")
+        return
+    if len(forms) == 1:
+        if result is not forms[0]:
+            raise InterpreterReplayError(
+                "singleton flat sequence result is not the exact selected form"
+            )
+        return
+
+    current = result
+    for expected_end in reversed(forms[1:]):
+        link = network.link(current)
+        if link.end is not expected_end:
+            raise InterpreterReplayError(
+                "flat sequence result does not match exact left-fold denotation"
+            )
+        current = link.start
+    if current is not forms[0]:
+        raise InterpreterReplayError(
+            "flat sequence result does not start from the first exact form"
+        )
+
+
 def _expected_result_poles(
     network: LinkNetwork,
     form: OccurrenceRef,
@@ -371,6 +477,48 @@ def _verify_relation_act_fields(
             "before-context",
         ),
         (evidence.roles.binding, evidence.binding, "binding"),
+        (evidence.roles.result, evidence.result, "result"),
+        (evidence.roles.after_context, evidence.after_context, "after-context"),
+    )
+    _verify_exact_act_fields(network, evidence.act, expected)
+
+
+def _verify_flat_sequence_act_header(
+    network: LinkNetwork,
+    evidence: FlatSequenceReadingEvidence,
+) -> None:
+    try:
+        header = act_header(network, evidence.act)
+    except FoundationStateError as exc:
+        raise InterpreterReplayError("invalid flat-reading actual-act header") from exc
+    expected = (evidence.interpreter, evidence.role_dictionary, evidence.after_context)
+    if header != expected:
+        raise InterpreterReplayError(
+            "flat-reading actual-act header does not match I/D_roles/K_after"
+        )
+
+
+def _verify_flat_sequence_act_fields(
+    network: LinkNetwork,
+    evidence: FlatSequenceReadingEvidence,
+) -> None:
+    source = evidence.source_evidence
+    expected = (
+        (evidence.roles.source, source.source, "source"),
+        (
+            evidence.roles.source_selection,
+            source.selection_sequence,
+            "source-selection",
+        ),
+        (evidence.roles.form_sequence, source.form_sequence, "form-sequence"),
+        (evidence.roles.dictionary, source.dictionary, "dictionary"),
+        (evidence.roles.grammar, source.grammar, "grammar"),
+        (evidence.roles.theory, source.theory, "theory"),
+        (
+            evidence.roles.before_context,
+            evidence.before_context,
+            "before-context",
+        ),
         (evidence.roles.result, evidence.result, "result"),
         (evidence.roles.after_context, evidence.after_context, "after-context"),
     )

--- a/tests/test_mts_foundation_v2_interpreter.py
+++ b/tests/test_mts_foundation_v2_interpreter.py
@@ -7,9 +7,12 @@ import pytest
 
 from core.exact_link_network import LinkNetworkBuilder
 from core.foundation_v2_interpreter import (
+    FlatSequenceReadingEvidence,
+    FlatSequenceReadingRoleRefs,
     InterpreterReplayError,
     RelationStepEvidence,
     RelationStepRoleRefs,
+    replay_flat_sequence_reading,
     replay_relation_step,
 )
 from core.foundation_v2_source import SegmentSpec, SourceFrontEndBuilder
@@ -33,6 +36,17 @@ ROLE_NAMES = (
     "form",
     "before-context",
     "binding",
+    "result",
+    "after-context",
+)
+FLAT_ROLE_NAMES = (
+    "source",
+    "source-selection",
+    "form-sequence",
+    "dictionary",
+    "grammar",
+    "theory",
+    "before-context",
     "result",
     "after-context",
 )
@@ -82,6 +96,35 @@ def _role_items(roles: RelationStepRoleRefs):
         ("form", roles.form),
         ("before-context", roles.before_context),
         ("binding", roles.binding),
+        ("result", roles.result),
+        ("after-context", roles.after_context),
+    )
+
+
+def _flat_roles(builder: LinkNetworkBuilder) -> FlatSequenceReadingRoleRefs:
+    refs = {name: _anchor(builder) for name in FLAT_ROLE_NAMES}
+    return FlatSequenceReadingRoleRefs(
+        source=refs["source"],
+        source_selection=refs["source-selection"],
+        form_sequence=refs["form-sequence"],
+        dictionary=refs["dictionary"],
+        grammar=refs["grammar"],
+        theory=refs["theory"],
+        before_context=refs["before-context"],
+        result=refs["result"],
+        after_context=refs["after-context"],
+    )
+
+
+def _flat_role_items(roles: FlatSequenceReadingRoleRefs):
+    return (
+        ("source", roles.source),
+        ("source-selection", roles.source_selection),
+        ("form-sequence", roles.form_sequence),
+        ("dictionary", roles.dictionary),
+        ("grammar", roles.grammar),
+        ("theory", roles.theory),
+        ("before-context", roles.before_context),
         ("result", roles.result),
         ("after-context", roles.after_context),
     )
@@ -197,6 +240,110 @@ def _fixture(
     return network, byte_refs, evidence, duplicate, fixed_pole
 
 
+def _flat_reading_fixture(*, duplicate_pair_result_field: bool = False):
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    byte_refs = _byte_vocabulary(builder)
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+
+    a = _anchor(builder)
+    b = _anchor(builder)
+    carrier_a = _new_link(builder, root, a)
+    carrier_ab = _new_link(builder, carrier_a, b)
+    pair_result = _new_link(builder, a, b)
+
+    source = front_end.source_occurrence(b"ab")
+    dictionary = define_dictionary_scope(builder, root, root)
+    history = root
+    occurrences = {}
+    for raw, form in ((b"a", a), (b"b", b), (b"ab", carrier_ab)):
+        dictionary, history, occurrence = _define_scoped_mapping(
+            builder,
+            root,
+            dictionary,
+            history,
+            front_end.content_ref(raw),
+            form,
+        )
+        occurrences[raw] = occurrence
+
+    pair_grammar = _anchor(builder)
+    pair_theory = _anchor(builder)
+    carrier_grammar = _anchor(builder)
+    carrier_theory = _anchor(builder)
+    pair_source = front_end.build_selected_evidence(
+        source,
+        (
+            SegmentSpec(0, 1, a, occurrences[b"a"]),
+            SegmentSpec(1, 2, b, occurrences[b"b"]),
+        ),
+        dictionary=dictionary,
+        grammar=pair_grammar,
+        theory=pair_theory,
+    )
+    carrier_source = front_end.build_selected_evidence(
+        source,
+        (SegmentSpec(0, 2, carrier_ab, occurrences[b"ab"]),),
+        dictionary=dictionary,
+        grammar=carrier_grammar,
+        theory=carrier_theory,
+    )
+
+    interpreter = _anchor(builder)
+    parent = _anchor(builder)
+    prior = _anchor(builder)
+    before_context = define_context(builder, parent, prior)
+    pair_after = define_context(builder, parent, pair_result)
+    carrier_after = define_context(builder, parent, carrier_ab)
+
+    roles = _flat_roles(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    role_history = root
+    for role_name, role_ref in _flat_role_items(roles):
+        role_dictionary, role_history, _ = _define_scoped_mapping(
+            builder,
+            root,
+            role_dictionary,
+            role_history,
+            front_end.content_ref(role_name.encode("utf-8")),
+            role_ref,
+        )
+
+    def reading(source_evidence, result, after_context):
+        act = define_act_header(builder, interpreter, role_dictionary, after_context)
+        fields = (
+            (roles.source, source_evidence.source),
+            (roles.source_selection, source_evidence.selection_sequence),
+            (roles.form_sequence, source_evidence.form_sequence),
+            (roles.dictionary, source_evidence.dictionary),
+            (roles.grammar, source_evidence.grammar),
+            (roles.theory, source_evidence.theory),
+            (roles.before_context, before_context),
+            (roles.result, result),
+            (roles.after_context, after_context),
+        )
+        for role, value in fields:
+            define_act_field(builder, act, role, value)
+        return FlatSequenceReadingEvidence(
+            source_evidence=source_evidence,
+            interpreter=interpreter,
+            before_context=before_context,
+            result=result,
+            after_context=after_context,
+            act=act,
+            role_dictionary=role_dictionary,
+            roles=roles,
+        )
+
+    pair_reading = reading(pair_source, pair_result, pair_after)
+    carrier_reading = reading(carrier_source, carrier_ab, carrier_after)
+    if duplicate_pair_result_field:
+        define_act_field(builder, pair_reading.act, roles.result, carrier_ab)
+
+    network = builder.freeze(root)
+    return network, byte_refs, pair_reading, carrier_reading, carrier_ab
+
+
 def test_start_open_relation_replays_from_exact_current_read_only() -> None:
     network, byte_refs, evidence, _, fixed_pole = _fixture("start-open")
     before = network.snapshot()
@@ -290,6 +437,45 @@ def test_forged_act_header_rejects() -> None:
 
     with pytest.raises(InterpreterReplayError, match="header does not match"):
         replay_relation_step(network, forged, byte_refs)
+
+
+def test_same_source_has_two_verified_flat_readings_without_hidden_mode() -> None:
+    network, byte_refs, pair_reading, carrier_reading, carrier_ab = (
+        _flat_reading_fixture()
+    )
+    before = network.snapshot()
+
+    assert pair_reading.source_evidence.source is carrier_reading.source_evidence.source
+    assert pair_reading.source_evidence.dictionary is carrier_reading.source_evidence.dictionary
+    assert pair_reading.source_evidence.form_sequence is not carrier_reading.source_evidence.form_sequence
+    assert pair_reading.source_evidence.grammar is not carrier_reading.source_evidence.grammar
+    assert pair_reading.source_evidence.theory is not carrier_reading.source_evidence.theory
+
+    pair_result = replay_flat_sequence_reading(network, pair_reading, byte_refs)
+    carrier_result = replay_flat_sequence_reading(network, carrier_reading, byte_refs)
+
+    pair_link = network.link(pair_result)
+    assert pair_link.start is not network.root
+    assert pair_result is not carrier_ab
+    assert carrier_result is carrier_ab
+    assert network.snapshot() == before
+
+
+def test_flat_reading_rejects_result_from_other_valid_segmentation() -> None:
+    network, byte_refs, pair_reading, _, carrier_ab = _flat_reading_fixture()
+    forged = replace(pair_reading, result=carrier_ab)
+
+    with pytest.raises(InterpreterReplayError, match="left-fold denotation"):
+        replay_flat_sequence_reading(network, forged, byte_refs)
+
+
+def test_flat_reading_rejects_duplicate_exact_act_result_field() -> None:
+    network, byte_refs, pair_reading, _, _ = _flat_reading_fixture(
+        duplicate_pair_result_field=True
+    )
+
+    with pytest.raises(InterpreterReplayError, match="field 'result'"):
+        replay_flat_sequence_reading(network, pair_reading, byte_refs)
 
 
 def test_interpreter_replay_has_no_legacy_parser_ast_or_interpreter_dependency() -> None:

--- a/tests/test_mts_foundation_v2_interpreter.py
+++ b/tests/test_mts_foundation_v2_interpreter.py
@@ -465,7 +465,7 @@ def test_flat_reading_rejects_result_from_other_valid_segmentation() -> None:
     network, byte_refs, pair_reading, _, carrier_ab = _flat_reading_fixture()
     forged = replace(pair_reading, result=carrier_ab)
 
-    with pytest.raises(InterpreterReplayError, match="left-fold denotation"):
+    with pytest.raises(InterpreterReplayError, match="does not start"):
         replay_flat_sequence_reading(network, forged, byte_refs)
 
 


### PR DESCRIPTION
Продолжает #123 после #315–#320 минимальным read-only trusted slice.

Добавляется `replay_flat_sequence_reading`: он не парсит, не ищет и не материализует связи. Входом является уже выбранное `SourceFrontEndEvidence` с exact source/D/G/T/form-sequence и exact actual act.

Проверка:

```text
source/D/G/T replay
→ exact flat form sequence
→ проверить существующий result как left fold
→ проверить K_before / K_after
→ проверить header A = I / D_roles / K_after
→ потребовать ровно одно exact значение каждой обязательной роли A
```

Для последовательности:

```text
ε     -> R
a     -> a
a b   -> exact a⟼b
a b c -> exact (a⟼b)⟼c
```

результат только проверяется; недостающая связь не создаётся.

Главный вектор использует **один exact source `ab` и один D**, но две явные сегментации:

```text
a | b  -> result X = a⟼b
ab     -> result C_ab (один уже существующий carrier)
```

с разными G/T/form-sequence и разными actual acts. Это показывает, что лабораторный `pass(C_ab)` не требует отдельной операции: singleton `des(C_ab)=C_ab` уже даёт zero-effect pass.

Вложенные O/C groups, `enc`, универсальная bracket semantics и hidden depth state в PR не входят.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_interpreter.py
  - tests/test_mts_foundation_v2_interpreter.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 400
must_touch:
  - core/foundation_v2_interpreter.py
  - tests/test_mts_foundation_v2_interpreter.py
must_not_touch:
  - contracts/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - replay one selected flat Anum reading read-only
  - verify exact left-fold result without search or materialization
  - bind source D G T contexts and result to one exact actual act
  - allow same exact source to have occurrence-distinct verified readings
  - introduce no bracket opcode relative context or pair interning
```