### PR TITLE
Проверить один уровень последовательности через результаты вложенных групп

### DIFF
--- a/core/foundation_v2_materialization.py
+++ b/core/foundation_v2_materialization.py
@@ -299,6 +299,92 @@ def replay_sequence_materialization(
             raise SequenceMaterializationError("replay mutated the after network")
 
 
+def replay_sequence_level_fold(
+    network: LinkNetwork,
+    description: SequenceDescription,
+    *,
+    group_results: tuple[OccurrenceRef, ...],
+    fold_results: tuple[OccurrenceRef, ...],
+    result: OccurrenceRef,
+) -> OccurrenceRef:
+    """Replay one level after immediate groups have returned exact values.
+
+    ``SequenceAtom`` contributes its own exact value. Each immediate
+    ``SequenceGroup`` consumes one caller-selected exact result in source order.
+    How the group produced that result is deliberately outside this checker and
+    may be verified by a separate nested chain of acts. The resulting level
+    values are then checked as one existing exact left fold.
+
+    The operation is read-only: ``fold_results`` names already-existing exact
+    occurrences. No relation is searched for or created, and no semantic
+    ``value-sequence`` type is introduced.
+    """
+
+    before_snapshot = network.snapshot()
+    try:
+        _require_description_root(network, description)
+
+        values: list[OccurrenceRef] = []
+        group_cursor = 0
+        for item in description.items:
+            if isinstance(item, SequenceAtom):
+                network.link(item.value)
+                values.append(item.value)
+                continue
+
+            if group_cursor >= len(group_results):
+                raise SequenceMaterializationError("missing immediate group result")
+            group_result = group_results[group_cursor]
+            network.link(group_result)
+            values.append(group_result)
+            group_cursor += 1
+
+        if group_cursor != len(group_results):
+            raise SequenceMaterializationError("unconsumed immediate group result")
+
+        if not values:
+            if fold_results:
+                raise SequenceMaterializationError(
+                    "empty level cannot contain fold results"
+                )
+            expected = description.root
+        elif len(values) == 1:
+            if fold_results:
+                raise SequenceMaterializationError(
+                    "singleton level cannot contain fold results"
+                )
+            expected = values[0]
+        else:
+            if len(fold_results) != len(values) - 1:
+                raise SequenceMaterializationError(
+                    "wrong number of level fold results"
+                )
+            current = values[0]
+            for fold_ref, expected_end in zip(
+                fold_results,
+                values[1:],
+                strict=True,
+            ):
+                link = network.link(fold_ref)
+                if link.start is not current or link.end is not expected_end:
+                    raise SequenceMaterializationError(
+                        "sequence-level fold result has forged exact poles"
+                    )
+                current = fold_ref
+            expected = current
+
+        if result is not expected:
+            raise SequenceMaterializationError(
+                "sequence-level result is not exact fold result"
+            )
+        return result
+    except LinkNetworkError as exc:
+        raise SequenceMaterializationError("invalid exact occurrence evidence") from exc
+    finally:
+        if network.snapshot() != before_snapshot:
+            raise SequenceMaterializationError("sequence-level replay mutated the network")
+
+
 def _validate_resolved_grouping_inputs(
     network: LinkNetwork,
     forms: tuple[OccurrenceRef, ...],

--- a/tests/test_mts_foundation_v2_sequence_level_replay.py
+++ b/tests/test_mts_foundation_v2_sequence_level_replay.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pytest
+
+from core.exact_link_network import LinkNetworkBuilder
+from core.foundation_v2_materialization import (
+    SequenceAtom,
+    SequenceDescription,
+    SequenceGroup,
+    SequenceMaterializationError,
+    replay_sequence_level_fold,
+)
+
+
+def _anchor(builder: LinkNetworkBuilder):
+    ref = builder.reserve()
+    builder.define(ref, ref, ref)
+    return ref
+
+
+def _link(builder: LinkNetworkBuilder, start, end):
+    ref = builder.reserve()
+    builder.define(ref, start, end)
+    return ref
+
+
+def test_immediate_group_result_becomes_one_outer_left_fold_value() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    a = _anchor(builder)
+    b = _anchor(builder)
+
+    inner_ab = _link(builder, a, b)
+    outer_ab = _link(builder, a, b)
+    full = _link(builder, outer_ab, inner_ab)
+    network = builder.freeze(root)
+    snapshot = network.snapshot()
+
+    description = SequenceDescription(
+        root=root,
+        items=(
+            SequenceAtom(a),
+            SequenceAtom(b),
+            SequenceGroup((SequenceAtom(a), SequenceAtom(b))),
+        ),
+    )
+
+    assert replay_sequence_level_fold(
+        network,
+        description,
+        group_results=(inner_ab,),
+        fold_results=(outer_ab, full),
+        result=full,
+    ) is full
+
+    assert inner_ab is not outer_ab
+    assert network.link(inner_ab) == network.link(outer_ab)
+    assert network.link(full).start is outer_ab
+    assert network.link(full).end is inner_ab
+    assert network.snapshot() == snapshot
+
+
+def test_outer_level_uses_selected_nested_run_result_not_group_structure() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    a = _anchor(builder)
+    b = _anchor(builder)
+
+    carrier_a = _link(builder, root, a)
+    carrier_ab = _link(builder, carrier_a, b)
+    nested_result = _link(builder, root, carrier_ab)
+    nested_a = _link(builder, nested_result, a)
+    full = _link(builder, nested_a, b)
+    wrong_a = _link(builder, carrier_ab, a)
+    wrong_full = _link(builder, wrong_a, b)
+    network = builder.freeze(root)
+    snapshot = network.snapshot()
+
+    description = SequenceDescription(
+        root=root,
+        items=(
+            SequenceGroup(
+                (SequenceGroup((SequenceAtom(carrier_ab),)),)
+            ),
+            SequenceAtom(a),
+            SequenceAtom(b),
+        ),
+    )
+
+    assert replay_sequence_level_fold(
+        network,
+        description,
+        group_results=(nested_result,),
+        fold_results=(nested_a, full),
+        result=full,
+    ) is full
+
+    with pytest.raises(
+        SequenceMaterializationError,
+        match="forged exact poles",
+    ):
+        replay_sequence_level_fold(
+            network,
+            description,
+            group_results=(carrier_ab,),
+            fold_results=(nested_a, full),
+            result=full,
+        )
+
+    assert network.link(wrong_full).start is wrong_a
+    assert network.link(wrong_full).end is b
+    assert wrong_full is not full
+    assert network.snapshot() == snapshot
+
+
+def test_group_result_cardinality_and_level_result_are_exact() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    a = _anchor(builder)
+    b = _anchor(builder)
+    inner = _link(builder, a, b)
+    other = _link(builder, root, b)
+    network = builder.freeze(root)
+
+    description = SequenceDescription(
+        root=root,
+        items=(SequenceGroup((SequenceAtom(a), SequenceAtom(b))),),
+    )
+
+    assert replay_sequence_level_fold(
+        network,
+        description,
+        group_results=(inner,),
+        fold_results=(),
+        result=inner,
+    ) is inner
+
+    with pytest.raises(SequenceMaterializationError, match="missing immediate group"):
+        replay_sequence_level_fold(
+            network,
+            description,
+            group_results=(),
+            fold_results=(),
+            result=inner,
+        )
+
+    with pytest.raises(SequenceMaterializationError, match="unconsumed immediate group"):
+        replay_sequence_level_fold(
+            network,
+            description,
+            group_results=(inner, other),
+            fold_results=(),
+            result=inner,
+        )
+
+    with pytest.raises(SequenceMaterializationError, match="not exact fold result"):
+        replay_sequence_level_fold(
+            network,
+            description,
+            group_results=(inner,),
+            fold_results=(),
+            result=other,
+        )


### PR DESCRIPTION
Продолжает #123 после #336 и переводит рекурсивную гипотезу в минимальный read-only checker.

Добавляется `replay_sequence_level_fold(...)`:

```text
SequenceAtom  -> собственное exact value
SequenceGroup -> предъявленный exact result отдельно проверенной вложенной цепочки актов

values уровня -> обычная exact left fold
```

Checker не рекурсирует внутрь группы и не решает, как она получила результат. Он только:
- требует по одному `group_result` на каждую непосредственную `SequenceGroup` в source order;
- проверяет уже существующие exact `fold_results` текущего уровня;
- требует exact final `result`;
- ничего не ищет и не материализует;
- не вводит semantic `value-sequence`.

Архитектурные тесты покрывают:

```text
ab[ab]
inner group -> X_inner=a⟼b
outer values -> a,b,X_inner
outer fold -> X_outer⟼X_inner
```

и:

```text
[[ab]]ab
outer immediate group -> selected nested Run result P
outer values -> P,a,b
outer fold -> (P⟼a)⟼b
```

Отрицательные векторы проверяют подмену nested result, missing/extra group results и forged final result.

Новый тестовый файл оправдан архитектурным уровнем: он проверяет общий recursive-level checker, а не отдельный bracket-example.

```repo-guard-yaml
change_type: feature
scope:
  - core/foundation_v2_materialization.py
  - tests/test_mts_foundation_v2_sequence_level_replay.py
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 260
must_touch:
  - core/foundation_v2_materialization.py
  - tests/test_mts_foundation_v2_sequence_level_replay.py
must_not_touch:
  - contracts/**
  - docs/**
  - .github/**
  - repo-policy.json
expected_effects:
  - immediate nested group contributes only exact result of its separately verified act-chain
  - current sequence level is verified as ordinary exact left fold
  - ab[ab] and [[ab]]ab share one hierarchical composition rule
  - no value-sequence ontology hidden depth state or bracket opcode is introduced
```