### PR TITLE
C1: хранить non-accepted cutover contract как cutover evidence

### DIFF
--- a/cutover/foundation-v2-cutover-candidate-v0.1.json
+++ b/cutover/foundation-v2-cutover-candidate-v0.1.json
@@ -16,6 +16,10 @@
   "candidateBoundary": {
     "contractSchema": "foundation-v2-cutover-contract/v0.1",
     "conformanceSchema": "foundation-v2-cutover-conformance/v0.1",
+    "contract": "cutover/foundation-v2-cutover-contract-v0.1.json",
+    "conformance": "cutover/foundation-v2-cutover-conformance-v0.1.json",
+    "consumerDisposition": "cutover/foundation-v2-consumer-disposition-v0.1.json",
+    "consumerMatrix": "cutover/foundation-v2-c7-consumer-matrix-v0.1.json",
     "acceptedMtsVersionAssignedHere": false,
     "mustReferenceOnlyExistingPostC7Owners": true
   },

--- a/cutover/foundation-v2-cutover-conformance-v0.1.json
+++ b/cutover/foundation-v2-cutover-conformance-v0.1.json
@@ -1,0 +1,71 @@
+{
+  "schema": "foundation-v2-cutover-conformance/v0.1",
+  "status": "candidate",
+  "accepted": false,
+  "issue": 394,
+  "contract": "cutover/foundation-v2-cutover-contract-v0.1.json",
+  "candidateManifest": "cutover/foundation-v2-cutover-candidate-v0.1.json",
+  "requiredExecutableGates": [
+    "tests/test_mts_rooted_link_network.py",
+    "tests/test_mts_foundation_v2_root.py",
+    "tests/test_mts_foundation_v2_source.py",
+    "tests/test_mts_foundation_v2_state.py",
+    "tests/test_mts_foundation_v2_interpreter.py",
+    "tests/test_mts_foundation_v2_colon.py",
+    "tests/test_mts_foundation_v2_equality.py",
+    "tests/test_mts_foundation_v2_run.py",
+    "tests/test_mts_foundation_v2_proof.py",
+    "tests/test_mts_foundation_v2_checker.py",
+    "tests/test_mts_foundation_v2_direct_deixis.py",
+    "tests/test_mts_foundation_v2_value_bundle.py",
+    "tests/test_anum_deserialization_v04.py",
+    "tests/test_anum_carrier.py",
+    "tests/test_mts_foundation_v2_persistent.py",
+    "tests/test_foundation_v2_cutover_gate.py",
+    "tests/test_foundation_v2_c7_preflight.py"
+  ],
+  "integratedPath": [
+    "root",
+    "source",
+    "D/G/T",
+    "K/A",
+    ":/=",
+    "Run/proof",
+    "Anum materialization",
+    "persistent close/reopen"
+  ],
+  "requiredNegativeVectors": [
+    "second-fully-self-closed-by-physical-id",
+    "duplicate-same-pair",
+    "same-form-distinguished-only-by-runtime-handle",
+    "id-only-mutual-cycle",
+    "read-or-replay-materializes",
+    "historical-female-F-or-F-male-projection-meaning",
+    "root-as-fifth-abit",
+    "empty-group-rejected"
+  ],
+  "migrationPrerequisite": {
+    "dispositionManifest": "cutover/foundation-v2-consumer-disposition-v0.1.json",
+    "consumerMatrix": "cutover/foundation-v2-c7-consumer-matrix-v0.1.json",
+    "allExternalHistoricalImportsMustBeResolvedBeforeC7": true,
+    "allMachineHistoricalReferencesMustBeSupersededAtAtomicRelease": true
+  },
+  "requiredInvariants": {
+    "linkIdentityByOrderedPoles": true,
+    "rootIsOnlyFullySelfClosedLink": true,
+    "samePairReused": true,
+    "runtimeHandleRenamingInvariant": true,
+    "readOnlyQueriesDoNotWrite": true,
+    "rootIsNotFifthAbit": true,
+    "emptyGroupIsRoot": true,
+    "rawAndCarrierAnumTransportsConverge": true,
+    "directDeixisUsesRootedEvidence": true,
+    "valueBundleUsesRootedEvidence": true
+  },
+  "acceptance": {
+    "performedHere": false,
+    "acceptedMtsVersionAssignedHere": false,
+    "downstreamRepinAllowed": false,
+    "requiresSeparateC9": true
+  }
+}

