### PR TITLE
C0: зафиксировать Foundation-v2 cutover candidate

### DIFF
--- a/cutover/foundation-v2-cutover-candidate-v0.1.json
+++ b/cutover/foundation-v2-cutover-candidate-v0.1.json
@@ -1,0 +1,95 @@
+{
+  "schema": "foundation-v2-cutover-candidate/v0.1",
+  "issue": 394,
+  "parentIssue": 271,
+  "status": "frozen-candidate",
+  "accepted": false,
+  "cutoverPerformed": false,
+  "downstreamRepinAllowed": false,
+  "previousAcceptedRelease": {
+    "contract": "contracts/mts-contract-v0.6.json",
+    "conformance": "contracts/mts-conformance-v0.6.json",
+    "immutable": true,
+    "remainsAcceptedUntilC9": true,
+    "isLiveOwnerManifestAfterC7": false
+  },
+  "candidateBoundary": {
+    "contractSchema": "foundation-v2-cutover-contract/v0.1",
+    "conformanceSchema": "foundation-v2-cutover-conformance/v0.1",
+    "acceptedMtsVersionAssignedHere": false,
+    "mustReferenceOnlyExistingPostC7Owners": true
+  },
+  "owners": {
+    "publicFacade": "core/foundation_v2.py",
+    "rootedSubstrate": "core/rooted_link_network.py",
+    "root": "core/foundation_v2_root.py",
+    "source": "core/foundation_v2_source.py",
+    "state": "core/foundation_v2_state.py",
+    "interpreter": "core/foundation_v2_interpreter.py",
+    "run": "core/foundation_v2_run.py",
+    "proof": "core/foundation_v2_proof.py",
+    "checker": "core/foundation_v2_checker.py",
+    "directDeixis": "core/foundation_v2_direct_deixis.py",
+    "valueBundle": "core/foundation_v2_value_bundle.py",
+    "anumStreamDenotation": "core/anum_protocol.py",
+    "anumExistingCarrier": "core/anum_carrier.py",
+    "anumMaterialization": "core/foundation_v2_materialization.py",
+    "persistence": "core/foundation_v2_persistent.py"
+  },
+  "historicalClassification": "cutover/foundation-v2-import-classification-v0.1.json",
+  "p3Decisions": {
+    "directDeixis": "cutover/direct-deixis-rooted-migration-decision-v0.1.json",
+    "valueBundle": "cutover/value-bundle-rooted-migration-decision-v0.1.json"
+  },
+  "c7DeletionSet": [
+    "core/mtc_ast.py",
+    "core/mtc_context_analysis.py",
+    "core/mtc_definitions.py",
+    "core/mtc_interpreter.py",
+    "core/mtc_opening_path.py",
+    "core/mtc_parser.py",
+    "core/mtc_value_bundle.py",
+    "core/proof_checker.py",
+    "core/root_library.py",
+    "core/validate_root.py"
+  ],
+  "c8IntegratedPath": [
+    "root",
+    "source",
+    "D/G/T",
+    "K/A",
+    ":/=",
+    "Run/proof",
+    "Anum materialization",
+    "persistent close/reopen"
+  ],
+  "requiredNegativeVectors": [
+    "second-fully-self-closed-by-physical-id",
+    "duplicate-same-pair",
+    "same-form-distinguished-only-by-runtime-handle",
+    "id-only-mutual-cycle",
+    "read-or-replay-materializes",
+    "historical-female-F-or-F-male-projection-meaning",
+    "root-as-fifth-abit",
+    "empty-group-rejected"
+  ],
+  "veto": {
+    "secondLiveSemanticRuntime": false,
+    "compatibilityOccurrenceMode": false,
+    "runtimeIdAsSemanticIdentity": false,
+    "sourcePositionAsSemanticIdentity": false,
+    "contextFrameDisguisedAsK": false,
+    "astOrTokenSemanticAuthority": false,
+    "readMayMaterialize": false,
+    "mutateMtsV06InPlace": false,
+    "deleteBeforeCandidateOwnerMigration": false,
+    "acceptInsideC7OrC8": false
+  },
+  "stageOrder": [
+    "C0-freeze-candidate",
+    "C1-migrate-consumers-and-candidate-contract",
+    "C7-atomic-delete-historical-runtime",
+    "C8-integrated-conformance",
+    "C9-explicit-acceptance-and-downstream-repin"
+  ]
+}

--- a/tests/test_foundation_v2_cutover_gate.py
+++ b/tests/test_foundation_v2_cutover_gate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
+CANDIDATE = ROOT / "cutover/foundation-v2-cutover-candidate-v0.1.json"
 VALUE_BUNDLE_DECISION = ROOT / "cutover/value-bundle-rooted-migration-decision-v0.1.json"
 SURFACE_DIRS = (ROOT / "core", ROOT / "converters")
 HISTORICAL_CLASSES = {"HISTORICAL_SEMANTIC_ISLAND", "HISTORICAL_ENTRYPOINT"}
