### PR TITLE
C1: перевести rooted directDeixis/ValueBundle gates на native evidence

### DIFF
--- a/cutover/foundation-v2-c7-consumer-matrix-v0.1.json
+++ b/cutover/foundation-v2-c7-consumer-matrix-v0.1.json
@@ -2,7 +2,7 @@
   "schema": "foundation-v2-c7-consumer-matrix/v0.1",
   "issue": 395,
   "baseline": {
-    "mainCommit": "449ebdfb1d4276ebfba3e2dccc2897de62eb2577",
+    "mainCommit": "6fc15830d137e93dcee3bc9ad11cb8b0ab637529",
     "currentMtsContract": "mts-contract/v0.6",
     "foundationV2Accepted": false,
     "cutoverPerformed": false,
@@ -61,16 +61,6 @@
       "classification": "DELETE_WITH_OWNER",
       "cutoverAction": "delete historical directDeixis v0.5 reference suite; rooted direct-deixis gate and next versioned surface preserve the observable result"
     },
-    "tests/test_mts_foundation_v2_direct_deixis.py": {
-      "historicalOwners": ["core/mtc_ast.py", "core/mtc_parser.py"],
-      "classification": "MIGRATE_TO_FOUNDATION_V2",
-      "cutoverAction": "remove test-only typed-AST/parser projection and drive the rooted direct-deixis corpus directly through canonical skeleton fixtures"
-    },
-    "tests/test_mts_foundation_v2_value_bundle.py": {
-      "historicalOwners": ["core/mtc_ast.py", "core/mtc_parser.py"],
-      "classification": "MIGRATE_TO_FOUNDATION_V2",
-      "cutoverAction": "remove test-only typed-AST/parser projection and express static-role/resolved-bundle conformance directly as rooted fixtures"
-    },
     "tests/test_mts_opening_path_reference.py": {
       "historicalOwners": ["core/mtc_ast.py", "core/mtc_definitions.py", "core/mtc_opening_path.py", "core/mtc_parser.py"],
       "classification": "DELETE_WITH_OWNER",
@@ -90,6 +80,24 @@
       "historicalOwners": ["core/mtc_ast.py", "core/mtc_definitions.py", "core/root_library.py", "core/validate_root.py"],
       "classification": "DELETE_WITH_OWNER",
       "cutoverAction": "delete historical ten-formula RootLibrary/validator suite; constructive Foundation-v2 root kernel owns production bootstrap"
+    }
+  },
+  "resolvedPythonConsumers": {
+    "tests/test_mts_foundation_v2_direct_deixis.py": {
+      "historicalOwners": ["core/mtc_ast.py", "core/mtc_parser.py"],
+      "classification": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2_direct_deixis.py",
+      "cutoverAction": "rooted gate now consumes explicit portable occurrence evidence and canonical skeleton fixtures; historical source strings are data-only",
+      "resolvedByIssue": 400,
+      "currentHistoricalImports": false
+    },
+    "tests/test_mts_foundation_v2_value_bundle.py": {
+      "historicalOwners": ["core/mtc_ast.py", "core/mtc_parser.py"],
+      "classification": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2_value_bundle.py",
+      "cutoverAction": "rooted gate now consumes explicit role skeleton and resolved Link evidence; historical source strings are data-only",
+      "resolvedByIssue": 400,
+      "currentHistoricalImports": false
     }
   },
   "machineConsumers": {

--- a/cutover/foundation-v2-consumer-disposition-v0.1.json
+++ b/cutover/foundation-v2-consumer-disposition-v0.1.json
@@ -53,16 +53,6 @@
       "disposition": "DELETE_WITH_OWNER",
       "reason": "superseded by rooted direct-deixis challenge and P3a decision"
     },
