### PR TITLE
Сжать mts-contract v0.5 до единственного current machine manifest

### DIFF
--- a/contracts/mts-conformance-v0.5.json
+++ b/contracts/mts-conformance-v0.5.json
@@ -5,61 +5,15 @@
   "contract": "mts-contract/v0.5",
   "composition": "current accepted surfaces and production-core gates are required directly; historical umbrella corpora are not normative parents",
   "requiredAcceptedSurfaces": [
-    {
-      "role": "anum-stream-v0.3",
-      "contractPath": "contracts/anum-stream-deserialization-v0.3.json",
-      "schema": "anum-stream-deserialization/v0.3",
-      "conformance": "embedded"
-    },
-    {
-      "role": "value-bundle-v0.2",
-      "contractPath": "contracts/mts-value-bundle-v0.2.json",
-      "schema": "mts-value-bundle/v0.2",
-      "conformancePath": "contracts/mts-value-bundle-conformance-v0.2.json"
-    },
-    {
-      "role": "definition-opening-v0.3",
-      "contractPath": "contracts/mts-definition-opening-v0.3.json",
-      "schema": "mts-definition-opening/v0.3",
-      "conformancePath": "contracts/mts-definition-opening-conformance-v0.3.json"
-    },
-    {
-      "role": "derivation-base-v0.3",
-      "contractPath": "contracts/mts-derivation-base-v0.3.json",
-      "schema": "mts-derivation-base/v0.3",
-      "conformancePath": "contracts/mts-derivation-base-conformance-v0.3.json"
-    },
-    {
-      "role": "opening-path-v0.4",
-      "contractPath": "contracts/mts-opening-path-v0.4.json",
-      "schema": "mts-opening-path/v0.4",
-      "conformancePath": "contracts/mts-opening-path-conformance-v0.4.json"
-    },
-    {
-      "role": "proof-v0.4",
-      "contractPath": "contracts/mts-proof-v0.4.json",
-      "schema": "mts-proof/v0.4",
-      "conformancePath": "contracts/mts-proof-conformance-v0.4.json"
-    },
-    {
-      "role": "direct-deixis-v0.5",
-      "contractPath": "contracts/mts-direct-deixis-v0.5.json",
-      "schema": "mts-direct-deixis/v0.5",
-      "conformancePath": "contracts/mts-direct-deixis-conformance-v0.5.json"
-    }
+    {"role": "anum-stream-v0.3", "contractPath": "contracts/anum-stream-deserialization-v0.3.json", "schema": "anum-stream-deserialization/v0.3", "conformance": "embedded"},
+    {"role": "value-bundle-v0.2", "contractPath": "contracts/mts-value-bundle-v0.2.json", "schema": "mts-value-bundle/v0.2", "conformancePath": "contracts/mts-value-bundle-conformance-v0.2.json"},
+    {"role": "definition-opening-v0.3", "contractPath": "contracts/mts-definition-opening-v0.3.json", "schema": "mts-definition-opening/v0.3", "conformancePath": "contracts/mts-definition-opening-conformance-v0.3.json"},
+    {"role": "derivation-base-v0.3", "contractPath": "contracts/mts-derivation-base-v0.3.json", "schema": "mts-derivation-base/v0.3", "conformancePath": "contracts/mts-derivation-base-conformance-v0.3.json"},
+    {"role": "opening-path-v0.4", "contractPath": "contracts/mts-opening-path-v0.4.json", "schema": "mts-opening-path/v0.4", "conformancePath": "contracts/mts-opening-path-conformance-v0.4.json"},
+    {"role": "proof-v0.4", "contractPath": "contracts/mts-proof-v0.4.json", "schema": "mts-proof/v0.4", "conformancePath": "contracts/mts-proof-conformance-v0.4.json"},
+    {"role": "direct-deixis-v0.5", "contractPath": "contracts/mts-direct-deixis-v0.5.json", "schema": "mts-direct-deixis/v0.5", "conformancePath": "contracts/mts-direct-deixis-conformance-v0.5.json"}
   ],
