### PR TITLE
[superseded by #393] P3b decision: сохранить ValueBundle через rooted migration

### DIFF
--- a/cutover/foundation-v2-import-classification-v0.1.json
+++ b/cutover/foundation-v2-import-classification-v0.1.json
@@ -116,8 +116,8 @@
       "replacementLiveOwners": [
         "core/foundation_v2_value_bundle.py"
       ],
-      "deleteInC7": false,
-      "deletePrecondition": "P3b rooted challenge #387 must pass and a separate P3b decision must authorize current value-bundle migration or intentional delta before deletion"
+      "deleteInC7": true,
+      "deletePrecondition": "P3b decision #391 preserves current ValueBundle through rooted quotient; delete old owner only during atomic C7 with the new versioned ValueBundle surface"
     }
   },
   "publicFacadeDirectDeps": [
@@ -140,6 +140,7 @@
     "core/mtc_interpreter.py",
     "core/mtc_opening_path.py",
     "core/mtc_parser.py",
+    "core/mtc_value_bundle.py",
     "core/proof_checker.py",
     "core/root_library.py",
     "core/validate_root.py"

--- a/cutover/value-bundle-rooted-migration-decision-v0.1.json
+++ b/cutover/value-bundle-rooted-migration-decision-v0.1.json
@@ -1,0 +1,65 @@
+{
+  "schema": "value-bundle-rooted-migration-decision/v0.1",
+  "issue": 391,
+  "parentIssue": 382,
+  "evidence": {
+    "challengeIssue": 387,
+    "pullRequest": 389,
+    "mergeCommit": "775078f95995b1de6157ace10a033b36af496ab3",
+    "executableCorpusGate": "tests/test_mts_foundation_v2_value_bundle.py"
+  },
+  "decision": "PRESERVE_BY_ROOTED_MIGRATION",
+  "current": {
+    "outerContract": "mts-contract/v0.6",
+    "surface": "mts-value-bundle/v0.2",
+    "referenceCore": "core/mtc_value_bundle.py",
+    "mutateInPlace": false
+  },
+  "next": {
+    "surfaceCandidate": "mts-value-bundle/v0.3",
+    "referenceCore": "core/foundation_v2_value_bundle.py",
+    "staticInput": "explicit rooted kind-tag -> R-rooted(children...) role skeleton",
+    "resolvedInput": "canonical semantic Links plus ordered occurrence checker coordinates",
+    "observableStaticRolesChanged": false,
+    "observableStaticErrorCodesChanged": false,
+    "observableValueEqualityChanged": false,
+    "observableExpansionChanged": false,
+    "historicalTypedAstIsNormativeInput": false,
+    "sourceOffsetIsSemanticIdentity": false,
+    "runtimeHandleIsSemanticIdentity": false,
+    "occurrencePathIsSemanticIdentity": false,
+    "occurrencePathRole": "ordered provenance/checker coordinate only",
+    "bundleIdentity": "extensional set of resolved canonical semantic Links",
+    "occurrenceResolutionBeforeDedup": true,
+    "singletonBundleCoercion": false,
+    "expansionSearchOwner": "core/foundation_v2_materialization.py:find_links",
+    "readOnly": true,
+    "materializesMissingPairs": false
+  },
+  "preservedBoundaries": {
+    "nestedValueBundleAccepted": false,
+    "bundleValuedDefinitionAccepted": false,
+    "scalarOperatorLiftingAccepted": false,
+    "emptyBundleWildcardOnlyInExpansionEndpoint": true,
+    "missingPairOmitted": true,
+    "interpretMayRealize": false,
+    "interpretMayDelete": false,
+    "globalRewrite": false
+  },
+  "c7": {
+    "deleteOldOwner": true,
+    "deletePath": "core/mtc_value_bundle.py",
+    "replacementLiveOwner": "core/foundation_v2_value_bundle.py",
+    "deleteOnlyDuringAtomicCutover": true,
+    "currentContractsRemainUntilCutover": true
+  },
+  "veto": {
+    "compatibilityAstSemanticMode": false,
+    "valueBundleEqualsSequenceGroup": false,
+    "implicitWrites": false,
+    "dedupBeforeOccurrenceResolution": false,
+    "singletonBundleCoercion": false,
+    "technicalIdentitySemantics": false,
+    "currentV06Mutation": false
+  }
+}

--- a/tests/test_direct_deixis_cutover_decision.py
+++ b/tests/test_direct_deixis_cutover_decision.py
@@ -55,13 +55,6 @@ def test_direct_deixis_old_owner_is_now_planned_for_atomic_c7_deletion() -> None
     assert decision["deleteInC7"] is True
     assert "core/mtc_context_analysis.py" in manifest["c7DeletionSet"]
 
-    unresolved = {
-        path
-        for path, item in manifest["historicalDecisions"].items()
-        if not item["deleteInC7"]
-    }
-    assert unresolved == {"core/mtc_value_bundle.py"}
-
 
 def test_current_v06_is_not_mutated_by_the_cutover_decision() -> None:
     contract = read(CONTRACT)

--- a/tests/test_foundation_v2_cutover_gate.py
+++ b/tests/test_foundation_v2_cutover_gate.py
@@ -144,7 +144,7 @@ def test_historical_deletion_decisions_are_complete_and_c7_set_is_exact() -> Non
     assert manifest["c7DeletionSet"] == expected_delete
     assert {
         path for path, decision in decisions.items() if not decision["deleteInC7"]
-    } == {"core/mtc_value_bundle.py"}
+    } == set()
 
 
 def test_gate_does_not_claim_cutover_acceptance_or_downstream_repin() -> None:

