### PR TITLE
Сделать current proof-v0.4 независимым от historical proof chain

### DIFF
--- a/contracts/mts-derivation-base-v0.3.json
+++ b/contracts/mts-derivation-base-v0.3.json
@@ -3,15 +3,13 @@
   "status": "accepted",
   "accepted": true,
   "issue": 122,
-  "dependsOn": [
-    "mts-contract/v0.3"
-  ],
   "conformanceCorpus": "contracts/mts-derivation-base-conformance-v0.3.json",
-  "scope": "accepted primitive typed derivation relations backed by independent replay of already accepted canonical operations; no multi-step composition rules",
+  "foundation": "self-contained primitive derivation relations defined by independent replay of the canonical operations named below; no historical MTS umbrella or proof release is part of relation identity",
+  "scope": "accepted primitive typed derivation relations backed by independent replay of canonical operations; no multi-step composition rules",
   "judgmentShape": {
     "relation": "explicit tagged relation name",
     "subject": "all operation inputs required by the relation",
-    "evidence": "validated OperationalReplayClaim for the exact accepted canonical operation",
+    "evidence": "validated OperationalReplayClaim for the exact canonical operation",
     "hiddenGlobalStateAllowed": false,
     "globalTruthPredicateIntroduced": false
   },
@@ -57,7 +55,7 @@
       "sourceOperation": "open_definition",
       "precondition": "independent replay returns kind=non-addressable",
       "arguments": ["target"],
-      "meaning": "the target is outside the accepted v0.3 definition-addressability subset",
+      "meaning": "the target is outside the accepted definition-addressability subset",
       "globalSemanticInvalidity": false
     }
   ],
@@ -88,15 +86,9 @@
     "recursiveNormalizationAccepted": false
   },
   "productionIntegration": {
-    "proofContract": "mts-proof/v0.3",
-    "proofConformance": "contracts/mts-proof-conformance-v0.3.json",
     "checker": "core/proof_checker.py",
-    "acceptedRelationsPublished": true,
+    "canonicalReplay": "check_base_judgment",
     "proofSearchTrusted": false,
     "genericCompositionAccepted": false
-  },
-  "downstream": {
-    "aproverProofRepinAllowed": false,
-    "reason": "downstream exact pin follows additive accepted umbrella contracts rather than this base relation contract directly"
   }
 }

--- a/contracts/mts-opening-path-v0.4.json
+++ b/contracts/mts-opening-path-v0.4.json
@@ -4,11 +4,10 @@
   "accepted": true,
   "issue": 161,
   "dependsOn": [
-    "mts-definition-opening/v0.3",
-    "mts-derivation-base/v0.3",
-    "mts-proof/v0.3"
+    "mts-definition-opening/v0.3"
   ],
   "conformanceCorpus": "contracts/mts-opening-path-conformance-v0.4.json",
+  "foundation": "self-contained finite composition of the accepted one-step DefinitionOpening operation; historical proof or umbrella releases are not semantic dependencies",
   "scope": "normative read-only verification of one finite self-contained DefinitionOpeningPath operational composite certificate; no equality, normalization, evaluation, generic composition, memory or context effects",
   "relation": {
     "name": "DefinitionOpeningPath",
@@ -38,7 +37,7 @@
   },
   "portableCertificate": {
     "sharedFields": ["scopes", "lookupScope", "startTarget", "edges", "finalBody"],
-    "scopes": "same explicit lexical snapshot semantics as mts-proof/v0.3 definition relations",
+    "scopes": "explicit lexical DefinitionEnvironment snapshot used by the canonical one-step opening operation",
     "lookupScope": "one exact serialized scope path used for every edge",
     "startTarget": "parseable Form source; structural identity after parsing",
     "edges": {
@@ -48,7 +47,7 @@
     },
     "finalBody": "canonical format_expression transport of the final expected replay body",
     "transportDecoderOwnedByCoreVerifier": false,
-    "reason": "transport/version validation belongs to the consuming artifact layer; every consumer must construct the same typed witness and invoke the one canonical verifier"
+    "reason": "transport validation belongs to the consuming artifact layer; every consumer must construct the same typed witness and invoke the one canonical verifier"
   },
   "verificationOrder": [
     "reject empty path",
@@ -111,10 +110,7 @@
   },
   "proofBoundary": {
     "trustedProofRelationAddedByThisContract": false,
-    "eligibleForFutureProofRelation": true,
-    "futureRelationName": "DefinitionOpeningPath",
-    "futureTrustedMeaningMustEqualThisVerifier": true,
-    "mtsProofV03Modified": false,
+    "currentProofConsumerMustReplayExactVerifier": true,
     "genericCompositionAccepted": false,
     "openingPathPlusContextuallySatisfiesAccepted": false
   },
@@ -122,17 +118,5 @@
     "referenceCore": "core/mtc_opening_path.py",
     "productionConformance": "tests/test_mts_opening_path_reference.py",
     "acceptedConformance": "contracts/mts-opening-path-conformance-v0.4.json"