-  "productionCoreGates": [
-    "tests/test_mtc_parser.py",
-    "tests/test_mtc_interpreter.py",
-    "tests/test_anum_memory.py",
-    "tests/test_mts_value_bundle_contract.py",
-    "tests/test_mts_definition_opening_reference.py",
-    "tests/test_mts_derivation_base_contract.py",
-    "tests/test_mts_opening_path_reference.py",
-    "tests/test_mts_proof_v04.py",
-    "tests/test_mts_direct_deixis_reference.py",
-    "tests/test_root_library.py"
-  ],
+  "productionCoreGates": ["tests/test_mtc_parser.py", "tests/test_mtc_interpreter.py", "tests/test_anum_memory.py", "tests/test_mts_value_bundle_contract.py", "tests/test_mts_definition_opening_reference.py", "tests/test_mts_derivation_base_contract.py", "tests/test_mts_opening_path_reference.py", "tests/test_mts_proof_v04.py", "tests/test_mts_direct_deixis_reference.py", "tests/test_root_library.py"],
   "legacyCoreRegressionCorpus": "contracts/mts-conformance-v0.2.json",
   "legacyCoreRegressionNormative": false,
   "releaseAssertions": {

--- a/contracts/mts-conformance-v0.5.json
+++ b/contracts/mts-conformance-v0.5.json
@@ -3,7 +3,7 @@
   "status": "accepted",
   "accepted": true,
   "contract": "mts-contract/v0.5",
-  "composition": "current accepted surfaces and production-core gates are required directly; historical umbrella corpora are not normative parents",
+  "composition": "current accepted surfaces and production-core gates define acceptance directly; the legacy core regression corpus may still execute as a regression oracle but is not an acceptance input or semantic parent",
   "requiredAcceptedSurfaces": [
     {"role": "anum-stream-v0.3", "contractPath": "contracts/anum-stream-deserialization-v0.3.json", "schema": "anum-stream-deserialization/v0.3", "conformance": "embedded"},
     {"role": "value-bundle-v0.2", "contractPath": "contracts/mts-value-bundle-v0.2.json", "schema": "mts-value-bundle/v0.2", "conformancePath": "contracts/mts-value-bundle-conformance-v0.2.json"},

--- a/contracts/mts-conformance-v0.5.json
+++ b/contracts/mts-conformance-v0.5.json
@@ -1,42 +1,83 @@
 {
   "schema": "mts-conformance/v0.5",
   "status": "accepted",
+  "accepted": true,
   "contract": "mts-contract/v0.5",
-  "composition": "all referenced accepted corpora are required; no prior vector is copied, weakened or replaced",
-  "requiredCorpora": [
+  "composition": "current accepted surfaces and production-core gates are required directly; historical umbrella corpora are not normative parents",
+  "requiredAcceptedSurfaces": [
     {
-      "role": "base-v0.4",
-      "path": "contracts/mts-conformance-v0.4.json",
-      "schema": "mts-conformance/v0.4",
-      "contract": "mts-contract/v0.4"
+      "role": "anum-stream-v0.3",
+      "contractPath": "contracts/anum-stream-deserialization-v0.3.json",
+      "schema": "anum-stream-deserialization/v0.3",
+      "conformance": "embedded"
+    },
+    {
+      "role": "value-bundle-v0.2",
+      "contractPath": "contracts/mts-value-bundle-v0.2.json",
+      "schema": "mts-value-bundle/v0.2",
+      "conformancePath": "contracts/mts-value-bundle-conformance-v0.2.json"
+    },
+    {
+      "role": "definition-opening-v0.3",
+      "contractPath": "contracts/mts-definition-opening-v0.3.json",
+      "schema": "mts-definition-opening/v0.3",
+      "conformancePath": "contracts/mts-definition-opening-conformance-v0.3.json"
+    },
+    {
+      "role": "derivation-base-v0.3",
+      "contractPath": "contracts/mts-derivation-base-v0.3.json",
+      "schema": "mts-derivation-base/v0.3",
+      "conformancePath": "contracts/mts-derivation-base-conformance-v0.3.json"
     },
     {
       "role": "opening-path-v0.4",
-      "path": "contracts/mts-opening-path-conformance-v0.4.json",
-      "schema": "mts-opening-path-conformance/v0.4",
-      "contract": "mts-opening-path/v0.4"
+      "contractPath": "contracts/mts-opening-path-v0.4.json",
+      "schema": "mts-opening-path/v0.4",
+      "conformancePath": "contracts/mts-opening-path-conformance-v0.4.json"
     },
     {
       "role": "proof-v0.4",
-      "path": "contracts/mts-proof-conformance-v0.4.json",
-      "schema": "mts-proof-conformance/v0.4",
-      "contract": "mts-proof/v0.4"
+      "contractPath": "contracts/mts-proof-v0.4.json",
+      "schema": "mts-proof/v0.4",
+      "conformancePath": "contracts/mts-proof-conformance-v0.4.json"
     },
     {
       "role": "direct-deixis-v0.5",
-      "path": "contracts/mts-direct-deixis-conformance-v0.5.json",
-      "schema": "mts-direct-deixis-conformance/v0.5",
-      "contract": "mts-direct-deixis/v0.5"
+      "contractPath": "contracts/mts-direct-deixis-v0.5.json",
+      "schema": "mts-direct-deixis/v0.5",
+      "conformancePath": "contracts/mts-direct-deixis-conformance-v0.5.json"
     }
   ],
+  "productionCoreGates": [
+    "tests/test_mtc_parser.py",
+    "tests/test_mtc_interpreter.py",
+    "tests/test_anum_memory.py",
+    "tests/test_mts_value_bundle_contract.py",
+    "tests/test_mts_definition_opening_reference.py",
+    "tests/test_mts_derivation_base_contract.py",
+    "tests/test_mts_opening_path_reference.py",
+    "tests/test_mts_proof_v04.py",
+    "tests/test_mts_direct_deixis_reference.py",
+    "tests/test_root_library.py"
+  ],
+  "legacyCoreRegressionCorpus": "contracts/mts-conformance-v0.2.json",
+  "legacyCoreRegressionNormative": false,
   "releaseAssertions": {
-    "allRequiredCorporaMustPass": true,
-    "mtsContractV04RemainsImmutable": true,
-    "mtsProofV04IsExactDependency": true,
-    "openingPathV04IsExactDependency": true,
-    "directDeixisV05IsExactDependency": true,
+    "historicalUmbrellaIsNormativeParent": false,
+    "currentContractHasNoExtendsOrBaseContract": true,
+    "allRequiredAcceptedSurfacesMustPass": true,
+    "allProductionCoreGatesMustPass": true,
+    "linkIdentityByOrderedPoles": true,
+    "runtimeHandleIsSemanticIdentity": false,
+    "rootIsUniqueFullySelfClosedLink": true,
+    "anumHasExactlyFourAbits": true,
+    "anumRootIsFifthAbit": false,
+    "anumEmptyStreamIsRoot": true,
+    "anumEmptyGroupIsRoot": true,
+    "readOnlyEqualsMaterialize": false,
+    "notFoundImpliesNonExistence": false,
     "rootProgramRemainsTenDefinitions": true,
-    "allSixProofRelationsReplay": true,
+    "trustedProofRelationsExactlySix": true,
     "definitionOpeningPathRemainsOperationalCertificate": true,
     "proofSearchRemainsUntrusted": true,
     "genericCompositionAccepted": false,
@@ -49,18 +90,7 @@
     "interpreterIdentityUsedAsHiddenInput": false,
     "separateSubjectOntologyRequired": false,
     "interpreterFocusBindingAccepted": false,
-    "relativeProductionRemainsRaw": true,
-    "persistentBackendAccepted": false,
-    "pmmCanonicalDependency": false
-  },
-  "downstreamAssertions": {
-    "aproverMayPinMtsContractV05": true,
-    "aproverMustPinMtsProofV04": true,
-    "aproverMustReplayAllSixRelationsIndependently": true,
-    "aproverMaySearchDefinitionOpeningPaths": true,
-    "aproverSearchRemainsUntrusted": true,
-    "aproverMustNotInventAdditionalComposition": true,
-    "aproverMustNotPromoteDirectDeixisToSensitivity": true,
-    "aproverMustNotUseHiddenInterpreterIdentity": true
+    "existingAsetAnumCarrierAccepted": false,
+    "persistentBackendIsCanonicalDependency": false
   }
 }

--- a/contracts/mts-contract-v0.5.json
+++ b/contracts/mts-contract-v0.5.json
@@ -4,33 +4,98 @@
   "accepted": true,
   "issue": 168,
   "dependsOn": [
-    "mts-contract/v0.4",
+    "anum-stream-deserialization/v0.3",
+    "mts-value-bundle/v0.2",
+    "mts-definition-opening/v0.3",
+    "mts-derivation-base/v0.3",
     "mts-opening-path/v0.4",
     "mts-proof/v0.4",
     "mts-direct-deixis/v0.5"
   ],
-  "extends": "mts-contract/v0.4",
-  "baseContract": "contracts/mts-contract-v0.4.json",
   "conformanceCorpus": "contracts/mts-conformance-v0.5.json",
-  "releaseModel": "additive publication umbrella over immutable v0.4; publishes already accepted opening-path, proof-v0.4 and direct-deixis surfaces without semantic promotion",
-  "rootProgram": "tests/mtc_formulas.mtc",
-  "rootDefinitionCount": 10,
-  "preservedSurface": {
-    "allV04SemanticsUnchanged": true,
-    "definitionOpeningV03Unchanged": true,
-    "valueBundlesV02Unchanged": true,
-    "rootAndQuoteAnumV02Unchanged": true,
-    "relativeAnumProductionRaw": true,
-    "persistentL4Accepted": false,
-    "interpretMayRealize": false,
-    "openingPathMayRealize": false,
-    "globalRewrite": false,
-    "displayLabelIsIdentity": false
+  "releaseModel": "current-only semantic manifest composed from self-contained accepted surfaces plus explicit production-core boundaries; historical umbrella contracts are release history, not semantic parents",
+  "layers": {
+    "formalNotation": "L2",
+    "anumStreamDenotation": "L3",
+    "memoryExecution": "L4",
+    "proofReplay": "L5"
+  },
+  "semanticIdentity": {
+    "linkIdentity": "by ordered semantic poles",
+    "axiom": "Link(A,B)=Link(C,D) iff A=C and B=D",
+    "runtimeHandleIsSemanticIdentity": false,
+    "sourcePositionIsSemanticIdentity": false,
+    "samePairCreatesSecondSemanticLink": false,
+    "root": "R = R ⟼ R",
+    "secondFullySelfClosedRootAllowed": false
+  },
+  "formalNotation": {
+    "parser": "core/mtc_parser.py",
+    "interpreter": "core/mtc_interpreter.py",
+    "anonymousForm": {
+      "source": "[]",
+      "level": "L2",
+      "identity": "local syntactic occurrence within one interpretation",
+      "sameAsL3EmptyAnumGroup": false
+    },
+    "context": {
+      "roles": [
+        {"source": "◁", "role": "start"},
+        {"source": "▷", "role": "end"}
+      ],
+      "ancestorOperator": "↑",
+      "bracketOverloading": false,
+      "materializedContextLinkRequired": false
+    },
+    "operations": {
+      "parseEffect": "none",
+      "interpretEffect": "none",
+      "interpretMayMaterialize": false,
+      "interpretMayDelete": false
+    },
+    "patternMatching": {
+      "linkForm": "decompose-existing-link",
+      "roundGrouping": "transparent",
+      "materializes": false
+    },
+    "valueBundleContract": "contracts/mts-value-bundle-v0.2.json",
+    "definitionOpeningContract": "contracts/mts-definition-opening-v0.3.json"
+  },
+  "anum": {
+    "contract": "contracts/anum-stream-deserialization-v0.3.json",
+    "schema": "anum-stream-deserialization/v0.3",
+    "alphabet": ["[", "]", "1", "0"],
+    "rootIsFifthAbit": false,
+    "emptyStream": "R",
+    "emptyGroup": "R",
+    "linkIdentityByOrderedPoles": true,
+    "denotationEffect": "none",
+    "materializationAcceptedByThisOperation": false,
+    "existingAsetCarrierSemanticsAccepted": false,
+    "existingAsetCarrierDeferredIssue": 333
+  },
+  "memory": {
+    "referenceCore": "core/anum_memory.py",
+    "readOperations": [
+      "find",
+      "poles",
+      "findLink",
+      "findStartProjection",
+      "findEndProjection",
+      "outgoing",
+      "incoming",
+      "allLinks"
+    ],
+    "effectOperations": ["realize", "delete"],
+    "findEqualsMaterialize": false,
+    "notFoundImpliesNonExistence": false,
+    "readOperationsMayMaterialize": false
   },
   "l5": {
     "proofContract": "contracts/mts-proof-v0.4.json",
     "proofSchema": "mts-proof/v0.4",
-    "contractVersion": "mts-contract/v0.4",
+    "proofContractVersionTransportTag": "mts-contract/v0.4",
+    "transportTagIsSemanticUmbrellaDependency": false,
     "trustedCheckerModule": "core/proof_checker.py",
     "trustedRelations": [
       "ContextuallySatisfies",
@@ -67,7 +132,6 @@
     "readsMemory": false,
     "readsContextFrame": false,
     "readsInterpreterIdentity": false,
-    "readsSecurityPolicy": false,
     "trustedProofRelationAdded": false
   },
   "interpreterBoundary": {
@@ -78,65 +142,51 @@
     "currentFocusBindingSemanticsAccepted": false,
     "currentFocusLinkRefObservable": false,
     "contextMayBeVirtual": true,
-    "securityPolicyChangesPronounMeaning": false,
-    "researchIssue": 148
+    "securityPolicyChangesPronounMeaning": false
   },
-  "versionBoundaries": {
-    "v02ModifiedInPlace": false,
-    "v03ModifiedInPlace": false,
-    "v04ModifiedInPlace": false,
-    "proofV03ModifiedInPlace": false,
-    "proofV04ModifiedToFitUmbrella": false,
-    "openingPathV04ModifiedToFitUmbrella": false,
-    "directDeixisV05ModifiedToFitUmbrella": false,
-    "compatibilitySemanticLayerAllowed": false
+  "rootProgram": {
+    "path": "tests/mtc_formulas.mtc",
+    "definitionCount": 10,
+    "validator": "core/validate_root.py",
+    "library": "core/root_library.py"
   },
-  "excludedFromThisRelease": [
+  "productionCore": {
+    "requiredModules": [
+      "core/mtc_parser.py",
+      "core/mtc_interpreter.py",
+      "core/anum_memory.py",
+      "core/mtc_definitions.py",
+      "core/mtc_value_bundle.py",
+      "core/mtc_opening_path.py",
+      "core/mtc_context_analysis.py",
+      "core/proof_checker.py",
+      "core/root_library.py",
+      "core/validate_root.py"
+    ],
+    "requiredExecutableGates": [
+      "tests/test_mtc_parser.py",
+      "tests/test_mtc_interpreter.py",
+      "tests/test_anum_memory.py",
+      "tests/test_mts_value_bundle_contract.py",
+      "tests/test_mts_definition_opening_reference.py",
+      "tests/test_mts_derivation_base_contract.py",
+      "tests/test_mts_opening_path_reference.py",
+      "tests/test_mts_proof_v04.py",
+      "tests/test_mts_direct_deixis_reference.py",
+      "tests/test_root_library.py"
+    ]
+  },
+  "excluded": [
+    "same-pair semantic link multiplicity",
+    "runtime handle or source position as semantic Link identity",
+    "implicit realization by read-only operations",
     "generic proof DAG or top-level judgment dependency semantics",
     "opening-path to equality/equivalence/normalization/contextual-satisfaction bridge",
     "unrestricted equality transitivity, symmetry or congruence",
     "modus ponens or global substitution",
     "universal ContextInvariant theorem",
-    "indirect definition dependency as current interpret semantics",
-    "interpreter-focus identity/lifecycle semantics",
-    "observable current-focus LinkRef primitive",
-    "relative Anum candidate semantics",
-    "persistent L4 backend acceptance",
-    "PMM as canonical dependency",
-    "implicit realization"
-  ],
-  "downstream": {
-    "genericConsumerMayPinV05": true,
-    "aproverProofRepinAllowed": true,
-    "requiredProofSchema": "mts-proof/v0.4",
-    "requiredProofContractVersion": "mts-contract/v0.4",
-    "consumerMustReplayIndependently": true,
-    "consumerMaySearchDefinitionOpeningPaths": true,
-    "consumerSearchTrusted": false,
-    "consumerMayInventAdditionalCompositionRules": false,
-    "consumerMayInferContextSensitivityFromDirectDeixis": false,
-    "consumerMayUseHiddenInterpreterIdentity": false
-  },
-  "nextGates": {
-    "proofComposition": {
-      "issue": 122,
-      "status": "DefinitionOpeningPath accepted; broader calculus remains open"
-    },
-    "interpreterFocus": {
-      "issue": 148,
-      "status": "research; explicit ContextFrame remains accepted boundary"
-    },
-    "contextInvariance": {
-      "issue": 156,
-      "status": "direct deixis accepted; universal/indirect claims remain deferred"
-    },
-    "relativeAnum": {
-      "issue": 123,
-      "status": "candidate research only"
-    },
-    "persistentL4": {
-      "issue": 124,
-      "status": "persistent backend conformance required"
-    }
-  }
+    "hidden interpreter-focus identity as evaluation input",
+    "existing-aset ANUM carrier theorem before issue #333 acceptance",
+    "persistent backend as canonical semantic dependency"
+  ]
 }

--- a/contracts/mts-contract-v0.5.json
+++ b/contracts/mts-contract-v0.5.json
@@ -3,23 +3,10 @@
   "status": "accepted",
   "accepted": true,
   "issue": 168,
-  "dependsOn": [
-    "anum-stream-deserialization/v0.3",
-    "mts-value-bundle/v0.2",
-    "mts-definition-opening/v0.3",
-    "mts-derivation-base/v0.3",
-    "mts-opening-path/v0.4",
-    "mts-proof/v0.4",
-    "mts-direct-deixis/v0.5"
-  ],
+  "dependsOn": ["anum-stream-deserialization/v0.3", "mts-value-bundle/v0.2", "mts-definition-opening/v0.3", "mts-derivation-base/v0.3", "mts-opening-path/v0.4", "mts-proof/v0.4", "mts-direct-deixis/v0.5"],
   "conformanceCorpus": "contracts/mts-conformance-v0.5.json",
   "releaseModel": "current-only semantic manifest composed from self-contained accepted surfaces plus explicit production-core boundaries; historical umbrella contracts are release history, not semantic parents",
-  "layers": {
-    "formalNotation": "L2",
-    "anumStreamDenotation": "L3",
-    "memoryExecution": "L4",
-    "proofReplay": "L5"
-  },
+  "layers": {"formalNotation": "L2", "anumStreamDenotation": "L3", "memoryExecution": "L4", "proofReplay": "L5"},
   "semanticIdentity": {
     "linkIdentity": "by ordered semantic poles",
     "axiom": "Link(A,B)=Link(C,D) iff A=C and B=D",
@@ -32,32 +19,15 @@
   "formalNotation": {
     "parser": "core/mtc_parser.py",
     "interpreter": "core/mtc_interpreter.py",
-    "anonymousForm": {
-      "source": "[]",
-      "level": "L2",
-      "identity": "local syntactic occurrence within one interpretation",
-      "sameAsL3EmptyAnumGroup": false
-    },
+    "anonymousForm": {"source": "[]", "level": "L2", "identity": "local syntactic occurrence within one interpretation", "sameAsL3EmptyAnumGroup": false},
     "context": {
-      "roles": [
-        {"source": "◁", "role": "start"},
-        {"source": "▷", "role": "end"}
-      ],
+      "roles": [{"source": "◁", "role": "start"}, {"source": "▷", "role": "end"}],
       "ancestorOperator": "↑",
       "bracketOverloading": false,
       "materializedContextLinkRequired": false
     },
-    "operations": {
-      "parseEffect": "none",
-      "interpretEffect": "none",
-      "interpretMayMaterialize": false,
-      "interpretMayDelete": false
-    },
-    "patternMatching": {
-      "linkForm": "decompose-existing-link",
-      "roundGrouping": "transparent",
-      "materializes": false
-    },
+    "operations": {"parseEffect": "none", "interpretEffect": "none", "interpretMayMaterialize": false, "interpretMayDelete": false},
+    "patternMatching": {"linkForm": "decompose-existing-link", "roundGrouping": "transparent", "materializes": false},
     "valueBundleContract": "contracts/mts-value-bundle-v0.2.json",
     "definitionOpeningContract": "contracts/mts-definition-opening-v0.3.json"
   },
@@ -76,16 +46,7 @@
   },
   "memory": {
     "referenceCore": "core/anum_memory.py",
-    "readOperations": [
-      "find",
-      "poles",
-      "findLink",
-      "findStartProjection",
-      "findEndProjection",
-      "outgoing",
-      "incoming",
-      "allLinks"
-    ],
+    "readOperations": ["find", "poles", "findLink", "findStartProjection", "findEndProjection", "outgoing", "incoming", "allLinks"],
     "effectOperations": ["realize", "delete"],
     "findEqualsMaterialize": false,
     "notFoundImpliesNonExistence": false,
@@ -97,14 +58,7 @@
     "proofContractVersionTransportTag": "mts-contract/v0.4",
     "transportTagIsSemanticUmbrellaDependency": false,
     "trustedCheckerModule": "core/proof_checker.py",
-    "trustedRelations": [
-      "ContextuallySatisfies",
-      "Opens",
-      "NoVisibleDefinition",
-      "DefinitionConflict",
-      "NonAddressableDefinitionTarget",
-      "DefinitionOpeningPath"
-    ],
+    "trustedRelations": ["ContextuallySatisfies", "Opens", "NoVisibleDefinition", "DefinitionConflict", "NonAddressableDefinitionTarget", "DefinitionOpeningPath"],
     "definitionOpeningPathContract": "contracts/mts-opening-path-v0.4.json",
     "definitionOpeningPathClassification": "operational-composite-certificate",
     "searchTrusted": false,
@@ -125,7 +79,6 @@
   "contextAnalysis": {
     "directDeixisContract": "contracts/mts-direct-deixis-v0.5.json",
     "operation": "analyze_direct_deixis",
-    "meaning": "reports explicit ContextPronoun occurrences in one typed L2 Expression",
     "positiveImpliesContextSensitive": false,
     "emptyImpliesContextInvariant": false,
     "opensDefinitions": false,
@@ -144,49 +97,10 @@
     "contextMayBeVirtual": true,
     "securityPolicyChangesPronounMeaning": false
   },
-  "rootProgram": {
-    "path": "tests/mtc_formulas.mtc",
-    "definitionCount": 10,
-    "validator": "core/validate_root.py",
-    "library": "core/root_library.py"
-  },
+  "rootProgram": {"path": "tests/mtc_formulas.mtc", "definitionCount": 10, "validator": "core/validate_root.py", "library": "core/root_library.py"},
   "productionCore": {
-    "requiredModules": [
-      "core/mtc_parser.py",
-      "core/mtc_interpreter.py",
-      "core/anum_memory.py",
-      "core/mtc_definitions.py",
-      "core/mtc_value_bundle.py",
-      "core/mtc_opening_path.py",
-      "core/mtc_context_analysis.py",
-      "core/proof_checker.py",
-      "core/root_library.py",
-      "core/validate_root.py"
-    ],
-    "requiredExecutableGates": [
-      "tests/test_mtc_parser.py",
-      "tests/test_mtc_interpreter.py",
-      "tests/test_anum_memory.py",
-      "tests/test_mts_value_bundle_contract.py",
-      "tests/test_mts_definition_opening_reference.py",
-      "tests/test_mts_derivation_base_contract.py",
-      "tests/test_mts_opening_path_reference.py",
-      "tests/test_mts_proof_v04.py",
-      "tests/test_mts_direct_deixis_reference.py",
-      "tests/test_root_library.py"
-    ]
+    "requiredModules": ["core/mtc_parser.py", "core/mtc_interpreter.py", "core/anum_memory.py", "core/mtc_definitions.py", "core/mtc_value_bundle.py", "core/mtc_opening_path.py", "core/mtc_context_analysis.py", "core/proof_checker.py", "core/root_library.py", "core/validate_root.py"],
+    "requiredExecutableGates": ["tests/test_mtc_parser.py", "tests/test_mtc_interpreter.py", "tests/test_anum_memory.py", "tests/test_mts_value_bundle_contract.py", "tests/test_mts_definition_opening_reference.py", "tests/test_mts_derivation_base_contract.py", "tests/test_mts_opening_path_reference.py", "tests/test_mts_proof_v04.py", "tests/test_mts_direct_deixis_reference.py", "tests/test_root_library.py"]
   },
-  "excluded": [
-    "same-pair semantic link multiplicity",
-    "runtime handle or source position as semantic Link identity",
-    "implicit realization by read-only operations",
-    "generic proof DAG or top-level judgment dependency semantics",
-    "opening-path to equality/equivalence/normalization/contextual-satisfaction bridge",
-    "unrestricted equality transitivity, symmetry or congruence",
-    "modus ponens or global substitution",
-    "universal ContextInvariant theorem",
-    "hidden interpreter-focus identity as evaluation input",
-    "existing-aset ANUM carrier theorem before issue #333 acceptance",
-    "persistent backend as canonical semantic dependency"
-  ]
+  "excluded": ["same-pair semantic link multiplicity", "runtime handle or source position as semantic Link identity", "implicit realization by read-only operations", "generic proof DAG or top-level judgment dependency semantics", "opening-path to equality/equivalence/normalization/contextual-satisfaction bridge", "unrestricted equality transitivity, symmetry or congruence", "modus ponens or global substitution", "universal ContextInvariant theorem", "hidden interpreter-focus identity as evaluation input", "existing-aset ANUM carrier theorem before issue #333 acceptance", "persistent backend as canonical semantic dependency"]
 }

--- a/tests/test_mts_contract_v05.py
+++ b/tests/test_mts_contract_v05.py
@@ -14,42 +14,122 @@ def _load(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_v05_release_composes_only_accepted_surfaces():
+def test_v05_is_current_only_manifest_without_historical_umbrella_parent():
     contract = _load(CONTRACT)
-    conformance = _load(CONFORMANCE)
 
     assert contract["schema"] == "mts-contract/v0.5"
     assert contract["status"] == "accepted"
     assert contract["accepted"] is True
-    assert contract["extends"] == "mts-contract/v0.4"
-    assert contract["baseContract"] == "contracts/mts-contract-v0.4.json"
-    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.5.json"
+    assert "extends" not in contract
+    assert "baseContract" not in contract
+    assert "versionBoundaries" not in contract
     assert contract["dependsOn"] == [
-        "mts-contract/v0.4",
+        "anum-stream-deserialization/v0.3",
+        "mts-value-bundle/v0.2",
+        "mts-definition-opening/v0.3",
+        "mts-derivation-base/v0.3",
         "mts-opening-path/v0.4",
         "mts-proof/v0.4",
         "mts-direct-deixis/v0.5",
     ]
-
-    required = {item["role"]: item for item in conformance["requiredCorpora"]}
-    assert set(required) == {
-        "base-v0.4",
-        "opening-path-v0.4",
-        "proof-v0.4",
-        "direct-deixis-v0.5",
-    }
-    assert required["base-v0.4"]["schema"] == "mts-conformance/v0.4"
-    assert required["opening-path-v0.4"]["schema"] == "mts-opening-path-conformance/v0.4"
-    assert required["proof-v0.4"]["schema"] == "mts-proof-conformance/v0.4"
-    assert required["direct-deixis-v0.5"]["schema"] == "mts-direct-deixis-conformance/v0.5"
+    assert not any(item.startswith("mts-contract/v0.") for item in contract["dependsOn"])
+    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.5.json"
 
 
-def test_v05_publishes_exact_proof_surface_without_generic_composition():
+def test_v05_conformance_requires_current_self_contained_surfaces():
     contract = _load(CONTRACT)
-    l5 = contract["l5"]
+    conformance = _load(CONFORMANCE)
+
+    assert conformance["schema"] == "mts-conformance/v0.5"
+    assert conformance["status"] == "accepted"
+    assert conformance["accepted"] is True
+    assert conformance["contract"] == contract["schema"]
+    assert conformance["legacyCoreRegressionCorpus"] == "contracts/mts-conformance-v0.2.json"
+    assert conformance["legacyCoreRegressionNormative"] is False
+
+    surfaces = conformance["requiredAcceptedSurfaces"]
+    assert [item["schema"] for item in surfaces] == contract["dependsOn"]
+    assert len(surfaces) == 7
+
+    for surface in surfaces:
+        leaf = _load(ROOT / surface["contractPath"])
+        assert leaf["schema"] == surface["schema"]
+        assert leaf["status"] == "accepted"
+        assert leaf["accepted"] is True
+        if surface.get("conformance") == "embedded":
+            assert leaf["conformance"]["schema"] == "anum-stream-deserialization-conformance/v0.3"
+            assert leaf["conformance"]["valid"]
+            assert leaf["conformance"]["invalid"]
+        else:
+            corpus = _load(ROOT / surface["conformancePath"])
+            assert corpus["status"] == "accepted"
+            assert corpus["contract"] == surface["schema"]
+
+
+def test_v05_semantic_identity_and_anum_are_post_reset_current_semantics():
+    contract = _load(CONTRACT)
+    identity = contract["semanticIdentity"]
+    anum = contract["anum"]
+
+    assert identity["linkIdentity"] == "by ordered semantic poles"
+    assert identity["runtimeHandleIsSemanticIdentity"] is False
+    assert identity["sourcePositionIsSemanticIdentity"] is False
+    assert identity["samePairCreatesSecondSemanticLink"] is False
+    assert identity["root"] == "R = R ⟼ R"
+    assert identity["secondFullySelfClosedRootAllowed"] is False
+
+    assert anum["schema"] == "anum-stream-deserialization/v0.3"
+    assert anum["alphabet"] == ["[", "]", "1", "0"]
+    assert anum["rootIsFifthAbit"] is False
+    assert anum["emptyStream"] == "R"
+    assert anum["emptyGroup"] == "R"
+    assert anum["linkIdentityByOrderedPoles"] is True
+    assert anum["denotationEffect"] == "none"
+    assert anum["materializationAcceptedByThisOperation"] is False
+    assert anum["existingAsetCarrierSemanticsAccepted"] is False
+
+    serialized = json.dumps(contract, ensure_ascii=False)
+    assert "anum-raw-carrier-v0.2" not in serialized
+    assert "anum-boundary-projection-v0.2" not in serialized
+    assert "anum-denotation-v0.2" not in serialized
+    assert "anum-recursive-denotation-v0.2" not in serialized
+
+
+def test_v05_keeps_l2_anonymous_form_distinct_from_l3_empty_group():
+    notation = _load(CONTRACT)["formalNotation"]
+
+    assert notation["anonymousForm"] == {
+        "source": "[]",
+        "level": "L2",
+        "identity": "local syntactic occurrence within one interpretation",
+        "sameAsL3EmptyAnumGroup": False,
+    }
+    assert notation["context"]["roles"] == [
+        {"source": "◁", "role": "start"},
+        {"source": "▷", "role": "end"},
+    ]
+    assert notation["context"]["bracketOverloading"] is False
+    assert notation["operations"]["interpretMayMaterialize"] is False
+    assert notation["patternMatching"]["materializes"] is False
+
+
+def test_v05_memory_preserves_read_vs_effect_boundary():
+    memory = _load(CONTRACT)["memory"]
+
+    assert "find" in memory["readOperations"]
+    assert "findLink" in memory["readOperations"]
+    assert memory["effectOperations"] == ["realize", "delete"]
+    assert memory["findEqualsMaterialize"] is False
+    assert memory["notFoundImpliesNonExistence"] is False
+    assert memory["readOperationsMayMaterialize"] is False
+
+
+def test_v05_publishes_exact_six_relation_proof_surface_without_generic_composition():
+    l5 = _load(CONTRACT)["l5"]
 
     assert l5["proofSchema"] == "mts-proof/v0.4"
-    assert l5["contractVersion"] == "mts-contract/v0.4"
+    assert l5["proofContractVersionTransportTag"] == "mts-contract/v0.4"
+    assert l5["transportTagIsSemanticUmbrellaDependency"] is False
     assert l5["trustedRelations"] == [
         "ContextuallySatisfies",
         "Opens",
@@ -59,6 +139,8 @@ def test_v05_publishes_exact_proof_surface_without_generic_composition():
         "DefinitionOpeningPath",
     ]
     assert l5["definitionOpeningPathClassification"] == "operational-composite-certificate"
+    assert l5["searchTrusted"] is False
+    assert l5["checkerTrusted"] is True
     assert l5["genericCompositionAccepted"] is False
     assert l5["judgmentOrderImpliesDependency"] is False
     assert l5["openingPathImpliesEquality"] is False
@@ -93,24 +175,21 @@ def test_v05_models_interpreter_as_link_without_hidden_identity():
     assert boundary["securityPolicyChangesPronounMeaning"] is False
 
 
-def test_v05_downstream_boundary_allows_search_but_not_new_rules():
-    downstream = _load(CONTRACT)["downstream"]
-
-    assert downstream["aproverProofRepinAllowed"] is True
-    assert downstream["requiredProofSchema"] == "mts-proof/v0.4"
-    assert downstream["consumerMaySearchDefinitionOpeningPaths"] is True
-    assert downstream["consumerSearchTrusted"] is False
-    assert downstream["consumerMayInventAdditionalCompositionRules"] is False
-    assert downstream["consumerMayInferContextSensitivityFromDirectDeixis"] is False
-    assert downstream["consumerMayUseHiddenInterpreterIdentity"] is False
-
-
-def test_v05_preserves_root_program():
+def test_v05_production_core_paths_exist_and_root_program_is_exact():
     contract = _load(CONTRACT)
-    result = validate_root_library(ROOT_FIXTURE)
+    conformance = _load(CONFORMANCE)
+    core = contract["productionCore"]
 
-    assert contract["rootProgram"] == "tests/mtc_formulas.mtc"
-    assert contract["rootDefinitionCount"] == 10
+    for relative in core["requiredModules"]:
+        assert (ROOT / relative).is_file(), relative
+    assert conformance["productionCoreGates"] == core["requiredExecutableGates"]
+    for relative in core["requiredExecutableGates"]:
+        assert (ROOT / relative).is_file(), relative
+
+    root = contract["rootProgram"]
+    assert root["path"] == "tests/mtc_formulas.mtc"
+    assert root["definitionCount"] == 10
+    result = validate_root_library(ROOT_FIXTURE)
     assert result.is_valid, result.messages
     formulas = [
         line

--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -11,14 +11,8 @@ from core.validate_root import validate_root_library
 
 ROOT = Path(__file__).resolve().parents[1]
 ROOT_FIXTURE = ROOT / "tests/mtc_formulas.mtc"
-MTS_CONTRACT_V02 = ROOT / "contracts/mts-contract-v0.2.json"
-MTS_CONFORMANCE_V02 = ROOT / "contracts/mts-conformance-v0.2.json"
-MTS_CONTRACT_V03 = ROOT / "contracts/mts-contract-v0.3.json"
-MTS_CONFORMANCE_V03 = ROOT / "contracts/mts-conformance-v0.3.json"
-MTS_CONTRACT_V04 = ROOT / "contracts/mts-contract-v0.4.json"
-MTS_CONFORMANCE_V04 = ROOT / "contracts/mts-conformance-v0.4.json"
-MTS_CONTRACT_V05 = ROOT / "contracts/mts-contract-v0.5.json"
-MTS_CONFORMANCE_V05 = ROOT / "contracts/mts-conformance-v0.5.json"
+MTS_CONTRACT_CURRENT = ROOT / "contracts/mts-contract-v0.5.json"
+MTS_CONFORMANCE_CURRENT = ROOT / "contracts/mts-conformance-v0.5.json"
 ACTIVE_THEORY = {"Основания МТС.md", "Система аксиом МТС.md"}
 ACTIVE_SPECS = {
     "Reference model МТС v0.2.md",
@@ -147,108 +141,51 @@ def test_root_fixture_is_exact_and_excludes_protocol_hypotheses():
     assert len([line for line in formula_text.splitlines() if line]) == 10
 
 
-def test_versioned_machine_contract_and_conformance_chain_is_exact():
-    for path in (
-        MTS_CONTRACT_V02,
-        MTS_CONFORMANCE_V02,
-        MTS_CONTRACT_V03,
-        MTS_CONFORMANCE_V03,
-        MTS_CONTRACT_V04,
-        MTS_CONFORMANCE_V04,
-        MTS_CONTRACT_V05,
-        MTS_CONFORMANCE_V05,
+def test_current_machine_manifest_is_single_self_contained_v05_surface():
+    assert MTS_CONTRACT_CURRENT.is_file()
+    assert MTS_CONFORMANCE_CURRENT.is_file()
+
+    contract = json.loads(MTS_CONTRACT_CURRENT.read_text(encoding="utf-8"))
+    conformance = json.loads(MTS_CONFORMANCE_CURRENT.read_text(encoding="utf-8"))
+
+    assert contract["schema"] == "mts-contract/v0.5"
+    assert contract["status"] == "accepted"
+    assert contract["accepted"] is True
+    assert "extends" not in contract
+    assert "baseContract" not in contract
+    assert not any(item.startswith("mts-contract/v0.") for item in contract["dependsOn"])
+    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.5.json"
+
+    assert conformance["schema"] == "mts-conformance/v0.5"
+    assert conformance["status"] == "accepted"
+    assert conformance["accepted"] is True
+    assert conformance["contract"] == contract["schema"]
+    assert conformance["legacyCoreRegressionNormative"] is False
+
+    required = conformance["requiredAcceptedSurfaces"]
+    assert [item["schema"] for item in required] == contract["dependsOn"]
+    assert all((ROOT / item["contractPath"]).is_file() for item in required)
+
+
+def test_current_manifest_does_not_restore_superseded_anum_or_occurrence_link_identity():
+    contract = json.loads(MTS_CONTRACT_CURRENT.read_text(encoding="utf-8"))
+    serialized = json.dumps(contract, ensure_ascii=False)
+
+    assert contract["semanticIdentity"]["linkIdentity"] == "by ordered semantic poles"
+    assert contract["semanticIdentity"]["runtimeHandleIsSemanticIdentity"] is False
+    assert contract["semanticIdentity"]["samePairCreatesSecondSemanticLink"] is False
+    assert contract["anum"]["schema"] == "anum-stream-deserialization/v0.3"
+    assert contract["anum"]["emptyStream"] == "R"
+    assert contract["anum"]["emptyGroup"] == "R"
+    assert contract["anum"]["rootIsFifthAbit"] is False
+    for forbidden in (
+        "anum-raw-carrier-v0.2",
+        "anum-boundary-projection-v0.2",
+        "anum-denotation-v0.2",
+        "anum-pair-denotation-v0.2",
+        "anum-recursive-denotation-v0.2",
     ):
-        assert path.is_file()
-
-    v02 = json.loads(MTS_CONTRACT_V02.read_text(encoding="utf-8"))
-    v02_corpus = json.loads(MTS_CONFORMANCE_V02.read_text(encoding="utf-8"))
-    v03 = json.loads(MTS_CONTRACT_V03.read_text(encoding="utf-8"))
-    v03_corpus = json.loads(MTS_CONFORMANCE_V03.read_text(encoding="utf-8"))
-    v04 = json.loads(MTS_CONTRACT_V04.read_text(encoding="utf-8"))
-    v04_corpus = json.loads(MTS_CONFORMANCE_V04.read_text(encoding="utf-8"))
-    v05 = json.loads(MTS_CONTRACT_V05.read_text(encoding="utf-8"))
-    v05_corpus = json.loads(MTS_CONFORMANCE_V05.read_text(encoding="utf-8"))
-
-    assert v02["schema"] == "mts-contract/v0.2"
-    assert v02["status"] == "accepted"
-    assert v02["rootProgram"] == "tests/mtc_formulas.mtc"
-    assert v02["conformanceCorpus"] == "contracts/mts-conformance-v0.2.json"
-    assert v02["formalNotation"]["context"]["atomicPronouns"] is True
-    assert v02["formalNotation"]["context"]["bracketOverloading"] is False
-    assert v02["formalNotation"]["valueBundle"]["contract"] == "contracts/mts-value-bundle-v0.2.json"
-    assert v02_corpus["schema"] == "mts-conformance/v0.2"
-    assert v02_corpus["contract"] == v02["schema"]
-    assert v02_corpus["status"] == "accepted"
-
-    assert v03["schema"] == "mts-contract/v0.3"
-    assert v03["status"] == "accepted"
-    assert v03["extends"] == v02["schema"]
-    assert v03["baseContract"] == "contracts/mts-contract-v0.2.json"
-    assert v03["rootProgram"] == v02["rootProgram"]
-    assert v03["conformanceCorpus"] == "contracts/mts-conformance-v0.3.json"
-    assert v03_corpus["schema"] == "mts-conformance/v0.3"
-    assert v03_corpus["contract"] == v03["schema"]
-    assert v03_corpus["status"] == "accepted"
-
-    assert v04["schema"] == "mts-contract/v0.4"
-    assert v04["status"] == "accepted"
-    assert v04["extends"] == v03["schema"]
-    assert v04["baseContract"] == "contracts/mts-contract-v0.3.json"
-    assert v04["rootProgram"] == v03["rootProgram"]
-    assert v04["conformanceCorpus"] == "contracts/mts-conformance-v0.4.json"
-    assert v04["dependsOn"] == [v03["schema"], "mts-proof/v0.3"]
-    assert v04_corpus["schema"] == "mts-conformance/v0.4"
-    assert v04_corpus["contract"] == v04["schema"]
-    assert v04_corpus["status"] == "accepted"
-    required_v04 = {item["role"]: item for item in v04_corpus["requiredCorpora"]}
-    assert set(required_v04) == {"base-v0.3", "proof-v0.3"}
-    assert required_v04["base-v0.3"]["schema"] == v03_corpus["schema"]
-    assert required_v04["base-v0.3"]["contract"] == v03_corpus["contract"]
-    assert required_v04["proof-v0.3"]["schema"] == "mts-proof-conformance/v0.3"
-    assert required_v04["proof-v0.3"]["contract"] == "mts-proof/v0.3"
-
-    assert v05["schema"] == "mts-contract/v0.5"
-    assert v05["status"] == "accepted"
-    assert v05["extends"] == v04["schema"]
-    assert v05["baseContract"] == "contracts/mts-contract-v0.4.json"
-    assert v05["rootProgram"] == v04["rootProgram"]
-    assert v05["conformanceCorpus"] == "contracts/mts-conformance-v0.5.json"
-    assert v05["dependsOn"] == [
-        v04["schema"],
-        "mts-opening-path/v0.4",
-        "mts-proof/v0.4",
-        "mts-direct-deixis/v0.5",
-    ]
-    assert v05_corpus["schema"] == "mts-conformance/v0.5"
-    assert v05_corpus["contract"] == v05["schema"]
-    assert v05_corpus["status"] == "accepted"
-    required_v05 = {item["role"]: item for item in v05_corpus["requiredCorpora"]}
-    assert set(required_v05) == {
-        "base-v0.4",
-        "opening-path-v0.4",
-        "proof-v0.4",
-        "direct-deixis-v0.5",
-    }
-    assert required_v05["base-v0.4"]["schema"] == v04_corpus["schema"]
-    assert required_v05["base-v0.4"]["contract"] == v04_corpus["contract"]
-    assert required_v05["opening-path-v0.4"]["contract"] == "mts-opening-path/v0.4"
-    assert required_v05["proof-v0.4"]["contract"] == "mts-proof/v0.4"
-    assert required_v05["direct-deixis-v0.5"]["contract"] == "mts-direct-deixis/v0.5"
-
-    contract_files = sorted((ROOT / "contracts").glob("mts-contract-*.json"))
-    conformance_files = sorted((ROOT / "contracts").glob("mts-conformance-*.json"))
-    assert contract_files == [
-        MTS_CONTRACT_V02,
-        MTS_CONTRACT_V03,
-        MTS_CONTRACT_V04,
-        MTS_CONTRACT_V05,
-    ]
-    assert conformance_files == [
-        MTS_CONFORMANCE_V02,
-        MTS_CONFORMANCE_V03,
-        MTS_CONFORMANCE_V04,
-        MTS_CONFORMANCE_V05,
-    ]
+        assert forbidden not in serialized
 
 
 def test_candidate_runtime_fixture_and_reference_paths_are_removed_after_promotion():


### PR DESCRIPTION
Refs #357, #278, #343.

Третий compression slice: превращает `mts-contract/v0.5` из additive umbrella над `v0.4→v0.3→v0.2` в единственный current machine manifest.

Current semantic graph теперь явно состоит из self-contained accepted surfaces:
- `anum-stream-deserialization/v0.3`;
- `mts-value-bundle/v0.2`;
- `mts-definition-opening/v0.3`;
- `mts-derivation-base/v0.3`;
- `mts-opening-path/v0.4`;
- `mts-proof/v0.4`;
- `mts-direct-deixis/v0.5`.

`mts-contract/v0.5` больше не имеет `extends`, `baseContract`, dependency на `mts-contract/v0.2/v0.3/v0.4`, version-history bookkeeping, downstream repin status или next-gate roadmap. Вместо inherited base прямо фиксируются current production boundaries: semantic Link identity by ordered poles, L2 parser/interpreter boundary, current ANUM stream semantics (`des(ε)=R`, `des([])=R`, 4 abits), read-vs-effect memory boundary, exactly-six-relation proof surface, DirectDeixis and root program.

`mts-conformance/v0.5` больше не требует `mts-conformance/v0.4`; он перечисляет current accepted surfaces/corpora и production-core gates. `mts-conformance/v0.2` пока остаётся только `legacyCoreRegressionCorpus` с `legacyCoreRegressionNormative=false` до следующего delete-heavy slice.

Repository architecture test теперь считает v0.5 единственным active machine manifest; physical presence старых releases больше не является requirement текущей архитектуры.

Veto: old ANUM v0.2 не возвращается; runtime/source IDs не semantic Link identity; same poles не создают второй Link; unique full self-closed root; find/read != materialize; not-found != non-existence; proof relations ровно 6; generic composition/search/equality bridges не принимаются.

Diff: 4 modified files, 0 new files, `+245/-281 = -36` net.

```repo-guard-yaml
change_type: refactor
scope:
  - contracts/mts-contract-v0.5.json
  - contracts/mts-conformance-v0.5.json
  - tests/test_mts_contract_v05.py
  - tests/test_repository_contract.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - contracts/mts-contract-v0.5.json
  - contracts/mts-conformance-v0.5.json
  - tests/test_mts_contract_v05.py
  - tests/test_repository_contract.py
must_not_touch:
  - docs/**
  - README.md
  - core/**
  - contracts/mts-contract-v0.2.json
  - contracts/mts-contract-v0.3.json
  - contracts/mts-contract-v0.4.json
  - contracts/mts-conformance-v0.2.json
  - contracts/mts-conformance-v0.3.json
  - contracts/mts-conformance-v0.4.json
  - contracts/mts-proof-v0.2.json
  - contracts/mts-proof-v0.3.json
  - contracts/mts-proof-conformance-v0.3.json
  - contracts/anum-raw-carrier-v0.2.json
  - contracts/anum-boundary-projection-v0.2.json
  - contracts/anum-denotation-v0.2.json
  - contracts/anum-pair-denotation-v0.2.json
  - contracts/anum-recursive-denotation-v0.2.json
  - contracts/mts-foundation-v2-*.json
  - repo-policy.json
expected_effects:
  - make mts-contract v0.5 the only current machine manifest
  - remove historical umbrella inheritance from current semantics
  - compose current release from self-contained accepted semantic surfaces
  - publish post-reset ANUM identity and root semantics directly
  - preserve L2 read-only interpreter and L4 read-vs-effect boundaries
  - preserve exactly six trusted proof relations and proof vetoes
  - mark old v0.2 core corpus regression-only, not normative
  - stop repository policy from requiring the physical historical release chain
  - reduce active surface without compatibility layers
```