### PR TITLE
Связать flat reading с trusted source-подвыборкой

### DIFF
--- a/core/foundation_v2_interpreter.py
+++ b/core/foundation_v2_interpreter.py
@@ -24,6 +24,7 @@ from .foundation_v2_source import (
     SourceFrontEndEvidence,
     SourceReplayError,
     replay_source_front_end,
+    replay_source_subselection,
 )
 from .foundation_v2_state import (
     DictionaryLookupError,
@@ -237,28 +238,75 @@ def replay_flat_sequence_reading(
     before_snapshot = network.snapshot()
     try:
         forms = _replay_source(network, evidence.source_evidence, byte_refs)
-        _verify_flat_sequence_result(network, forms, evidence.result)
-
-        try:
-            parent = parent_of_context(network, evidence.before_context)
-            current_of_context(network, evidence.before_context)
-            after_parent = parent_of_context(network, evidence.after_context)
-            after_current = current_of_context(network, evidence.after_context)
-        except FoundationStateError as exc:
-            raise InterpreterReplayError("invalid flat-reading context") from exc
-        if after_parent is not parent:
-            raise InterpreterReplayError("flat reading changed the explicit parent")
-        if after_current is not evidence.result:
-            raise InterpreterReplayError(
-                "flat-reading after-context current is not the exact result"
-            )
-
-        _verify_flat_sequence_act_header(network, evidence)
-        _verify_flat_sequence_act_fields(network, evidence)
-        return evidence.result
+        return _replay_flat_selected_forms(
+            network,
+            evidence,
+            forms,
+            source_selection=evidence.source_evidence.selection_sequence,
+            form_sequence=evidence.source_evidence.form_sequence,
+            grammar=evidence.source_evidence.grammar,
+            theory=evidence.source_evidence.theory,
+        )
     finally:
         if network.snapshot() != before_snapshot:
             raise InterpreterReplayError("flat-reading replay mutated the network")
+
+
+def replay_flat_source_subselection_reading(
+    network: LinkNetwork,
+    evidence: FlatSequenceReadingEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+    *,
+    start_segment: int,
+    end_segment: int,
+    selection_sequence: OccurrenceRef,
+    form_sequence: OccurrenceRef,
+    grammar: OccurrenceRef,
+    theory: OccurrenceRef,
+    grammar_membership: OccurrenceRef,
+    theory_membership: OccurrenceRef,
+) -> OccurrenceRef:
+    """Replay a flat reading of one trusted subselection of the same whole source.
+
+    ``evidence.source_evidence`` remains the whole exact source occurrence. The
+    selected source/form folds and G/T refs name only the requested contiguous
+    subselection. Segment indices are checker coordinates; actual-act identity
+    is carried by exact link fields. No nested source occurrence is introduced.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        try:
+            forms = replay_source_subselection(
+                network,
+                evidence.source_evidence,
+                byte_refs,
+                start_segment=start_segment,
+                end_segment=end_segment,
+                selection_sequence=selection_sequence,
+                form_sequence=form_sequence,
+                grammar=grammar,
+                theory=theory,
+                grammar_membership=grammar_membership,
+                theory_membership=theory_membership,
+            )
+        except SourceReplayError as exc:
+            raise InterpreterReplayError("invalid source subselection evidence") from exc
+
+        return _replay_flat_selected_forms(
+            network,
+            evidence,
+            forms,
+            source_selection=selection_sequence,
+            form_sequence=form_sequence,
+            grammar=grammar,
+            theory=theory,
+        )
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise InterpreterReplayError(
+                "flat source-subselection replay mutated the network"
+            )
 
 
 def replay_colon_effect(
@@ -395,6 +443,44 @@ def _replay_source(
         raise InterpreterReplayError("invalid source-front-end evidence") from exc
 
 
+def _replay_flat_selected_forms(
+    network: LinkNetwork,
+    evidence: FlatSequenceReadingEvidence,
+    forms: tuple[OccurrenceRef, ...],
+    *,
+    source_selection: OccurrenceRef,
+    form_sequence: OccurrenceRef,
+    grammar: OccurrenceRef,
+    theory: OccurrenceRef,
+) -> OccurrenceRef:
+    _verify_flat_sequence_result(network, forms, evidence.result)
+
+    try:
+        parent = parent_of_context(network, evidence.before_context)
+        current_of_context(network, evidence.before_context)
+        after_parent = parent_of_context(network, evidence.after_context)
+        after_current = current_of_context(network, evidence.after_context)
+    except FoundationStateError as exc:
+        raise InterpreterReplayError("invalid flat-reading context") from exc
+    if after_parent is not parent:
+        raise InterpreterReplayError("flat reading changed the explicit parent")
+    if after_current is not evidence.result:
+        raise InterpreterReplayError(
+            "flat-reading after-context current is not the exact result"
+        )
+
+    _verify_flat_sequence_act_header(network, evidence)
+    _verify_flat_sequence_act_fields(
+        network,
+        evidence,
+        source_selection=source_selection,
+        form_sequence=form_sequence,
+        grammar=grammar,
+        theory=theory,
+    )
+    return evidence.result
+
+
 def _verify_flat_sequence_result(
     network: LinkNetwork,
     forms: tuple[OccurrenceRef, ...],
@@ -501,19 +587,20 @@ def _verify_flat_sequence_act_header(
 def _verify_flat_sequence_act_fields(
     network: LinkNetwork,
     evidence: FlatSequenceReadingEvidence,
+    *,
+    source_selection: OccurrenceRef,
+    form_sequence: OccurrenceRef,
+    grammar: OccurrenceRef,
+    theory: OccurrenceRef,
 ) -> None:
     source = evidence.source_evidence
     expected = (
         (evidence.roles.source, source.source, "source"),
-        (
-            evidence.roles.source_selection,
-            source.selection_sequence,
-            "source-selection",
-        ),
-        (evidence.roles.form_sequence, source.form_sequence, "form-sequence"),
+        (evidence.roles.source_selection, source_selection, "source-selection"),
+        (evidence.roles.form_sequence, form_sequence, "form-sequence"),
         (evidence.roles.dictionary, source.dictionary, "dictionary"),
-        (evidence.roles.grammar, source.grammar, "grammar"),
-        (evidence.roles.theory, source.theory, "theory"),
+        (evidence.roles.grammar, grammar, "grammar"),
+        (evidence.roles.theory, theory, "theory"),
         (
             evidence.roles.before_context,
             evidence.before_context,

--- a/tests/test_mts_foundation_v2_interpreter.py
+++ b/tests/test_mts_foundation_v2_interpreter.py
@@ -13,6 +13,7 @@ from core.foundation_v2_interpreter import (
     RelationStepEvidence,
     RelationStepRoleRefs,
     replay_flat_sequence_reading,
+    replay_flat_source_subselection_reading,
     replay_relation_step,
 )
 from core.foundation_v2_source import SegmentSpec, SourceFrontEndBuilder
@@ -22,6 +23,7 @@ from core.foundation_v2_state import (
     define_context,
     define_dictionary_effect,
     define_dictionary_scope,
+    define_membership,
 )
 
 
@@ -66,6 +68,13 @@ def _new_link(builder: LinkNetworkBuilder, start, end):
     ref = builder.reserve()
     builder.define(ref, start, end)
     return ref
+
+
+def _fold(builder: LinkNetworkBuilder, root, values):
+    current = root
+    for value in values:
+        current = _new_link(builder, current, value)
+    return current
 
 
 def _roles(builder: LinkNetworkBuilder) -> RelationStepRoleRefs:
@@ -476,6 +485,163 @@ def test_flat_reading_rejects_duplicate_exact_act_result_field() -> None:
 
     with pytest.raises(InterpreterReplayError, match="field 'result'"):
         replay_flat_sequence_reading(network, pair_reading, byte_refs)
+
+
+def test_flat_subselection_reading_keeps_whole_source_in_actual_act() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    byte_refs = _byte_vocabulary(builder)
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+
+    opening = _anchor(builder)
+    a = _anchor(builder)
+    b = _anchor(builder)
+    closing = _anchor(builder)
+    result = _new_link(builder, a, b)
+
+    source = front_end.source_occurrence(b"[ab]")
+    dictionary = define_dictionary_scope(builder, root, root)
+    history = root
+    occurrences = {}
+    for raw, form in ((b"[", opening), (b"a", a), (b"b", b), (b"]", closing)):
+        dictionary, history, occurrence = _define_scoped_mapping(
+            builder,
+            root,
+            dictionary,
+            history,
+            front_end.content_ref(raw),
+            form,
+        )
+        occurrences[raw] = occurrence
+
+    outer_grammar = _anchor(builder)
+    outer_theory = _anchor(builder)
+    outer = front_end.build_selected_evidence(
+        source,
+        (
+            SegmentSpec(0, 1, opening, occurrences[b"["]),
+            SegmentSpec(1, 2, a, occurrences[b"a"]),
+            SegmentSpec(2, 3, b, occurrences[b"b"]),
+            SegmentSpec(3, 4, closing, occurrences[b"]"]),
+        ),
+        dictionary=dictionary,
+        grammar=outer_grammar,
+        theory=outer_theory,
+    )
+
+    body_selection = _fold(
+        builder,
+        root,
+        (outer.segments[1].selection, outer.segments[2].selection),
+    )
+    body_forms = _fold(builder, root, (a, b))
+    body_grammar = _anchor(builder)
+    body_theory = _anchor(builder)
+    body_grammar_membership = define_membership(builder, body_grammar, body_forms)
+    body_theory_membership = define_membership(builder, body_theory, body_forms)
+
+    alternate_grammar = _anchor(builder)
+    alternate_theory = _anchor(builder)
+    alternate_grammar_membership = define_membership(
+        builder, alternate_grammar, body_forms
+    )
+    alternate_theory_membership = define_membership(
+        builder, alternate_theory, body_forms
+    )
+
+    interpreter = _anchor(builder)
+    parent = _anchor(builder)
+    prior = _anchor(builder)
+    before_context = define_context(builder, parent, prior)
+    after_context = define_context(builder, parent, result)
+    roles = _flat_roles(builder)
+
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    role_history = root
+    for role_name, role_ref in _flat_role_items(roles):
+        role_dictionary, role_history, _ = _define_scoped_mapping(
+            builder,
+            root,
+            role_dictionary,
+            role_history,
+            front_end.content_ref(role_name.encode("utf-8")),
+            role_ref,
+        )
+
+    act = define_act_header(builder, interpreter, role_dictionary, after_context)
+    for role, value in (
+        (roles.source, outer.source),
+        (roles.source_selection, body_selection),
+        (roles.form_sequence, body_forms),
+        (roles.dictionary, dictionary),
+        (roles.grammar, body_grammar),
+        (roles.theory, body_theory),
+        (roles.before_context, before_context),
+        (roles.result, result),
+        (roles.after_context, after_context),
+    ):
+        define_act_field(builder, act, role, value)
+
+    evidence = FlatSequenceReadingEvidence(
+        source_evidence=outer,
+        interpreter=interpreter,
+        before_context=before_context,
+        result=result,
+        after_context=after_context,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+    network = builder.freeze(root)
+    snapshot = network.snapshot()
+
+    assert replay_flat_source_subselection_reading(
+        network,
+        evidence,
+        byte_refs,
+        start_segment=1,
+        end_segment=3,
+        selection_sequence=body_selection,
+        form_sequence=body_forms,
+        grammar=body_grammar,
+        theory=body_theory,
+        grammar_membership=body_grammar_membership,
+        theory_membership=body_theory_membership,
+    ) is result
+    assert network.link(result).start is a
+    assert network.link(result).end is b
+    assert outer.source is evidence.source_evidence.source
+
+    with pytest.raises(InterpreterReplayError, match="source subselection evidence"):
+        replay_flat_source_subselection_reading(
+            network,
+            evidence,
+            byte_refs,
+            start_segment=1,
+            end_segment=3,
+            selection_sequence=outer.selection_sequence,
+            form_sequence=body_forms,
+            grammar=body_grammar,
+            theory=body_theory,
+            grammar_membership=body_grammar_membership,
+            theory_membership=body_theory_membership,
+        )
+
+    with pytest.raises(InterpreterReplayError, match="field 'grammar'"):
+        replay_flat_source_subselection_reading(
+            network,
+            evidence,
+            byte_refs,
+            start_segment=1,
+            end_segment=3,
+            selection_sequence=body_selection,
+            form_sequence=body_forms,
+            grammar=alternate_grammar,
+            theory=alternate_theory,
+            grammar_membership=alternate_grammar_membership,
+            theory_membership=alternate_theory_membership,
+        )
+    assert network.snapshot() == snapshot
 
 
 def test_interpreter_replay_has_no_legacy_parser_ast_or_interpreter_dependency() -> None:


### PR DESCRIPTION
Продолжает #123 после #324 и закрывает мост между whole source и внутренним flat-reading act без нового `NestedSource` или нового evidence-класса.

Новый `replay_flat_source_subselection_reading(...)` использует существующий `FlatSequenceReadingEvidence`, где `source_evidence` остаётся **whole source**. Подвыборка задаётся уже trusted exact refs из `replay_source_subselection`:

```text
whole source
body source-selection
body form-sequence
body G/T
```

Проверка затем переиспользует тот же trusted flat-reading spine:

```text
source subselection replay
→ existing exact left-fold result
→ K_before / K_after
→ actual-act header
→ singleton exact act fields
```

В actual act:

```text
source = whole exact source [ab]
source-selection = exact body selection(a,b)
form-sequence = exact body form fold(a,b)
D = whole selected dictionary
G/T = body G/T
result = exact X=a⟼b
```

Тест доказывает:
- inner `ab -> X` привязан к тому же whole source `[ab]`;
- подмена outer full selection вместо body selection отвергается;
- альтернативные G/T могут быть структурно валидной subselection-admission, но отвергаются, если exact actual act свидетельствует другие G/T;
- replay read-only.

O/C boundary semantics в PR намеренно не входит: он доказывает только привязку внутреннего чтения к trusted subselection того же source.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_interpreter.py
  - tests/test_mts_foundation_v2_interpreter.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 320
must_touch:
  - core/foundation_v2_interpreter.py
  - tests/test_mts_foundation_v2_interpreter.py
must_not_touch:
  - contracts/**
  - docs/**
  - docs/research/Исходные мысли МТС.md
expected_effects:
  - bind one flat reading act to an exact subselection of the same whole source
  - reuse trusted source-subselection replay and flat left-fold verification
  - keep whole source identity in the actual act
  - reject forged selection or G T act fields
  - introduce no NestedSource type or bracket opcode
```