--- a/cutover/foundation-v2-cutover-contract-v0.1.json
+++ b/cutover/foundation-v2-cutover-contract-v0.1.json
@@ -1,0 +1,75 @@
+{
+  "schema": "foundation-v2-cutover-contract/v0.1",
+  "status": "candidate",
+  "accepted": false,
+  "issue": 394,
+  "parentIssue": 271,
+  "candidateManifest": "cutover/foundation-v2-cutover-candidate-v0.1.json",
+  "consumerDisposition": "cutover/foundation-v2-consumer-disposition-v0.1.json",
+  "consumerMatrix": "cutover/foundation-v2-c7-consumer-matrix-v0.1.json",
+  "conformance": "cutover/foundation-v2-cutover-conformance-v0.1.json",
+  "previousAcceptedRelease": "mts-contract/v0.6",
+  "acceptedMtsVersion": null,
+  "semanticIdentity": {
+    "linkIdentity": "by ordered semantic poles",
+    "axiom": "Link(A,B)=Link(C,D) iff A=C and B=D",
+    "runtimeHandleIsSemanticIdentity": false,
+    "sourcePositionIsSemanticIdentity": false,
+    "pathIsSemanticIdentity": false,
+    "samePairCreatesSecondSemanticLink": false,
+    "root": "R = R ⟼ R",
+    "secondFullySelfClosedRootAllowed": false
+  },
+  "transport": {
+    "abits": ["[", "]", "1", "0"],
+    "exactlyFour": true,
+    "rootIsFifthAbit": false,
+    "emptyStream": "R",
+    "emptyGroup": "R",
+    "rawAndExistingCarrierShareOneStackMachine": true,
+    "existingCarrierReadOnly": true
+  },
+  "owners": {
+    "publicFacade": "core/foundation_v2.py",
+    "rootedSubstrate": "core/rooted_link_network.py",
+    "root": "core/foundation_v2_root.py",
+    "source": "core/foundation_v2_source.py",
+    "state": "core/foundation_v2_state.py",
+    "interpreter": "core/foundation_v2_interpreter.py",
+    "run": "core/foundation_v2_run.py",
+    "proof": "core/foundation_v2_proof.py",
+    "checker": "core/foundation_v2_checker.py",
+    "directDeixis": "core/foundation_v2_direct_deixis.py",
+    "valueBundle": "core/foundation_v2_value_bundle.py",
+    "anumStreamDenotation": "core/anum_protocol.py",
+    "anumExistingCarrier": "core/anum_carrier.py",
+    "anumMaterialization": "core/foundation_v2_materialization.py",
+    "persistence": "core/foundation_v2_persistent.py"
+  },
+  "surfaces": {
+    "root": {"referenceCore": "core/foundation_v2_root.py", "effect": "construct/validate explicit rooted kernel"},
+    "source": {"referenceCore": "core/foundation_v2_source.py", "semanticAuthority": "rooted evidence, not AST/token identity"},
+    "state": {"referenceCore": "core/foundation_v2_state.py", "contextFrameAdapterAccepted": false},
+    "interpreter": {"referenceCore": "core/foundation_v2_interpreter.py", "readOnlyReplayMayMaterialize": false},
+    "run": {"referenceCore": "core/foundation_v2_run.py", "readOnlyReplayMayMaterialize": false},
+    "proof": {"referenceCore": "core/foundation_v2_proof.py", "trustedChecker": "core/foundation_v2_checker.py"},
+    "directDeixis": {"referenceCore": "core/foundation_v2_direct_deixis.py", "migrationDecision": "cutover/direct-deixis-rooted-migration-decision-v0.1.json"},
+    "valueBundle": {"referenceCore": "core/foundation_v2_value_bundle.py", "migrationDecision": "cutover/value-bundle-rooted-migration-decision-v0.1.json"},
+    "anum": {"streamReferenceCore": "core/anum_protocol.py", "carrierReferenceCore": "core/anum_carrier.py", "materializationReferenceCore": "core/foundation_v2_materialization.py"},
+    "persistence": {"referenceCore": "core/foundation_v2_persistent.py", "runtimeHandleIsPortableIdentity": false}
+  },
+  "effects": {
+    "findEqualsMaterialize": false,
+    "notFoundImpliesNonExistence": false,
+    "readMayMaterialize": false,
+    "replayMayMaterialize": false,
+    "explicitMaterializationMustReuseSamePair": true
+  },
+  "cutover": {
+    "foundationV2Accepted": false,
+    "cutoverPerformed": false,
+    "downstreamRepinAllowed": false,
+    "historicalRuntimeSelectableAfterC7": false,
+    "compatibilityOccurrenceMode": false
+  }
+}

