### PR TITLE
C1: классифицировать consumers исторического runtime перед C7

### DIFF
--- a/cutover/foundation-v2-consumer-disposition-v0.1.json
+++ b/cutover/foundation-v2-consumer-disposition-v0.1.json
@@ -1,0 +1,91 @@
+{
+  "schema": "foundation-v2-consumer-disposition/v0.1",
+  "issue": 394,
+  "parentIssue": 271,
+  "historicalOwners": [
+    "core/mtc_ast.py",
+    "core/mtc_context_analysis.py",
+    "core/mtc_definitions.py",
+    "core/mtc_interpreter.py",
+    "core/mtc_opening_path.py",
+    "core/mtc_parser.py",
+    "core/mtc_value_bundle.py",
+    "core/proof_checker.py",
+    "core/root_library.py",
+    "core/validate_root.py"
+  ],
+  "allowedDispositions": [
+    "DELETE_WITH_OWNER",
+    "MIGRATE_TO_FOUNDATION_V2",
+    "HISTORICAL_REPLAY_ONLY",
+    "NON_SEMANTIC_TOOLING"
+  ],
+  "externalDirectConsumers": {
+    "tests/test_context_pronouns.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "typed parser/AST historical acceptance tests; source history remains in Git"
+    },
+    "tests/test_mtc_definitions.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical definition environment unit tests are owned by mtc_definitions"
+    },
+    "tests/test_mtc_interpreter.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical ContextFrame/MemoryView interpreter tests"
+    },
+    "tests/test_mtc_parser.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical typed parser/AST semantic front-end tests"
+    },
+    "tests/test_mtc_value_bundle_reference.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "superseded by rooted ValueBundle challenge and P3b decision"
+    },
+    "tests/test_mts_contract_v06.py": {
+      "disposition": "HISTORICAL_REPLAY_ONLY",
+      "reason": "v0.6 remains immutable accepted previous-release evidence; C7 must remove executable historical-core imports and retain data-only manifest checks"
+    },
+    "tests/test_mts_definition_opening_reference.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical definition-opening reference runtime; rooted owner evidence is frozen by cutover decisions"
+    },
+    "tests/test_mts_direct_deixis_reference.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "superseded by rooted direct-deixis challenge and P3a decision"
+    },
+    "tests/test_mts_foundation_v2_direct_deixis.py": {
+      "disposition": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2_direct_deixis.py",
+      "reason": "keep rooted conformance but replace test-only historical AST/parser projection with explicit rooted fixtures"
+    },
+    "tests/test_mts_foundation_v2_value_bundle.py": {
+      "disposition": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2_value_bundle.py",
+      "reason": "keep rooted conformance but replace test-only historical AST/parser projection with explicit rooted fixtures"
+    },
+    "tests/test_mts_opening_path_reference.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical opening-path reference runtime is not a post-C7 live owner"
+    },
+    "tests/test_mts_proof_v04.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical proof_checker acceptance runtime is replaced by Foundation-v2 proof/checker evidence"
+    },
+    "tests/test_repository_contract.py": {
+      "disposition": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2.py",
+      "reason": "repository architecture gate must survive C7 but stop importing validate_root"
+    },
+    "tests/test_root_library.py": {
+      "disposition": "DELETE_WITH_OWNER",
+      "reason": "historical root-library/parser semantics, including superseded projection notation, must leave the live tree"
+    }
+  },
+  "c7Rule": {
+    "noExternalDirectHistoricalImportsAfterMigration": true,
+    "unknownConsumerAllowed": false,
+    "compatibilityFacadeAllowed": false,
+    "historicalRuntimeSelectableAfterC7": false,
+    "frozenV06MayImportDeletedRuntime": false
+  }
+}

--- a/tests/test_direct_deixis_cutover_decision.py
+++ b/tests/test_direct_deixis_cutover_decision.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 
@@ -7,6 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DECISION = ROOT / "cutover/direct-deixis-rooted-migration-decision-v0.1.json"
 MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
+DISPOSITION = ROOT / "cutover/foundation-v2-consumer-disposition-v0.1.json"
 CONTRACT = ROOT / "contracts/mts-contract-v0.6.json"
 CONFORMANCE = ROOT / "contracts/mts-conformance-v0.6.json"
 
@@ -96,4 +98,98 @@ def test_decision_preserves_current_non_implication_and_identity_vetoes() -> Non
         "contextInvarianceTheorem": False,
         "queryMaterialization": False,
         "currentV06Mutation": False,
