### PR TITLE
P3b decision: сохранить ValueBundle через rooted migration

### DIFF
--- a/cutover/foundation-v2-import-classification-v0.1.json
+++ b/cutover/foundation-v2-import-classification-v0.1.json
@@ -116,8 +116,8 @@
       "replacementLiveOwners": [
         "core/foundation_v2_value_bundle.py"
       ],
-      "deleteInC7": false,
-      "deletePrecondition": "P3b rooted challenge #387 must pass and a separate P3b decision must authorize current value-bundle migration or intentional delta before deletion"
+      "deleteInC7": true,
+      "deletePrecondition": "P3b decision #391 preserves ValueBundle through rooted migration; delete old owner only during atomic C7 with the new versioned value-bundle surface"
     }
   },
   "publicFacadeDirectDeps": [
@@ -140,6 +140,7 @@
     "core/mtc_interpreter.py",
     "core/mtc_opening_path.py",
     "core/mtc_parser.py",
+    "core/mtc_value_bundle.py",
     "core/proof_checker.py",
     "core/root_library.py",
     "core/validate_root.py"

--- a/cutover/value-bundle-rooted-migration-decision-v0.1.json
+++ b/cutover/value-bundle-rooted-migration-decision-v0.1.json
@@ -1,0 +1,60 @@
+{
+  "schema": "value-bundle-rooted-migration-decision/v0.1",
+  "issue": 391,
+  "parentIssue": 382,
+  "evidence": {
+    "challengeIssue": 387,
+    "pullRequest": 389,
+    "mergeCommit": "775078f95995b1de6157ace10a033b36af496ab3",
+    "executableCorpusGate": "tests/test_mts_foundation_v2_value_bundle.py"
+  },
+  "decision": "PRESERVE_BY_ROOTED_MIGRATION",
+  "current": {
+    "outerContract": "mts-contract/v0.6",
+    "surface": "mts-value-bundle/v0.2",
+    "referenceCore": "core/mtc_value_bundle.py",
+    "mutateInPlace": false
+  },
+  "next": {
+    "surfaceCandidate": "mts-value-bundle/v0.3",
+    "referenceCore": "core/foundation_v2_value_bundle.py",
+    "staticInput": "explicit rooted role skeleton carrier",
+    "resolvedInput": "ordered occurrence evidence (path, canonical Link) with extensional bundle membership",
+    "observableResultSemanticsChanged": false,
+    "historicalTypedAstIsNormativeInput": false,
+    "runtimeHandleIsSemanticIdentity": false,
+    "sourcePositionIsSemanticIdentity": false,
+    "pathIsSemanticIdentity": false,
+    "pathRole": "checker coordinate induced by ordered occurrence evidence",
+    "expansionUsesSharedReadOnlyFindLinks": true,
+    "readOnlyQueries": true,
+    "materializesDuringQuery": false
+  },
+  "preservedBoundaries": {
+    "staticRolesExact": true,
+    "staticRejectionCodesExact": true,
+    "occurrencesResolvedBeforeDeduplication": true,
+    "bundleMembershipExtensional": true,
+    "scalarAndSingletonBundleRemainDistinct": true,
+    "emptyBundleExpansionEndpointIsWildcard": true,
+    "missingPairIsOmitted": true,
+    "unresolvedOrForeignOccurrenceFailsClosed": true,
+    "sharingCreatesSecondSemanticLink": false
+  },
+  "c7": {
+    "deleteOldOwner": true,
+    "deletePath": "core/mtc_value_bundle.py",
+    "replacementLiveOwner": "core/foundation_v2_value_bundle.py",
+    "deleteOnlyDuringAtomicCutover": true,
+    "currentContractsRemainUntilCutover": true
+  },
+  "veto": {
+    "compatibilityAstSemanticMode": false,
+    "identifyBundleWithSequenceGroup": false,
+    "implicitQueryWrites": false,
+    "deduplicateBeforeOccurrenceResolution": false,
+    "singletonBundleCoercion": false,
+    "numericOrRuntimeHandleIdentity": false,
+    "currentV06Mutation": false
+  }
+}

--- a/tests/test_direct_deixis_cutover_decision.py
+++ b/tests/test_direct_deixis_cutover_decision.py
@@ -60,7 +60,7 @@ def test_direct_deixis_old_owner_is_now_planned_for_atomic_c7_deletion() -> None
         for path, item in manifest["historicalDecisions"].items()
         if not item["deleteInC7"]
     }
-    assert unresolved == {"core/mtc_value_bundle.py"}
+    assert "core/mtc_context_analysis.py" not in unresolved
 
 
 def test_current_v06_is_not_mutated_by_the_cutover_decision() -> None:

--- a/tests/test_foundation_v2_cutover_gate.py
+++ b/tests/test_foundation_v2_cutover_gate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
+VALUE_BUNDLE_DECISION = ROOT / "cutover/value-bundle-rooted-migration-decision-v0.1.json"
 SURFACE_DIRS = (ROOT / "core", ROOT / "converters")
 HISTORICAL_CLASSES = {"HISTORICAL_SEMANTIC_ISLAND", "HISTORICAL_ENTRYPOINT"}
 