--- a/tests/test_value_bundle_cutover_decision.py
+++ b/tests/test_value_bundle_cutover_decision.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DECISION = ROOT / "cutover/value-bundle-rooted-migration-decision-v0.1.json"
+MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
+CONTRACT = ROOT / "contracts/mts-contract-v0.6.json"
+CONFORMANCE = ROOT / "contracts/mts-conformance-v0.6.json"
+
+
+def read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_p3b_decision_preserves_value_bundle_by_rooted_migration() -> None:
+    decision = read(DECISION)
+
+    assert decision["schema"] == "value-bundle-rooted-migration-decision/v0.1"
+    assert decision["issue"] == 391
+    assert decision["parentIssue"] == 382
+    assert decision["decision"] == "PRESERVE_BY_ROOTED_MIGRATION"
+    assert decision["evidence"] == {
+        "challengeIssue": 387,
+        "pullRequest": 389,
+        "mergeCommit": "775078f95995b1de6157ace10a033b36af496ab3",
+        "executableCorpusGate": "tests/test_mts_foundation_v2_value_bundle.py",
+    }
+
+
+def test_next_surface_changes_input_authority_not_observable_v02_semantics() -> None:
+    next_surface = read(DECISION)["next"]
+
+    assert next_surface["surfaceCandidate"] == "mts-value-bundle/v0.3"
+    assert next_surface["referenceCore"] == "core/foundation_v2_value_bundle.py"
+    assert next_surface["observableStaticRolesChanged"] is False
+    assert next_surface["observableStaticErrorCodesChanged"] is False
+    assert next_surface["observableValueEqualityChanged"] is False
+    assert next_surface["observableExpansionChanged"] is False
+    assert next_surface["historicalTypedAstIsNormativeInput"] is False
+    assert next_surface["sourceOffsetIsSemanticIdentity"] is False
+    assert next_surface["runtimeHandleIsSemanticIdentity"] is False
+    assert next_surface["occurrencePathIsSemanticIdentity"] is False
+    assert next_surface["occurrenceResolutionBeforeDedup"] is True
+    assert next_surface["singletonBundleCoercion"] is False
+    assert (
+        next_surface["expansionSearchOwner"]
+        == "core/foundation_v2_materialization.py:find_links"
+    )
+    assert next_surface["readOnly"] is True
+    assert next_surface["materializesMissingPairs"] is False
+
+
+def test_value_bundle_old_owner_is_now_planned_for_atomic_c7_deletion() -> None:
+    manifest = read(MANIFEST)
+    decision = manifest["historicalDecisions"]["core/mtc_value_bundle.py"]
+
+    assert decision["replacementLiveOwners"] == [
+        "core/foundation_v2_value_bundle.py"
+    ]
+    assert decision["deleteInC7"] is True
+    assert "core/mtc_value_bundle.py" in manifest["c7DeletionSet"]
+
+    unresolved = {
+        path
+        for path, item in manifest["historicalDecisions"].items()
+        if not item["deleteInC7"]
+    }
+    assert unresolved == set()
+
+
+def test_current_v06_and_value_bundle_v02_are_not_mutated_by_the_decision() -> None:
+    contract = read(CONTRACT)
+    conformance = read(CONFORMANCE)
+    value_bundle = contract["surfaces"]["valueBundle"]
+
+    assert contract["schema"] == "mts-contract/v0.6"
+    assert conformance["schema"] == "mts-conformance/v0.6"
+    assert value_bundle["schema"] == "mts-value-bundle/v0.2"
+    assert (
+        value_bundle["productionIntegration"]["referenceCore"]
+        == "core/mtc_value_bundle.py"
+    )
+    assert conformance["corpora"]["valueBundle"]["contract"] == value_bundle["schema"]
+
+    baseline = read(MANIFEST)["baseline"]
+    assert baseline["foundationV2Accepted"] is False
+    assert baseline["cutoverPerformed"] is False
+    assert baseline["downstreamRepinAllowed"] is False
+
+
+def test_decision_preserves_value_bundle_v02_veto_boundaries() -> None:
+    decision = read(DECISION)
+
+    assert decision["preservedBoundaries"] == {
+        "nestedValueBundleAccepted": False,
+        "bundleValuedDefinitionAccepted": False,
+        "scalarOperatorLiftingAccepted": False,
+        "emptyBundleWildcardOnlyInExpansionEndpoint": True,
+        "missingPairOmitted": True,
+        "interpretMayRealize": False,
+        "interpretMayDelete": False,
+        "globalRewrite": False,
+    }
+    assert decision["veto"] == {
+        "compatibilityAstSemanticMode": False,
+        "valueBundleEqualsSequenceGroup": False,
+        "implicitWrites": False,
+        "dedupBeforeOccurrenceResolution": False,
+        "singletonBundleCoercion": False,
+        "technicalIdentitySemantics": False,
+        "currentV06Mutation": False,
+    }


