### PR TITLE
Добавить read-only ANUM carrier input

### DIFF
--- a/core/anum_carrier.py
+++ b/core/anum_carrier.py
@@ -1,0 +1,110 @@
+"""Read-only rooted-link carrier input for ANUM issue #333.
+
+This module does not change the accepted raw/channel
+``anum-stream-deserialization/v0.3`` surface.  It proves a second input path:
+an already-existing R-rooted link sequence is unfolded to the four transmitted
+abits and then delegated to the existing ``deserialize_stream`` stack machine.
+No second OPEN/CLOSE/VALUE semantics and no materialization are introduced.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.anum_model import Abit
+from core.anum_protocol import StreamDenotation, deserialize_stream
+from core.rooted_link_network import (
+    LinkNetwork,
+    LinkNetworkError,
+    LinkRef,
+    read_rooted_sequence,
+)
+
+
+class CarrierInputError(ValueError):
+    """The selected link/vocabulary is not a readable quaternary carrier."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class AnumCarrierVocabulary:
+    """Technical handles for the four already-distinguished root abits."""
+
+    opening: LinkRef
+    closing: LinkRef
+    linked: LinkRef
+    unlinked: LinkRef
+
+    def as_tuple(self) -> tuple[LinkRef, ...]:
+        return (self.opening, self.closing, self.linked, self.unlinked)
+
+
+def _validate_vocabulary(
+    network: LinkNetwork,
+    vocabulary: AnumCarrierVocabulary,
+) -> None:
+    if not isinstance(vocabulary, AnumCarrierVocabulary):
+        raise CarrierInputError("invalid-vocabulary")
+
+    root = network.root
+    if len(set((root, *vocabulary.as_tuple()))) != 5:
+        raise CarrierInputError("invalid-vocabulary")
+
+    expected = (
+        (vocabulary.opening, vocabulary.opening, root),
+        (vocabulary.closing, root, vocabulary.closing),
+        (vocabulary.linked, vocabulary.opening, vocabulary.closing),
+        (vocabulary.unlinked, vocabulary.closing, vocabulary.opening),
+    )
+    try:
+        for ref, start, end in expected:
+            link = network.link(ref)
+            if link.start is not start or link.end is not end:
+                raise CarrierInputError("invalid-vocabulary")
+    except LinkNetworkError as exc:
+        raise CarrierInputError("invalid-vocabulary") from exc
+
+
+def decode_carrier_stream(
+    network: LinkNetwork,
+    carrier: LinkRef,
+    vocabulary: AnumCarrierVocabulary,
+) -> str:
+    """Recover the canonical quaternary source sequence from an existing link.
+
+    The *carrier role* is explicit: the selected link is read through its start
+    history.  It is not automatically treated as one abit merely because the
+    same semantic Link can also occur as a vocabulary value in another context.
+    """
+
+    _validate_vocabulary(network, vocabulary)
+    try:
+        sequence = read_rooted_sequence(network, carrier)
+    except LinkNetworkError as exc:
+        raise CarrierInputError("not-rooted-sequence") from exc
+
+    inverse = {
+        vocabulary.opening: Abit.OPEN.value,
+        vocabulary.closing: Abit.CLOSE.value,
+        vocabulary.linked: Abit.LINK.value,
+        vocabulary.unlinked: Abit.UNLINK.value,
+    }
+    source: list[str] = []
+    for value_ref in sequence.values:
+        try:
+            source.append(inverse[value_ref])
+        except KeyError as exc:
+            raise CarrierInputError("non-abit") from exc
+    return "".join(source)
+
+
+def deserialize_carrier(
+    network: LinkNetwork,
+    carrier: LinkRef,
+    vocabulary: AnumCarrierVocabulary,
+) -> StreamDenotation:
+    """Deserialize an existing carrier through the accepted raw stack machine."""
+
+    return deserialize_stream(decode_carrier_stream(network, carrier, vocabulary))

--- a/core/foundation_v2_source.py
+++ b/core/foundation_v2_source.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Mapping, Sequence
 
