### PR TITLE
P3a decision: сохранить directDeixis через rooted migration

### DIFF
--- a/cutover/direct-deixis-rooted-migration-decision-v0.1.json
+++ b/cutover/direct-deixis-rooted-migration-decision-v0.1.json
@@ -1,0 +1,58 @@
+{
+  "schema": "direct-deixis-rooted-migration-decision/v0.1",
+  "issue": 385,
+  "parentIssue": 382,
+  "evidence": {
+    "challengeIssue": 383,
+    "pullRequest": 384,
+    "mergeCommit": "efc6b405fab6f927da9e6465a57de486a6868bcd",
+    "executableCorpusGate": "tests/test_mts_foundation_v2_direct_deixis.py"
+  },
+  "decision": "PRESERVE_BY_ROOTED_MIGRATION",
+  "current": {
+    "outerContract": "mts-contract/v0.6",
+    "surface": "mts-direct-deixis/v0.5",
+    "referenceCore": "core/mtc_context_analysis.py",
+    "mutateInPlace": false
+  },
+  "next": {
+    "surfaceCandidate": "mts-direct-deixis/v0.6",
+    "input": "explicit rooted NODE/OPAQUE/PRONOUN skeleton carrier",
+    "referenceCore": "core/foundation_v2_direct_deixis.py",
+    "observableResult": [
+      "path",
+      "up",
+      "pole"
+    ],
+    "observableResultSemanticsChanged": false,
+    "historicalTypedAstIsNormativeInput": false,
+    "sourceOffsetIsSemanticIdentity": false,
+    "runtimeHandleIsSemanticIdentity": false,
+    "pathIsSemanticIdentity": false,
+    "pathRole": "checker coordinate induced by ordered child occurrence",
+    "readOnly": true,
+    "materializes": false
+  },
+  "preservedBoundaries": {
+    "groupingVisibleInPath": true,
+    "positiveImpliesContextSensitivity": false,
+    "emptyImpliesContextInvariance": false,
+    "trustedProofRelationAdded": false,
+    "sharingCreatesSecondSemanticSubtree": false
+  },
+  "c7": {
+    "deleteOldOwner": true,
+    "deletePath": "core/mtc_context_analysis.py",
+    "replacementLiveOwner": "core/foundation_v2_direct_deixis.py",
+    "deleteOnlyDuringAtomicCutover": true,
+    "currentContractsRemainUntilCutover": true
+  },
+  "veto": {
+    "compatibilityAstSemanticMode": false,
+    "contextFrameToKAdapter": false,
+    "contextSensitivityTheorem": false,
+    "contextInvarianceTheorem": false,
+    "queryMaterialization": false,
+    "currentV06Mutation": false
+  }
+}

--- a/cutover/foundation-v2-import-classification-v0.1.json
+++ b/cutover/foundation-v2-import-classification-v0.1.json
@@ -50,6 +50,13 @@
       "deleteInC7": true,
       "deletePrecondition": "all semantic parser/AST consumers migrate to selected source evidence; any surviving AST is reclassified NON_SEMANTIC_TOOLING"
     },