@@ -144,7 +145,62 @@ def test_historical_deletion_decisions_are_complete_and_c7_set_is_exact() -> Non
     assert manifest["c7DeletionSet"] == expected_delete
     assert {
         path for path, decision in decisions.items() if not decision["deleteInC7"]
-    } == {"core/mtc_value_bundle.py"}
+    } == set()
+
+
+def test_p3b_value_bundle_decision_is_machine_readable_and_delete_ready() -> None:
+    decision = json.loads(VALUE_BUNDLE_DECISION.read_text(encoding="utf-8"))
+    manifest = load_manifest()
+
+    assert decision["schema"] == "value-bundle-rooted-migration-decision/v0.1"
+    assert decision["issue"] == 391
+    assert decision["parentIssue"] == 382
+    assert decision["decision"] == "PRESERVE_BY_ROOTED_MIGRATION"
+    assert decision["evidence"] == {
+        "challengeIssue": 387,
+        "pullRequest": 389,
+        "mergeCommit": "775078f95995b1de6157ace10a033b36af496ab3",
+        "executableCorpusGate": "tests/test_mts_foundation_v2_value_bundle.py",
+    }
+    assert decision["current"] == {
+        "outerContract": "mts-contract/v0.6",
+        "surface": "mts-value-bundle/v0.2",
+        "referenceCore": "core/mtc_value_bundle.py",
+        "mutateInPlace": False,
+    }
+
+    old_owner = manifest["historicalDecisions"]["core/mtc_value_bundle.py"]
+    assert old_owner["replacementLiveOwners"] == [
+        "core/foundation_v2_value_bundle.py"
+    ]
+    assert old_owner["deleteInC7"] is True
+    assert "core/mtc_value_bundle.py" in manifest["c7DeletionSet"]
+
+
+def test_p3b_decision_preserves_identity_and_read_only_vetoes() -> None:
+    decision = json.loads(VALUE_BUNDLE_DECISION.read_text(encoding="utf-8"))
+    next_surface = decision["next"]
+
+    assert next_surface["surfaceCandidate"] == "mts-value-bundle/v0.3"
+    assert next_surface["referenceCore"] == "core/foundation_v2_value_bundle.py"
+    assert next_surface["observableResultSemanticsChanged"] is False
+    assert next_surface["historicalTypedAstIsNormativeInput"] is False
+    assert next_surface["runtimeHandleIsSemanticIdentity"] is False
+    assert next_surface["sourcePositionIsSemanticIdentity"] is False
+    assert next_surface["pathIsSemanticIdentity"] is False
+    assert next_surface["expansionUsesSharedReadOnlyFindLinks"] is True
+    assert next_surface["readOnlyQueries"] is True
+    assert next_surface["materializesDuringQuery"] is False
+
+    assert decision["veto"] == {
+        "compatibilityAstSemanticMode": False,
+        "identifyBundleWithSequenceGroup": False,
+        "implicitQueryWrites": False,
+        "deduplicateBeforeOccurrenceResolution": False,
+        "singletonBundleCoercion": False,
+        "numericOrRuntimeHandleIdentity": False,
+        "currentV06Mutation": False,
+    }
 
 
 def test_gate_does_not_claim_cutover_acceptance_or_downstream_repin() -> None:


### PR DESCRIPTION
## Decision

После полного executable challenge #387/#389 фиксируется:

```text
PRESERVE_BY_ROOTED_MIGRATION
```

Current `mts-value-bundle/v0.2` и outer `mts-contract/v0.6` не мутируются. На atomic Foundation-v2 cutover новая surface получает отдельную границу версии, candidate `mts-value-bundle/v0.3`.

## Machine-readable decision

`cutover/value-bundle-rooted-migration-decision-v0.1.json` фиксирует:
- evidence #387 / PR #389 / merge `775078f…`;
- static input переходит с typed AST authority на explicit rooted role skeleton;
- resolved bundle остаётся extensional set canonical Links с отдельным ordered occurrence evidence;
- runtime handle/source position/path не являются semantic Link identity;
- scalar и singleton bundle не коэрцируются;
- expansion использует общий read-only rooted `find_links` и не materialize-ит missing pair;
- old owner удаляется только в atomic C7.

## C7 manifest

`core/mtc_value_bundle.py` теперь:

```text
replacementLiveOwner = core/foundation_v2_value_bundle.py
deleteInC7 = true
```

После этого `deleteInC7=false` historical set становится пустым. Exact C7 deletion set расширяется ровно на `core/mtc_value_bundle.py`.

При этом gate по-прежнему требует:

```text
foundationV2Accepted=false
cutoverPerformed=false
downstreamRepinAllowed=false
```

То есть это разрешение будущего atomic C7, а не сам cutover.

Тест P3a скорректирован так, чтобы не фиксировать временное состояние «ValueBundle — последний blocker» как вечный инвариант; финальное отсутствие unresolved historical decisions проверяет общий cutover gate.

```repo-guard-yaml
change_type: feature
scope:
  - cutover/foundation-v2-import-classification-v0.1.json
  - cutover/value-bundle-rooted-migration-decision-v0.1.json
  - tests/test_foundation_v2_cutover_gate.py
  - tests/test_direct_deixis_cutover_decision.py
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 140
must_touch:
  - cutover/value-bundle-rooted-migration-decision-v0.1.json
  - cutover/foundation-v2-import-classification-v0.1.json
  - tests/test_foundation_v2_cutover_gate.py
must_not_touch:
  - contracts/**
  - core/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - record PRESERVE_BY_ROOTED_MIGRATION for accepted ValueBundle evidence
  - mark the historical ValueBundle owner delete-ready only for atomic C7
  - make the unresolved historical decision set empty
  - preserve current MTS v0.6 acceptance and keep cutover/downstream flags false
```

Closes #391. Refs #387, #389, #382, #276, #271, #343.