### PR TITLE
Зафиксировать Foundation-v2 isolation gate перед C7

### DIFF
--- a/cutover/foundation-v2-import-classification-v0.1.json
+++ b/cutover/foundation-v2-import-classification-v0.1.json
@@ -1,0 +1,148 @@
+{
+  "schema": "foundation-v2-cutover-classification/v0.1",
+  "issue": 276,
+  "baseline": {
+    "currentMtsContract": "mts-contract/v0.6",
+    "foundationV2Accepted": false,
+    "cutoverPerformed": false,
+    "downstreamRepinAllowed": false
+  },
+  "consumerScope": "direct Python imports among core/*.py and converters/*.py; tests/docs are ownership evidence, not production consumers",
+  "classifications": {
+    "core/foundation_v2.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_checker.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_interpreter.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_materialization.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_persistent.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_proof.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_root.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_run.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_source.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_state.py": "FOUNDATION_V2_LIVE",
+    "core/rooted_link_network.py": "FOUNDATION_V2_LIVE",
+    "core/anum_carrier.py": "PRESERVED_NEUTRAL",
+    "core/anum_memory.py": "PRESERVED_NEUTRAL",
+    "core/anum_model.py": "PRESERVED_NEUTRAL",
+    "core/anum_parser.py": "PRESERVED_NEUTRAL",
+    "core/anum_protocol.py": "PRESERVED_NEUTRAL",
+    "core/mtc_ast.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/mtc_context_analysis.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/mtc_definitions.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/mtc_interpreter.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/mtc_opening_path.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/mtc_parser.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/mtc_value_bundle.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/proof_checker.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/root_library.py": "HISTORICAL_SEMANTIC_ISLAND",
+    "core/validate_root.py": "HISTORICAL_ENTRYPOINT",
+    "converters/__init__.py": "NON_SEMANTIC_TOOLING",
+    "converters/anum_cli.py": "NON_SEMANTIC_TOOLING",
+    "converters/anum_to_text.py": "NON_SEMANTIC_TOOLING",
+    "converters/ascii_unicode.py": "NON_SEMANTIC_TOOLING",
+    "converters/text_to_anum.py": "NON_SEMANTIC_TOOLING"
+  },
+  "historicalDecisions": {
+    "core/mtc_ast.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_source.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "all semantic parser/AST consumers migrate to selected source evidence; any surviving AST is reclassified NON_SEMANTIC_TOOLING"
+    },
+    "core/mtc_definitions.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_state.py",
+        "core/foundation_v2_source.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "definition/dictionary consumers migrate to rooted state/source evidence"
+    },
+    "core/mtc_interpreter.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_interpreter.py",
+        "core/foundation_v2_run.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "all trusted interpretation consumers use the Foundation-v2 replay path"
+    },
+    "core/mtc_opening_path.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_checker.py",
+        "core/foundation_v2_proof.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "opening-path behavior is either represented by accepted Foundation-v2 evidence or explicitly classified as an intentional delta"
+    },
+    "core/mtc_parser.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_source.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "semantic source consumers migrate; any parser kept for presentation is reclassified NON_SEMANTIC_TOOLING"
+    },
+    "core/proof_checker.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_checker.py",
+        "core/foundation_v2_proof.py",
+        "core/foundation_v2_run.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "trusted proof consumers migrate to the Foundation-v2 checker/replay path"
+    },
+    "core/root_library.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_root.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "root/bootstrap consumers use constructive rooted Foundation-v2 bootstrap"
+    },
+    "core/validate_root.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_root.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "historical ten-formula root validation is no longer a production gate"
+    },
+    "core/mtc_context_analysis.py": {
+      "replacementLiveOwners": [],
+      "deleteInC7": false,
+      "deletePrecondition": "requires an explicit P3 decision for current direct-deixis v0.5 before deletion; do not invent a Foundation-v2 replacement"
+    },
+    "core/mtc_value_bundle.py": {
+      "replacementLiveOwners": [],
+      "deleteInC7": false,
+      "deletePrecondition": "requires an explicit P3 decision for current value-bundle v0.2 before deletion; do not invent a Foundation-v2 replacement"
+    }
+  },
+  "publicFacadeDirectDeps": [
+    "core/rooted_link_network.py",
+    "core/foundation_v2_checker.py",
+    "core/foundation_v2_interpreter.py",
+    "core/foundation_v2_materialization.py",
+    "core/foundation_v2_persistent.py",
+    "core/foundation_v2_proof.py",
+    "core/foundation_v2_root.py",
+    "core/foundation_v2_run.py",
+    "core/foundation_v2_source.py"
+  ],
+  "c7DeletionSet": [
+    "core/mtc_ast.py",
+    "core/mtc_definitions.py",
+    "core/mtc_interpreter.py",
+    "core/mtc_opening_path.py",
+    "core/mtc_parser.py",
+    "core/proof_checker.py",
+    "core/root_library.py",
+    "core/validate_root.py"
+  ],
+  "rootedVetoTests": {
+    "tests/test_mts_rooted_link_network.py": [
+      "test_root_is_the_only_fully_self_closed_link",
+      "test_second_fully_self_closed_link_is_rejected_before_freeze",
+      "test_duplicate_equal_pair_definition_is_rejected",
+      "test_mutual_cycle_cannot_be_created_from_only_reserved_ids",
+      "test_ensure_reuses_the_same_link_for_the_same_pair",
+      "test_snapshot_slots_are_transport_coordinates_not_semantic_identity"
+    ]
+  }
+}