-  },
-  "versioning": {
-    "mtsContractV04Modified": false,
-    "mtsProofV03Modified": false,
-    "publishedThroughUmbrella": false,
-    "futureUmbrellaMustBeAdditive": true
-  },
-  "nextBoundary": {
-    "proofV04MayConsumeThisRelationAfterSeparateAcceptance": true,
-    "otherCompositionRulesAccepted": false,
-    "compositionIssue": 122,
-    "aproverMayInventAdditionalRules": false
   }
 }

--- a/contracts/mts-proof-conformance-v0.4.json
+++ b/contracts/mts-proof-conformance-v0.4.json
@@ -3,12 +3,13 @@
   "status": "accepted",
   "accepted": true,
   "contract": "mts-proof/v0.4",
-  "baseCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "baseSemanticCorpus": "contracts/mts-derivation-base-conformance-v0.3.json",
+  "legacyBaseRegressionCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "legacyBaseRegressionNormative": false,
   "openingPathCorpus": "contracts/mts-opening-path-conformance-v0.4.json",
   "selection": {
-    "baseValidJudgments": "all",
-    "baseForgeries": "all",
-    "baseInvalidArtifactsForV03Regression": "all",
+    "legacyBaseValidJudgments": "all",
+    "legacyBaseForgeries": "all",
     "openingPathValidPaths": "all",
     "openingPathInvalidPaths": "all",
     "v04InvalidArtifacts": "all",
@@ -120,17 +121,16 @@
   },
   "releaseAssertions": {
     "trustedRelationsExactlySix": true,
-    "fiveBaseRelationsReuseV03TrustedMeaning": true,
-    "allV03ValidBaseJudgmentsLift": true,
-    "allV03BaseForgeriesRemainRejected": true,
-    "allV03InvalidArtifactsRemainRejectedByV03Api": true,
+    "fiveBaseRelationsUseVersionNeutralReplay": true,
+    "legacyBaseRegressionIsNonNormative": true,
+    "allLegacyBaseValidJudgmentsLift": true,
+    "allLegacyBaseForgeriesRemainRejected": true,
     "allOpeningPathValidVectorsLift": true,
     "allOpeningPathInvalidVectorsReject": true,
     "allV04TransportForgeriesReject": true,
     "openingPathUsesCanonicalVerifier": true,
     "mixedJudgmentOrderDoesNotCreateDependency": true,
     "canonicalRoundTripRequired": true,
-    "mtsProofV03Unchanged": true,
     "genericCompositionAccepted": false,
     "tenRootDefinitionsUnchanged": true
   },
@@ -140,11 +140,5 @@
     "openingPathReadsInterpreterIdentity": false,
     "materializes": false,
     "deletes": false
-  },
-  "versioningAssertions": {
-    "proofVersion": "mts-proof/v0.4",
-    "contractVersion": "mts-contract/v0.4",
-    "publishedThroughUmbrella": false,
-    "futureUmbrella": "mts-contract/v0.5"
   }
 }

--- a/contracts/mts-proof-v0.4.json
+++ b/contracts/mts-proof-v0.4.json
@@ -4,12 +4,12 @@
   "accepted": true,
   "issue": 165,
   "dependsOn": [
-    "mts-contract/v0.4",
-    "mts-proof/v0.3",
+    "mts-derivation-base/v0.3",
     "mts-opening-path/v0.4"
   ],
   "conformanceCorpus": "contracts/mts-proof-conformance-v0.4.json",
