### PR TITLE
Governance: разрешить ровно выпуск второй пары MTS contracts

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -32,7 +32,7 @@
   },
   "diff_rules": {
     "max_new_docs": 0,
-    "max_new_files": 3,
+    "max_new_files": 4,
     "max_net_added_lines": 800
   },
   "size_rules": [
@@ -41,8 +41,8 @@
       "scope": "directory",
       "metric": "files",
       "glob": "contracts/**",
-      "max": 1000,
-      "max_growth": 0,
+      "max": 4,
+      "max_growth": 2,
       "count": "all_tracked",
       "level": "blocking"
     },


### PR DESCRIPTION
Closes #404. Prerequisite for #401 / #403.

Governance-only изменение. Production/runtime/contracts/tests/docs не затрагиваются.

Разрешаются ровно два policy relaxation, санкционированные trusted issue #404:

- `/diff_rules/max_new_files`: `3 → 4`;
- `/size_rules/contracts-file-count-no-growth/max_growth`: `0 → 2`.

Одновременно absolute cap `contracts/**` ужесточается `1000 → 4`, поэтому после выпуска пары v0.7 пятый contract JSON снова блокируется.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - .github/**
  - contracts/**
  - core/**
  - tests/**
  - docs/**
expected_effects:
  - authorize exactly four new files for the pending atomic v0.7 release
  - allow exactly two new versioned contract files in that release
  - tighten the absolute contracts file cap to four
```