+    "core/mtc_context_analysis.py": {
+      "replacementLiveOwners": [
+        "core/foundation_v2_direct_deixis.py"
+      ],
+      "deleteInC7": true,
+      "deletePrecondition": "P3a decision #385 preserves direct-deixis through rooted skeleton; delete old owner only during atomic C7 with the new versioned direct-deixis surface"
+    },
     "core/mtc_definitions.py": {
       "replacementLiveOwners": [
         "core/foundation_v2_state.py",
@@ -104,13 +111,6 @@
       "deleteInC7": true,
       "deletePrecondition": "historical ten-formula root validation is no longer a production gate"
     },
-    "core/mtc_context_analysis.py": {
-      "replacementLiveOwners": [
-        "core/foundation_v2_direct_deixis.py"
-      ],
-      "deleteInC7": false,
-      "deletePrecondition": "P3a rooted skeleton challenge #383 must pass and a separate P3a decision must authorize current direct-deixis migration before deletion"
-    },
     "core/mtc_value_bundle.py": {
       "replacementLiveOwners": [],
       "deleteInC7": false,
@@ -131,6 +131,7 @@
   ],
   "c7DeletionSet": [
     "core/mtc_ast.py",
+    "core/mtc_context_analysis.py",
     "core/mtc_definitions.py",
     "core/mtc_interpreter.py",
     "core/mtc_opening_path.py",

--- a/tests/test_direct_deixis_cutover_decision.py
+++ b/tests/test_direct_deixis_cutover_decision.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DECISION = ROOT / "cutover/direct-deixis-rooted-migration-decision-v0.1.json"
+MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
+CONTRACT = ROOT / "contracts/mts-contract-v0.6.json"
+CONFORMANCE = ROOT / "contracts/mts-conformance-v0.6.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_p3a_decision_preserves_direct_deixis_by_rooted_migration() -> None:
+    decision = read(DECISION)
+
+    assert decision["schema"] == "direct-deixis-rooted-migration-decision/v0.1"
+    assert decision["issue"] == 385
+    assert decision["parentIssue"] == 382
+    assert decision["decision"] == "PRESERVE_BY_ROOTED_MIGRATION"
+    assert decision["evidence"] == {
+        "challengeIssue": 383,
+        "pullRequest": 384,
+        "mergeCommit": "efc6b405fab6f927da9e6465a57de486a6868bcd",
+        "executableCorpusGate": "tests/test_mts_foundation_v2_direct_deixis.py",
+    }
+
+
+def test_next_surface_changes_input_boundary_not_observable_result_semantics() -> None:
+    next_surface = read(DECISION)["next"]
+
+    assert next_surface["surfaceCandidate"] == "mts-direct-deixis/v0.6"
+    assert next_surface["referenceCore"] == "core/foundation_v2_direct_deixis.py"
+    assert next_surface["observableResult"] == ["path", "up", "pole"]
+    assert next_surface["observableResultSemanticsChanged"] is False
+    assert next_surface["historicalTypedAstIsNormativeInput"] is False
+    assert next_surface["sourceOffsetIsSemanticIdentity"] is False
+    assert next_surface["runtimeHandleIsSemanticIdentity"] is False
+    assert next_surface["pathIsSemanticIdentity"] is False
+    assert next_surface["readOnly"] is True
+    assert next_surface["materializes"] is False
+
+
+def test_direct_deixis_old_owner_is_now_planned_for_atomic_c7_deletion() -> None:
+    manifest = read(MANIFEST)
+    decision = manifest["historicalDecisions"]["core/mtc_context_analysis.py"]
+
+    assert decision["replacementLiveOwners"] == [
+        "core/foundation_v2_direct_deixis.py"
+    ]
+    assert decision["deleteInC7"] is True
+    assert "core/mtc_context_analysis.py" in manifest["c7DeletionSet"]
+
+    unresolved = {
+        path
+        for path, item in manifest["historicalDecisions"].items()
+        if not item["deleteInC7"]
+    }
+    assert unresolved == {"core/mtc_value_bundle.py"}
+
+
+def test_current_v06_is_not_mutated_by_the_cutover_decision() -> None:
+    contract = read(CONTRACT)
+    conformance = read(CONFORMANCE)
+    direct = contract["surfaces"]["directDeixis"]
+
+    assert contract["schema"] == "mts-contract/v0.6"
+    assert conformance["schema"] == "mts-conformance/v0.6"
+    assert direct["schema"] == "mts-direct-deixis/v0.5"
+    assert conformance["corpora"]["directDeixis"]["contract"] == direct["schema"]
+
+    baseline = read(MANIFEST)["baseline"]
+    assert baseline["foundationV2Accepted"] is False
+    assert baseline["cutoverPerformed"] is False
+    assert baseline["downstreamRepinAllowed"] is False
+
+
+def test_decision_preserves_current_non_implication_and_identity_vetoes() -> None:
+    decision = read(DECISION)
+
+    assert decision["preservedBoundaries"] == {
+        "groupingVisibleInPath": True,
+        "positiveImpliesContextSensitivity": False,
+        "emptyImpliesContextInvariance": False,
+        "trustedProofRelationAdded": False,
+        "sharingCreatesSecondSemanticSubtree": False,
+    }
+    assert decision["veto"] == {
+        "compatibilityAstSemanticMode": False,
+        "contextFrameToKAdapter": False,
+        "contextSensitivityTheorem": False,
+        "contextInvarianceTheorem": False,
+        "queryMaterialization": False,
+        "currentV06Mutation": False,
+    }

--- a/tests/test_foundation_v2_cutover_gate.py
+++ b/tests/test_foundation_v2_cutover_gate.py
@@ -28,9 +28,7 @@ def _module_path(parts: list[str], discovered: set[str]) -> str | None:
     if candidate in discovered:
         return candidate
     package_init = "/".join(parts + ["__init__"]) + ".py"
-    if package_init in discovered:
-        return package_init
-    return None
+    return package_init if package_init in discovered else None
 
 
 def imported_surface(source: str, discovered: set[str]) -> set[str]:
@@ -45,26 +43,27 @@ def imported_surface(source: str, discovered: set[str]) -> set[str]:
                 target = _module_path(alias.name.split("."), discovered)
                 if target:
                     targets.add(target)
-        elif isinstance(node, ast.ImportFrom):
-            if node.level:
-                keep = len(package) - (node.level - 1)
-                if keep < 0:
-                    continue
-                base = package[:keep]
-            else:
-                base = []
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
 
-            if node.module:
-                parts = base + node.module.split(".")
-                target = _module_path(parts, discovered)
+        if node.level:
+            keep = len(package) - (node.level - 1)
+            if keep < 0:
+                continue
+            base = package[:keep]
+        else:
+            base = []
+
+        if node.module:
+            target = _module_path(base + node.module.split("."), discovered)
+            if target:
+                targets.add(target)
+        elif node.level:
+            for alias in node.names:
+                target = _module_path(base + alias.name.split("."), discovered)
                 if target:
                     targets.add(target)
-            elif node.level:
-                for alias in node.names:
-                    target = _module_path(base + alias.name.split("."), discovered)
-                    if target:
-                        targets.add(target)
-
     return targets
 
 
@@ -112,23 +111,20 @@ def test_manifest_classifies_the_entire_core_and_converter_surface() -> None:
 
 def test_foundation_v2_live_surface_cannot_reach_historical_semantics() -> None:
     manifest = load_manifest()
-    graph = import_graph()
-
-    assert historical_reachability(graph, manifest["classifications"]) == []
+    assert historical_reachability(import_graph(), manifest["classifications"]) == []
 
 
 def test_public_foundation_v2_facade_has_an_exact_direct_dependency_set() -> None:
     manifest = load_manifest()
-    graph = import_graph()
-
-    assert sorted(graph["core/foundation_v2.py"]) == sorted(manifest["publicFacadeDirectDeps"])
+    assert sorted(import_graph()["core/foundation_v2.py"]) == sorted(
+        manifest["publicFacadeDirectDeps"]
+    )
 
 
 def test_historical_deletion_decisions_are_complete_and_c7_set_is_exact() -> None:
     manifest = load_manifest()
     classifications = manifest["classifications"]
     decisions = manifest["historicalDecisions"]
-
     historical = {
         path
         for path, classification in classifications.items()
@@ -146,22 +142,13 @@ def test_historical_deletion_decisions_are_complete_and_c7_set_is_exact() -> Non
         path for path, decision in decisions.items() if decision["deleteInC7"]
     )
     assert manifest["c7DeletionSet"] == expected_delete
-
-    deferred = {
-        path
-        for path, decision in decisions.items()
-        if not decision["deleteInC7"]
-    }
-    assert deferred == {
-        "core/mtc_context_analysis.py",
-        "core/mtc_value_bundle.py",
-    }
+    assert {
+        path for path, decision in decisions.items() if not decision["deleteInC7"]
+    } == {"core/mtc_value_bundle.py"}
 
 
 def test_gate_does_not_claim_cutover_acceptance_or_downstream_repin() -> None:
-    baseline = load_manifest()["baseline"]
-
-    assert baseline == {
+    assert load_manifest()["baseline"] == {
         "currentMtsContract": "mts-contract/v0.6",
         "foundationV2Accepted": False,
         "cutoverPerformed": False,
@@ -170,9 +157,7 @@ def test_gate_does_not_claim_cutover_acceptance_or_downstream_repin() -> None:
 
 
 def test_rooted_identity_veto_tests_are_part_of_the_gate() -> None:
-    manifest = load_manifest()
-
-    for relative_path, required_names in manifest["rootedVetoTests"].items():
+    for relative_path, required_names in load_manifest()["rootedVetoTests"].items():
         path = ROOT / relative_path
         assert path.is_file()
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative_path)
@@ -191,7 +176,6 @@ def test_current_production_contract_remains_v06_not_foundation_v2() -> None:
     conformance = json.loads(
         (ROOT / "contracts/mts-conformance-v0.6.json").read_text(encoding="utf-8")
     )
-
     assert contract["schema"] == "mts-contract/v0.6"
     assert conformance["schema"] == "mts-conformance/v0.6"
     assert contract["accepted"] is True
@@ -203,14 +187,14 @@ def test_historical_reverse_consumers_have_no_foundation_v2_live_owner() -> None
     graph = import_graph()
     classifications = manifest["classifications"]
     reverse: dict[str, set[str]] = defaultdict(set)
-
     for consumer, dependencies in graph.items():
         for dependency in dependencies:
             reverse[dependency].add(consumer)
 
-    violations = []
-    for historical in manifest["historicalDecisions"]:
-        for consumer in reverse.get(historical, set()):
-            if classifications[consumer] == "FOUNDATION_V2_LIVE":
-                violations.append((consumer, historical))
+    violations = [
+        (consumer, historical)
+        for historical in manifest["historicalDecisions"]
+        for consumer in reverse.get(historical, set())
+        if classifications[consumer] == "FOUNDATION_V2_LIVE"
+    ]
     assert violations == []


### PR DESCRIPTION
## Decision

Фиксирует P3a outcome после зелёного executable challenge #383/#384:

```text
PRESERVE_BY_ROOTED_MIGRATION
```

Current `mts-direct-deixis/v0.5` и outer `mts-contract/v0.6` не мутируются. На atomic Foundation-v2 cutover новая surface получает отдельный version boundary `mts-direct-deixis/v0.6` и rooted skeleton input.

## Machine-readable decision

`cutover/direct-deixis-rooted-migration-decision-v0.1.json` фиксирует:
- challenge evidence #383 / PR #384 / merge `efc6b405…`;
- observable result остаётся `(path,up,pole)`;
- typed AST/source offset/runtime handle/path не являются Link identity;
- query read-only, no materialization;
- positive/empty direct deixis не становятся ContextSensitive/ContextInvariant theorem;
- old owner удаляется только atomic C7.

## C7 manifest

`core/mtc_context_analysis.py` теперь:

```text
replacementLiveOwner = core/foundation_v2_direct_deixis.py
deleteInC7 = true
```

Exact C7 set расширен на этот файл. `core/mtc_value_bundle.py` теперь единственный `deleteInC7=false` blocker.

## Gate update

Isolation gate продолжает проверять:
- exact full Python classification;
- no transitive Foundation-v2 live → historical dependency;
- exact public facade deps;
- exact deletion set;
- current MTS v0.6 remains accepted and Foundation-v2/cutover/downstream flags remain false.

Новый decision test отдельно запрещает current v0.6 mutation.

Closes #385
Refs #382, #383, #384, #276, #271, #343, #156