-  "purpose": "Trusted independent replay of the five accepted v0.3 base relations plus the accepted finite DefinitionOpeningPath operational composite certificate; no other composition or inference rule is accepted.",
+  "foundation": "current trusted proof artifact over two self-contained semantic leaves: the five primitive derivation relations and the finite DefinitionOpeningPath verifier; no historical proof or umbrella release is a semantic parent",
+  "purpose": "Trusted independent replay of exactly five primitive derivation relations plus the accepted finite DefinitionOpeningPath operational composite certificate; no other composition or inference rule is accepted.",
   "proofObject": {
     "required": ["proofVersion", "contractVersion", "judgments"],
     "proofVersion": "mts-proof/v0.4",
@@ -25,16 +25,17 @@
     "DefinitionOpeningPath"
   ],
   "baseRelations": {
-    "shapesIdenticalToV03": true,
-    "trustedMeaningIdenticalToV03": true,
-    "checkerPath": "core/proof_checker.py::check_v03_judgment",
-    "reimplementedForV04": false,
-    "proofV03ArtifactsReinterpretedAsV04": false
+    "contract": "mts-derivation-base/v0.3",
+    "checkerPath": "core/proof_checker.py::check_base_judgment",
+    "parserPath": "core/proof_checker.py::_base_judgment_from_data",
+    "serializerPath": "core/proof_checker.py::_base_judgment_to_data",
+    "versionedProofDelegation": false
   },
   "definitionOpeningPath": {
+    "contract": "mts-opening-path/v0.4",
     "required": ["relation", "scopes", "lookupScope", "startTarget", "edges", "finalBody"],
     "relation": "DefinitionOpeningPath",
-    "scopes": "same explicit canonical lexical snapshot semantics as v0.3 definition judgments",
+    "scopes": "explicit canonical lexical DefinitionEnvironment snapshot",
     "lookupScope": "one exact serialized scope path used for every opening edge",
     "startTarget": "parseable Form source; structural identity after parsing; equivalent whitespace permitted",
     "edges": {
@@ -63,8 +64,9 @@
   },
   "checker": {
     "module": "core/proof_checker.py",
-    "singleTrustedModuleForV02V03V04": true,
-    "baseRelationsDelegateExistingV03Replay": true,
+    "currentTrustedModule": true,
+    "baseRelationsUseCanonicalReplayCore": true,
+    "baseRelationsDelegateVersionedProof": false,
     "openingPathDelegatesCanonicalVerifier": true,
     "trustsSerializedOpeningBodyWithoutReplay": false,
     "trustsSerializedDefinitionIdWithoutReplay": false,
@@ -97,14 +99,6 @@
     "openingPathMaterializes": false,
     "openingPathDeletes": false
   },
-  "v03Compatibility": {
-    "mtsProofV03Modified": false,
-    "mtsProofV03Schema": "mts-proof/v0.3",
-    "mtsProofV03ContractVersion": "mts-contract/v0.3",
-    "trustedRelationsRemainExactlyFive": true,
-    "existingV03ArtifactsReplayByExistingApi": true,
-    "retroactiveReinterpretation": false
-  },
   "serialization": {
     "typedApi": [
       "proof_v04_from_data",
@@ -121,15 +115,8 @@
     "definitionCount": 10,
     "mustRemainUnchanged": true
   },
-  "versioning": {
-    "mtsContractV04Modified": false,
-    "publishedThroughUmbrella": false,
-    "futureUmbrella": "mts-contract/v0.5",
-    "futureUmbrellaMustBeAdditive": true
-  },
   "downstream": {
-    "directAproverRepinAllowedBeforeUmbrella": false,
-    "reason": "publish the full new context/proof surface through additive mts-contract/v0.5 before downstream exact pin",
-    "aproverMayInventAdditionalRules": false
+    "aproverMayInventAdditionalRules": false,
+    "proofSearchTrusted": false
   }
 }

--- a/contracts/mts-proof-v0.4.json
+++ b/contracts/mts-proof-v0.4.json
@@ -8,7 +8,7 @@
     "mts-opening-path/v0.4"
   ],
   "conformanceCorpus": "contracts/mts-proof-conformance-v0.4.json",
