### PR TITLE
P3a: доказать directDeixis через rooted structural skeleton

### DIFF
--- a/core/foundation_v2.py
+++ b/core/foundation_v2.py
@@ -16,6 +16,15 @@ from .foundation_v2_checker import (
     ProofJudgmentEvidence,
     replay_integrated_proof,
 )
+from .foundation_v2_direct_deixis import (
+    DeicticOccurrence,
+    DeicticPole,
+    DirectDeixisReplayError,
+    DirectDeixisSkeletonBuilder,
+    DirectDeixisVocabulary,
+    analyze_direct_deixis_carrier,
+    build_direct_deixis_vocabulary,
+)
 from .foundation_v2_interpreter import (
     ColonEffectEvidence,
     EqualityEvaluationEvidence,
@@ -68,6 +77,11 @@ from .foundation_v2_source import (
 __all__ = [
     "ColonEffectEvidence",
     "DecomposeEqualityEvidence",
+    "DeicticOccurrence",
+    "DeicticPole",
+    "DirectDeixisReplayError",
+    "DirectDeixisSkeletonBuilder",
+    "DirectDeixisVocabulary",
     "EqualityEvaluationEvidence",
     "FoundationRootKernel",
     "FoundationRootRefs",
@@ -92,6 +106,8 @@ __all__ = [
     "SequenceMaterialization",
     "SourceFrontEndBuilder",
     "SourceFrontEndEvidence",
+    "analyze_direct_deixis_carrier",
+    "build_direct_deixis_vocabulary",
     "build_root_kernel",
     "find_links",
     "materialize_persistent_sequence",

--- a/core/foundation_v2_direct_deixis.py
+++ b/core/foundation_v2_direct_deixis.py
@@ -1,0 +1,254 @@
+"""Rooted read-only direct-deixis skeleton for the Foundation-v2 candidate.
+
+The accepted historical direct-deixis operation observes only an ordered
+structural path plus explicit ``(up, pole)`` pronoun payload. Operator names,
+source offsets and runtime handles are not part of that result. This module
+therefore challenges the historical typed-AST authority with a smaller rooted
+carrier:
+
+* ``NODE`` carries an R-rooted ordered sequence of child skeleton links;
+* ``OPAQUE`` is the single non-deictic leaf value;
+* ``PRONOUN`` carries an R-rooted sequence of zero or more UP markers followed
+  by exactly one START/END pole marker.
+
+All objects are ordinary canonical links in :mod:`rooted_link_network`. A path
+is only a checker coordinate induced by an ordered child occurrence. Reusing
+one semantic subtree in two child positions therefore yields two paths without
+creating a second semantic link. Query/replay is read-only and never performs
+``ensure`` or any other materialization operation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+from .rooted_link_network import (
+    LinkNetwork,
+    LinkNetworkBuilder,
+    LinkNetworkError,
+    LinkNetworkEvolutionBuilder,
+    LinkRef,
+    RootedSequence,
+    read_rooted_sequence,
+)
+
+
+class DirectDeixisReplayError(ValueError):
+    """Malformed or non-rooted direct-deixis skeleton evidence."""
+
+
+class DeicticPole(str, Enum):
+    START = "◁"
+    END = "▷"
+
+
+@dataclass(frozen=True, order=True)
+class DeicticOccurrence:
+    """One explicit pronoun occurrence; ``path`` is a checker coordinate only."""
+
+    path: tuple[int, ...]
+    up: int
+    pole: DeicticPole
+
+
+@dataclass(frozen=True)
+class DirectDeixisVocabulary:
+    """Canonical rooted role links for the minimal deictic skeleton."""
+
+    node_tag: LinkRef
+    opaque_tag: LinkRef
+    pronoun_tag: LinkRef
+    up_step: LinkRef
+    start_pole: LinkRef
+    end_pole: LinkRef
+
+
+Builder = LinkNetworkBuilder | LinkNetworkEvolutionBuilder
+
+
+def build_direct_deixis_vocabulary(builder: Builder) -> DirectDeixisVocabulary:
+    """Construct/reuse one rooted role vocabulary without technical-ID semantics."""
+
+    root = builder.ensure_root()
+    start_pole = builder.ensure_start_self_closed(root)
+    end_pole = builder.ensure_end_self_closed(root)
+    node_tag = builder.ensure(start_pole, end_pole)
+    opaque_tag = builder.ensure(end_pole, start_pole)
+    pronoun_tag = builder.ensure(node_tag, opaque_tag)
+    up_step = builder.ensure(opaque_tag, node_tag)
+    return DirectDeixisVocabulary(
+        node_tag=node_tag,
+        opaque_tag=opaque_tag,
+        pronoun_tag=pronoun_tag,
+        up_step=up_step,
+        start_pole=start_pole,
+        end_pole=end_pole,
+    )
+
+
+class DirectDeixisSkeletonBuilder:
+    """Untrusted construction helper for challenge fixtures and future producers."""
+
+    def __init__(self, builder: Builder, vocabulary: DirectDeixisVocabulary) -> None:
+        self._builder = builder
+        self._vocabulary = vocabulary
+        self._root = builder.ensure_root()
+
+    def opaque(self) -> LinkRef:
+        """Return the shared semantic leaf for any non-deictic opaque form."""
+
+        return self._builder.ensure(self._vocabulary.opaque_tag, self._root)
+
+    def node(self, children: Iterable[LinkRef]) -> LinkRef:
+        """Return one structural node over an ordered R-rooted child sequence."""
+
+        child_sequence = self._fold(tuple(children))
+        return self._builder.ensure(self._vocabulary.node_tag, child_sequence)
+
+    def pronoun(self, up: int, pole: DeicticPole) -> LinkRef:
+        """Return one canonical PRONOUN node for ``up`` and START/END pole."""
+
+        if isinstance(up, bool) or not isinstance(up, int) or up < 0:
+            raise DirectDeixisReplayError("pronoun up-count must be a non-negative integer")
+        if not isinstance(pole, DeicticPole):
+            raise DirectDeixisReplayError("pronoun pole must be DeicticPole.START or END")
+
+        pole_ref = (
+            self._vocabulary.start_pole
+            if pole is DeicticPole.START
+            else self._vocabulary.end_pole
+        )
+        metadata = self._fold((self._vocabulary.up_step,) * up + (pole_ref,))
+        return self._builder.ensure(self._vocabulary.pronoun_tag, metadata)
+
+    def _fold(self, values: tuple[LinkRef, ...]) -> LinkRef:
+        current = self._root
+        for value in values:
+            current = self._builder.ensure(current, value)
+        return current
+
+
+def analyze_direct_deixis_carrier(
+    network: LinkNetwork,
+    carrier: LinkRef,
+    vocabulary: DirectDeixisVocabulary,
+) -> tuple[DeicticOccurrence, ...]:
+    """Replay direct-deixis over one already-existing rooted skeleton carrier."""
+
+    _validate_vocabulary(network, vocabulary)
+    before = network.snapshot()
+    occurrences: list[DeicticOccurrence] = []
+    try:
+        _visit(network, carrier, vocabulary, (), set(), occurrences)
+    finally:
+        if network.snapshot() != before:
+            raise DirectDeixisReplayError("direct-deixis query mutated the network")
+    return tuple(occurrences)
+
+
+def _visit(
+    network: LinkNetwork,
+    carrier: LinkRef,
+    vocabulary: DirectDeixisVocabulary,
+    path: tuple[int, ...],
+    active: set[LinkRef],
+    occurrences: list[DeicticOccurrence],
+) -> None:
+    if carrier in active:
+        raise DirectDeixisReplayError("direct-deixis skeleton contains a traversal cycle")
+
+    active.add(carrier)
+    try:
+        link = network.link(carrier)
+        if link.start is vocabulary.opaque_tag:
+            if link.end is not network.root:
+                raise DirectDeixisReplayError("malformed OPAQUE skeleton leaf")
+            return
+
+        if link.start is vocabulary.pronoun_tag:
+            up, pole = _decode_pronoun(network, link.end, vocabulary)
+            occurrences.append(DeicticOccurrence(path=path, up=up, pole=pole))
+            return
+
+        if link.start is vocabulary.node_tag:
+            children = _read_sequence(network, link.end, "NODE children")
+            for index, child in enumerate(children.values):
+                _visit(
+                    network,
+                    child,
+                    vocabulary,
+                    path + (index,),
+                    active,
+                    occurrences,
+                )
+            return
+
+        raise DirectDeixisReplayError("link is not a direct-deixis skeleton node")
+    except LinkNetworkError as exc:
+        raise DirectDeixisReplayError("invalid direct-deixis skeleton link") from exc
+    finally:
+        active.remove(carrier)
+
+
+def _decode_pronoun(
+    network: LinkNetwork,
+    metadata: LinkRef,
+    vocabulary: DirectDeixisVocabulary,
+) -> tuple[int, DeicticPole]:
+    sequence = _read_sequence(network, metadata, "PRONOUN metadata")
+    if not sequence.values:
+        raise DirectDeixisReplayError("PRONOUN metadata must end in one pole marker")
+
+    pole_ref = sequence.values[-1]
+    if pole_ref is vocabulary.start_pole:
+        pole = DeicticPole.START
+    elif pole_ref is vocabulary.end_pole:
+        pole = DeicticPole.END
+    else:
+        raise DirectDeixisReplayError("PRONOUN metadata has an invalid pole marker")
+
+    prefix = sequence.values[:-1]
+    if any(value is not vocabulary.up_step for value in prefix):
+        raise DirectDeixisReplayError("PRONOUN metadata contains a non-UP prefix value")
+    return len(prefix), pole
+
+
+def _read_sequence(network: LinkNetwork, final: LinkRef, label: str) -> RootedSequence:
+    try:
+        return read_rooted_sequence(network, final)
+    except LinkNetworkError as exc:
+        raise DirectDeixisReplayError(f"{label} is not a finite R-rooted sequence") from exc
+
+
+def _validate_vocabulary(
+    network: LinkNetwork,
+    vocabulary: DirectDeixisVocabulary,
+) -> None:
+    refs = (
+        vocabulary.node_tag,
+        vocabulary.opaque_tag,
+        vocabulary.pronoun_tag,
+        vocabulary.up_step,
+        vocabulary.start_pole,
+        vocabulary.end_pole,
+    )
+    if len(set(refs)) != len(refs):
+        raise DirectDeixisReplayError("direct-deixis vocabulary links must be distinct")
+
+    root = network.root
+    expected = (
+        (vocabulary.start_pole, vocabulary.start_pole, root),
+        (vocabulary.end_pole, root, vocabulary.end_pole),
+        (vocabulary.node_tag, vocabulary.start_pole, vocabulary.end_pole),
+        (vocabulary.opaque_tag, vocabulary.end_pole, vocabulary.start_pole),
+        (vocabulary.pronoun_tag, vocabulary.node_tag, vocabulary.opaque_tag),
+        (vocabulary.up_step, vocabulary.opaque_tag, vocabulary.node_tag),
+    )
+    try:
+        for ref, start, end in expected:
+            link = network.link(ref)
+            if link.start is not start or link.end is not end:
+                raise DirectDeixisReplayError("invalid rooted direct-deixis vocabulary")
+    except LinkNetworkError as exc:
+        raise DirectDeixisReplayError("invalid rooted direct-deixis vocabulary") from exc

--- a/cutover/foundation-v2-import-classification-v0.1.json
+++ b/cutover/foundation-v2-import-classification-v0.1.json
@@ -11,6 +11,7 @@
   "classifications": {
     "core/foundation_v2.py": "FOUNDATION_V2_LIVE",
     "core/foundation_v2_checker.py": "FOUNDATION_V2_LIVE",
+    "core/foundation_v2_direct_deixis.py": "FOUNDATION_V2_LIVE",
     "core/foundation_v2_interpreter.py": "FOUNDATION_V2_LIVE",
     "core/foundation_v2_materialization.py": "FOUNDATION_V2_LIVE",
     "core/foundation_v2_persistent.py": "FOUNDATION_V2_LIVE",
@@ -104,9 +105,11 @@
       "deletePrecondition": "historical ten-formula root validation is no longer a production gate"
     },
     "core/mtc_context_analysis.py": {
-      "replacementLiveOwners": [],
+      "replacementLiveOwners": [
+        "core/foundation_v2_direct_deixis.py"
+      ],
       "deleteInC7": false,
-      "deletePrecondition": "requires an explicit P3 decision for current direct-deixis v0.5 before deletion; do not invent a Foundation-v2 replacement"
+      "deletePrecondition": "P3a rooted skeleton challenge #383 must pass and a separate P3a decision must authorize current direct-deixis migration before deletion"
     },
     "core/mtc_value_bundle.py": {
       "replacementLiveOwners": [],
@@ -117,6 +120,7 @@
   "publicFacadeDirectDeps": [
     "core/rooted_link_network.py",
     "core/foundation_v2_checker.py",
+    "core/foundation_v2_direct_deixis.py",
     "core/foundation_v2_interpreter.py",
     "core/foundation_v2_materialization.py",
     "core/foundation_v2_persistent.py",

--- a/tests/test_mts_foundation_v2_direct_deixis.py
+++ b/tests/test_mts_foundation_v2_direct_deixis.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from core.foundation_v2_direct_deixis import (
+    DeicticOccurrence,
+    DeicticPole,
+    DirectDeixisReplayError,
+    DirectDeixisSkeletonBuilder,
+    DirectDeixisVocabulary,
+    analyze_direct_deixis_carrier,
+    build_direct_deixis_vocabulary,
+)
+from core.mtc_ast import (
+    BundleForm,
+    ContextPronoun,
+    Definition,
+    EndProjection,
+    Equality,
+    Inequality,
+    Inversion,
+    LinkForm,
+    Literal,
+    RoundForm,
+    Sequence,
+    SquareForm,
+    StartProjection,
+    Symbol,
+)
+from core.mtc_parser import parse_formula
+from core.rooted_link_network import LinkNetwork, LinkNetworkBuilder, read_rooted_sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFORMANCE = ROOT / "contracts/mts-conformance-v0.6.json"
+CORE = ROOT / "core/foundation_v2_direct_deixis.py"
+
+
+def direct_deixis_corpus() -> dict:
+    data = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
+    return data["corpora"]["directDeixis"]
+
+
+def portable(occurrences: tuple[DeicticOccurrence, ...]) -> list[dict]:
+    return [
+        {"path": list(item.path), "up": item.up, "pole": item.pole.value}
+        for item in occurrences
+    ]
+
+
+def ast_children(expression) -> tuple:
+    if isinstance(expression, (Symbol, Literal, ContextPronoun)):
+        return ()
+    if isinstance(expression, (RoundForm, SquareForm)):
+        return () if expression.content is None else (expression.content,)
+    if isinstance(expression, (BundleForm, Sequence)):
+        return expression.items
+    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
+        return (expression.value,)
+    if isinstance(expression, (LinkForm, Equality, Inequality)):
+        return (expression.left, expression.right)
+    if isinstance(expression, Definition):
+        return (expression.target, expression.value)
+    raise TypeError(f"unsupported challenge AST node: {type(expression).__name__}")
+
+
+def project_ast(expression, skeleton: DirectDeixisSkeletonBuilder):
+    """Test-only differential projection; never imported by Foundation-v2 core."""
+
+    if isinstance(expression, ContextPronoun):
+        pole = (
+            DeicticPole.START
+            if expression.pole.value == DeicticPole.START.value
+            else DeicticPole.END
+        )
+        return skeleton.pronoun(expression.up, pole)
+    if isinstance(expression, (Symbol, Literal)):
+        return skeleton.opaque()
+    return skeleton.node(project_ast(child, skeleton) for child in ast_children(expression))
+
+
+def build_challenge(source: str):
+    builder = LinkNetworkBuilder()
+    root = builder.ensure_root()
+    vocabulary = build_direct_deixis_vocabulary(builder)
+    skeleton = DirectDeixisSkeletonBuilder(builder, vocabulary)
+    carrier = project_ast(parse_formula(source), skeleton)
+    return builder.freeze(root), carrier, vocabulary
+
+
+def remap_vocabulary(
+    network: LinkNetwork,
+    vocabulary: DirectDeixisVocabulary,
+) -> DirectDeixisVocabulary:
+    def mapped(ref):
+        return network.refs[ref.slot]
+
+    return DirectDeixisVocabulary(
+        node_tag=mapped(vocabulary.node_tag),
+        opaque_tag=mapped(vocabulary.opaque_tag),
+        pronoun_tag=mapped(vocabulary.pronoun_tag),
+        up_step=mapped(vocabulary.up_step),
+        start_pole=mapped(vocabulary.start_pole),
+        end_pole=mapped(vocabulary.end_pole),
+    )
+
+
+def test_current_direct_deixis_vectors_factor_through_rooted_skeleton() -> None:
+    for vector in direct_deixis_corpus()["vectors"]:
+        network, carrier, vocabulary = build_challenge(vector["source"])
+        result = analyze_direct_deixis_carrier(network, carrier, vocabulary)
+        assert portable(result) == vector["expected"], vector["id"]
+
+
+def test_equivalent_spellings_factor_to_the_same_rooted_query_result() -> None:
+    for vector in direct_deixis_corpus()["equivalentSpellings"]:
+        observed = []
+        for source in vector["sources"]:
+            network, carrier, vocabulary = build_challenge(source)
+            observed.append(portable(analyze_direct_deixis_carrier(network, carrier, vocabulary)))
+        assert all(result == vector["expected"] for result in observed), vector["id"]
+
+
+def test_grouping_stays_visible_as_structural_child_path() -> None:
+    network, carrier, vocabulary = build_challenge("((↑↑◁)) = a")
+
+    assert portable(analyze_direct_deixis_carrier(network, carrier, vocabulary)) == [
+        {"path": [0, 0, 0], "up": 2, "pole": "◁"}
+    ]
+
+
+def test_shared_semantic_subtree_produces_two_occurrence_paths() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.ensure_root()
+    vocabulary = build_direct_deixis_vocabulary(builder)
+    skeleton = DirectDeixisSkeletonBuilder(builder, vocabulary)
+    pronoun = skeleton.pronoun(1, DeicticPole.END)
+    shared = skeleton.node((pronoun,))
+    carrier = skeleton.node((shared, shared))
+    network = builder.freeze(root)
+
+    child_sequence = read_rooted_sequence(network, network.link(carrier).end)
+    assert child_sequence.values == (shared, shared)
+    assert portable(analyze_direct_deixis_carrier(network, carrier, vocabulary)) == [
+        {"path": [0, 0], "up": 1, "pole": "▷"},
+        {"path": [1, 0], "up": 1, "pole": "▷"},
+    ]
+
+
+def test_query_is_read_only_and_round_trip_storage_handles_do_not_change_result() -> None:
+    network, carrier, vocabulary = build_challenge("{◁ = a, ↑▷ = b, ▷ = c}")
+    before = network.snapshot()
+    expected = analyze_direct_deixis_carrier(network, carrier, vocabulary)
+    assert network.snapshot() == before
+
+    restored = LinkNetwork.from_snapshot(before)
+    restored_carrier = restored.refs[carrier.slot]
+    restored_vocabulary = remap_vocabulary(restored, vocabulary)
+
+    assert restored_carrier != carrier
+    assert analyze_direct_deixis_carrier(
+        restored,
+        restored_carrier,
+        restored_vocabulary,
+    ) == expected
+
+
+def test_non_rooted_child_history_and_invalid_pronoun_metadata_reject() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.ensure_root()
+    vocabulary = build_direct_deixis_vocabulary(builder)
+
+    non_terminating_children = builder.ensure(vocabulary.node_tag, vocabulary.start_pole)
+    invalid_metadata = builder.ensure(root, vocabulary.opaque_tag)
+    bad_pronoun = builder.ensure(vocabulary.pronoun_tag, invalid_metadata)
+    network = builder.freeze(root)
+
+    with pytest.raises(DirectDeixisReplayError, match="NODE children"):
+        analyze_direct_deixis_carrier(network, non_terminating_children, vocabulary)
+    with pytest.raises(DirectDeixisReplayError, match="invalid pole marker"):
+        analyze_direct_deixis_carrier(network, bad_pronoun, vocabulary)
+
+
+def test_rooted_vocabulary_is_structural_not_numeric_identity() -> None:
+    builder = LinkNetworkBuilder()
+    root = builder.ensure_root()
+    vocabulary = build_direct_deixis_vocabulary(builder)
+    network = builder.freeze(root)
+
+    expected = (
+        (vocabulary.start_pole, vocabulary.start_pole, root),
+        (vocabulary.end_pole, root, vocabulary.end_pole),
+        (vocabulary.node_tag, vocabulary.start_pole, vocabulary.end_pole),
+        (vocabulary.opaque_tag, vocabulary.end_pole, vocabulary.start_pole),
+        (vocabulary.pronoun_tag, vocabulary.node_tag, vocabulary.opaque_tag),
+        (vocabulary.up_step, vocabulary.opaque_tag, vocabulary.node_tag),
+    )
+    for ref, start, end in expected:
+        assert network.link(ref).start is start
+        assert network.link(ref).end is end
+    assert len(set(vocabulary.__dict__.values())) == 6
+
+
+def test_new_core_has_no_historical_ast_parser_interpreter_dependency() -> None:
+    source = CORE.read_text(encoding="utf-8")
+    query_source = inspect.getsource(analyze_direct_deixis_carrier)
+
+    for forbidden in (
+        "mtc_ast",
+        "mtc_parser",
+        "mtc_interpreter",
+        "ContextFrame",
+        "MemoryView",
+        "DefinitionEnvironment",
+    ):
+        assert forbidden not in source
+    assert "ensure(" not in query_source
+
+
+def test_challenge_preserves_non_implication_boundary() -> None:
+    positive_network, positive, positive_vocabulary = build_challenge("◁ = ◁")
+    empty_network, empty, empty_vocabulary = build_challenge("[] = []")
+
+    assert len(
+        analyze_direct_deixis_carrier(
+            positive_network,
+            positive,
+            positive_vocabulary,
+        )
+    ) == 2
+    assert analyze_direct_deixis_carrier(empty_network, empty, empty_vocabulary) == ()
+
+    negative = {item["id"]: item for item in direct_deixis_corpus()["negativeClaims"]}
+    assert negative["empty-does-not-mean-invariant"]["forbiddenConclusion"] == "ContextInvariant"
+    assert negative["present-does-not-mean-sensitive"]["forbiddenConclusion"] == "ContextSensitive"


### PR DESCRIPTION
## Scope

Executable challenge для #383 / P3a из #382. Accepted MTS v0.6 **не меняется**, Foundation-v2 acceptance/cutover/downstream repin остаются false.

## Минимальный rooted quotient historical AST

`core/foundation_v2_direct_deixis.py` вводит только наблюдаемую direct-deixis структуру:

```text
NODE(children...)  — ordered structural children
OPAQUE              — один shared non-deictic leaf
PRONOUN(up,pole)    — explicit ◁/▷ + parent-step count
```

Операторный tag/source spelling/offset не кодируются, потому что current direct-deixis их не возвращает.

Все значения — canonical links `rooted_link_network`:
- child lists и pronoun metadata — finite R-rooted sequences;
- role vocabulary структурно выводится из R/O/C/L/U-подобного rooted basis;
- query использует только `LinkNetwork.link()` + `read_rooted_sequence()`;
- no ensure/materialization during query;
- path — checker coordinate child occurrence, не Link identity.

## Differential challenge

`tests/test_mts_foundation_v2_direct_deixis.py`:
- читает exact accepted `corpora.directDeixis` из current `mts-conformance-v0.6.json`;
- historical parser/AST используется **только в тесте** как fixture projection;
- every current vector должен дать exact portable `{path,up,pole}`;
- equivalent spellings должны дать current expected result;
- grouping остаётся path-visible;
- один shared semantic subtree в двух child positions даёт два occurrence paths при одном LinkRef;
- snapshot round-trip с новыми runtime handles сохраняет результат;
- malformed/non-terminating rooted evidence rejected;
- positive/empty result не поднимаются до ContextSensitive/ContextInvariant.

## Isolation gate integration

- module classified `FOUNDATION_V2_LIVE`;
- public `foundation_v2.py` facade экспортирует challenge surface;
- old import graph gate обязан доказать no live→historical edge;
- `mtc_context_analysis.py` получает `replacementLiveOwners=[foundation_v2_direct_deixis.py]`, но `deleteInC7=false` до отдельного P3a decision;
- `mtc_value_bundle.py` остаётся unresolved blocker.

Closes #383
Refs #382, #276, #271, #343, #156