+    }
+
+
+def _historical_module_names() -> set[str]:
+    return {
+        path.removesuffix(".py").replace("/", ".")
+        for path in read(DISPOSITION)["historicalOwners"]
+    }
+
+
+def _imports_historical(path: Path, historical: set[str]) -> bool:
+    source = path.relative_to(ROOT).as_posix()
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=source)
+    package = list(path.relative_to(ROOT).with_suffix("").parts[:-1])
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name in historical for alias in node.names):
+                return True
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        if node.level:
+            keep = len(package) - (node.level - 1)
+            if keep < 0:
+                continue
+            parts = package[:keep]
+            if node.module:
+                parts += node.module.split(".")
+            module = ".".join(parts)
+        else:
+            module = node.module or ""
+
+        if module in historical:
+            return True
+        if module == "core" and any(f"core.{alias.name}" in historical for alias in node.names):
+            return True
+    return False
+
+
+def _external_direct_historical_consumers() -> set[str]:
+    disposition = read(DISPOSITION)
+    historical_paths = set(disposition["historicalOwners"])
+    historical_modules = _historical_module_names()
+    roots = (ROOT / "core", ROOT / "converters", ROOT / "tests")
+    result: set[str] = set()
+
+    for directory in roots:
+        for path in directory.glob("*.py"):
+            relative = path.relative_to(ROOT).as_posix()
+            if relative in historical_paths:
+                continue
+            if _imports_historical(path, historical_modules):
+                result.add(relative)
+    return result
+
+
+def test_c1_consumer_disposition_is_exact_for_all_external_direct_importers() -> None:
+    disposition = read(DISPOSITION)
+
+    assert disposition["schema"] == "foundation-v2-consumer-disposition/v0.1"
+    assert disposition["issue"] == 394
+    assert disposition["parentIssue"] == 271
+    assert disposition["historicalOwners"] == read(MANIFEST)["c7DeletionSet"]
+    assert set(disposition["externalDirectConsumers"]) == _external_direct_historical_consumers()
+
+
+def test_c1_dispositions_are_closed_and_migration_targets_exist() -> None:
+    disposition = read(DISPOSITION)
+    allowed = set(disposition["allowedDispositions"])
+    assert allowed == {
+        "DELETE_WITH_OWNER",
+        "MIGRATE_TO_FOUNDATION_V2",
+        "HISTORICAL_REPLAY_ONLY",
+        "NON_SEMANTIC_TOOLING",
+    }
+
+    for path, item in disposition["externalDirectConsumers"].items():
+        assert (ROOT / path).is_file(), path
+        assert item["disposition"] in allowed, path
+        assert item["reason"].strip(), path
+        if item["disposition"] == "MIGRATE_TO_FOUNDATION_V2":
+            assert (ROOT / item["target"]).is_file(), path
+
+
+def test_c1_freezes_no_legacy_runtime_after_atomic_c7() -> None:
+    rule = read(DISPOSITION)["c7Rule"]
+    assert rule == {
+        "noExternalDirectHistoricalImportsAfterMigration": True,
+        "unknownConsumerAllowed": False,
+        "compatibilityFacadeAllowed": False,
+        "historicalRuntimeSelectableAfterC7": False,
+        "frozenV06MayImportDeletedRuntime": False,
     }


### PR DESCRIPTION
Второй slice #394: фиксирует exact disposition всех **внешних Python consumers**, которые напрямую импортируют один из 10 historical semantic owners из C7 deletion set.

Категории закрыты:
- `DELETE_WITH_OWNER` — исторические acceptance/reference tests уходят вместе со своим owner;
- `MIGRATE_TO_FOUNDATION_V2` — текущие rooted challenge/repository gates остаются, но должны избавиться от test-only AST/parser/validate_root dependency;
- `HISTORICAL_REPLAY_ONLY` — `mts-contract/v0.6` остаётся frozen release evidence, но его test должен стать data-only до physical deletion;
- `NON_SEMANTIC_TOOLING` — зарезервировано только для реально несмысловых consumers.

Executable gate сам AST-сканирует `core/*.py`, `converters/*.py`, `tests/*.py`, исключает сам C7 deletion set и требует **точного** совпадения найденных direct importers с manifest. Поэтому новый consumer нельзя добавить незаметно.

Этот PR ничего не мигрирует и не удаляет: он закрывает C1 discovery/classification перед отдельными migration slices.

```repo-guard-yaml
change_type: feature
scope:
  - cutover/foundation-v2-consumer-disposition-v0.1.json
  - tests/test_direct_deixis_cutover_decision.py
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 220
must_touch:
  - cutover/foundation-v2-consumer-disposition-v0.1.json
  - tests/test_direct_deixis_cutover_decision.py
must_not_touch:
  - contracts/**
  - core/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - enumerate every external direct importer of the historical C7 semantic owners
  - assign every importer a closed migration/deletion/replay disposition with no UNKNOWN state
  - prevent a frozen v0.6 test from depending on physically deleted runtime after C7
  - keep compatibility facades and selectable legacy runtime forbidden
```

Refs #394, #271, #276, #393, #343.