### PR TITLE
Research: отвергнуть process-tag как достаточную реконструкцию actuality

### DIFF
--- a/tests/test_mts_foundation_v2_state.py
+++ b/tests/test_mts_foundation_v2_state.py
@@ -53,6 +53,33 @@ def test_explicit_context_resolves_current_without_ambient_stack() -> None:
     assert network.snapshot() == before
 
 
+def test_unused_process_tag_does_not_change_rooted_event_selection() -> None:
+    builder = LinkNetworkBuilder()
+    root = _anchor(builder)
+    semantic_act = _anchor(builder)
+
+    first_position = builder.ensure(root, semantic_act)
+    second_position = builder.ensure(first_position, semantic_act)
+    assert first_position is not second_position
+
+    parent = _anchor(builder)
+    context = define_context(builder, parent, second_position)
+
+    process_role = _anchor(builder)
+    process_tag = builder.ensure(process_role, second_position)
+    network = builder.freeze(root)
+    snapshot = network.snapshot()
+
+    assert current_of_context(network, context) is second_position
+    assert network.link(first_position).end is semantic_act
+    assert network.link(second_position).start is first_position
+    assert network.link(second_position).end is semantic_act
+    assert network.link(process_tag).start is process_role
+    assert network.link(process_tag).end is second_position
+    assert process_tag is not second_position
+    assert network.snapshot() == snapshot
+
+
 def test_same_source_can_resolve_differently_under_two_scoped_dictionaries() -> None:
     builder = LinkNetworkBuilder()
     root = _anchor(builder)


### PR DESCRIPTION
Closes #417. Parent #229. Refs #343, #401, #412.

Добавляет отрицательный rooted challenge без изменения runtime: один semantic act `A` участвует в двух history positions `H1=R⟼A`, `H2=H1⟼A`; explicit context выбирает `H2`. Дополнительная независимая связь `processRole⟼H2` остаётся обычной структурой и не меняет `current(K)`.

Вместе с существующими Run-векторами (`same act` в двух позициях и невыбранная структурная ветвь не влияет на replay) это отвергает модель «процессуальность = произвольная метка над событием».

Результат не закрывает #229: содержательная processual theory должна дать новое внутреннее отличимое следствие, а не ещё одну роль.

```repo-guard-yaml
change_type: test
scope:
  - tests/test_mts_foundation_v2_state.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 40
must_touch:
  - tests/test_mts_foundation_v2_state.py
must_not_touch:
  - core/**
  - contracts/**
  - docs/**
  - cutover/**
  - repo-policy.json
  - .github/**
expected_effects:
  - preserve one semantic act across two rooted history positions
  - keep explicit K.current bound to H2
  - show an unused structural process tag does not redefine currentness
  - add no process primitive or runtime semantics
```