--- a/tests/test_direct_deixis_cutover_decision.py
+++ b/tests/test_direct_deixis_cutover_decision.py
@@ -11,6 +11,10 @@ MANIFEST = ROOT / "cutover/foundation-v2-import-classification-v0.1.json"
 DISPOSITION = ROOT / "cutover/foundation-v2-consumer-disposition-v0.1.json"
 CONTRACT = ROOT / "contracts/mts-contract-v0.6.json"
 CONFORMANCE = ROOT / "contracts/mts-conformance-v0.6.json"
+CANDIDATE = ROOT / "cutover/foundation-v2-cutover-candidate-v0.1.json"
+CANDIDATE_CONTRACT = ROOT / "cutover/foundation-v2-cutover-contract-v0.1.json"
+CANDIDATE_CONFORMANCE = ROOT / "cutover/foundation-v2-cutover-conformance-v0.1.json"
+CONSUMER_MATRIX = ROOT / "cutover/foundation-v2-c7-consumer-matrix-v0.1.json"
 
 
 def read(path: Path) -> dict:
@@ -192,4 +196,92 @@ def test_c1_freezes_no_legacy_runtime_after_atomic_c7() -> None:
         "compatibilityFacadeAllowed": False,
         "historicalRuntimeSelectableAfterC7": False,
         "frozenV06MayImportDeletedRuntime": False,
+    }
+
+
+def test_candidate_artifacts_are_non_authoritative_cutover_evidence() -> None:
+    assert CANDIDATE_CONTRACT.parent == ROOT / "cutover"
+    assert CANDIDATE_CONFORMANCE.parent == ROOT / "cutover"
+    assert {path.name for path in (ROOT / "contracts").glob("*.json")} == {
+        "mts-contract-v0.6.json",
+        "mts-conformance-v0.6.json",
+    }
+
+
+def test_candidate_contract_is_nonaccepted_and_uses_only_frozen_candidate_owners() -> None:
+    candidate = read(CANDIDATE)
+    contract = read(CANDIDATE_CONTRACT)
+
+    assert contract["schema"] == "foundation-v2-cutover-contract/v0.1"
+    assert contract["status"] == "candidate"
+    assert contract["accepted"] is False
+    assert contract["acceptedMtsVersion"] is None
+    assert contract["owners"] == candidate["owners"]
+    assert contract["consumerMatrix"] == candidate["candidateBoundary"]["consumerMatrix"]
+    assert set(contract["owners"].values()).isdisjoint(candidate["c7DeletionSet"])
+    for owner in contract["owners"].values():
+        assert (ROOT / owner).is_file(), owner
+
+    cutover = contract["cutover"]
+    assert cutover["foundationV2Accepted"] is False
+    assert cutover["cutoverPerformed"] is False
+    assert cutover["downstreamRepinAllowed"] is False
+    assert cutover["historicalRuntimeSelectableAfterC7"] is False
+    assert cutover["compatibilityOccurrenceMode"] is False
+
+
+def test_candidate_contract_freezes_identity_transport_and_read_only_boundaries() -> None:
+    contract = read(CANDIDATE_CONTRACT)
+
+    assert contract["semanticIdentity"]["runtimeHandleIsSemanticIdentity"] is False
+    assert contract["semanticIdentity"]["sourcePositionIsSemanticIdentity"] is False
+    assert contract["semanticIdentity"]["pathIsSemanticIdentity"] is False
+    assert contract["semanticIdentity"]["samePairCreatesSecondSemanticLink"] is False
+    assert contract["semanticIdentity"]["secondFullySelfClosedRootAllowed"] is False
+
+    assert contract["transport"]["abits"] == ["[", "]", "1", "0"]
+    assert contract["transport"]["exactlyFour"] is True
+    assert contract["transport"]["rootIsFifthAbit"] is False
+    assert contract["transport"]["emptyStream"] == "R"
+    assert contract["transport"]["emptyGroup"] == "R"
+    assert contract["transport"]["rawAndExistingCarrierShareOneStackMachine"] is True
+    assert contract["transport"]["existingCarrierReadOnly"] is True
+
+    assert contract["effects"] == {
+        "findEqualsMaterialize": False,
+        "notFoundImpliesNonExistence": False,
+        "readMayMaterialize": False,
+        "replayMayMaterialize": False,
+        "explicitMaterializationMustReuseSamePair": True,
+    }
+
+
+def test_candidate_conformance_points_only_to_existing_executable_gates() -> None:
+    candidate = read(CANDIDATE)
+    contract = read(CANDIDATE_CONTRACT)
+    conformance = read(CANDIDATE_CONFORMANCE)
+
+    assert conformance["schema"] == "foundation-v2-cutover-conformance/v0.1"
+    assert conformance["status"] == "candidate"
+    assert conformance["accepted"] is False
+    assert conformance["contract"] == candidate["candidateBoundary"]["contract"]
+    assert contract["conformance"] == candidate["candidateBoundary"]["conformance"]
+    assert conformance["integratedPath"] == candidate["c8IntegratedPath"]
+    assert conformance["requiredNegativeVectors"] == candidate["requiredNegativeVectors"]
+    assert conformance["migrationPrerequisite"]["consumerMatrix"] == str(
+        CONSUMER_MATRIX.relative_to(ROOT)
+    )
+
+    assert len(conformance["requiredExecutableGates"]) == len(
+        set(conformance["requiredExecutableGates"])
+    )
+    for gate in conformance["requiredExecutableGates"]:
+        assert gate.startswith("tests/") and gate.endswith(".py"), gate
+        assert (ROOT / gate).is_file(), gate
+
+    assert conformance["acceptance"] == {
+        "performedHere": False,
+        "acceptedMtsVersionAssignedHere": False,
+        "downstreamRepinAllowed": False,
+        "requiresSeparateC9": True,
     }


