### PR TITLE
Обновить repo-guard до Compression 2.0

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@2543721de5f0ef50af0bd4ab9bbea5b47cdb8092
+        uses: netkeep80/repo-guard@b3a2c0c60631a4aaba38100c28fb6535e13fe018
         with:
           mode: check-pr
           enforcement: blocking


### PR DESCRIPTION
Обновляет только immutable pin GitHub Action `netkeep80/repo-guard` с `2543721de5f0ef50af0bd4ab9bbea5b47cdb8092` на актуальный `b3a2c0c60631a4aaba38100c28fb6535e13fe018`.

Между ними 17 коммитов repo-guard, включая Architecture Compression 2.0, единый Constraint Program и разделение ChangeIntent/GovernanceGrant. Интерфейс action `mode: check-pr` / `enforcement: blocking` сохранён.

Fixes #326

```repo-guard-yaml
change_type: chore
scope:
  - .github/workflows/repo-guard.yml
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - .github/workflows/repo-guard.yml
must_not_touch:
  - repo-policy.json
  - .github/workflows/ci.yml
  - core/**
  - tests/**
  - docs/**
expected_effects:
  - anum_docs использует актуальный repo-guard Compression 2.0
  - blocking policy check остаётся включён
  - action закреплён на неизменяемый commit SHA
```