@@ -14,6 +15,10 @@ HISTORICAL_CLASSES = {"HISTORICAL_SEMANTIC_ISLAND", "HISTORICAL_ENTRYPOINT"}
 
 def load_manifest() -> dict:
     return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def load_candidate() -> dict:
+    return json.loads(CANDIDATE.read_text(encoding="utf-8"))
 
 
 def discover_surface() -> set[str]:
@@ -254,3 +259,61 @@ def test_historical_reverse_consumers_have_no_foundation_v2_live_owner() -> None
         if classifications[consumer] == "FOUNDATION_V2_LIVE"
     ]
     assert violations == []
+
+
+def test_c0_candidate_freezes_exact_post_p3_owner_and_deletion_surface() -> None:
+    candidate = load_candidate()
+    manifest = load_manifest()
+
+    assert candidate["schema"] == "foundation-v2-cutover-candidate/v0.1"
+    assert candidate["issue"] == 394
+    assert candidate["parentIssue"] == 271
+    assert candidate["status"] == "frozen-candidate"
+    assert candidate["c7DeletionSet"] == manifest["c7DeletionSet"]
+    assert set(candidate["c7DeletionSet"]) == set(manifest["historicalDecisions"])
+
+    classifications = manifest["classifications"]
+    neutral = {"core/anum_protocol.py", "core/anum_carrier.py"}
+    for owner in candidate["owners"].values():
+        assert (ROOT / owner).is_file(), owner
+        if owner in neutral:
+            assert classifications[owner] == "PRESERVED_NEUTRAL"
+        else:
+            assert classifications[owner] == "FOUNDATION_V2_LIVE"
+        assert owner not in candidate["c7DeletionSet"]
+
+
+def test_c0_candidate_keeps_v06_frozen_and_does_not_smuggle_c9_acceptance() -> None:
+    candidate = load_candidate()
+    previous = candidate["previousAcceptedRelease"]
+    boundary = candidate["candidateBoundary"]
+
+    assert candidate["accepted"] is False
+    assert candidate["cutoverPerformed"] is False
+    assert candidate["downstreamRepinAllowed"] is False
+    assert previous == {
+        "contract": "contracts/mts-contract-v0.6.json",
+        "conformance": "contracts/mts-conformance-v0.6.json",
+        "immutable": True,
+        "remainsAcceptedUntilC9": True,
+        "isLiveOwnerManifestAfterC7": False,
+    }
+    assert boundary["acceptedMtsVersionAssignedHere"] is False
+    assert boundary["mustReferenceOnlyExistingPostC7Owners"] is True
+    assert candidate["stageOrder"][-1] == "C9-explicit-acceptance-and-downstream-repin"
+
+
+def test_c0_candidate_freezes_identity_and_read_only_vetoes() -> None:
+    veto = load_candidate()["veto"]
+    assert veto == {
+        "secondLiveSemanticRuntime": False,
+        "compatibilityOccurrenceMode": False,
+        "runtimeIdAsSemanticIdentity": False,
+        "sourcePositionAsSemanticIdentity": False,
+        "contextFrameDisguisedAsK": False,
+        "astOrTokenSemanticAuthority": False,
+        "readMayMaterialize": False,
+        "mutateMtsV06InPlace": False,
+        "deleteBeforeCandidateOwnerMigration": False,
+        "acceptInsideC7OrC8": False,
+    }


### PR DESCRIPTION
Первый slice #394: machine-readable C0 freeze перед миграцией consumers и atomic C7.

Что фиксируется:
- отдельная **cutover candidate** boundary без назначения будущей accepted MTS version;
- exact rooted owners root/source/state/interpreter/run/proof/checker/directDeixis/ValueBundle/Anum/persistence;
- accepted ANUM v0.4 owners `anum_protocol`/`anum_carrier` остаются нейтральными rooted-compatible owners, а не вторым semantic runtime;
- exact C7 deletion set равен post-P3 classification manifest;
- `mts-contract/v0.6`/conformance остаются immutable previous accepted release evidence и не мутируются in-place;
- candidate не выставляет acceptance, cutoverPerformed или downstream repin;
- C8 path и negative vectors заморожены;
- identity/read-only/AST/ContextFrame vetoes закреплены executable gate.

Этот PR **не** создаёт новый accepted MTS contract, не мигрирует consumers и ничего не удаляет. Следующий slice — exact executable consumer disposition + candidate contract/conformance.

```repo-guard-yaml
change_type: feature
scope:
  - cutover/foundation-v2-cutover-candidate-v0.1.json
  - tests/test_foundation_v2_cutover_gate.py
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 180
must_touch:
  - cutover/foundation-v2-cutover-candidate-v0.1.json
  - tests/test_foundation_v2_cutover_gate.py
must_not_touch:
  - contracts/**
  - core/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - freeze exact post-P3 Foundation-v2 cutover owners and C7 deletion set
  - keep MTS v0.6 immutable and accepted until a separate C9 decision
  - prevent hidden acceptance, downstream repin or semantic compatibility mode in C7/C8
  - establish a versioned non-accepted cutover contract/conformance namespace
```

Refs #394, #271, #237, #276, #382, #391, #393, #343.