-  "foundation": "current trusted proof artifact over two self-contained semantic leaves: the five primitive derivation relations and the finite DefinitionOpeningPath verifier; no historical proof or umbrella release is a semantic parent",
+  "foundation": "current trusted proof artifact over two self-contained semantic leaves: the five primitive derivation relations and the finite DefinitionOpeningPath verifier; no historical proof or umbrella release is a semantic parent; proofObject.contractVersion remains only a transport discriminator and does not reintroduce an umbrella dependency",
   "purpose": "Trusted independent replay of exactly five primitive derivation relations plus the accepted finite DefinitionOpeningPath operational composite certificate; no other composition or inference rule is accepted.",
   "proofObject": {
     "required": ["proofVersion", "contractVersion", "judgments"],

--- a/core/proof_checker.py
+++ b/core/proof_checker.py
@@ -3,10 +3,12 @@
 v0.2 deliberately trusts only replay of the accepted read-only contextual
 ``interpret`` semantics.
 
-v0.3 adds replay of the five already accepted base derivation relations from
-``mts-derivation-base/v0.3``.  It still does not implement proof search,
-multi-step composition, global rewriting, classical inference rules, hidden
-root injection, or ambient interpreter/subject access.
+The five primitive derivation relations are implemented once as a
+version-neutral base replay core. v0.3 packages exactly those five relations;
+v0.4 packages the same five plus the accepted finite DefinitionOpeningPath
+certificate. No proof version implements proof search, generic composition,
+global rewriting, classical inference rules, hidden root injection, or ambient
+interpreter/subject access.
 """
 
 from dataclasses import dataclass
@@ -223,13 +225,14 @@ class NonAddressableDefinitionTargetJudgment:
     relation: str = "NonAddressableDefinitionTarget"
 
 
-V03Judgment: TypeAlias = (
+BaseJudgment: TypeAlias = (
     ContextuallySatisfiesJudgment
     | OpensJudgment
     | NoVisibleDefinitionJudgment
     | DefinitionConflictJudgment
     | NonAddressableDefinitionTargetJudgment
 )
+V03Judgment: TypeAlias = BaseJudgment
 
 
 @dataclass(frozen=True)
@@ -256,7 +259,7 @@ def _parse_definition(source: str) -> Definition:
 
 
 def _parse_definition_target(source: str) -> Form:
-    value = parse_formula(f"{source} : __proof_v03_query__")
+    value = parse_formula(f"{source} : __proof_query__")
     if not isinstance(value, Definition):
         raise ValueError("definition target must parse as Form")
     return value.target
@@ -408,7 +411,9 @@ def check_non_addressable_definition_target(
     return result.kind is DefinitionLookupKind.NON_ADDRESSABLE
 
 
-def check_v03_judgment(judgment: V03Judgment) -> bool:
+def check_base_judgment(judgment: BaseJudgment) -> bool:
+    """Replay one of the five primitive accepted derivation relations."""
+
     if isinstance(judgment, ContextuallySatisfiesJudgment):
         return check_contextually_satisfies(judgment)
     if isinstance(judgment, OpensJudgment):
@@ -430,7 +435,7 @@ def check_proof_v03(proof: ProofObjectV03) -> bool:
         or proof.contract_version != CONTRACT_VERSION_V03
     ):
         return False
-    return all(check_v03_judgment(judgment) for judgment in proof.judgments)
+    return all(check_base_judgment(judgment) for judgment in proof.judgments)
 
 
 def _require_exact_keys(data: dict, expected: set[str], label: str) -> None:
@@ -581,7 +586,7 @@ def _definition_id_from_data(data: object) -> ExpectedDefinitionId:
     )
 
 
-def _judgment_from_data(data: object) -> V03Judgment:
+def _base_judgment_from_data(data: object) -> BaseJudgment:
     if not isinstance(data, dict):
         raise ValueError("judgment must be an object")
     relation = data.get("relation")
@@ -651,7 +656,7 @@ def _judgment_from_data(data: object) -> V03Judgment:
             raise ValueError("target must be a string")
         return NonAddressableDefinitionTargetJudgment(target=data["target"])
 
-    raise ValueError("unknown v0.3 proof relation")
+    raise ValueError("unknown base proof relation")
 
 
 def proof_v03_from_data(data: object) -> ProofObjectV03:
@@ -671,7 +676,7 @@ def proof_v03_from_data(data: object) -> ProofObjectV03:
     if not isinstance(data["judgments"], list):
         raise ValueError("judgments must be an array")
     return ProofObjectV03(
-        judgments=tuple(_judgment_from_data(item) for item in data["judgments"]),
+        judgments=tuple(_base_judgment_from_data(item) for item in data["judgments"]),
     )
 
 
@@ -727,7 +732,7 @@ def _scopes_to_data(scopes: tuple[DefinitionScopeSnapshot, ...]) -> list[dict]:
     ]
 
 
-def _judgment_to_data(judgment: V03Judgment) -> dict:
+def _base_judgment_to_data(judgment: BaseJudgment) -> dict:
     if isinstance(judgment, ContextuallySatisfiesJudgment):
         return {
             "relation": judgment.relation,
@@ -770,7 +775,7 @@ def _judgment_to_data(judgment: V03Judgment) -> dict:
         }
     if isinstance(judgment, NonAddressableDefinitionTargetJudgment):
         return {"relation": judgment.relation, "target": judgment.target}
-    raise TypeError("unknown v0.3 proof judgment")
+    raise TypeError("unknown base proof judgment")
 
 
 def proof_v03_to_data(proof: ProofObjectV03) -> dict:
@@ -781,7 +786,7 @@ def proof_v03_to_data(proof: ProofObjectV03) -> dict:
     return {
         "proofVersion": proof.proof_version,
         "contractVersion": proof.contract_version,
-        "judgments": [_judgment_to_data(item) for item in proof.judgments],
+        "judgments": [_base_judgment_to_data(item) for item in proof.judgments],
     }
 
 
@@ -794,9 +799,9 @@ def canonical_proof_v03_json(proof: ProofObjectV03) -> str:
     )
 
 
-# v0.4 extends the same trusted module with exactly one accepted composite
-# certificate relation.  Existing v0.2/v0.3 APIs and semantics above remain
-# independent and unchanged.
+# v0.4 adds exactly one accepted composite certificate relation to the same
+# version-neutral primitive relation core. Existing v0.2/v0.3 artifact APIs do
+# not define or mediate v0.4 semantics.
 CONTRACT_VERSION_V04 = "mts-contract/v0.4"
 PROOF_SCHEMA_V04 = "mts-proof/v0.4"
 
@@ -811,7 +816,7 @@ class DefinitionOpeningPathJudgment:
     relation: str = "DefinitionOpeningPath"
 
 
-V04Judgment: TypeAlias = V03Judgment | DefinitionOpeningPathJudgment
+V04Judgment: TypeAlias = BaseJudgment | DefinitionOpeningPathJudgment
 
 
 @dataclass(frozen=True)
@@ -904,7 +909,7 @@ def check_definition_opening_path(judgment: DefinitionOpeningPathJudgment) -> bo
 def check_v04_judgment(judgment: V04Judgment) -> bool:
     if isinstance(judgment, DefinitionOpeningPathJudgment):
         return check_definition_opening_path(judgment)
-    return check_v03_judgment(judgment)
+    return check_base_judgment(judgment)
 
 
 def check_proof_v04(proof: ProofObjectV04) -> bool:
@@ -921,7 +926,7 @@ def check_proof_v04(proof: ProofObjectV04) -> bool:
 def _v04_judgment_from_data(data: object) -> V04Judgment:
     if isinstance(data, dict) and data.get("relation") == "DefinitionOpeningPath":
         return _opening_path_judgment_from_data(data)
-    return _judgment_from_data(data)
+    return _base_judgment_from_data(data)
 
 
 def proof_v04_from_data(data: object) -> ProofObjectV04:
@@ -978,7 +983,7 @@ def _opening_path_judgment_to_data(judgment: DefinitionOpeningPathJudgment) -> d
 def _v04_judgment_to_data(judgment: V04Judgment) -> dict:
     if isinstance(judgment, DefinitionOpeningPathJudgment):
         return _opening_path_judgment_to_data(judgment)
-    return _judgment_to_data(judgment)
+    return _base_judgment_to_data(judgment)
 
 
 def proof_v04_to_data(proof: ProofObjectV04) -> dict:

--- a/tests/test_mts_derivation_base_contract.py
+++ b/tests/test_mts_derivation_base_contract.py
@@ -1,4 +1,4 @@
-"""Acceptance checks for replay-backed primitive MTS derivation relations v0.3."""
+"""Acceptance checks for self-contained primitive MTS derivation relations."""
 
 import json
 from pathlib import Path
@@ -7,20 +7,22 @@ from pathlib import Path
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-derivation-base-v0.3.json"
 CONFORMANCE = ROOT / "contracts" / "mts-derivation-base-conformance-v0.3.json"
-PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
 
 
 def read(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_contract_is_accepted_and_depends_only_on_normative_v03_surface():
+def test_contract_is_accepted_self_contained_and_has_no_release_parent():
     contract = read(CONTRACT)
 
     assert contract["schema"] == "mts-derivation-base/v0.3"
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
-    assert contract["dependsOn"] == ["mts-contract/v0.3"]
+    assert "dependsOn" not in contract
+    serialized = json.dumps(contract, ensure_ascii=False)
+    assert "mts-contract/v0." not in serialized
+    assert "mts-proof/v0." not in serialized
     assert contract["conformanceCorpus"] == "contracts/mts-derivation-base-conformance-v0.3.json"
 
 
@@ -103,24 +105,12 @@ def test_no_composition_or_classical_rule_is_accepted_by_base_contract():
     }
 
 
-def test_accepted_proof_v03_is_current_production_consumer_without_search_trust():
-    contract = read(CONTRACT)
-    proof = read(PROOF_V03)
-    integration = contract["productionIntegration"]
+def test_production_integration_points_to_version_neutral_base_replay():
+    integration = read(CONTRACT)["productionIntegration"]
 
-    assert proof["schema"] == "mts-proof/v0.3"
-    assert proof["accepted"] is True
-    assert set(proof["trustedRelations"]) == {
-        "ContextuallySatisfies",
-        "Opens",
-        "NoVisibleDefinition",
-        "DefinitionConflict",
-        "NonAddressableDefinitionTarget",
+    assert integration == {
+        "checker": "core/proof_checker.py",
+        "canonicalReplay": "check_base_judgment",
+        "proofSearchTrusted": False,
+        "genericCompositionAccepted": False,
     }
-    assert integration["proofContract"] == "mts-proof/v0.3"
-    assert integration["proofConformance"] == "contracts/mts-proof-conformance-v0.3.json"
-    assert integration["checker"] == "core/proof_checker.py"
-    assert integration["acceptedRelationsPublished"] is True
-    assert integration["proofSearchTrusted"] is False
-    assert integration["genericCompositionAccepted"] is False
-    assert contract["downstream"]["aproverProofRepinAllowed"] is False

--- a/tests/test_mts_opening_path_reference.py
+++ b/tests/test_mts_opening_path_reference.py
@@ -1,4 +1,4 @@
-"""Production conformance for accepted mts-opening-path/v0.4."""
+"""Production conformance for self-contained accepted mts-opening-path/v0.4."""
 
 import inspect
 import json
@@ -19,8 +19,6 @@ from core.mtc_parser import parse_formula
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-opening-path-v0.4.json"
 CONFORMANCE = ROOT / "contracts" / "mts-opening-path-conformance-v0.4.json"
-MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
-PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
 CORE = ROOT / "core" / "mtc_opening_path.py"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
@@ -114,22 +112,22 @@ def root_sources() -> tuple[str, ...]:
     )
 
 
-def test_contract_is_accepted_standalone_and_old_releases_are_immutable():
+def test_contract_is_accepted_self_contained_and_has_only_real_dependency():
     contract = read(CONTRACT)
     conformance = read(CONFORMANCE)
 
     assert contract["schema"] == "mts-opening-path/v0.4"
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
+    assert contract["dependsOn"] == ["mts-definition-opening/v0.3"]
+    serialized = json.dumps(contract, ensure_ascii=False)
+    assert "mts-contract/v0." not in serialized
+    assert "mts-proof/v0." not in serialized
+    assert "versioning" not in contract
     assert conformance["schema"] == "mts-opening-path-conformance/v0.4"
     assert conformance["accepted"] is True
     assert conformance["contract"] == contract["schema"]
     assert contract["conformanceCorpus"] == "contracts/mts-opening-path-conformance-v0.4.json"
-    assert contract["versioning"]["mtsContractV04Modified"] is False
-    assert contract["versioning"]["mtsProofV03Modified"] is False
-    assert contract["versioning"]["publishedThroughUmbrella"] is False
-    assert contract["schema"] not in MTS_V04.read_text(encoding="utf-8")
-    assert contract["schema"] not in PROOF_V03.read_text(encoding="utf-8")
 
 
 def test_accepted_conformance_owns_complete_vector_corpus():
@@ -385,9 +383,12 @@ def test_relation_does_not_claim_logical_or_evaluation_semantics():
     assert meaning["readsInterpreterIdentity"] is False
     assert meaning["materializes"] is False
     assert meaning["deletes"] is False
-    assert proof["trustedProofRelationAddedByThisContract"] is False
-    assert proof["genericCompositionAccepted"] is False
-    assert proof["openingPathPlusContextuallySatisfiesAccepted"] is False
+    assert proof == {
+        "trustedProofRelationAddedByThisContract": False,
+        "currentProofConsumerMustReplayExactVerifier": True,
+        "genericCompositionAccepted": False,
+        "openingPathPlusContextuallySatisfiesAccepted": False,
+    }
 
 
 def test_all_ten_root_definitions_are_unchanged_one_edge_certificates():

--- a/tests/test_mts_proof_v04.py
+++ b/tests/test_mts_proof_v04.py
@@ -1,4 +1,4 @@
-"""Production acceptance for mts-proof/v0.4 with DefinitionOpeningPath."""
+"""Production acceptance for self-contained mts-proof/v0.4."""
 
 import json
 from copy import deepcopy
@@ -10,7 +10,6 @@ from core.proof_checker import (
     DefinitionOpeningPathJudgment,
     ProofObjectV04,
     canonical_proof_v04_json,
-    check_proof_v03_data,
     check_proof_v04,
     check_proof_v04_data,
     proof_v04_from_data,
@@ -21,10 +20,10 @@ from core.proof_checker import (
 ROOT = Path(__file__).parents[1]
 CONTRACT = ROOT / "contracts" / "mts-proof-v0.4.json"
 CONFORMANCE = ROOT / "contracts" / "mts-proof-conformance-v0.4.json"
-BASE_CORPUS = ROOT / "contracts" / "mts-proof-conformance-v0.3.json"
+BASE_SEMANTIC_CORPUS = ROOT / "contracts" / "mts-derivation-base-conformance-v0.3.json"
+LEGACY_BASE_REGRESSION = ROOT / "contracts" / "mts-proof-conformance-v0.3.json"
 OPENING_CONFORMANCE = ROOT / "contracts" / "mts-opening-path-conformance-v0.4.json"
-PROOF_V03 = ROOT / "contracts" / "mts-proof-v0.3.json"
-MTS_V04 = ROOT / "contracts" / "mts-contract-v0.4.json"
+CHECKER = ROOT / "core" / "proof_checker.py"
 ROOT_PROGRAM = ROOT / "tests" / "mtc_formulas.mtc"
 
 BASE_RELATIONS = {
@@ -56,14 +55,6 @@ def v04_artifact(judgments: list[dict]) -> dict:
     }
 
 
-def v03_artifact(judgments: list[dict]) -> dict:
-    return {
-        "proofVersion": "mts-proof/v0.3",
-        "contractVersion": "mts-contract/v0.3",
-        "judgments": judgments,
-    }
-
-
 def opening_judgment(vector: dict) -> dict:
     return {
         "relation": "DefinitionOpeningPath",
@@ -89,7 +80,7 @@ def patch_dotted(source: dict, patch: dict) -> dict:
 def base_by_id() -> dict[str, dict]:
     return {
         item["id"]: item["judgment"]
-        for item in read(BASE_CORPUS)["validJudgments"]
+        for item in read(LEGACY_BASE_REGRESSION)["validJudgments"]
     }
 
 
@@ -109,13 +100,21 @@ def forged_base(vector: dict) -> dict:
     return result
 
 
-def test_contract_is_accepted_with_exact_six_relation_surface():
+def test_contract_is_accepted_self_contained_with_exact_six_relation_surface():
     contract = read(CONTRACT)
     conformance = read(CONFORMANCE)
 
     assert contract["schema"] == "mts-proof/v0.4"
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
+    assert contract["dependsOn"] == [
+        "mts-derivation-base/v0.3",
+        "mts-opening-path/v0.4",
+    ]
+    serialized = json.dumps(contract, ensure_ascii=False)
+    assert "mts-proof/v0.3" not in serialized
+    assert "v03Compatibility" not in contract
+    assert "versioning" not in contract
     assert contract["proofObject"]["proofVersion"] == PROOF_SCHEMA_V04
     assert contract["proofObject"]["contractVersion"] == CONTRACT_VERSION_V04
     assert set(contract["trustedRelations"]) == BASE_RELATIONS | {"DefinitionOpeningPath"}
@@ -126,44 +125,50 @@ def test_contract_is_accepted_with_exact_six_relation_surface():
     assert contract["conformanceCorpus"] == "contracts/mts-proof-conformance-v0.4.json"
 
 
-def test_accepted_conformance_owns_v04_vectors_and_uses_only_accepted_dependencies():
+def test_conformance_uses_semantic_leaf_and_marks_historical_corpus_regression_only():
     conformance = read(CONFORMANCE)
+    base_semantics = read(BASE_SEMANTIC_CORPUS)
 
-    assert conformance["baseCorpus"] == "contracts/mts-proof-conformance-v0.3.json"
+    assert conformance["baseSemanticCorpus"] == "contracts/mts-derivation-base-conformance-v0.3.json"
+    assert base_semantics["contract"] == "mts-derivation-base/v0.3"
+    assert conformance["legacyBaseRegressionCorpus"] == "contracts/mts-proof-conformance-v0.3.json"
+    assert conformance["legacyBaseRegressionNormative"] is False
     assert conformance["openingPathCorpus"] == "contracts/mts-opening-path-conformance-v0.4.json"
     assert conformance["invalidArtifacts"]
     assert conformance["mixedArtifact"]["openingPathId"] == "two-edge"
+    assert "versioningAssertions" not in conformance
 
 
-def test_every_v03_valid_base_judgment_replays_identically_when_lifted():
-    for vector in read(BASE_CORPUS)["validJudgments"]:
-        judgment = vector["judgment"]
-        assert check_proof_v03_data(v03_artifact([judgment])), vector["id"]
-        assert check_proof_v04_data(v04_artifact([judgment])), vector["id"]
+def test_legacy_base_valid_judgments_replay_directly_in_current_v04():
+    for vector in read(LEGACY_BASE_REGRESSION)["validJudgments"]:
+        assert check_proof_v04_data(v04_artifact([vector["judgment"]])), vector["id"]
 
     base = read(CONTRACT)["baseRelations"]
-    assert base["shapesIdenticalToV03"] is True
-    assert base["trustedMeaningIdenticalToV03"] is True
-    assert base["reimplementedForV04"] is False
+    assert base == {
+        "contract": "mts-derivation-base/v0.3",
+        "checkerPath": "core/proof_checker.py::check_base_judgment",
+        "parserPath": "core/proof_checker.py::_base_judgment_from_data",
+        "serializerPath": "core/proof_checker.py::_base_judgment_to_data",
+        "versionedProofDelegation": False,
+    }
 
 
-def test_every_v03_base_forgery_remains_rejected_by_both_versioned_paths():
-    for vector in read(BASE_CORPUS)["forgeries"]:
+def test_legacy_base_forgeries_are_rejected_directly_by_current_v04():
+    for vector in read(LEGACY_BASE_REGRESSION)["forgeries"]:
         forged = forged_base(vector)
         assert vector["mustReject"] is True
-        assert not check_proof_v03_data(v03_artifact([forged])), vector["id"]
         assert not check_proof_v04_data(v04_artifact([forged])), vector["id"]
 
 
-def test_every_existing_v03_invalid_artifact_remains_rejected_by_v03_api():
-    for vector in read(BASE_CORPUS)["invalidArtifacts"]:
-        assert not check_proof_v03_data(vector["artifact"]), vector["id"]
+def test_current_checker_has_no_versioned_v03_dispatch_path():
+    source = CHECKER.read_text(encoding="utf-8")
 
-    compatibility = read(CONTRACT)["v03Compatibility"]
-    assert compatibility["mtsProofV03Modified"] is False
-    assert compatibility["trustedRelationsRemainExactlyFive"] is True
-    assert compatibility["existingV03ArtifactsReplayByExistingApi"] is True
-    assert compatibility["retroactiveReinterpretation"] is False
+    assert "def check_base_judgment" in source
+    assert "def _base_judgment_from_data" in source
+    assert "def _base_judgment_to_data" in source
+    assert "def check_v03_judgment" not in source
+    assert "return check_v03_judgment(judgment)" not in source
+    assert "V04Judgment: TypeAlias = BaseJudgment | DefinitionOpeningPathJudgment" in source
 
 
 def test_every_opening_path_valid_vector_lifts_to_trusted_v04_relation():
@@ -277,13 +282,14 @@ def test_opening_path_relation_uses_no_equality_or_other_generic_rule():
     assert boundary["globalSubstitutionAccepted"] is False
 
 
-def test_checker_and_effect_boundaries_remain_explicit():
+def test_checker_and_effect_boundaries_are_current_and_explicit():
     checker = read(CONTRACT)["checker"]
     effects = read(CONTRACT)["effectsBoundary"]
 
     assert checker["module"] == "core/proof_checker.py"
-    assert checker["singleTrustedModuleForV02V03V04"] is True
-    assert checker["baseRelationsDelegateExistingV03Replay"] is True
+    assert checker["currentTrustedModule"] is True
+    assert checker["baseRelationsUseCanonicalReplayCore"] is True
+    assert checker["baseRelationsDelegateVersionedProof"] is False
     assert checker["openingPathDelegatesCanonicalVerifier"] is True
     assert checker["trustsSearchTrace"] is False
     assert checker["mayAutoExtendOpeningPath"] is False
@@ -299,26 +305,20 @@ def test_checker_and_effect_boundaries_remain_explicit():
     assert effects["openingPathDeletes"] is False
 
 
-def test_standalone_proof_release_waits_for_additive_v05_umbrella_before_aprover_repin():
-    versioning = read(CONTRACT)["versioning"]
-    downstream = read(CONTRACT)["downstream"]
+def test_current_proof_has_no_historical_release_gate_or_compatibility_surface():
+    contract = read(CONTRACT)
+    downstream = contract["downstream"]
 
-    assert versioning["mtsContractV04Modified"] is False
-    assert versioning["publishedThroughUmbrella"] is False
-    assert versioning["futureUmbrella"] == "mts-contract/v0.5"
-    assert downstream["directAproverRepinAllowedBeforeUmbrella"] is False
-    assert downstream["aproverMayInventAdditionalRules"] is False
-    assert "mts-proof/v0.4" not in MTS_V04.read_text(encoding="utf-8")
+    assert "v03Compatibility" not in contract
+    assert "versioning" not in contract
+    assert "futureUmbrella" not in json.dumps(contract, ensure_ascii=False)
+    assert downstream == {
+        "aproverMayInventAdditionalRules": False,
+        "proofSearchTrusted": False,
+    }
 
 
 def test_root_program_remains_exactly_ten_and_unchanged():
     before = root_sources()
     assert len(before) == 10
     assert root_sources() == before
-
-
-def test_v03_contract_artifact_is_still_the_original_five_relation_release():
-    v03 = read(PROOF_V03)
-    assert v03["schema"] == "mts-proof/v0.3"
-    assert len(v03["trustedRelations"]) == 5
-    assert "DefinitionOpeningPath" not in v03["trustedRelations"]


### PR DESCRIPTION
Refs #357, #278, #343.

Второй compression slice: разрывает runtime/normative зависимость current `mts-proof/v0.4` от versioned `mts-proof/v0.3` и historical MTS umbrella chain без изменения шести принятых relations.

Что меняется:
- `mts-derivation-base/v0.3` становится self-contained semantic leaf пяти primitive relations;
- `mts-opening-path/v0.4` зависит только от accepted one-step DefinitionOpening, а не от proof-v0.3/umbrella;
- `core/proof_checker.py` получает version-neutral `BaseJudgment` + base parse/serialize/replay core;
- v0.3 artifact API и v0.4 artifact API используют общее primitive ядро, но v0.4 больше не вызывает versioned v0.3 API;
- `mts-proof/v0.4` зависит только от `mts-derivation-base/v0.3` и `mts-opening-path/v0.4`;
- `mts-proof-conformance/v0.4` считает derivation-base conformance нормативным semantic corpus.

Временно `mts-proof-conformance/v0.3` остаётся только как `legacyBaseRegressionCorpus` с `legacyBaseRegressionNormative=false`: current v0.4 checker сам replay-ит эти old vectors для проверки эквивалентности accepted primitive behavior. Это не runtime/normative dependency и не compatibility semantic layer; следующий delete-heavy slice #357 перенесёт/сожмёт необходимые regression vectors перед физическим удалением historical proof chain.

Семантические veto неизменны: ровно 6 trusted relations; proof search untrusted; generic composition/transitivity/symmetry/congruence/MP/global substitution не принимаются; DefinitionOpeningPath не означает equality/equivalence/normalization; checker read-only и не materialize/delete.

Текущий diff: 8 modified files, 0 new files, net-negative.

```repo-guard-yaml
change_type: refactor
scope:
  - contracts/mts-derivation-base-v0.3.json
  - contracts/mts-opening-path-v0.4.json
  - contracts/mts-proof-v0.4.json
  - contracts/mts-proof-conformance-v0.4.json
  - core/proof_checker.py
  - tests/test_mts_derivation_base_contract.py
  - tests/test_mts_opening_path_reference.py
  - tests/test_mts_proof_v04.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - contracts/mts-derivation-base-v0.3.json
  - contracts/mts-opening-path-v0.4.json
  - contracts/mts-proof-v0.4.json
  - contracts/mts-proof-conformance-v0.4.json
  - core/proof_checker.py
  - tests/test_mts_derivation_base_contract.py
  - tests/test_mts_opening_path_reference.py
  - tests/test_mts_proof_v04.py
must_not_touch:
  - docs/**
  - README.md
  - contracts/mts-contract-v0.2.json
  - contracts/mts-contract-v0.3.json
  - contracts/mts-contract-v0.4.json
  - contracts/mts-contract-v0.5.json
  - contracts/mts-proof-v0.2.json
  - contracts/mts-proof-v0.3.json
  - contracts/mts-proof-conformance-v0.3.json
  - contracts/anum-*.json
  - core/foundation_v2_*.py
  - contracts/mts-foundation-v2-*.json
  - repo-policy.json
expected_effects:
  - make primitive derivation relations self-contained
  - detach opening-path from historical proof and umbrella releases
  - replace v0.4 versioned-v0.3 delegation with one version-neutral base replay core
  - keep exactly six current trusted proof relations
  - preserve all proof/effect/composition vetoes
  - keep old v0.3 proof corpus regression-only, not normative
  - reduce active release coupling without compatibility facades
```