-from .rooted_link_network import LinkNetwork, LinkNetworkBuilder, LinkRef
+from .rooted_link_network import (
+    LinkNetwork,
+    LinkNetworkBuilder,
+    LinkNetworkError,
+    LinkRef,
+    read_rooted_sequence,
+)
 from .foundation_v2_state import (
     DictionaryLookupError,
     define_membership,
@@ -424,31 +430,22 @@ def _decode_content(
     root: LinkRef,
     inverse_bytes: Mapping[LinkRef, int],
 ) -> tuple[bytes, tuple[LinkRef, ...]]:
-    if content is root:
-        return b"", (root,)
+    if root is not network.root:
+        raise SourceReplayError("source content root does not match network root")
+    try:
+        sequence = read_rooted_sequence(network, content)
+    except LinkNetworkError as exc:
+        raise SourceReplayError(
+            "source content is not a finite R-rooted sequence"
+        ) from exc
 
-    reversed_bytes: list[int] = []
-    reversed_prefix_refs: list[LinkRef] = [content]
-    current = content
-    visited: set[LinkRef] = set()
-
-    while current is not root:
-        if current in visited:
-            raise SourceReplayError("cyclic canonical source-content history")
-        visited.add(current)
-        link = network.link(current)
+    decoded: list[int] = []
+    for value_ref in sequence.values:
         try:
-            value = inverse_bytes[link.end]
+            decoded.append(inverse_bytes[value_ref])
         except KeyError as exc:
             raise SourceReplayError("source content contains a non-byte occurrence") from exc
-        reversed_bytes.append(value)
-        current = link.start
-        reversed_prefix_refs.append(current)
-
-    return (
-        bytes(reversed(reversed_bytes)),
-        tuple(reversed(reversed_prefix_refs)),
-    )
+    return bytes(decoded), sequence.prefixes
 
 
 def _verify_direct_membership(

--- a/core/rooted_link_network.py
+++ b/core/rooted_link_network.py
@@ -249,6 +249,55 @@ class LinkNetwork:
             raise LinkNetworkError("link handle was not issued by this network")
 
 
+@dataclass(frozen=True)
+class RootedSequence:
+    """Read-only view of one finite start-history rooted in ``R``.
+
+    This is not a second Link kind.  It records a structural property of an
+    already-existing link selected as a sequence carrier.  ``prefixes`` starts
+    with ``R`` and ends with the selected carrier; ``values`` are the successive
+    end poles in forward order.
+    """
+
+    values: tuple[LinkRef, ...]
+    prefixes: tuple[LinkRef, ...]
+
+
+def read_rooted_sequence(network: LinkNetwork, final: LinkRef) -> RootedSequence:
+    """Unfold ``final`` through start poles until the distinguished root.
+
+    ``R`` denotes the empty sequence.  Every non-root carrier contributes its
+    end pole as the last value and continues through its start pole.  A
+    start-self-closed form (or any other non-terminating start history) is not a
+    finite rooted sequence and is rejected.  No link is created or modified.
+    """
+
+    root = network.root
+    if final is root:
+        return RootedSequence(values=(), prefixes=(root,))
+
+    reversed_values: list[LinkRef] = []
+    reversed_prefixes: list[LinkRef] = [final]
+    current = final
+    visited: set[LinkRef] = set()
+
+    while current is not root:
+        if current in visited:
+            raise LinkNetworkError(
+                "selected link does not encode a finite R-rooted start-history"
+            )
+        visited.add(current)
+        link = network.link(current)
+        reversed_values.append(link.end)
+        current = link.start
+        reversed_prefixes.append(current)
+
+    return RootedSequence(
+        values=tuple(reversed(reversed_values)),
+        prefixes=tuple(reversed(reversed_prefixes)),
+    )
+
+
 class LinkNetworkBuilder:
     """Construct a semantic network outward from self-closure and root.
 

--- a/tests/test_anum_carrier.py
+++ b/tests/test_anum_carrier.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.anum_carrier import (
+    AnumCarrierVocabulary,
+    CarrierInputError,
+    decode_carrier_stream,
+    deserialize_carrier,
+)
+from core.anum_protocol import StreamError, deserialize_stream
+from core.rooted_link_network import (
+    LinkNetworkBuilder,
+    LinkNetworkError,
+    read_rooted_sequence,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFORMANCE = ROOT / "contracts/mts-conformance-v0.5.json"
+
+
+def _fixture():
+    builder = LinkNetworkBuilder()
+    root = builder.ensure_root()
+    opening = builder.ensure_start_self_closed(root)
+    closing = builder.ensure_end_self_closed(root)
+    linked = builder.ensure(opening, closing)
+    unlinked = builder.ensure(closing, opening)
+    return (
+        builder,
+        root,
+        AnumCarrierVocabulary(
+            opening=opening,
+            closing=closing,
+            linked=linked,
+            unlinked=unlinked,
+        ),
+    )
+
+
+def _carrier(builder, root, vocabulary, source: str):
+    values = {
+        "[": vocabulary.opening,
+        "]": vocabulary.closing,
+        "1": vocabulary.linked,
+        "0": vocabulary.unlinked,
+    }
+    current = root
+    for token in source:
+        current = builder.ensure(current, values[token])
+    return current
+
+
+def _anum_corpus() -> dict:
+    current = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
+    return current["corpora"]["anum"]
+
+
+def test_rooted_sequence_is_a_property_not_a_second_link_kind() -> None:
+    builder, root, vocabulary = _fixture()
+    closing = vocabulary.closing
+    opening_carrier = _carrier(builder, root, vocabulary, "[")
+    network = builder.freeze(root)
+
+    assert read_rooted_sequence(network, root).values == ()
+    closing_sequence = read_rooted_sequence(network, closing)
+    assert closing_sequence.values == (closing,)
+    assert closing_sequence.prefixes == (root, closing)
+
+    assert opening_carrier is not vocabulary.opening
+    assert decode_carrier_stream(network, opening_carrier, vocabulary) == "["
+    with pytest.raises(LinkNetworkError, match="finite R-rooted"):
+        read_rooted_sequence(network, vocabulary.opening)
+
+
+def test_carrier_role_is_explicit_when_one_link_has_another_structural_reading() -> None:
+    builder, root, vocabulary = _fixture()
+    single_zero = _carrier(builder, root, vocabulary, "0")
+    close_open = _carrier(builder, root, vocabulary, "][")
+    assert close_open is vocabulary.unlinked
+    assert single_zero is not vocabulary.unlinked
+    network = builder.freeze(root)
+
+    assert decode_carrier_stream(network, single_zero, vocabulary) == "0"
+    assert decode_carrier_stream(network, vocabulary.unlinked, vocabulary) == "]["
+
+
+def test_multielement_carrier_preserves_exact_source_order_read_only() -> None:
+    builder, root, vocabulary = _fixture()
+    source = "10[1]0"
+    carrier = _carrier(builder, root, vocabulary, source)
+    network = builder.freeze(root)
+    before = network.snapshot()
+
+    sequence = read_rooted_sequence(network, carrier)
+    assert decode_carrier_stream(network, carrier, vocabulary) == source
+    assert sequence.prefixes[0] is root
+    assert sequence.prefixes[-1] is carrier
+    assert len(sequence.values) == len(source)
+    assert network.snapshot() == before
+
+
+def test_every_accepted_valid_raw_vector_replays_identically_from_carrier() -> None:
+    for vector in _anum_corpus()["valid"]:
+        source = vector["source"]
+        builder, root, vocabulary = _fixture()
+        carrier = _carrier(builder, root, vocabulary, source)
+        network = builder.freeze(root)
+        before = network.snapshot()
+
+        assert decode_carrier_stream(network, carrier, vocabulary) == source
+        assert deserialize_carrier(network, carrier, vocabulary) == deserialize_stream(source)
+        assert network.snapshot() == before
+
+
+def test_applicable_invalid_raw_vectors_keep_the_same_stack_error_code() -> None:
+    applicable = [
+        vector
+        for vector in _anum_corpus()["invalid"]
+        if set(vector["source"]) <= set("[]10")
+    ]
+    assert applicable
+
+    for vector in applicable:
+        source = vector["source"]
+        builder, root, vocabulary = _fixture()
+        carrier = _carrier(builder, root, vocabulary, source)
+        network = builder.freeze(root)
+
+        with pytest.raises(StreamError) as raw_error:
+            deserialize_stream(source)
+        with pytest.raises(StreamError) as carrier_error:
+            deserialize_carrier(network, carrier, vocabulary)
+        assert carrier_error.value.code == raw_error.value.code == vector["error"]
+
+
+def test_non_abit_sequence_element_is_rejected_without_guessing() -> None:
+    builder, root, vocabulary = _fixture()
+    other = builder.ensure_start_self_closed(vocabulary.linked)
+    carrier = builder.ensure(root, other)
+    network = builder.freeze(root)
+
+    with pytest.raises(CarrierInputError) as caught:
+        decode_carrier_stream(network, carrier, vocabulary)
+    assert caught.value.code == "non-abit"
+
+
+def test_non_rooted_carrier_and_wrong_vocabulary_fail_closed() -> None:
+    builder, root, vocabulary = _fixture()
+    network = builder.freeze(root)
+
+    with pytest.raises(CarrierInputError) as non_rooted:
+        decode_carrier_stream(network, vocabulary.opening, vocabulary)
+    assert non_rooted.value.code == "not-rooted-sequence"
+
+    wrong = AnumCarrierVocabulary(
+        opening=vocabulary.closing,
+        closing=vocabulary.opening,
+        linked=vocabulary.linked,
+        unlinked=vocabulary.unlinked,
+    )
+    with pytest.raises(CarrierInputError) as invalid_vocabulary:
+        decode_carrier_stream(network, root, wrong)
+    assert invalid_vocabulary.value.code == "invalid-vocabulary"


### PR DESCRIPTION
## Что добавлено

- `RootedSequence` и `read_rooted_sequence()` в `core/rooted_link_network.py`: read-only unfold выбранной существующей связи по `start` до `R`, без нового типа связи и без materialization;
- `core/anum_carrier.py`: явный carrier-role, проверка точного корневого O/C/L/U vocabulary, восстановление `[ ] 1 0` и делегирование **тому же** `deserialize_stream()`;
- `foundation_v2_source` теперь использует общий rooted-sequence traversal вместо собственного дублирующего цикла;
- 7 executable tests на порядок, canonical collapse, role ambiguity, fail-closed boundary и equivalence с accepted raw conformance vectors.

## Ключевой семантический результат

Связь-последовательность здесь — **структурное свойство/роль выбранной связи**, а не новый онтологический тип или identity.

Carrier читается только так:

```text
S = R -> пустая последовательность
S != R -> end(S) является последним элементом, затем продолжаем по start(S)
start-chain обязана конечным образом прийти в R
```

Из-за canonical link identity роль обязана быть явной. Например `U = C⟼O` как элемент vocabulary означает `0`, но та же `U`, выбранная именно как carrier, разворачивается по start-chain в `][`. Поэтому shortcut «abit link = singleton carrier» намеренно отсутствует.

## Граница с accepted v0.3

Этот PR **не меняет** `anum-stream-deserialization/v0.3` и вообще не меняет `contracts/`/`conformance`.

Executable path:

```text
existing carrier LinkRef
  -> read_rooted_sequence
  -> raw []10 stream
  -> existing deserialize_stream()
```

Нет второго OPEN/CLOSE/VALUE алгоритма, нового semantic id, L4 materialization или Foundation-v2 acceptance.

## Проверка

На итоговом дереве до очистки технической истории:

- `python -m pytest tests -v --tb=short` — **423 passed**;
- Ruff — success;
- `git diff --check` — success;
- `contracts/` byte-unchanged относительно `main`;
- все accepted valid raw ANUM vectors дают тот же `StreamDenotation` через carrier;
- применимые invalid raw vectors дают тот же `StreamError.code`;
- чтение carrier не изменяет network snapshot.

Final diff: 4 files, один чистый commit.

Closes #377
Refs #333, #343, #355, #356