### PR TITLE
Добавить trusted replay source-подвыборки

### DIFF
--- a/core/foundation_v2_source.py
+++ b/core/foundation_v2_source.py
@@ -320,6 +320,70 @@ def replay_source_front_end(
     return tuple(forms)
 
 
+def replay_source_subselection(
+    network: LinkNetwork,
+    evidence: SourceFrontEndEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+    *,
+    start_segment: int,
+    end_segment: int,
+    selection_sequence: OccurrenceRef,
+    form_sequence: OccurrenceRef,
+    grammar: OccurrenceRef,
+    theory: OccurrenceRef,
+    grammar_membership: OccurrenceRef,
+    theory_membership: OccurrenceRef,
+) -> tuple[OccurrenceRef, ...]:
+    """Replay one exact contiguous subselection of an already-replayed source.
+
+    Segment indices are checker coordinates only. Semantic evidence remains the
+    exact segment ``selection`` occurrences, their R-seeded ordered fold, the
+    selected exact form fold and explicit G/T memberships. Empty ranges are
+    valid and therefore use the distinguished exact root for both folds.
+
+    This layer is intentionally bracket-agnostic: it does not decide whether a
+    selected range is a group body. A higher layer may independently verify O/C
+    boundaries around the same exact segment range.
+    """
+
+    before = network.snapshot()
+    forms = replay_source_front_end(network, evidence, byte_refs)
+    if (
+        start_segment < 0
+        or end_segment < start_segment
+        or end_segment > len(evidence.segments)
+    ):
+        raise SourceReplayError("invalid source subselection segment range")
+
+    segments = evidence.segments[start_segment:end_segment]
+    selected_forms = forms[start_segment:end_segment]
+    _verify_fold(
+        network,
+        selection_sequence,
+        tuple(segment.selection for segment in segments),
+        network.root,
+    )
+    _verify_fold(network, form_sequence, selected_forms, network.root)
+    _verify_direct_membership(
+        network,
+        grammar_membership,
+        grammar,
+        form_sequence,
+        "subselection grammar",
+    )
+    _verify_direct_membership(
+        network,
+        theory_membership,
+        theory,
+        form_sequence,
+        "subselection theory",
+    )
+
+    if network.snapshot() != before:
+        raise SourceReplayError("source subselection replay mutated the network")
+    return selected_forms
+
+
 def _validate_spans(raw_bytes: bytes, specs: Sequence[SegmentSpec]) -> None:
     boundaries = tuple((spec.start, spec.end) for spec in specs)
     _validate_boundaries(raw_bytes, boundaries)

--- a/tests/test_anum_protocol_projection.py
+++ b/tests/test_anum_protocol_projection.py
@@ -23,7 +23,9 @@ from core.foundation_v2_root import build_root_kernel
 from core.foundation_v2_source import (
     SegmentSpec,
     SourceFrontEndBuilder,
+    SourceReplayError,
     replay_source_front_end,
+    replay_source_subselection,
 )
 from core.foundation_v2_state import (
     define_dictionary_effect,
@@ -304,6 +306,10 @@ def test_nested_body_selection_reuses_exact_segments_of_whole_source() -> None:
     body_theory = _anchor(builder)
     body_grammar_membership = define_membership(builder, body_grammar, body_forms)
     body_theory_membership = define_membership(builder, body_theory, body_forms)
+    empty_grammar = _anchor(builder)
+    empty_theory = _anchor(builder)
+    empty_grammar_membership = define_membership(builder, empty_grammar, root)
+    empty_theory_membership = define_membership(builder, empty_theory, root)
     network = builder.freeze()
     before = network.snapshot()
 
@@ -318,6 +324,62 @@ def test_nested_body_selection_reuses_exact_segments_of_whole_source() -> None:
         root=root,
         items=(SequenceGroup((SequenceAtom(a), SequenceAtom(b))),),
     )
+
+    assert replay_source_subselection(
+        network,
+        outer,
+        byte_refs,
+        start_segment=1,
+        end_segment=3,
+        selection_sequence=body_selection,
+        form_sequence=body_forms,
+        grammar=body_grammar,
+        theory=body_theory,
+        grammar_membership=body_grammar_membership,
+        theory_membership=body_theory_membership,
+    ) == (a, b)
+    assert replay_source_subselection(
+        network,
+        outer,
+        byte_refs,
+        start_segment=1,
+        end_segment=1,
+        selection_sequence=root,
+        form_sequence=root,
+        grammar=empty_grammar,
+        theory=empty_theory,
+        grammar_membership=empty_grammar_membership,
+        theory_membership=empty_theory_membership,
+    ) == ()
+
+    with pytest.raises(SourceReplayError, match="ordered sequence evidence"):
+        replay_source_subselection(
+            network,
+            outer,
+            byte_refs,
+            start_segment=1,
+            end_segment=3,
+            selection_sequence=outer.selection_sequence,
+            form_sequence=body_forms,
+            grammar=body_grammar,
+            theory=body_theory,
+            grammar_membership=body_grammar_membership,
+            theory_membership=body_theory_membership,
+        )
+    with pytest.raises(SourceReplayError, match="invalid source subselection"):
+        replay_source_subselection(
+            network,
+            outer,
+            byte_refs,
+            start_segment=3,
+            end_segment=2,
+            selection_sequence=root,
+            form_sequence=root,
+            grammar=empty_grammar,
+            theory=empty_theory,
+            grammar_membership=empty_grammar_membership,
+            theory_membership=empty_theory_membership,
+        )
 
     selection_tail = network.link(body_selection)
     selection_head = network.link(selection_tail.start)


### PR DESCRIPTION
Продолжает #123 после topology challenge #323 и добавляет минимальный read-only trusted слой без нового `NestedSource` типа.

`replay_source_subselection(...)` сначала воспроизводит весь `SourceFrontEndEvidence`, затем проверяет непрерывный диапазон уже валидированных segments через:

```text
fold(R, exact segment.selection...)
fold(R, exact selected forms...)
G ⟼ selected form-sequence
T ⟼ selected form-sequence
```

Host `start_segment/end_segment` — только координаты checker. Семантическое свидетельство остаётся exact-link структурой. Пустой диапазон допустим и использует distinguished `R` как обе пустые свёртки.

Функция намеренно ничего не знает про `O/C` и не решает, является ли диапазон телом группы. Такая проверка остаётся более высоким уровнем.

Тест расширяет `[ab]` challenge #323:
- whole source replay остаётся `(O,a,b,C)`;
- body subselection `1:3` trusted-replay возвращает `(a,b)`;
- пустая subselection проверяется через `R`;
- forged full selection sequence вместо body sequence отвергается;
- обратный диапазон отвергается;
- сеть остаётся неизменной.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_source.py
  - tests/test_anum_protocol_projection.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 160
must_touch:
  - core/foundation_v2_source.py
  - tests/test_anum_protocol_projection.py
must_not_touch:
  - contracts/**
  - docs/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - replay exact contiguous subselection of an already verified whole source
  - keep segment indices as checker coordinates only
  - preserve exact selection and form folds plus G T memberships
  - support empty subselection as exact root
  - introduce no NestedSource type or bracket semantics
```