### PR DESCRIPTION
## Decision

Фиксирует P3b outcome после зелёного executable challenge #387/#389:

```text
PRESERVE_BY_ROOTED_MIGRATION
```

Current `mts-value-bundle/v0.2` и outer `mts-contract/v0.6` не мутируются. На atomic Foundation-v2 cutover новая surface получает отдельный version boundary `mts-value-bundle/v0.3`.

## Machine-readable decision

`cutover/value-bundle-rooted-migration-decision-v0.1.json` фиксирует:
- evidence #387 / PR #389 / merge `775078f9…`;
- static input = rooted kind-tag/ordered-children skeleton;
- resolved input = canonical Links + separate occurrence checker coordinates;
- current static roles/error codes/value equality/expansion не меняются;
- occurrence resolution происходит до dedup;
- singleton bundle coercion отсутствует;
- expansion search owner = shared `foundation_v2_materialization.find_links`;
- no AST/source/handle/path semantic identity;
- read-only, missing pair never materialized.

## C7 manifest

`core/mtc_value_bundle.py` теперь:

```text
replacementLiveOwner = core/foundation_v2_value_bundle.py
deleteInC7 = true
```

Exact C7 set расширен на последний historical owner. Machine gate теперь требует:

```text
{ historical decision with deleteInC7=false } == ∅
```

## Safety boundary

Несмотря на готовность deletion decisions:

```text
foundationV2Accepted=false
cutoverPerformed=false
downstreamRepinAllowed=false
```

Current MTS v0.6 / ValueBundle v0.2 остаются byte/current semantics до отдельного atomic cutover release.

Closes #391
Refs #387, #389, #382, #385, #276, #271, #343