### PR TITLE
Research: rebase relational actuality onto rooted run positions

### DIFF
--- a/tests/test_mts_foundation_v2_run.py
+++ b/tests/test_mts_foundation_v2_run.py
@@ -168,13 +168,8 @@ def test_explicit_context_can_select_run_position_without_duplicate_act() -> Non
         after_role=after_role,
     )
 
-    same_act = define_act_header(
-        builder,
-        interpreter,
-        builder._links[step.act.slot].start,
-        k0,
-    )
-    assert same_act is step.act
+    act_header = builder._links[step.act.slot].end
+    assert builder.ensure_start_self_closed(act_header) is step.act
 
     evidence = _run(builder, root, (step, step), k0, k0)
     first_position = builder.ensure(root, step.act)

--- a/tests/test_mts_foundation_v2_run.py
+++ b/tests/test_mts_foundation_v2_run.py
@@ -14,6 +14,7 @@ from core.foundation_v2_run import (
     replay_run,
 )
 from core.foundation_v2_state import (
+    current_of_context,
     define_act_field,
     define_act_header,
     define_context,
@@ -148,6 +149,52 @@ def test_same_act_can_occupy_two_run_positions_without_copying_act() -> None:
     assert head.end is step.act
     assert tail.end is step.act
     assert tail.start is not root
+
+
+def test_explicit_context_can_select_run_position_without_duplicate_act() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    k0 = _context(builder)
+    before_role = _anchor(builder)
+    after_role = _anchor(builder)
+    interpreter = _anchor(builder)
+    step = _step(
+        builder,
+        root,
+        k0,
+        k0,
+        interpreter=interpreter,
+        before_role=before_role,
+        after_role=after_role,
+    )
+
+    same_act = define_act_header(
+        builder,
+        interpreter,
+        builder._links[step.act.slot].start,
+        k0,
+    )
+    assert same_act is step.act
+
+    evidence = _run(builder, root, (step, step), k0, k0)
+    first_position = builder.ensure(root, step.act)
+    second_position = evidence.run_root
+    assert second_position is builder.ensure(first_position, step.act)
+    assert first_position is not second_position
+
+    deictic_parent = _anchor(builder)
+    first_current = _context(builder, deictic_parent, first_position)
+    second_current = _context(builder, deictic_parent, second_position)
+    network = builder.freeze(root)
+    snapshot = network.snapshot()
+
+    assert replay_run(network, evidence) == (step.act, step.act)
+    assert current_of_context(network, first_current) is first_position
+    assert current_of_context(network, second_current) is second_position
+    assert network.link(first_position).end is step.act
+    assert network.link(second_position).end is step.act
+    assert network.link(second_position).start is first_position
+    assert network.snapshot() == snapshot
 
 
 def test_finite_context_return_replays_without_recursive_unfolding() -> None:


### PR DESCRIPTION
Closes #170. Refs #229, #343, #401.

Старый executable challenge в `agent/foundation-v2-deictic-actuality-boundary` опирался на pre-reset утверждение:

```text
два структурно одинаковых act header
=> два exact-distinct act occurrences
```

После #343 это недопустимо: одна и та же связевая форма акта является одной смысловой связью.

Этот PR сохраняет полезную часть Candidate A, но переносит различие туда, где оно действительно структурно существует — в **позицию explicit run/history**.

## Rooted reconstruction

Для одной смысловой связи акта `A`:

```text
H0 = R
H1 = H0 ⟼ A
H2 = H1 ⟼ A
```

Повтор `A` не создаёт `A1/A2`. Вместо этого:

```text
end(H1) = A
end(H2) = A
H1 != H2
```

потому что их начала структурно различны (`R` и `H1`). Это уже соответствует принятому A17 и существующему `define_run_chain()`.

Явный контекст затем может выбрать одну из history positions:

```text
K1 = K1 ⟼ (parent ⟼ H1)
K2 = K2 ⟼ (parent ⟼ H2)
```

и read-only `current_of_context()` возвращает соответственно `H1/H2`.

## Что это решает

Внутри link-only MTS можно выразить **относительную текущесть структурного события** без:

- duplicate semantic act occurrences;
- host-global `now`;
- глобального `Actual(A)`;
- timestamp/clock;
- runtime-ID как источника различия.

Run position одновременно хранит predecessor history и сам semantic act, поэтому повтор одного `A` в разное время/место истории различается именно связевой структурой.

## Что это НЕ доказывает

Этот PR намеренно не утверждает:

```text
описано как current
=> онтологически происходит
```

`K.current = H2` остаётся структурным фактом асети. Candidate A тем самым достаточен для внутренней **relational/currentness semantics**, но не превращается в доказательство метафизической/processual actuality.

Поэтому #229 остаётся отдельной будущей исследовательской ветвью только для более сильного понятия «происходит», если оно вообще понадобится. Оно не является необходимым для текущей link-only runtime semantics.

## Test

Новый test в существующем `tests/test_mts_foundation_v2_run.py` проверяет:

- повторная канонизация act header не создаёт копию `A`;
- `(A,A)` в run использует одну и ту же `A`;
- `H1` и `H2` structurally distinct;
- `H2 = H1 ⟼ A`;
- два explicit context выбирают `H1/H2` как current;
- replay возвращает `(A,A)`;
- чтение current/replay не меняет snapshot.

Никакой production/runtime surface не добавляется.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_mts_foundation_v2_run.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 60
must_touch:
  - tests/test_mts_foundation_v2_run.py
must_not_touch:
  - core/**
  - contracts/**
  - docs/**
  - cutover/**
  - repo-policy.json
  - .github/**
expected_effects:
  - replace pre-reset duplicate-act occurrence identity with structurally distinct run/history positions
  - preserve one semantic act when the same act is repeated in a run
  - demonstrate explicit context selection of either rooted run position
  - introduce no global actuality marker, host clock or runtime-id identity
  - keep relational currentness explicitly weaker than ontological/processual actuality
```
