### PR TITLE
Clarify preserved-neutral L4 status

### DIFF
--- a/core/anum_memory.py
+++ b/core/anum_memory.py
@@ -1,7 +1,11 @@
-"""Finite explicit L4 ordered-pair memory used by current MTS tests and queries.
+"""Preserved-neutral finite L4 ordered-pair store.
 
-This module is intentionally independent of ANUM stream denotation. It stores a
-caller-supplied finite snapshot of local LinkRef handles, offers read-only pair
+The Foundation-v2 cutover classifies this module as ``PRESERVED_NEUTRAL``: it
+is an auxiliary finite memory view, not the accepted semantic runtime owner or
+part of the public Foundation-v2 facade. It remains intentionally independent
+of ANUM stream denotation and preserves useful storage/query invariants.
+
+The store keeps caller-supplied local LinkRef handles, offers read-only pair
 queries, and exposes explicit ``intern_link`` / ``delete_link`` effects. Local
 handles are storage coordinates, not an additional source of semantic Link
 identity. Imported-carrier admissibility beyond this finite memory-view boundary

--- a/tests/test_anum_memory.py
+++ b/tests/test_anum_memory.py
@@ -1,4 +1,4 @@
-"""Current L4 invariants for the finite ordered-pair memory view."""
+"""Preserved-neutral L4 invariants for the auxiliary finite pair store."""
 
 import pytest
 


### PR DESCRIPTION
Post-cutover status-only cleanup for the preserved-neutral finite L4 store. No API or behavior changes.

```repo-guard-yaml
change_type: chore
scope:
  - core/anum_memory.py
  - tests/test_anum_memory.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 20
must_touch:
  - core/anum_memory.py
  - tests/test_anum_memory.py
must_not_touch:
  - README.md
expected_effects:
  - align docstrings with PRESERVED_NEUTRAL cutover classification
  - preserve runtime behavior
```
