### PR TITLE
Отвязать accepted leaf-contracts от historical MTS umbrellas

### DIFF
--- a/contracts/mts-definition-opening-v0.3.json
+++ b/contracts/mts-definition-opening-v0.3.json
@@ -2,12 +2,10 @@
   "schema": "mts-definition-opening/v0.3",
   "status": "accepted",
   "accepted": true,
-  "dependsOn": [
-    "mts-contract/v0.2"
-  ],
-  "conformanceCorpus": "contracts/mts-definition-opening-conformance-v0.3.json",
   "issue": 121,
-  "scope": "normative one-step read-only definition opening semantics; trusted proof rules remain a separate versioned surface",
+  "conformanceCorpus": "contracts/mts-definition-opening-conformance-v0.3.json",
+  "foundation": "typed scalar Form plus explicit lexical DefinitionEnvironment; the accepted one-step operation is self-contained below and does not inherit a historical MTS umbrella",
+  "scope": "normative one-step read-only definition opening semantics; trusted proof rules remain a separate surface",
   "definitionEnvironment": {
     "identity": {
       "definitionId": "replay-local pair (scopePath, ordinal)",
@@ -33,16 +31,8 @@
   },
   "operation": {
     "name": "open_definition",
-    "inputs": [
-      "typed addressable target Form",
-      "explicit lexical DefinitionEnvironment"
-    ],
-    "doesNotTake": [
-      "ContextFrame",
-      "MemoryView",
-      "symbol-to-LinkRef bindings",
-      "proof state"
-    ],
+    "inputs": ["typed addressable target Form", "explicit lexical DefinitionEnvironment"],
+    "doesNotTake": ["ContextFrame", "MemoryView", "symbol-to-link bindings", "proof state"],
     "results": {
       "match": ["DefinitionId", "exact typed Definition.value", "provenance"],
       "no-match": "no visible definition for addressable target",
@@ -109,14 +99,10 @@
     "semanticContractAccepted": true,
     "productionReferenceCoreImplemented": true,
     "canonicalRootLibraryUsesDefinitionEnvironment": true,
-    "productionConformancePresent": true,
-    "mtsContractV03Published": true,
-    "aproverRepinAllowed": false
+    "productionConformancePresent": true
   },
   "downstream": {
-    "genericL2ConsumerMayPinMtsContractV03": true,
-    "aproverProofRepinAllowed": false,
     "aproverMustNotInventLocalOpeningSemantics": true,
-    "futureProofConsumerMustUseVersionedL5Acceptance": true
+    "proofUseRequiresExplicitAcceptedLift": true
   }
 }

--- a/contracts/mts-definition-opening-v0.3.json
+++ b/contracts/mts-definition-opening-v0.3.json
@@ -32,7 +32,7 @@
   "operation": {
     "name": "open_definition",
     "inputs": ["typed addressable target Form", "explicit lexical DefinitionEnvironment"],
-    "doesNotTake": ["ContextFrame", "MemoryView", "symbol-to-link bindings", "proof state"],
+    "doesNotTake": ["ContextFrame", "MemoryView", "symbol-to-LinkRef bindings", "proof state"],
     "results": {
       "match": ["DefinitionId", "exact typed Definition.value", "provenance"],
       "no-match": "no visible definition for addressable target",

--- a/contracts/mts-direct-deixis-v0.5.json
+++ b/contracts/mts-direct-deixis-v0.5.json
@@ -3,10 +3,8 @@
   "status": "accepted",
   "accepted": true,
   "issue": 156,
-  "dependsOn": [
-    "mts-contract/v0.4"
-  ],
   "conformanceCorpus": "contracts/mts-direct-deixis-conformance-v0.5.json",
+  "foundation": "one typed L2 Expression; this structural analysis is self-contained below and does not inherit a historical MTS umbrella",
   "scope": "normative read-only structural detection of explicit ContextPronoun occurrences in one typed L2 Expression; no evaluation, dependency closure, sensitivity or invariance theorem",
   "operation": {
     "name": "analyze_direct_deixis",
@@ -57,7 +55,6 @@
     "trustedProofRelationAdded": false,
     "ContextInvariantAccepted": false,
     "ContextSensitiveAccepted": false,
-    "mtsProofV03Modified": false,
     "futureProofUseRequiresExplicitAcceptedLift": true
   },
   "productionIntegration": {
@@ -73,15 +70,9 @@
     "mustRemainUnchanged": true,
     "analysisMayInspectWithoutMutation": true
   },
-  "versioning": {
-    "mtsContractV04Modified": false,
-    "publishedThroughUmbrella": false,
-    "futureUmbrellaMustBeAdditive": true
-  },
-  "nextBoundary": {
+  "deferred": {
     "indirectDefinitionDependencyAccepted": false,
     "universalContextInvarianceAccepted": false,
-    "coordinationIssueForComposition": 122,
-    "interpreterFocusResearchIssue": 148
+    "interpreterFocusBindingAccepted": false
   }
 }

--- a/contracts/mts-value-bundle-v0.2.json
+++ b/contracts/mts-value-bundle-v0.2.json
@@ -2,10 +2,8 @@
   "schema": "mts-value-bundle/v0.2",
   "status": "accepted",
   "accepted": true,
-  "acceptedContractLinkAllowed": true,
-  "dependsOn": [
-    "mts-contract/v0.2"
-  ],
+  "issue": 109,
+  "foundation": "typed L2 Form plus explicit read-only MemoryView; the accepted flat-bundle operation is self-contained below and does not inherit a historical MTS umbrella",
   "scope": {
     "valueBundle": "flat only",
     "constraintBundle": "existing accepted behavior unchanged",
@@ -26,10 +24,7 @@
   "elaboration": {
     "phase": "static-before-interpretation",
     "runtimeRoleGuessing": false,
-    "outputs": [
-      "ConstraintBundle",
-      "ValueBundle"
-    ],
+    "outputs": ["ConstraintBundle", "ValueBundle"],
     "operatorDomains": {
       "constraintEntry": "ConstraintBundle or existing Judgment semantics",
       "standaloneValueEntry": "flat ValueBundle allowed when value context is explicit",
@@ -43,46 +38,16 @@
       "definitionRhs": "existing scalar Form or ConstraintBundle only; ValueBundle deferred"
     },
     "rules": [
-      {
-        "when": "all non-empty direct items are Judgments",
-        "result": "ConstraintBundle"
-      },
-      {
-        "when": "all non-empty direct items are non-bundle Forms in a value-capable context",
-        "result": "ValueBundle"
-      },
-      {
-        "when": "direct items mix Judgment and Form evidence",
-        "result": "static-error:mixed-bundle-role-evidence"
-      },
-      {
-        "when": "empty {} occurs in a statically value-capable position",
-        "result": "ValueBundle"
-      },
-      {
-        "when": "empty {} is the constraint interpretation entry expression",
-        "result": "ConstraintBundle"
-      },
-      {
-        "when": "empty {} is a definition RHS",
-        "result": "ConstraintBundle"
-      },
-      {
-        "when": "non-empty ValueBundle is a definition RHS",
-        "result": "static-error:bundle-valued-definition-deferred"
-      },
-      {
-        "when": "ValueBundle appears under scalar-only ⟼/♀/♂/¬ operand position",
-        "result": "static-error:bundle-not-supported-in-scalar-operator"
-      },
-      {
-        "when": "empty {} has no static role context",
-        "result": "static-error:ambiguous-empty-bundle-role"
-      },
-      {
-        "when": "a ValueBundle directly contains another ValueBundle/CurlySyntax item",
-        "result": "static-error:nested-value-bundle-not-supported"
-      }
+      {"when": "all non-empty direct items are Judgments", "result": "ConstraintBundle"},
+      {"when": "all non-empty direct items are non-bundle Forms in a value-capable context", "result": "ValueBundle"},
+      {"when": "direct items mix Judgment and Form evidence", "result": "static-error:mixed-bundle-role-evidence"},
+      {"when": "empty {} occurs in a statically value-capable position", "result": "ValueBundle"},
+      {"when": "empty {} is the constraint interpretation entry expression", "result": "ConstraintBundle"},
+      {"when": "empty {} is a definition RHS", "result": "ConstraintBundle"},
+      {"when": "non-empty ValueBundle is a definition RHS", "result": "static-error:bundle-valued-definition-deferred"},
+      {"when": "ValueBundle appears under scalar-only ⟼/♀/♂/¬ operand position", "result": "static-error:bundle-not-supported-in-scalar-operator"},
+      {"when": "empty {} has no static role context", "result": "static-error:ambiguous-empty-bundle-role"},
+      {"when": "a ValueBundle directly contains another ValueBundle/CurlySyntax item", "result": "static-error:nested-value-bundle-not-supported"}
     ],
     "rootRegression": {
       "currentTenDefinitionsMustElaborateIdentically": true,
@@ -92,12 +57,12 @@
   "runtimeValueModel": {
     "scalar": {
       "kind": "link",
-      "identity": "resolved L1 LinkRef"
+      "identity": "canonical semantic Link resolved by the runtime memory view"
     },
     "bundle": {
       "kind": "bundle",
-      "identity": "extensional set of unique resolved L1 LinkRefs",
-      "occurrenceProvenanceSeparate": true
+      "identity": "extensional set of unique resolved semantic Links",
+      "sourceOccurrenceProvenanceSeparate": true
     },
     "crossKindEquality": false,
     "crossKindInequality": true,
@@ -107,8 +72,8 @@
   "elementResolution": {
     "eachOccurrenceResolvedIndependently": true,
     "deduplicateBeforeResolution": false,
-    "anonymousSquareIdentity": "ast-occurrence-path",
-    "unresolvedAnonymousOccurrence": "evaluation-unresolved/failure; never choose an arbitrary LinkRef",
+    "anonymousSquareIdentity": "ast-occurrence-path as syntactic-hole identity only",
+    "unresolvedAnonymousOccurrence": "evaluation-unresolved/failure; never choose an arbitrary link",
     "resolvedOccurrenceTraceRequired": true,
     "semanticSetBuiltAfterResolution": true,
     "semanticOrderRelevant": false,
@@ -122,16 +87,16 @@
     "historicalAnonymousClaim": {
       "source": "{[], []} = {[]}",
       "unconditional": false,
-      "conditional": "true only when independently resolved identity sets are equal"
+      "conditional": "true only when independently resolved semantic-link sets are equal"
     }
   },
   "expansionQuery": {
     "trigger": "Sequence/juxtaposition with exactly two endpoints and at least one statically elaborated ValueBundle operand",
-    "result": "flat ValueBundle of existing Link identities",
+    "result": "flat ValueBundle of existing semantic Links",
     "readOnly": true,
     "endpointDomains": {
-      "scalar": "singleton resolved identity",
-      "nonEmptyBundle": "resolved extensional identity set",
+      "scalar": "singleton resolved semantic link",
+      "nonEmptyBundle": "resolved extensional semantic-link set",
       "emptyBundle": "wildcard only in expansion endpoint position"
     },
     "operations": {
@@ -152,13 +117,9 @@
     "expansionIsCommand": false
   },
   "deferred": {
-    "nestedValueBundleSemantics": [
-      "first-class nested collection",
-      "flatten/union",
-      "other construction"
-    ],
+    "nestedValueBundleSemantics": ["first-class nested collection", "flatten/union", "other construction"],
     "bundleValuedDefinitions": "requires a tagged value environment/binding contract",
-    "bundleProjectionOrInversion": "requires an explicit lifting rule or rejection in a later version",
+    "bundleProjectionOrInversion": "requires an explicit lifting rule or rejection in a later accepted surface",
     "bundleAsExplicitLinkFormPole": "requires a separate lifting decision; current expansion uses juxtaposition only",
     "syntheticMissingLinkForms": "not part of current contract",
     "explicitBundleMaterialization": "separate L4 operation if ever needed"
@@ -170,7 +131,6 @@
     "constraintBundleRegression": "tests/test_mtc_value_bundle_reference.py"
   },
   "downstream": {
-    "aproverRepinRequired": true,
     "consumerMustExecuteConformance": true,
     "compatibilityImplementationAllowed": false
   }

--- a/tests/test_mts_contract_v03.py
+++ b/tests/test_mts_contract_v03.py
@@ -82,10 +82,12 @@ def test_v03_adds_only_the_production_conformant_one_step_opening_operation():
     extension = v03["formalNotationExtensions"]["definitionOpening"]
 
     assert opening["status"] == "accepted"
-    assert opening["integrationStatus"]["productionReferenceCoreImplemented"] is True
-    assert opening["integrationStatus"]["canonicalRootLibraryUsesDefinitionEnvironment"] is True
-    assert opening["integrationStatus"]["productionConformancePresent"] is True
-    assert opening["integrationStatus"]["mtsContractV03Published"] is True
+    assert opening["integrationStatus"] == {
+        "semanticContractAccepted": True,
+        "productionReferenceCoreImplemented": True,
+        "canonicalRootLibraryUsesDefinitionEnvironment": True,
+        "productionConformancePresent": True,
+    }
 
     assert extension["contract"] == "contracts/mts-definition-opening-v0.3.json"
     assert extension["conformanceCorpus"] == opening["conformanceCorpus"]

--- a/tests/test_mts_definition_opening_contract.py
+++ b/tests/test_mts_definition_opening_contract.py
@@ -72,7 +72,7 @@ def test_accepted_operation_is_exactly_one_step_and_effect_free():
     assert operation["doesNotTake"] == [
         "ContextFrame",
         "MemoryView",
-        "symbol-to-link bindings",
+        "symbol-to-LinkRef bindings",
         "proof state",
     ]
     assert set(operation["results"]) == {

--- a/tests/test_mts_definition_opening_contract.py
+++ b/tests/test_mts_definition_opening_contract.py
@@ -1,4 +1,4 @@
-"""Acceptance gate for normative one-step definition-opening semantics v0.3."""
+"""Acceptance gate for the self-contained one-step definition-opening semantics."""
 
 import json
 from pathlib import Path
@@ -10,9 +10,6 @@ from core.root_library import load_root_library
 
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-definition-opening-v0.3.json"
-MTS_V02 = ROOT / "contracts" / "mts-contract-v0.2.json"
-MTS_V03 = ROOT / "contracts" / "mts-contract-v0.3.json"
-PROOF_V02 = ROOT / "contracts" / "mts-proof-v0.2.json"
 CORPUS = ROOT / "contracts" / "mts-definition-opening-conformance-v0.3.json"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
@@ -21,22 +18,22 @@ def contract() -> dict:
     return json.loads(CONTRACT.read_text(encoding="utf-8"))
 
 
-def test_contract_is_accepted_integrated_and_published_only_through_v03_umbrella():
+def test_contract_is_accepted_integrated_and_not_inherited_from_historical_umbrella():
     data = contract()
-    mts_v02 = MTS_V02.read_text(encoding="utf-8")
-    mts_v03 = json.loads(MTS_V03.read_text(encoding="utf-8"))
-    proof_v02 = PROOF_V02.read_text(encoding="utf-8")
 
     assert data["schema"] == "mts-definition-opening/v0.3"
     assert data["status"] == "accepted"
     assert data["accepted"] is True
+    assert "dependsOn" not in data
+    assert "historical MTS umbrella" in data["foundation"]
+
     status = data["integrationStatus"]
-    assert status["semanticContractAccepted"] is True
-    assert status["productionReferenceCoreImplemented"] is True
-    assert status["canonicalRootLibraryUsesDefinitionEnvironment"] is True
-    assert status["productionConformancePresent"] is True
-    assert status["mtsContractV03Published"] is True
-    assert status["aproverRepinAllowed"] is False
+    assert status == {
+        "semanticContractAccepted": True,
+        "productionReferenceCoreImplemented": True,
+        "canonicalRootLibraryUsesDefinitionEnvironment": True,
+        "productionConformancePresent": True,
+    }
 
     integration = data["productionIntegration"]
     assert integration["referenceCore"] == "core/mtc_definitions.py"
@@ -47,16 +44,11 @@ def test_contract_is_accepted_integrated_and_published_only_through_v03_umbrella
     assert integration["challengeOnlyEnvironmentCloneRetained"] is False
     assert integration["interpretConstraintsExecutesDefinition"] is False
 
-    assert "mts-definition-opening/v0.3" not in mts_v02
-    assert "mts-definition-opening/v0.3" not in proof_v02
-    assert mts_v03["formalNotationExtensions"]["definitionOpening"]["contract"] == "contracts/mts-definition-opening-v0.3.json"
 
-
-def test_acceptance_depends_only_on_normative_surface_and_self_contained_conformance():
+def test_acceptance_depends_only_on_self_contained_contract_and_conformance():
     data = contract()
     corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
 
-    assert data["dependsOn"] == ["mts-contract/v0.2"]
     assert data["conformanceCorpus"] == "contracts/mts-definition-opening-conformance-v0.3.json"
     assert corpus["status"] == "accepted"
     assert corpus["accepted"] is True
@@ -64,6 +56,7 @@ def test_acceptance_depends_only_on_normative_surface_and_self_contained_conform
     assert corpus["rootOpenings"]
     assert corpus["scenarios"]
     serialized = json.dumps(data, ensure_ascii=False).lower()
+    assert "mts-contract/v0.2" not in serialized
     assert "candidate-challenge" not in serialized
     assert "candidate-decision" not in serialized
     assert "acceptanceevidence" not in serialized
@@ -79,7 +72,7 @@ def test_accepted_operation_is_exactly_one_step_and_effect_free():
     assert operation["doesNotTake"] == [
         "ContextFrame",
         "MemoryView",
-        "symbol-to-LinkRef bindings",
+        "symbol-to-link bindings",
         "proof state",
     ]
     assert set(operation["results"]) == {
@@ -185,10 +178,10 @@ def test_recursion_is_normatively_single_step_not_global_normalization():
     }
 
 
-def test_downstream_boundary_remains_explicit_without_historical_gate_notes():
+def test_downstream_boundary_is_current_and_has_no_release_history_status():
     downstream = contract()["downstream"]
 
-    assert downstream["genericL2ConsumerMayPinMtsContractV03"] is True
-    assert downstream["aproverProofRepinAllowed"] is False
-    assert downstream["aproverMustNotInventLocalOpeningSemantics"] is True
-    assert downstream["futureProofConsumerMustUseVersionedL5Acceptance"] is True
+    assert downstream == {
+        "aproverMustNotInventLocalOpeningSemantics": True,
+        "proofUseRequiresExplicitAcceptedLift": True,
+    }

--- a/tests/test_mts_direct_deixis_reference.py
+++ b/tests/test_mts_direct_deixis_reference.py
@@ -57,7 +57,7 @@ def test_contract_is_accepted_self_contained_and_conformant():
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
     assert "dependsOn" not in contract
-    assert "historical MTS umbrella" in contract["foundation"]
+    assert "mts-contract/v0." not in json.dumps(contract, ensure_ascii=False)
     assert conformance["schema"] == "mts-direct-deixis-conformance/v0.5"
     assert conformance["accepted"] is True
     assert conformance["contract"] == contract["schema"]

--- a/tests/test_mts_direct_deixis_reference.py
+++ b/tests/test_mts_direct_deixis_reference.py
@@ -1,4 +1,4 @@
-"""Production conformance for accepted mts-direct-deixis/v0.5."""
+"""Production conformance for self-contained accepted direct deixis."""
 
 import inspect
 import json
@@ -12,8 +12,6 @@ from core.mtc_parser import parse_formula
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-direct-deixis-v0.5.json"
 CONFORMANCE = ROOT / "contracts" / "mts-direct-deixis-conformance-v0.5.json"
-MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
-PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
 CORE = ROOT / "core" / "mtc_context_analysis.py"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
@@ -51,21 +49,19 @@ def root_sources() -> tuple[str, ...]:
     )
 
 
-def test_contract_is_accepted_but_not_retroactively_added_to_v04_umbrella():
+def test_contract_is_accepted_self_contained_and_conformant():
     contract = read(CONTRACT)
     conformance = read(CONFORMANCE)
 
     assert contract["schema"] == "mts-direct-deixis/v0.5"
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
-    assert contract["dependsOn"] == ["mts-contract/v0.4"]
+    assert "dependsOn" not in contract
+    assert "historical MTS umbrella" in contract["foundation"]
     assert conformance["schema"] == "mts-direct-deixis-conformance/v0.5"
     assert conformance["accepted"] is True
     assert conformance["contract"] == contract["schema"]
     assert contract["conformanceCorpus"] == "contracts/mts-direct-deixis-conformance-v0.5.json"
-    assert contract["versioning"]["mtsContractV04Modified"] is False
-    assert contract["versioning"]["publishedThroughUmbrella"] is False
-    assert contract["schema"] not in MTS_V04.read_text(encoding="utf-8")
 
 
 def test_accepted_conformance_owns_complete_portable_corpus():
@@ -154,6 +150,7 @@ def test_operation_has_no_runtime_definition_memory_or_interpreter_dependency():
     assert operation["readsContextFrame"] is False
     assert operation["readsInterpreterIdentity"] is False
     assert operation["readsSecurityPolicy"] is False
+    assert operation["writesAnything"] is False
 
 
 def test_positive_direct_deixis_does_not_imply_semantic_context_sensitivity():
@@ -191,14 +188,15 @@ def test_accepted_negative_claims_preserve_semantic_non_implications():
     assert negative["present-does-not-mean-sensitive"]["forbiddenConclusion"] == "ContextSensitive"
 
 
-def test_proof_surface_is_unchanged_and_no_new_trusted_relation_exists():
+def test_direct_deixis_does_not_add_any_trusted_proof_relation():
     contract = read(CONTRACT)
-    proof = read(PROOF_V03)
 
-    assert "DirectDeictic" not in proof["trustedRelations"]
-    assert "ContextInvariant" not in proof["trustedRelations"]
-    assert contract["proofBoundary"]["trustedProofRelationAdded"] is False
-    assert contract["proofBoundary"]["mtsProofV03Modified"] is False
+    assert contract["proofBoundary"] == {
+        "trustedProofRelationAdded": False,
+        "ContextInvariantAccepted": False,
+        "ContextSensitiveAccepted": False,
+        "futureProofUseRequiresExplicitAcceptedLift": True,
+    }
 
 
 def test_root_program_is_still_exactly_ten_and_analysis_is_repeatable():

--- a/tests/test_mts_value_bundle_contract.py
+++ b/tests/test_mts_value_bundle_contract.py
@@ -1,4 +1,4 @@
-"""Проверки согласованности принятого контракта плоских пучков значений."""
+"""Проверки самодостаточного принятого контракта плоских пучков значений."""
 
 import json
 from pathlib import Path
@@ -9,7 +9,6 @@ from core.mtc_parser import parse_formula
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-value-bundle-v0.2.json"
 CONFORMANCE = ROOT / "contracts" / "mts-value-bundle-conformance-v0.2.json"
-MTS_CONTRACT = ROOT / "contracts" / "mts-contract-v0.2.json"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 
@@ -17,24 +16,19 @@ def load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_value_bundle_contract_is_accepted_and_linked_from_mts_contract():
+def test_value_bundle_contract_is_accepted_self_contained_and_conformant():
     contract = load(CONTRACT)
     conformance = load(CONFORMANCE)
-    mts = load(MTS_CONTRACT)
 
     assert contract["schema"] == "mts-value-bundle/v0.2"
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
-    assert contract["acceptedContractLinkAllowed"] is True
-    assert contract["dependsOn"] == ["mts-contract/v0.2"]
+    assert "dependsOn" not in contract
+    assert "historical MTS umbrella" in contract["foundation"]
     assert conformance["schema"] == "mts-value-bundle-conformance/v0.2"
     assert conformance["status"] == "accepted"
     assert conformance["accepted"] is True
     assert conformance["contract"] == contract["schema"]
-    assert mts["formalNotation"]["valueBundle"]["contract"] == "contracts/mts-value-bundle-v0.2.json"
-    assert mts["formalNotation"]["valueBundle"]["conformanceCorpus"] == (
-        "contracts/mts-value-bundle-conformance-v0.2.json"
-    )
 
 
 def test_accepted_conformance_is_self_contained_across_all_semantic_sections():
@@ -68,12 +62,13 @@ def test_flat_value_model_is_extensional_only_after_occurrence_resolution():
     resolution = contract["elementResolution"]
 
     assert model["scalar"]["kind"] == "link"
+    assert "canonical semantic Link" in model["scalar"]["identity"]
     assert model["bundle"]["kind"] == "bundle"
     assert model["crossKindEquality"] is False
     assert model["crossKindInequality"] is True
     assert resolution["eachOccurrenceResolvedIndependently"] is True
     assert resolution["deduplicateBeforeResolution"] is False
-    assert resolution["anonymousSquareIdentity"] == "ast-occurrence-path"
+    assert "syntactic-hole identity" in resolution["anonymousSquareIdentity"]
     assert resolution["semanticSetBuiltAfterResolution"] is True
 
     cases = {case["id"]: case for case in load(CONFORMANCE)["valueEquality"]}
@@ -114,7 +109,7 @@ def test_current_ten_root_definitions_remain_parseable_and_value_bundle_cannot_e
     assert regression["valueBundleMayAppearInCurrentRoot"] is False
 
 
-def test_production_integration_and_downstream_boundary_are_explicit():
+def test_production_integration_and_downstream_boundary_are_current_only():
     contract = load(CONTRACT)
     integration = contract["productionIntegration"]
     downstream = contract["downstream"]
@@ -125,6 +120,6 @@ def test_production_integration_and_downstream_boundary_are_explicit():
         "rootRegression": "tests/mtc_formulas.mtc",
         "constraintBundleRegression": "tests/test_mtc_value_bundle_reference.py",
     }
-    assert downstream["aproverRepinRequired"] is True
+    assert "aproverRepinRequired" not in downstream
     assert downstream["consumerMustExecuteConformance"] is True
     assert downstream["compatibilityImplementationAllowed"] is False


### PR DESCRIPTION
Refs #357, #278, #343. Первый compression slice после downstream cutover `aprover#148`.

Удаляет только исторические release-dependencies из уже самодостаточных accepted leaf surfaces; production semantics и conformance corpora не меняются.

## Изменения

- `mts-value-bundle/v0.2`
  - больше не `dependsOn mts-contract/v0.2`;
  - stale `aproverRepinRequired` удалён;
  - occurrence path явно оставлен только syntactic-hole/provenance identity;
  - resolved bundle identity формулируется через canonical semantic Links, без второго occurrence-based Link identity.
- `mts-definition-opening/v0.3`
  - больше не `dependsOn mts-contract/v0.2`;
  - удалены historical publication/repin status fields;
  - accepted one-step read-only operation остаётся без изменений.
- `mts-direct-deixis/v0.5`
  - больше не `dependsOn mts-contract/v0.4`;
  - удалена release-history `versioning` bookkeeping;
  - regression suite больше не читает old proof-v0.3 лишь чтобы доказать отсутствие новой relation.
- `tests/test_mts_contract_v03.py`
  - historical umbrella regression больше не требует удалённый leaf publication flag `mtsContractV03Published`;
  - сам historical v0.3 umbrella в этом PR не меняется и остаётся следующим compression target.

Production core, root program и conformance corpora не изменяются.

Текущий diff: 7 modified files, `+79/-154 = -75` net.

```repo-guard-yaml
change_type: refactor
scope:
  - contracts/mts-value-bundle-v0.2.json
  - contracts/mts-definition-opening-v0.3.json
  - contracts/mts-direct-deixis-v0.5.json
  - tests/test_mts_value_bundle_contract.py
  - tests/test_mts_definition_opening_contract.py
  - tests/test_mts_direct_deixis_reference.py
  - tests/test_mts_contract_v03.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - contracts/mts-value-bundle-v0.2.json
  - contracts/mts-definition-opening-v0.3.json
  - contracts/mts-direct-deixis-v0.5.json
  - tests/test_mts_value_bundle_contract.py
  - tests/test_mts_definition_opening_contract.py
  - tests/test_mts_direct_deixis_reference.py
  - tests/test_mts_contract_v03.py
must_not_touch:
  - core/**
  - docs/**
  - README.md
  - contracts/mts-contract-v0.2.json
  - contracts/mts-contract-v0.3.json
  - contracts/mts-contract-v0.4.json
  - contracts/mts-contract-v0.5.json
  - contracts/mts-proof-*.json
  - contracts/anum-*.json
  - repo-policy.json
expected_effects:
  - remove historical MTS umbrella dependencies from three self-contained accepted leaf contracts
  - preserve existing production operations and conformance vectors
  - keep ValueBundle occurrence identity syntactic/provenance-only and semantic Link identity canonical
  - remove stale downstream release-status bookkeeping
  - keep historical umbrella tests from depending on leaf publication bookkeeping
  - reduce active surface without adding compatibility layers
```