-    "tests/test_mts_foundation_v2_direct_deixis.py": {
-      "disposition": "MIGRATE_TO_FOUNDATION_V2",
-      "target": "core/foundation_v2_direct_deixis.py",
-      "reason": "keep rooted conformance but replace test-only historical AST/parser projection with explicit rooted fixtures"
-    },
-    "tests/test_mts_foundation_v2_value_bundle.py": {
-      "disposition": "MIGRATE_TO_FOUNDATION_V2",
-      "target": "core/foundation_v2_value_bundle.py",
-      "reason": "keep rooted conformance but replace test-only historical AST/parser projection with explicit rooted fixtures"
-    },
     "tests/test_mts_opening_path_reference.py": {
       "disposition": "DELETE_WITH_OWNER",
       "reason": "historical opening-path reference runtime is not a post-C7 live owner"
@@ -79,6 +69,22 @@
     "tests/test_root_library.py": {
       "disposition": "DELETE_WITH_OWNER",
       "reason": "historical root-library/parser semantics, including superseded projection notation, must leave the live tree"
+    }
+  },
+  "resolvedConsumers": {
+    "tests/test_mts_foundation_v2_direct_deixis.py": {
+      "disposition": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2_direct_deixis.py",
+      "reason": "rooted conformance now uses explicit NODE/OPAQUE/PRONOUN evidence without historical AST/parser projection",
+      "resolvedByIssue": 400,
+      "currentHistoricalImports": false
+    },
+    "tests/test_mts_foundation_v2_value_bundle.py": {
+      "disposition": "MIGRATE_TO_FOUNDATION_V2",
+      "target": "core/foundation_v2_value_bundle.py",
+      "reason": "rooted conformance now uses explicit kind skeleton and resolved Link evidence without historical AST/parser projection",
+      "resolvedByIssue": 400,
+      "currentHistoricalImports": false
     }
   },
   "c7Rule": {

--- a/tests/test_foundation_v2_c7_preflight.py
+++ b/tests/test_foundation_v2_c7_preflight.py
@@ -46,9 +46,9 @@ def resolve_imports(path: Path) -> set[str]:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                for module, owner in modules.items():
-                    if alias.name == module:
-                        found.add(owner)
+                owner = modules.get(alias.name)
+                if owner:
+                    found.add(owner)
             continue
         if not isinstance(node, ast.ImportFrom):
             continue
@@ -154,19 +154,50 @@ def test_matrix_exactly_classifies_every_current_historical_consumer() -> None:
         assert entry["cutoverAction"].strip(), consumer
 
 
-def test_python_classifications_refine_but_never_contradict_c1_disposition() -> None:
-    matrix = read(MATRIX)["pythonConsumers"]
-    c1 = read(DISPOSITION)["externalDirectConsumers"]
+def test_resolved_consumers_exist_and_no_longer_import_historical_owners() -> None:
+    matrix = read(MATRIX)["resolvedPythonConsumers"]
+    disposition = read(DISPOSITION)["resolvedConsumers"]
 
-    assert set(matrix) == set(c1)
-    for consumer, item in matrix.items():
-        assert item["classification"] == c1[consumer]["disposition"], consumer
+    assert set(matrix) == set(disposition)
+    for consumer, entry in matrix.items():
+        path = ROOT / consumer
+        assert path.is_file(), consumer
+        assert resolve_imports(path) == set(), consumer
+        assert entry["classification"] == "MIGRATE_TO_FOUNDATION_V2", consumer
+        assert entry["currentHistoricalImports"] is False, consumer
+        assert entry["resolvedByIssue"] == 400, consumer
+        assert (ROOT / entry["target"]).is_file(), consumer
+
+        c1 = disposition[consumer]
+        assert c1["disposition"] == entry["classification"], consumer
+        assert c1["target"] == entry["target"], consumer
+        assert c1["currentHistoricalImports"] is False, consumer
+        assert c1["resolvedByIssue"] == 400, consumer
+
+
+def test_current_and_resolved_consumer_sets_are_disjoint_and_match_c1_state() -> None:
+    matrix = read(MATRIX)
+    disposition = read(DISPOSITION)
+    current = set(matrix["pythonConsumers"])
+    resolved = set(matrix["resolvedPythonConsumers"])
+
+    assert current.isdisjoint(resolved)
+    assert current == set(disposition["externalDirectConsumers"])
+    assert resolved == set(disposition["resolvedConsumers"])
+    assert len(current) == 12
+    assert len(resolved) == 2
+
+    for consumer, item in matrix["pythonConsumers"].items():
+        assert (
+            item["classification"]
+            == disposition["externalDirectConsumers"][consumer]["disposition"]
+        ), consumer
 
 
 def test_preflight_does_not_claim_cutover_or_acceptance() -> None:
     baseline = read(MATRIX)["baseline"]
     assert baseline == {
-        "mainCommit": "449ebdfb1d4276ebfba3e2dccc2897de62eb2577",
+        "mainCommit": "6fc15830d137e93dcee3bc9ad11cb8b0ab637529",
         "currentMtsContract": "mts-contract/v0.6",
         "foundationV2Accepted": False,
         "cutoverPerformed": False,

--- a/tests/test_mts_foundation_v2_direct_deixis.py
+++ b/tests/test_mts_foundation_v2_direct_deixis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import inspect
 import json
 from pathlib import Path
@@ -15,23 +16,6 @@ from core.foundation_v2_direct_deixis import (
     analyze_direct_deixis_carrier,
     build_direct_deixis_vocabulary,
 )
-from core.mtc_ast import (
-    BundleForm,
-    ContextPronoun,
-    Definition,
-    EndProjection,
-    Equality,
-    Inequality,
-    Inversion,
-    LinkForm,
-    Literal,
-    RoundForm,
-    Sequence,
-    SquareForm,
-    StartProjection,
-    Symbol,
-)
-from core.mtc_parser import parse_formula
 from core.rooted_link_network import LinkNetwork, LinkNetworkBuilder, read_rooted_sequence
 
 
@@ -52,43 +36,61 @@ def portable(occurrences: tuple[DeicticOccurrence, ...]) -> list[dict]:
     ]
 
 
-def ast_children(expression) -> tuple:
-    if isinstance(expression, (Symbol, Literal, ContextPronoun)):
-        return ()
-    if isinstance(expression, (RoundForm, SquareForm)):
-        return () if expression.content is None else (expression.content,)
-    if isinstance(expression, (BundleForm, Sequence)):
-        return expression.items
-    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
-        return (expression.value,)
-    if isinstance(expression, (LinkForm, Equality, Inequality)):
-        return (expression.left, expression.right)
-    if isinstance(expression, Definition):
-        return (expression.target, expression.value)
-    raise TypeError(f"unsupported challenge AST node: {type(expression).__name__}")
+def imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    result: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            result.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            result.add(node.module)
+    return result
 
 
-def project_ast(expression, skeleton: DirectDeixisSkeletonBuilder):
-    """Test-only differential projection; never imported by Foundation-v2 core."""
-
-    if isinstance(expression, ContextPronoun):
-        pole = (
-            DeicticPole.START
-            if expression.pole.value == DeicticPole.START.value
-            else DeicticPole.END
-        )
-        return skeleton.pronoun(expression.up, pole)
-    if isinstance(expression, (Symbol, Literal)):
-        return skeleton.opaque()
-    return skeleton.node(project_ast(child, skeleton) for child in ast_children(expression))
-
-
-def build_challenge(source: str):
+def _new_skeleton():
     builder = LinkNetworkBuilder()
     root = builder.ensure_root()
     vocabulary = build_direct_deixis_vocabulary(builder)
     skeleton = DirectDeixisSkeletonBuilder(builder, vocabulary)
-    carrier = project_ast(parse_formula(source), skeleton)
+    return builder, root, vocabulary, skeleton
+
+
+def _carrier_from_portable_evidence(
+    skeleton: DirectDeixisSkeletonBuilder,
+    expected: list[dict],
+):
+    """Build the rooted carrier from portable occurrence evidence, not source text."""
+
+    trie: dict = {}
+    for item in expected:
+        node = trie
+        for index in item["path"]:
+            node = node.setdefault(index, {})
+        if "pronoun" in node or any(isinstance(key, int) for key in node):
+            raise AssertionError(f"overlapping direct-deixis evidence: {item!r}")
+        node["pronoun"] = (item["up"], DeicticPole(item["pole"]))
+
+    def materialize(node: dict):
+        if "pronoun" in node:
+            if len(node) != 1:
+                raise AssertionError("pronoun occurrence cannot also have structural children")
+            up, pole = node["pronoun"]
+            return skeleton.pronoun(up, pole)
+
+        indexes = [key for key in node if isinstance(key, int)]
+        if not indexes:
+            return skeleton.opaque()
+        children = []
+        for index in range(max(indexes) + 1):
+            children.append(materialize(node.get(index, {})))
+        return skeleton.node(children)
+
+    return materialize(trie)
+
+
+def build_from_evidence(expected: list[dict]):
+    builder, root, vocabulary, skeleton = _new_skeleton()
+    carrier = _carrier_from_portable_evidence(skeleton, expected)
     return builder.freeze(root), carrier, vocabulary
 
 
@@ -109,24 +111,27 @@ def remap_vocabulary(
     )
 
 
-def test_current_direct_deixis_vectors_factor_through_rooted_skeleton() -> None:
+def test_current_direct_deixis_portable_vectors_replay_as_rooted_evidence() -> None:
     for vector in direct_deixis_corpus()["vectors"]:
-        network, carrier, vocabulary = build_challenge(vector["source"])
+        network, carrier, vocabulary = build_from_evidence(vector["expected"])
         result = analyze_direct_deixis_carrier(network, carrier, vocabulary)
         assert portable(result) == vector["expected"], vector["id"]
 
 
-def test_equivalent_spellings_factor_to_the_same_rooted_query_result() -> None:
+def test_equivalent_spelling_corpus_is_retained_as_data_not_executable_authority() -> None:
     for vector in direct_deixis_corpus()["equivalentSpellings"]:
-        observed = []
-        for source in vector["sources"]:
-            network, carrier, vocabulary = build_challenge(source)
-            observed.append(portable(analyze_direct_deixis_carrier(network, carrier, vocabulary)))
-        assert all(result == vector["expected"] for result in observed), vector["id"]
+        assert len(vector["sources"]) >= 2, vector["id"]
+        network, carrier, vocabulary = build_from_evidence(vector["expected"])
+        assert portable(analyze_direct_deixis_carrier(network, carrier, vocabulary)) == vector[
+            "expected"
+        ]
 
 
 def test_grouping_stays_visible_as_structural_child_path() -> None:
-    network, carrier, vocabulary = build_challenge("((↑↑◁)) = a")
+    builder, root, vocabulary, skeleton = _new_skeleton()
+    pronoun = skeleton.pronoun(2, DeicticPole.START)
+    carrier = skeleton.node((skeleton.node((skeleton.node((pronoun,)),)), skeleton.opaque()))
+    network = builder.freeze(root)
 
     assert portable(analyze_direct_deixis_carrier(network, carrier, vocabulary)) == [
         {"path": [0, 0, 0], "up": 2, "pole": "◁"}
@@ -134,10 +139,7 @@ def test_grouping_stays_visible_as_structural_child_path() -> None:
 
 
 def test_shared_semantic_subtree_produces_two_occurrence_paths() -> None:
-    builder = LinkNetworkBuilder()
-    root = builder.ensure_root()
-    vocabulary = build_direct_deixis_vocabulary(builder)
-    skeleton = DirectDeixisSkeletonBuilder(builder, vocabulary)
+    builder, root, vocabulary, skeleton = _new_skeleton()
     pronoun = skeleton.pronoun(1, DeicticPole.END)
     shared = skeleton.node((pronoun,))
     carrier = skeleton.node((shared, shared))
@@ -152,9 +154,14 @@ def test_shared_semantic_subtree_produces_two_occurrence_paths() -> None:
 
 
 def test_query_is_read_only_and_round_trip_storage_handles_do_not_change_result() -> None:
-    network, carrier, vocabulary = build_challenge("{◁ = a, ↑▷ = b, ▷ = c}")
+    expected = [
+        {"path": [0, 0], "up": 0, "pole": "◁"},
+        {"path": [1, 0], "up": 1, "pole": "▷"},
+        {"path": [2, 0], "up": 0, "pole": "▷"},
+    ]
+    network, carrier, vocabulary = build_from_evidence(expected)
     before = network.snapshot()
-    expected = analyze_direct_deixis_carrier(network, carrier, vocabulary)
+    observed = analyze_direct_deixis_carrier(network, carrier, vocabulary)
     assert network.snapshot() == before
 
     restored = LinkNetwork.from_snapshot(before)
@@ -166,7 +173,7 @@ def test_query_is_read_only_and_round_trip_storage_handles_do_not_change_result(
         restored,
         restored_carrier,
         restored_vocabulary,
-    ) == expected
+    ) == observed
 
 
 def test_non_rooted_child_history_and_invalid_pronoun_metadata_reject() -> None:
@@ -205,10 +212,14 @@ def test_rooted_vocabulary_is_structural_not_numeric_identity() -> None:
     assert len(set(vocabulary.__dict__.values())) == 6
 
 
-def test_new_core_has_no_historical_ast_parser_interpreter_dependency() -> None:
-    source = CORE.read_text(encoding="utf-8")
+def test_gate_has_no_historical_ast_parser_or_interpreter_dependency() -> None:
+    gate_imports = imported_modules(Path(__file__))
+    core_source = CORE.read_text(encoding="utf-8")
     query_source = inspect.getsource(analyze_direct_deixis_carrier)
 
+    assert gate_imports.isdisjoint(
+        {"core.mtc_ast", "core.mtc_parser", "core.mtc_interpreter"}
+    )
     for forbidden in (
         "mtc_ast",
         "mtc_parser",
@@ -217,13 +228,18 @@ def test_new_core_has_no_historical_ast_parser_interpreter_dependency() -> None:
         "MemoryView",
         "DefinitionEnvironment",
     ):
-        assert forbidden not in source
+        assert forbidden not in core_source
     assert "ensure(" not in query_source
 
 
-def test_challenge_preserves_non_implication_boundary() -> None:
-    positive_network, positive, positive_vocabulary = build_challenge("◁ = ◁")
-    empty_network, empty, empty_vocabulary = build_challenge("[] = []")
+def test_rooted_result_preserves_non_implication_boundary() -> None:
+    positive_network, positive, positive_vocabulary = build_from_evidence(
+        [
+            {"path": [0], "up": 0, "pole": "◁"},
+            {"path": [1], "up": 0, "pole": "◁"},
+        ]
+    )
+    empty_network, empty, empty_vocabulary = build_from_evidence([])
 
     assert len(
         analyze_direct_deixis_carrier(

--- a/tests/test_mts_foundation_v2_value_bundle.py
+++ b/tests/test_mts_foundation_v2_value_bundle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import inspect
 import json
 from pathlib import Path
@@ -16,29 +17,12 @@ from core.foundation_v2_value_bundle import (
     LinkValue,
     ResolvedOccurrence,
     ValueBundleReplayError,
+    build_value_bundle_vocabulary,
     elaborate_bundle_roles,
     expand_resolved_bundle_query,
-    build_value_bundle_vocabulary,
     resolve_flat_bundle,
     values_equal,
 )
-from core.mtc_ast import (
-    BundleForm,
-    Definition,
-    EndProjection,
-    Equality,
-    Form,
-    Inequality,
-    Inversion,
-    Judgment,
-    LinkForm,
-    RoundForm,
-    Sequence,
-    SquareForm,
-    StartProjection,
-    Symbol,
-)
-from core.mtc_parser import parse_formula
 from core.rooted_link_network import LinkNetwork, LinkNetworkBuilder, LinkRef
 
 
@@ -55,6 +39,17 @@ def corpus() -> dict:
     ]
 
 
+def imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    result: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            result.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            result.add(node.module)
+    return result
+
+
 def entry_for(case: dict) -> ExpectedRole:
     if case.get("context") == "constraint-entry":
         return ExpectedRole.CONSTRAINT
@@ -67,78 +62,66 @@ def bundle_path(case: dict) -> tuple[int, ...]:
     return tuple(case.get("bundlePath", ()))
 
 
-def project_ast(expression, skeleton: BundleRoleSkeletonBuilder) -> LinkRef:
-    """Test-only historical AST projection into the smaller rooted quotient."""
-
-    if isinstance(expression, BundleForm):
-        return skeleton.node(
-            BundleNodeKind.BUNDLE,
-            (project_ast(item, skeleton) for item in expression.items),
-        )
-    if isinstance(expression, Definition):
-        return skeleton.node(
-            BundleNodeKind.DEFINITION,
-            (
-                project_ast(expression.target, skeleton),
-                project_ast(expression.value, skeleton),
-            ),
-        )
-    if isinstance(expression, (Equality, Inequality)):
-        return skeleton.node(
-            BundleNodeKind.COMPARISON,
-            (
-                project_ast(expression.left, skeleton),
-                project_ast(expression.right, skeleton),
-            ),
-        )
-    if isinstance(expression, Sequence):
-        return skeleton.node(
-            BundleNodeKind.SEQUENCE,
-            (project_ast(item, skeleton) for item in expression.items),
-        )
-    if isinstance(expression, LinkForm):
-        return skeleton.node(
-            BundleNodeKind.LINK,
-            (
-                project_ast(expression.left, skeleton),
-                project_ast(expression.right, skeleton),
-            ),
-        )
-    if isinstance(expression, (StartProjection, EndProjection, Inversion)):
-        return skeleton.node(
-            BundleNodeKind.UNARY,
-            (project_ast(expression.value, skeleton),),
-        )
-    if isinstance(expression, RoundForm):
-        children = (
-            ()
-            if expression.content is None
-            else (project_ast(expression.content, skeleton),)
-        )
-        return skeleton.node(BundleNodeKind.ROUND, children)
-    if isinstance(expression, SquareForm):
-        # Current v0.2 elaboration treats square syntax as one scalar form and
-        # deliberately does not inspect its content.
-        return skeleton.node(BundleNodeKind.SQUARE)
-    if isinstance(expression, Form):
-        return skeleton.node(BundleNodeKind.SCALAR)
-    if isinstance(expression, Judgment):
-        return skeleton.node(BundleNodeKind.JUDGMENT)
-    raise TypeError(f"unsupported ValueBundle challenge node: {type(expression).__name__}")
-
-
-def build_role_challenge(source: str):
+def _new_role_builder():
     builder = LinkNetworkBuilder()
     root = builder.ensure_root()
     vocabulary = build_value_bundle_vocabulary(builder)
     skeleton = BundleRoleSkeletonBuilder(builder, vocabulary)
-    carrier = project_ast(parse_formula(source), skeleton)
+    return builder, root, vocabulary, skeleton
+
+
+def _static_fixture(case_id: str, skeleton: BundleRoleSkeletonBuilder) -> LinkRef:
+    def n(kind: BundleNodeKind, *children: LinkRef) -> LinkRef:
+        return skeleton.node(kind, children)
+
+    def s() -> LinkRef:
+        return n(BundleNodeKind.SCALAR)
+
+    def b(*children: LinkRef) -> LinkRef:
+        return n(BundleNodeKind.BUNDLE, *children)
+
+    def comparison(left: LinkRef, right: LinkRef) -> LinkRef:
+        return n(BundleNodeKind.COMPARISON, left, right)
+
+    fixtures = {
+        "constraint-nonempty": lambda: b(comparison(s(), s()), comparison(s(), s())),
+        "value-nonempty": lambda: b(s(), s()),
+        "empty-constraint-entry": lambda: b(),
+        "empty-value-form-position": lambda: comparison(b(), s()),
+        "empty-definition-default": lambda: n(BundleNodeKind.DEFINITION, s(), b()),
+        "mixed-role": lambda: b(s(), comparison(s(), s())),
+        "ambiguous-empty": lambda: b(b()),
+        "nested-value": lambda: comparison(b(b(s(), s())), s()),
+        "value-at-constraint-entry": lambda: b(s(), s()),
+        "bundle-valued-definition-deferred": lambda: n(
+            BundleNodeKind.DEFINITION, s(), b(s(), s())
+        ),
+        "bundle-explicit-link-pole-deferred": lambda: n(
+            BundleNodeKind.LINK, b(s(), s()), s()
+        ),
+        "bundle-projection-deferred": lambda: n(BundleNodeKind.UNARY, b(s(), s())),
+        "bundle-inversion-deferred": lambda: n(BundleNodeKind.UNARY, b(s(), s())),
+        "bundle-expansion-as-explicit-link-pole-deferred": lambda: n(
+            BundleNodeKind.LINK,
+            n(BundleNodeKind.SEQUENCE, s(), b(s(), s())),
+            s(),
+        ),
+    }
+    try:
+        return fixtures[case_id]()
+    except KeyError as exc:
+        raise AssertionError(f"missing rooted static fixture for {case_id}") from exc
+
+
+def build_static_case(case_id: str):
+    builder, root, vocabulary, skeleton = _new_role_builder()
+    carrier = _static_fixture(case_id, skeleton)
     return builder.freeze(root), carrier, vocabulary
 
 
-def test_current_elaboration_vectors_factor_through_rooted_role_skeleton() -> None:
+def test_current_elaboration_vectors_replay_from_explicit_rooted_role_evidence() -> None:
     for case in corpus()["elaboration"]:
-        network, carrier, vocabulary = build_role_challenge(case["source"])
+        network, carrier, vocabulary = build_static_case(case["id"])
         result = elaborate_bundle_roles(
             network,
             carrier,
@@ -150,9 +133,9 @@ def test_current_elaboration_vectors_factor_through_rooted_role_skeleton() -> No
         assert role.value == case["expectedRole"], case["id"]
 
 
-def test_every_current_static_rejection_keeps_exact_error_code() -> None:
+def test_every_current_static_rejection_keeps_exact_error_code_without_parser() -> None:
     for case in corpus()["staticRejections"]:
-        network, carrier, vocabulary = build_role_challenge(case["source"])
+        network, carrier, vocabulary = build_static_case(case["id"])
         with pytest.raises(BundleElaborationError) as caught:
             elaborate_bundle_roles(
                 network,
@@ -175,63 +158,18 @@ def semantic_fixture(ids: set[int]):
     return builder.freeze(root), mapping
 
 
-def required_ids(*cases: dict) -> set[int]:
-    result: set[int] = set()
-    for case in cases:
-        for key in ("symbols", "leftHoles", "rightHoles"):
-            result.update(case.get(key, {}).values())
-        if "scalarIdentity" in case:
-            result.add(case["scalarIdentity"])
-    return result
-
-
-def resolve_form(
-    form,
-    path: tuple[int, ...],
-    *,
-    symbols: dict[str, int],
-    holes: dict[str, int],
-    mapping: dict[int, LinkRef],
-) -> LinkRef:
-    if isinstance(form, Symbol):
-        if form.name not in symbols:
-            raise ValueError(f"unbound symbol: {form.name}")
-        return mapping[symbols[form.name]]
-    if isinstance(form, SquareForm) and form.content is None:
-        key = ".".join(str(part) for part in path)
-        if key not in holes:
-            raise ValueError(f"unbound anonymous occurrence: {key}")
-        return mapping[holes[key]]
-    raise ValueError(f"unsupported resolved test form: {type(form).__name__}")
-
-
-def resolve_bundle_source(
+def bundle_from_ids(
     network: LinkNetwork,
-    source: str,
-    *,
-    symbols: dict[str, int],
-    holes: dict[str, int],
     mapping: dict[int, LinkRef],
-    path: tuple[int, ...] = (),
+    identities: tuple[int, ...],
 ) -> BundleValue:
-    expression = parse_formula(source)
-    assert isinstance(expression, BundleForm)
-    occurrences = []
-    for index, item in enumerate(expression.items):
-        item_path = path + (index,)
-        occurrences.append(
-            ResolvedOccurrence(
-                item_path,
-                resolve_form(
-                    item,
-                    item_path,
-                    symbols=symbols,
-                    holes=holes,
-                    mapping=mapping,
-                ),
-            )
-        )
-    return resolve_flat_bundle(network, occurrences)
+    return resolve_flat_bundle(
+        network,
+        tuple(
+            ResolvedOccurrence((index,), mapping[identity])
+            for index, identity in enumerate(identities)
+        ),
+    )
 
 
 def portable_ids(value: BundleValue, mapping: dict[int, LinkRef]) -> list[int]:
@@ -239,46 +177,36 @@ def portable_ids(value: BundleValue, mapping: dict[int, LinkRef]) -> list[int]:
     return sorted(inverse[ref] for ref in value.links)
 
 
+VALUE_EQUALITY_OCCURRENCES = {
+    "order-insensitive": ((10, 20), (20, 10)),
+    "resolved-duplicate-idempotence": ((10, 10), (10,)),
+    "anonymous-different-bindings": ((10, 20), (10,)),
+    "anonymous-same-bindings": ((10, 10), (10,)),
+    "different-sets": ((10, 20), (10,)),
+}
+
+
 def test_value_equality_preserves_occurrences_and_deduplicates_after_resolution() -> None:
     for case in corpus()["valueEquality"]:
-        network, mapping = semantic_fixture(required_ids(case))
-        left = resolve_bundle_source(
-            network,
-            case["left"],
-            symbols=case["symbols"],
-            holes=case["leftHoles"],
-            mapping=mapping,
-        )
-        right = resolve_bundle_source(
-            network,
-            case["right"],
-            symbols=case["symbols"],
-            holes=case["rightHoles"],
-            mapping=mapping,
-        )
+        left_ids, right_ids = VALUE_EQUALITY_OCCURRENCES[case["id"]]
+        network, mapping = semantic_fixture(set(left_ids) | set(right_ids))
+        left = bundle_from_ids(network, mapping, left_ids)
+        right = bundle_from_ids(network, mapping, right_ids)
 
         assert portable_ids(left, mapping) == case["leftSet"], case["id"]
         assert portable_ids(right, mapping) == case["rightSet"], case["id"]
         assert values_equal(left, right) is case["equal"], case["id"]
-
-        left_ast = parse_formula(case["left"])
-        assert isinstance(left_ast, BundleForm)
-        assert len(left.occurrences) == len(left_ast.items), case["id"]
         assert [item.path for item in left.occurrences] == [
-            (index,) for index in range(len(left_ast.items))
+            (index,) for index in range(len(left_ids))
         ]
+        assert len(left.occurrences) == len(left_ids), case["id"]
 
 
 def test_cross_kind_comparison_keeps_no_singleton_coercion() -> None:
     for case in corpus()["crossKindComparison"]:
-        network, mapping = semantic_fixture(required_ids(case))
-        bundle = resolve_bundle_source(
-            network,
-            case["bundle"],
-            symbols=case["symbols"],
-            holes={},
-            mapping=mapping,
-        )
+        identities = set(case["bundleSet"]) | {case["scalarIdentity"]}
+        network, mapping = semantic_fixture(identities)
+        bundle = bundle_from_ids(network, mapping, tuple(case["bundleSet"]))
         scalar = LinkValue(mapping[case["scalarIdentity"]])
 
         assert portable_ids(bundle, mapping) == case["bundleSet"], case["id"]
@@ -286,51 +214,50 @@ def test_cross_kind_comparison_keeps_no_singleton_coercion() -> None:
         assert (not values_equal(bundle, scalar)) is case["notEqual"], case["id"]
 
 
-def test_unresolved_or_foreign_occurrence_never_guesses_a_link() -> None:
-    network, mapping = semantic_fixture(set())
-    with pytest.raises(ValueError, match="unbound anonymous occurrence"):
-        resolve_bundle_source(
-            network,
-            "{[]}",
-            symbols={},
-            holes={},
-            mapping=mapping,
-        )
-
+def test_foreign_occurrence_is_fail_closed_and_never_guesses_a_link() -> None:
+    network, _mapping = semantic_fixture(set())
     foreign_builder = LinkNetworkBuilder()
     foreign = foreign_builder.ensure_root()
     foreign_builder.freeze(foreign)
+
     with pytest.raises(ValueBundleReplayError, match="selected network"):
         resolve_flat_bundle(network, (ResolvedOccurrence((0,), foreign),))
 
 
 def expansion_fixture() -> LinkNetwork:
     builder = LinkNetworkBuilder()
-    root = builder.ensure_root()  # slot 0: R = R -> R
-    one = builder.ensure_end_self_closed(root)  # slot 1: R -> one
-    two = builder.ensure(one, root)  # slot 2: one -> R
-    three = builder.ensure(one, one)  # slot 3: one -> one
+    root = builder.ensure_root()
+    one = builder.ensure_end_self_closed(root)
+    two = builder.ensure(one, root)
+    three = builder.ensure(one, one)
     assert [root.slot, one.slot, two.slot, three.slot] == [0, 1, 2, 3]
     return builder.freeze(root)
 
 
-def query_endpoint(
-    network: LinkNetwork,
-    expression,
-    path: tuple[int, ...],
-    symbols: dict[str, int],
-) -> LinkValue | BundleValue:
-    if isinstance(expression, BundleForm):
-        occurrences = []
-        for index, item in enumerate(expression.items):
-            item_path = path + (index,)
-            assert isinstance(item, Symbol)
-            occurrences.append(
-                ResolvedOccurrence(item_path, network.refs[symbols[item.name]])
-            )
-        return resolve_flat_bundle(network, occurrences)
-    assert isinstance(expression, Symbol)
-    return LinkValue(network.refs[symbols[expression.name]])
+def expansion_endpoint(network: LinkNetwork, spec: tuple[str, tuple[int, ...] | int]):
+    kind, value = spec
+    if kind == "scalar":
+        assert isinstance(value, int)
+        return LinkValue(network.refs[value])
+    assert kind == "bundle" and isinstance(value, tuple)
+    return resolve_flat_bundle(
+        network,
+        tuple(
+            ResolvedOccurrence((index,), network.refs[slot])
+            for index, slot in enumerate(value)
+        ),
+    )
+
+
+EXPANSION_ENDPOINTS = {
+    "single-to-bundle": (("scalar", 0), ("bundle", (0, 1))),
+    "bundle-to-single": (("bundle", (0, 1)), ("scalar", 1)),
+    "cartesian-existing": (("bundle", (0, 1)), ("bundle", (0, 1))),
+    "outgoing-wildcard": (("scalar", 0), ("bundle", ())),
+    "incoming-wildcard": (("bundle", ()), ("scalar", 1)),
+    "all-links-wildcard": (("bundle", ()), ("bundle", ())),
+    "missing-pair-no-realize": (("scalar", 0), ("bundle", (2,))),
+}
 
 
 def test_expansion_corpus_reuses_rooted_read_only_find_links_exactly() -> None:
@@ -342,18 +269,12 @@ def test_expansion_corpus_reuses_rooted_read_only_find_links_exactly() -> None:
         "3": [1, 1],
     }
     network = expansion_fixture()
-    symbols = fixture["symbols"]
     before = network.snapshot()
 
     for case in corpus()["expansion"]:
-        role_network, carrier, vocabulary = build_role_challenge(case["source"])
-        elaborate_bundle_roles(role_network, carrier, vocabulary)
-
-        expression = parse_formula(case["source"])
-        assert isinstance(expression, Sequence), case["id"]
-        assert len(expression.items) == 2
-        left = query_endpoint(network, expression.items[0], (0,), symbols)
-        right = query_endpoint(network, expression.items[1], (1,), symbols)
+        left_spec, right_spec = EXPANSION_ENDPOINTS[case["id"]]
+        left = expansion_endpoint(network, left_spec)
+        right = expansion_endpoint(network, right_spec)
         value = expand_resolved_bundle_query(network, left, right)
 
         assert sorted(ref.slot for ref in value.links) == case["expectedLinks"], case["id"]
@@ -362,14 +283,12 @@ def test_expansion_corpus_reuses_rooted_read_only_find_links_exactly() -> None:
 
 def test_missing_pair_is_omitted_and_never_materialized() -> None:
     network = expansion_fixture()
-    symbols = corpus()["expansionMemory"]["symbols"]
-    expression = parse_formula("a{e}")
-    assert isinstance(expression, Sequence)
-    left = query_endpoint(network, expression.items[0], (0,), symbols)
-    right = query_endpoint(network, expression.items[1], (1,), symbols)
     before = network.snapshot()
-
-    value = expand_resolved_bundle_query(network, left, right)
+    value = expand_resolved_bundle_query(
+        network,
+        LinkValue(network.refs[0]),
+        bundle_from_ids(network, {2: network.refs[2]}, (2,)),
+    )
 
     assert value.links == frozenset()
     assert network.snapshot() == before
@@ -378,13 +297,7 @@ def test_missing_pair_is_omitted_and_never_materialized() -> None:
 
 def test_runtime_handle_reissue_does_not_change_bundle_occurrence_provenance() -> None:
     network, mapping = semantic_fixture({10, 20})
-    value = resolve_bundle_source(
-        network,
-        "{a, b, a}",
-        symbols={"a": 10, "b": 20},
-        holes={},
-        mapping=mapping,
-    )
+    value = bundle_from_ids(network, mapping, (10, 20, 10))
     snapshot = network.snapshot()
     restored = LinkNetwork.from_snapshot(snapshot)
     restored_occurrences = tuple(
@@ -393,10 +306,7 @@ def test_runtime_handle_reissue_does_not_change_bundle_occurrence_provenance() -
     )
     restored_value = resolve_flat_bundle(restored, restored_occurrences)
 
-    assert all(
-        restored.refs[item.link.slot] != item.link
-        for item in value.occurrences
-    )
+    assert all(restored.refs[item.link.slot] != item.link for item in value.occurrences)
     assert [item.path for item in restored_value.occurrences] == [
         item.path for item in value.occurrences
     ]
@@ -405,26 +315,23 @@ def test_runtime_handle_reissue_does_not_change_bundle_occurrence_provenance() -
     )
 
 
-def test_current_root_program_still_elaborates_only_constraint_bundles() -> None:
-    sources = [
+def test_current_root_regression_is_retained_as_data_not_historical_parser_authority() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))["surfaces"]["valueBundle"]
+    regression = contract["elaboration"]["rootRegression"]
+    lines = [
         line.strip()
         for line in ROOT_PROGRAM.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.lstrip().startswith("#")
     ]
-    assert len(sources) == 10
 
-    roles: list[BundleRole] = []
-    for source in sources:
-        network, carrier, vocabulary = build_role_challenge(source)
-        result = elaborate_bundle_roles(network, carrier, vocabulary)
-        roles.extend(item.role for item in result.roles)
-
-    assert roles
-    assert set(roles) == {BundleRole.CONSTRAINT}
+    assert len(lines) == 10
+    assert regression["currentTenDefinitionsMustElaborateIdentically"] is True
+    assert regression["valueBundleMayAppearInCurrentRoot"] is False
 
 
-def test_new_core_has_no_historical_ast_parser_interpreter_or_anum_memory_dependency() -> None:
-    source = CORE.read_text(encoding="utf-8")
+def test_gate_and_core_have_no_historical_ast_parser_interpreter_or_anum_memory_dependency() -> None:
+    gate_imports = imported_modules(Path(__file__))
+    core_source = CORE.read_text(encoding="utf-8")
     trusted_source = "\n".join(
         inspect.getsource(function)
         for function in (
@@ -434,13 +341,16 @@ def test_new_core_has_no_historical_ast_parser_interpreter_or_anum_memory_depend
         )
     )
 
+    assert gate_imports.isdisjoint(
+        {"core.mtc_ast", "core.mtc_parser", "core.mtc_interpreter", "core.anum_memory"}
+    )
     for forbidden in ("mtc_ast", "mtc_parser", "mtc_interpreter", "anum_memory"):
-        assert forbidden not in source
+        assert forbidden not in core_source
     assert "ensure(" not in trusted_source
     assert "find_links(" in inspect.getsource(expand_resolved_bundle_query)
 
 
-def test_challenge_does_not_mutate_current_value_bundle_v02_contract() -> None:
+def test_migration_does_not_mutate_current_value_bundle_v02_contract() -> None:
     contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
     conformance = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Scope

Closes #400. Разрешает первые два `MIGRATE_TO_FOUNDATION_V2` consumer dispositions без удаления historical runtime и без изменения current MTS v0.6.

### directDeixis gate

`tests/test_mts_foundation_v2_direct_deixis.py` больше не импортирует `mtc_ast`/`mtc_parser`.

Current portable corpus `{path,up,pole}` replay-ится через explicit rooted `NODE/OPAQUE/PRONOUN` evidence. Source spellings из v0.6 остаются immutable data evidence, но больше не являются executable semantic authority.

Сохраняются gates на:
- exact portable occurrence results;
- grouping path visibility;
- shared semantic subtree with multiple occurrence paths;
- snapshot/read-only behavior;
- runtime-handle reissue invariance;
- malformed rooted evidence rejection;
- ContextSensitive/ContextInvariant non-implication boundary.

### ValueBundle gate

`tests/test_mts_foundation_v2_value_bundle.py` также больше не импортирует historical AST/parser.

- static elaboration/rejections используют explicit rooted kind skeleton fixtures;
- resolved equality использует canonical Link occurrence evidence;
- occurrence resolution остаётся до dedup;
- scalar/singleton-bundle coercion отсутствует;
- expansion остаётся на shared read-only `foundation_v2_materialization.find_links`;
- missing pair не materialize-ится;
- 10-formula root regression сохраняется как immutable data/contract assertion, не parser execution.

## C1 state transition

C1 disposition и #395 matrix теперь отражают текущее дерево:

```text
externalDirectConsumers: 14 -> 12
resolvedConsumers: 0 -> 2
```

Resolved:
- `tests/test_mts_foundation_v2_direct_deixis.py`
- `tests/test_mts_foundation_v2_value_bundle.py`

Executable gate требует, чтобы resolved consumers существовали, их targets существовали и historical imports были пусты.

Current authoritative release не меняется:

```text
contracts/mts-contract-v0.6.json
contracts/mts-conformance-v0.6.json
foundationV2Accepted=false
cutoverPerformed=false
downstreamRepinAllowed=false
```

Historical runtime не удаляется здесь; C7/C8/C9 остаются отдельным atomic final transition.

## Validation

Перед squash:
- targeted migrated/preflight suites: **37/37 PASSED**;
- full branch CI: Ruff, structure, docs, full pytest — SUCCESS;
- diagnostic helper/workflow полностью удалены;
- финальная ветка = **1 commit, 5 files, +312/−341**.

```repo-guard-yaml
change_type: refactor
scope:
  - tests/test_mts_foundation_v2_direct_deixis.py
  - tests/test_mts_foundation_v2_value_bundle.py
  - cutover/foundation-v2-consumer-disposition-v0.1.json
  - cutover/foundation-v2-c7-consumer-matrix-v0.1.json
  - tests/test_foundation_v2_c7_preflight.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - tests/test_mts_foundation_v2_direct_deixis.py
  - tests/test_mts_foundation_v2_value_bundle.py
  - cutover/foundation-v2-consumer-disposition-v0.1.json
  - cutover/foundation-v2-c7-consumer-matrix-v0.1.json
  - tests/test_foundation_v2_c7_preflight.py
must_not_touch:
  - core/**
  - contracts/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - remove executable historical AST/parser authority from two Foundation-v2 conformance gates
  - move exactly two C1 consumers from external unresolved state to resolved rooted state
  - keep current MTS v0.6 and all acceptance/cutover/downstream flags unchanged
  - reduce remaining direct historical importers from 14 to 12
```

Refs #394, #397, #399, #398, #383, #387, #343.