### PR DESCRIPTION
Следующий slice #394: вводит отдельную **непринятую** contract/conformance boundary для Foundation-v2 cutover candidate, не назначая будущую MTS release version и не мутируя v0.6.

Добавлено:
- `cutover/foundation-v2-cutover-contract-v0.1.json` — identity, four-abit transport, read/write boundaries и exact rooted owners;
- `cutover/foundation-v2-cutover-conformance-v0.1.json` — существующие executable gates, C8 integrated path и обязательные negative vectors;
- C0 candidate теперь ссылается на реальные candidate contract/conformance, C1 consumer-disposition и executable consumer-matrix;
- executable tests проверяют, что все owners/gates существуют, historical C7 paths не являются candidate owners, `[] = R`, root не fifth abit, same-pair multiplicity запрещена и acceptance/downstream repin остаются false.

Candidate boundary намеренно находится в `cutover/`, а не в `contracts/`: каталог `contracts/` остаётся frozen accepted MTS v0.6 release surface до отдельного C9.

Это всё ещё **не C7 и не C9**: historical runtime физически остаётся в дереве, current `mts-contract/v0.6` остаётся immutable accepted previous release.

```repo-guard-yaml
change_type: feature
scope:
  - cutover/foundation-v2-cutover-contract-v0.1.json
  - cutover/foundation-v2-cutover-conformance-v0.1.json
  - cutover/foundation-v2-cutover-candidate-v0.1.json
  - tests/test_direct_deixis_cutover_decision.py
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 360
must_touch:
  - cutover/foundation-v2-cutover-contract-v0.1.json
  - cutover/foundation-v2-cutover-conformance-v0.1.json
  - cutover/foundation-v2-cutover-candidate-v0.1.json
  - tests/test_direct_deixis_cutover_decision.py
must_not_touch:
  - contracts/mts-contract-v0.6.json
  - contracts/mts-conformance-v0.6.json
  - core/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - establish a non-accepted post-C7 owner contract without assigning an accepted MTS version
  - keep the frozen accepted contracts directory unchanged until C9
  - freeze current identity, four-abit and read-only boundaries for C7/C8
  - bind C8 to existing executable Foundation-v2/ANUM gates and negative vectors
  - preserve MTS v0.6 unchanged and keep acceptance/cutover/downstream-repin flags false
```

Refs #394, #271, #397, #393, #343.