--- a/tests/test_foundation_v2_cutover_gate.py
+++ b/tests/test_foundation_v2_cutover_gate.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import ast
+import json
+from collections import defaultdict, deque
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
+SURFACE_DIRS = (ROOT / "core", ROOT / "converters")
+HISTORICAL_CLASSES = {"HISTORICAL_SEMANTIC_ISLAND", "HISTORICAL_ENTRYPOINT"}
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def discover_surface() -> set[str]:
+    return {
+        path.relative_to(ROOT).as_posix()
+        for directory in SURFACE_DIRS
+        for path in directory.glob("*.py")
+    }
+
+
+def _module_path(parts: list[str], discovered: set[str]) -> str | None:
+    candidate = "/".join(parts) + ".py"
+    if candidate in discovered:
+        return candidate
+    package_init = "/".join(parts + ["__init__"]) + ".py"
+    if package_init in discovered:
+        return package_init
+    return None
+
+
+def imported_surface(source: str, discovered: set[str]) -> set[str]:
+    path = ROOT / source
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=source)
+    package = list(Path(source).with_suffix("").parts[:-1])
+    targets: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                target = _module_path(alias.name.split("."), discovered)
+                if target:
+                    targets.add(target)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                keep = len(package) - (node.level - 1)
+                if keep < 0:
+                    continue
+                base = package[:keep]
+            else:
+                base = []
+
+            if node.module:
+                parts = base + node.module.split(".")
+                target = _module_path(parts, discovered)
+                if target:
+                    targets.add(target)
+            elif node.level:
+                for alias in node.names:
+                    target = _module_path(base + alias.name.split("."), discovered)
+                    if target:
+                        targets.add(target)
+
+    return targets
+
+
+def import_graph() -> dict[str, set[str]]:
+    discovered = discover_surface()
+    return {
+        source: imported_surface(source, discovered)
+        for source in sorted(discovered)
+    }
+
+
+def historical_reachability(
+    graph: dict[str, set[str]],
+    classifications: dict[str, str],
+) -> list[tuple[str, ...]]:
+    failures: list[tuple[str, ...]] = []
+    for origin, origin_class in classifications.items():
+        if origin_class != "FOUNDATION_V2_LIVE":
+            continue
+        queue = deque([(origin, (origin,))])
+        visited = {origin}
+        while queue:
+            current, chain = queue.popleft()
+            for target in graph.get(current, set()):
+                if target in visited:
+                    continue
+                next_chain = chain + (target,)
+                if classifications[target] in HISTORICAL_CLASSES:
+                    failures.append(next_chain)
+                    continue
+                visited.add(target)
+                queue.append((target, next_chain))
+    return sorted(set(failures))
+
+
+def test_manifest_classifies_the_entire_core_and_converter_surface() -> None:
+    manifest = load_manifest()
+    classifications = manifest["classifications"]
+
+    assert manifest["schema"] == "foundation-v2-cutover-classification/v0.1"
+    assert manifest["issue"] == 276
+    assert set(classifications) == discover_surface()
+    assert "UNKNOWN" not in set(classifications.values())
+
+
+def test_foundation_v2_live_surface_cannot_reach_historical_semantics() -> None:
+    manifest = load_manifest()
+    graph = import_graph()
+
+    assert historical_reachability(graph, manifest["classifications"]) == []
+
+
+def test_public_foundation_v2_facade_has_an_exact_direct_dependency_set() -> None:
+    manifest = load_manifest()
+    graph = import_graph()
+
+    assert sorted(graph["core/foundation_v2.py"]) == sorted(manifest["publicFacadeDirectDeps"])
+
+
+def test_historical_deletion_decisions_are_complete_and_c7_set_is_exact() -> None:
+    manifest = load_manifest()
+    classifications = manifest["classifications"]
+    decisions = manifest["historicalDecisions"]
+
+    historical = {
+        path
+        for path, classification in classifications.items()
+        if classification in HISTORICAL_CLASSES
+    }
+    assert set(decisions) == historical
+
+    for decision in decisions.values():
+        assert isinstance(decision["deleteInC7"], bool)
+        assert decision["deletePrecondition"].strip()
+        for owner in decision["replacementLiveOwners"]:
+            assert classifications[owner] == "FOUNDATION_V2_LIVE"
+
+    expected_delete = sorted(
+        path for path, decision in decisions.items() if decision["deleteInC7"]
+    )
+    assert manifest["c7DeletionSet"] == expected_delete
+
+    deferred = {
+        path
+        for path, decision in decisions.items()
+        if not decision["deleteInC7"]
+    }
+    assert deferred == {
+        "core/mtc_context_analysis.py",
+        "core/mtc_value_bundle.py",
+    }
+
+
+def test_gate_does_not_claim_cutover_acceptance_or_downstream_repin() -> None:
+    baseline = load_manifest()["baseline"]
+
+    assert baseline == {
+        "currentMtsContract": "mts-contract/v0.6",
+        "foundationV2Accepted": False,
+        "cutoverPerformed": False,
+        "downstreamRepinAllowed": False,
+    }
+
+
+def test_rooted_identity_veto_tests_are_part_of_the_gate() -> None:
+    manifest = load_manifest()
+
+    for relative_path, required_names in manifest["rootedVetoTests"].items():
+        path = ROOT / relative_path
+        assert path.is_file()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative_path)
+        actual = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        assert set(required_names) <= actual
+
+
+def test_current_production_contract_remains_v06_not_foundation_v2() -> None:
+    contract = json.loads(
+        (ROOT / "contracts/mts-contract-v0.6.json").read_text(encoding="utf-8")
+    )
+    conformance = json.loads(
+        (ROOT / "contracts/mts-conformance-v0.6.json").read_text(encoding="utf-8")
+    )
+
+    assert contract["schema"] == "mts-contract/v0.6"
+    assert conformance["schema"] == "mts-conformance/v0.6"
+    assert contract["accepted"] is True
+    assert conformance["accepted"] is True
+
+
+def test_historical_reverse_consumers_have_no_foundation_v2_live_owner() -> None:
+    manifest = load_manifest()
+    graph = import_graph()
+    classifications = manifest["classifications"]
+    reverse: dict[str, set[str]] = defaultdict(set)
+
+    for consumer, dependencies in graph.items():
+        for dependency in dependencies:
+            reverse[dependency].add(consumer)
+
+    violations = []
+    for historical in manifest["historicalDecisions"]:
+        for consumer in reverse.get(historical, set()):
+            if classifications[consumer] == "FOUNDATION_V2_LIVE":
+                violations.append((consumer, historical))
+    assert violations == []


