### PR TITLE
Добавить trusted continuation левой свёртки от `K.current`

### DIFF
--- a/core/foundation_v2_interpreter.py
+++ b/core/foundation_v2_interpreter.py
@@ -347,6 +347,89 @@ def replay_flat_source_subselection_reading(
             )
 
 
+def replay_flat_source_subselection_continuation(
+    network: LinkNetwork,
+    evidence: FlatSequenceReadingEvidence,
+    byte_refs: Mapping[int, OccurrenceRef],
+    *,
+    start_segment: int,
+    end_segment: int,
+    selection_sequence: OccurrenceRef,
+    form_sequence: OccurrenceRef,
+    grammar: OccurrenceRef,
+    theory: OccurrenceRef,
+    grammar_membership: OccurrenceRef,
+    theory_membership: OccurrenceRef,
+) -> OccurrenceRef:
+    """Continue one exact left fold from ``K_before.current`` over a subselection.
+
+    This is sequence continuation, not bracket semantics. The selected source
+    suffix is trusted through the same source-subselection evidence as an
+    ordinary flat reading. Replay only verifies an already-existing exact result;
+    it never creates the intermediate or final links.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        try:
+            forms = replay_source_subselection(
+                network,
+                evidence.source_evidence,
+                byte_refs,
+                start_segment=start_segment,
+                end_segment=end_segment,
+                selection_sequence=selection_sequence,
+                form_sequence=form_sequence,
+                grammar=grammar,
+                theory=theory,
+                grammar_membership=grammar_membership,
+                theory_membership=theory_membership,
+            )
+        except SourceReplayError as exc:
+            raise InterpreterReplayError(
+                "invalid continuation source subselection evidence"
+            ) from exc
+
+        try:
+            parent = parent_of_context(network, evidence.before_context)
+            prefix = current_of_context(network, evidence.before_context)
+            after_parent = parent_of_context(network, evidence.after_context)
+            after_current = current_of_context(network, evidence.after_context)
+        except FoundationStateError as exc:
+            raise InterpreterReplayError("invalid continuation context") from exc
+
+        _verify_flat_sequence_continuation_result(
+            network,
+            prefix,
+            forms,
+            evidence.result,
+        )
+        if after_parent is not parent:
+            raise InterpreterReplayError(
+                "flat continuation changed the explicit parent"
+            )
+        if after_current is not evidence.result:
+            raise InterpreterReplayError(
+                "flat-continuation after-context current is not the exact result"
+            )
+
+        _verify_flat_sequence_act_header(network, evidence)
+        _verify_flat_sequence_act_fields(
+            network,
+            evidence,
+            source_selection=selection_sequence,
+            form_sequence=form_sequence,
+            grammar=grammar,
+            theory=theory,
+        )
+        return evidence.result
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise InterpreterReplayError(
+                "flat source-subselection continuation mutated the network"
+            )
+
+
 def replay_colon_effect(
     network: LinkNetwork,
     evidence: ColonEffectEvidence,
@@ -592,6 +675,26 @@ def _verify_flat_sequence_result(
     if current is not forms[0]:
         raise InterpreterReplayError(
             "flat sequence result does not start from the first exact form"
+        )
+
+
+def _verify_flat_sequence_continuation_result(
+    network: LinkNetwork,
+    prefix: OccurrenceRef,
+    forms: tuple[OccurrenceRef, ...],
+    result: OccurrenceRef,
+) -> None:
+    current = result
+    for expected_end in reversed(forms):
+        link = network.link(current)
+        if link.end is not expected_end:
+            raise InterpreterReplayError(
+                "flat continuation result does not match exact left fold"
+            )
+        current = link.start
+    if current is not prefix:
+        raise InterpreterReplayError(
+            "flat continuation result does not start from exact K current"
         )
 
 

--- a/tests/test_mts_foundation_v2_interpreter.py
+++ b/tests/test_mts_foundation_v2_interpreter.py
@@ -13,6 +13,7 @@ from core.foundation_v2_interpreter import (
     RelationStepEvidence,
     RelationStepRoleRefs,
     replay_flat_sequence_reading,
+    replay_flat_source_subselection_continuation,
     replay_flat_source_subselection_reading,
     replay_relation_step,
 )
@@ -640,6 +641,129 @@ def test_flat_subselection_reading_keeps_whole_source_in_actual_act() -> None:
             theory=alternate_theory,
             grammar_membership=alternate_grammar_membership,
             theory_membership=alternate_theory_membership,
+        )
+    assert network.snapshot() == snapshot
+
+
+def test_flat_subselection_continuation_starts_from_exact_current() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    byte_refs = _byte_vocabulary(builder)
+    front_end = SourceFrontEndBuilder(builder, root, byte_refs)
+
+    prefix = _anchor(builder)
+    a = _anchor(builder)
+    b = _anchor(builder)
+    prefix_a = _new_link(builder, prefix, a)
+    result = _new_link(builder, prefix_a, b)
+
+    source = front_end.source_occurrence(b"ab")
+    dictionary = define_dictionary_scope(builder, root, root)
+    history = root
+    occurrences = {}
+    for raw, form in ((b"a", a), (b"b", b)):
+        dictionary, history, occurrence = _define_scoped_mapping(
+            builder,
+            root,
+            dictionary,
+            history,
+            front_end.content_ref(raw),
+            form,
+        )
+        occurrences[raw] = occurrence
+
+    grammar = _anchor(builder)
+    theory = _anchor(builder)
+    source_evidence = front_end.build_selected_evidence(
+        source,
+        (
+            SegmentSpec(0, 1, a, occurrences[b"a"]),
+            SegmentSpec(1, 2, b, occurrences[b"b"]),
+        ),
+        dictionary=dictionary,
+        grammar=grammar,
+        theory=theory,
+    )
+
+    interpreter = _anchor(builder)
+    parent = _anchor(builder)
+    before_context = define_context(builder, parent, prefix)
+    after_context = define_context(builder, parent, result)
+    roles = _flat_roles(builder)
+    role_dictionary = define_dictionary_scope(builder, root, root)
+    role_history = root
+    for role_name, role_ref in _flat_role_items(roles):
+        role_dictionary, role_history, _ = _define_scoped_mapping(
+            builder,
+            root,
+            role_dictionary,
+            role_history,
+            front_end.content_ref(role_name.encode("utf-8")),
+            role_ref,
+        )
+
+    act = define_act_header(builder, interpreter, role_dictionary, after_context)
+    for role, value in (
+        (roles.source, source_evidence.source),
+        (roles.source_selection, source_evidence.selection_sequence),
+        (roles.form_sequence, source_evidence.form_sequence),
+        (roles.dictionary, source_evidence.dictionary),
+        (roles.grammar, source_evidence.grammar),
+        (roles.theory, source_evidence.theory),
+        (roles.before_context, before_context),
+        (roles.result, result),
+        (roles.after_context, after_context),
+    ):
+        define_act_field(builder, act, role, value)
+
+    evidence = FlatSequenceReadingEvidence(
+        source_evidence=source_evidence,
+        interpreter=interpreter,
+        before_context=before_context,
+        result=result,
+        after_context=after_context,
+        act=act,
+        role_dictionary=role_dictionary,
+        roles=roles,
+    )
+
+    wrong_prefix = _anchor(builder)
+    forged_before = define_context(builder, parent, wrong_prefix)
+    network = builder.freeze(root)
+    snapshot = network.snapshot()
+
+    assert replay_flat_source_subselection_continuation(
+        network,
+        evidence,
+        byte_refs,
+        start_segment=0,
+        end_segment=2,
+        selection_sequence=source_evidence.selection_sequence,
+        form_sequence=source_evidence.form_sequence,
+        grammar=source_evidence.grammar,
+        theory=source_evidence.theory,
+        grammar_membership=source_evidence.grammar_membership,
+        theory_membership=source_evidence.theory_membership,
+    ) is result
+    assert network.link(prefix_a).start is prefix
+    assert network.link(prefix_a).end is a
+    assert network.link(result).start is prefix_a
+    assert network.link(result).end is b
+
+    forged = replace(evidence, before_context=forged_before)
+    with pytest.raises(InterpreterReplayError, match="exact K current"):
+        replay_flat_source_subselection_continuation(
+            network,
+            forged,
+            byte_refs,
+            start_segment=0,
+            end_segment=2,
+            selection_sequence=source_evidence.selection_sequence,
+            form_sequence=source_evidence.form_sequence,
+            grammar=source_evidence.grammar,
+            theory=source_evidence.theory,
+            grammar_membership=source_evidence.grammar_membership,
+            theory_membership=source_evidence.theory_membership,
         )
     assert network.snapshot() == snapshot
 


### PR DESCRIPTION
Продолжает #123 после #332 общим, не скобочным шагом.

Добавляется read-only `replay_flat_source_subselection_continuation(...)`:

```text
K_before.current = P
selected forms = (v1,...,vn)
result = (((P⟼v1)⟼v2)...⟼vn)
```

Функция trusted-replay проверяет source subselection, точный prefix из K, существующую левую цепочку результата, K_after и singleton-поля actual act. Ничего не ищет и не материализует. Пустой suffix естественно требует `result is P`.

Новый тип evidence не вводится: переиспользуется `FlatSequenceReadingEvidence` и существующие роли source/source-selection/form-sequence/D/G/T/K/result.

Отрицательный тест подменяет `K_before.current` другим exact occurrence и получает отказ, даже при том же source/result.

Этот примитив нужен для следующего пользовательского `des('[[ab]]ab')`: после nested Run с `P=R⟼carrier(a,b)` suffix `a,b` должен дать `(P⟼a)⟼b`.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_interpreter.py
  - tests/test_mts_foundation_v2_interpreter.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 260
must_touch:
  - core/foundation_v2_interpreter.py
  - tests/test_mts_foundation_v2_interpreter.py
must_not_touch:
  - contracts/**
  - docs/**
  - .github/**
  - repo-policy.json
expected_effects:
  - trusted continuation левой свёртки начинается с exact K.current
  - selected suffix остаётся exact source-subselection с D G T evidence
  - replay не создаёт и не ищет связи
  - новый bracket mechanism не вводится
```