### PR TITLE
L5: зафиксировать минимальную границу proof calculus MTS v0.7

### DIFF
--- a/tests/test_mts_foundation_v2_checker.py
+++ b/tests/test_mts_foundation_v2_checker.py
@@ -311,6 +311,28 @@ def test_swapped_run_order_rejects() -> None:
         replay_integrated_proof(network, replace(evidence, run=swapped), byte_refs)
 
 
+def test_extra_valid_run_act_does_not_become_implicit_proof_step() -> None:
+    builder, root, byte_refs, evidence, _, _, _ = _fixture()
+    premise_step, proof_step = evidence.run.steps
+    extended_run = RunEvidence(
+        run_root=define_run_chain(
+            builder,
+            root,
+            (premise_step.act, proof_step.act, proof_step.act),
+        ),
+        initial_context=evidence.run.initial_context,
+        terminal_context=evidence.run.terminal_context,
+        steps=(premise_step, proof_step, proof_step),
+    )
+    network = builder.freeze(root)
+
+    with pytest.raises(
+        IntegratedCheckerError,
+        match="exactly equality premise then rule application",
+    ):
+        replay_integrated_proof(network, replace(evidence, run=extended_run), byte_refs)
+
+
 def test_structurally_other_run_context_rejects_before_replay() -> None:
     builder, root, byte_refs, evidence, _, _, context = _fixture()
     other_context = define_context(builder, _anchor(builder), _anchor(builder))
@@ -330,3 +352,6 @@ def test_integrated_checker_has_no_search_parser_or_legacy_proof_dependency() ->
     assert "proof_checker" not in source
     assert "carrier_isomorphic" not in source
     assert "materialize(" not in source
+    assert "replay_colon_effect" not in source
+    assert "ColonEffectEvidence" not in source
+    assert "lookup_scoped_dictionary" not in source


### PR DESCRIPTION
Closes #122. Refs #299, #262, #343, #401.

Test-only finalization of the already accepted MTS v0.7 proof/checker surface. Adds two vetoes: an extra valid Run act is not an implicit proof step, and colon/dictionary operations are not implicit trusted proof rules. No runtime, contract or documentation semantics change.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_mts_foundation_v2_checker.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 40
must_touch:
  - tests/test_mts_foundation_v2_checker.py
must_not_touch:
  - core/**
  - contracts/**
  - docs/**
  - cutover/**
  - repo-policy.json
  - .github/**
expected_effects:
  - extra valid Run acts do not become implicit inference steps
  - colon/dictionary opening is not an implicit trusted proof rule
  - accepted MTS v0.7 proof behavior remains unchanged
```