### PR DESCRIPTION
## Scope

Реализует isolation/classification gate из #276 без изменения accepted MTS v0.6 и без Foundation-v2 acceptance.

### Machine-readable cutover classification

Добавлен `cutover/foundation-v2-import-classification-v0.1.json`, который классифицирует **весь фактический** `core/*.py + converters/*.py` surface текущего main:

- `FOUNDATION_V2_LIVE` — rooted substrate + один Foundation-v2 facade и его implementation modules;
- `PRESERVED_NEUTRAL` — текущий ANUM transport/memory surface;
- `HISTORICAL_SEMANTIC_ISLAND`;
- `HISTORICAL_ENTRYPOINT`;
- `NON_SEMANTIC_TOOLING`.

UNKNOWN запрещён.

### Exact C7 deletion decision

В C7 deletion set включены:

- `core/mtc_ast.py`
- `core/mtc_definitions.py`
- `core/mtc_interpreter.py`
- `core/mtc_opening_path.py`
- `core/mtc_parser.py`
- `core/proof_checker.py`
- `core/root_library.py`
- `core/validate_root.py`

Сознательно **не** объявлены готовыми к удалению:

- `core/mtc_context_analysis.py` — current accepted `directDeixis` surface;
- `core/mtc_value_bundle.py` — current accepted `valueBundle` surface.

Для них сначала нужен явный P3 decision/replacement либо intentional delta; Foundation-v2 replacement не выдумывается.

### Executable import gate

`tests/test_foundation_v2_cutover_gate.py`:

- строит Python AST import graph `core/*.py + converters/*.py`;
- требует exact classification каждого модуля;
- проверяет **транзитивную** недостижимость historical semantics из любого `FOUNDATION_V2_LIVE` модуля;
- фиксирует exact direct deps public facade `core/foundation_v2.py`;
- требует deletion decision для каждого historical module/entrypoint;
- проверяет exact C7 set;
- сохраняет flags `cutoverPerformed=false`, `foundationV2Accepted=false`, `downstreamRepinAllowed=false`;
- связывает gate с существующими rooted #343 veto-tests: unique root, rejection second root, duplicate pair rejection, ID-only cycle rejection, pair reuse, storage-slot != semantic identity.

Новый manifest расположен **вне `contracts/`**, поэтому current-only invariant `contracts/ = ровно mts-contract-v0.6 + mts-conformance-v0.6` не меняется.

Closes #276
Refs #237, #271, #343