### PR TITLE
Docs: зафиксировать rooted Direct Deixis v0.6 в формальной нотации

### DIFF
--- a/docs/specs/Формальная нотация МТС.md
+++ b/docs/specs/Формальная нотация МТС.md
@@ -494,7 +494,73 @@ ensureLink(b,e)
 
 где `b/e` уже структурно различены.
 
-## 22. Проверка формы как суждение чтения
+## 22. Rooted Direct Deixis v0.6
+
+Принятая в MTS v0.7 поверхность `mts-direct-deixis/v0.6` читает уже предъявленный rooted carrier. Полный typed AST, написание операторов, source offset и технический runtime handle не являются семантическими входами этой операции.
+
+Минимальная предъявляемая структура:
+
+```text
+NODE(children...)  — упорядоченные структурные дочерние значения
+OPAQUE              — лист без direct deixis
+PRONOUN(up,pole)    — явный выбор полюса с числом подъёмов к родителю
+```
+
+Все три формы строятся из обычных канонических связей. Упорядоченные `children` и metadata `PRONOUN` представлены конечными R-корневыми последовательностями.
+
+Для канонического rooted vocabulary используются структурные роли:
+
+```text
+START = O = O ⟼ R       ≡ ◁
+END   = C = R ⟼ C       ≡ ▷
+NODE  = L = O ⟼ C
+OPAQUE_TAG = U = C ⟼ O
+PRONOUN_TAG = L ⟼ U
+POP         = U ⟼ L
+```
+
+`POP` здесь — имя одного шага подъёма в metadata pronoun, а не новый фундаментальный оператор МТС. Поэтому:
+
+```text
+PRONOUN(n, START) = PRONOUN_TAG ⟼ Seq(POP × n, START)
+PRONOUN(n, END)   = PRONOUN_TAG ⟼ Seq(POP × n, END)
+```
+
+где `Seq(...)` — уже определённая конечная R-корневая последовательность. `OPAQUE` предъявляется как общий лист `OPAQUE_TAG ⟼ R`, а `NODE(children...)` — как `NODE ⟼ Seq(children...)`.
+
+Результат direct-deixis состоит из occurrence-троек:
+
+```text
+(ROOTED_PATH, up, pole)
+```
+
+```text
+ROOTED_PATH = (i0, i1, ..., ik)
+```
+
+`ROOTED_PATH` — координата проверяющего обхода, полученная из индексов в упорядоченных child-позициях. Она **не является semantic identity связи**. Если одна и та же смысловая подасеть использована в двух позициях, остаётся одна semantic Link, но возникают две разные occurrence paths.
+
+Следовательно:
+
+```text
+одна semantic subtree
++ две child-позиции
+=> две ROOTED_PATH
+!= две semantic subtree links
+```
+
+Группировка остаётся видимой в пути именно как структура вложенных child-позиций. `up` равен числу последовательных `POP`, а `pole` принимает только `START/◁` или `END/▷`.
+
+Direct-deixis является операцией чтения:
+
+```text
+analyze / replay
+!= ensure / materialize
+```
+
+Она не должна менять апамять. Положительный результат сам по себе не доказывает `ContextSensitive`, а отсутствие pronoun occurrences не доказывает `ContextInvariant`.
+
+## 23. Проверка формы как суждение чтения
 
 Для уже предъявленной смысловой связи `X` и уже структурно различённых полюсов `A`, `B` вводится суждение:
 


### PR DESCRIPTION
Closes #425. Refs #343, #383, #385, #401.

Синхронизирует каноническую `Формальная нотация МТС.md` с уже принятой в MTS v0.7 поверхностью `mts-direct-deixis/v0.6`, не меняя runtime/contracts/tests.

Добавлено:
- минимальный rooted carrier `NODE / OPAQUE / PRONOUN`;
- структурный vocabulary `START/END/NODE/OPAQUE_TAG/PRONOUN_TAG/POP`;
- явная связь `POP` с одним `up`-step, без введения нового фундаментального оператора МТС;
- `ROOTED_PATH` как occurrence/checker coordinate по ordered child positions, не semantic Link identity;
- sharing одной semantic subtree в нескольких позициях без semantic copies;
- read-only граница `analyze/replay != ensure/materialize`;
- сохранены non-implications относительно `ContextSensitive/ContextInvariant`.

```repo-guard-yaml
change_type: docs
scope:
  - docs/specs/Формальная нотация МТС.md
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 80
must_touch:
  - docs/specs/Формальная нотация МТС.md
must_not_touch:
  - core/**
  - contracts/**
  - tests/**
  - cutover/**
  - repo-policy.json
  - .github/**
expected_effects:
  - document accepted mts-direct-deixis/v0.6 in the canonical notation
  - define ROOTED_PATH as checker occurrence coordinate rather than semantic identity
  - map POP to one rooted pronoun up-step without introducing a new MTS primitive
  - preserve runtime, contracts and behavior unchanged
```
