### PR TITLE
Pre-TS: transactional incremental decoder (#428)

### DIFF
--- a/core/anum_parser.py
+++ b/core/anum_parser.py
@@ -31,18 +31,26 @@ class IncrementalQuaternaryDecoder:
         return self._offset
 
     def feed(self, chunk: str) -> tuple[AnumToken, ...]:
+        """Decode one chunk atomically.
+
+        A successful call commits the whole chunk. If any character is invalid,
+        token, offset, and comment state remain exactly as they were before the
+        call so the caller may retry from the same absolute position.
+        """
+
         emitted: list[AnumToken] = []
+        in_comment = self._in_comment
 
         for index, char in enumerate(chunk):
             absolute_offset = self._offset + index
 
-            if self._in_comment:
+            if in_comment:
                 if char in "\r\n":
-                    self._in_comment = False
+                    in_comment = False
                 continue
 
             if char == "#":
-                self._in_comment = True
+                in_comment = True
                 continue
 
             if char.isspace():
@@ -55,10 +63,10 @@ class IncrementalQuaternaryDecoder:
                     f'{absolute_offset}: "{char}"'
                 )
 
-            token = AnumToken(abit=abit, offset=absolute_offset)
-            self._tokens.append(token)
-            emitted.append(token)
+            emitted.append(AnumToken(abit=abit, offset=absolute_offset))
 
+        self._tokens.extend(emitted)
+        self._in_comment = in_comment
         self._offset += len(chunk)
         return tuple(emitted)
 

--- a/tests/test_anum_parser.py
+++ b/tests/test_anum_parser.py
@@ -78,6 +78,56 @@ def test_incremental_decoder_reports_absolute_error_offset():
         decoder.feed("  x")
 
 
+def test_incremental_decoder_rejected_chunk_rolls_back_tokens_and_offset():
+    decoder = IncrementalQuaternaryDecoder()
+
+    with pytest.raises(ValueError, match="позиции 2"):
+        decoder.feed("[0x")
+
+    assert decoder.offset == 0
+    assert decoder.finish().tokens == ()
+
+    emitted = decoder.feed("[01]")
+    assert [token.offset for token in emitted] == [0, 1, 2, 3]
+    assert decoder.offset == 4
+    assert decoder.finish().values() == ("[", "0", "1", "]")
+
+
+def test_incremental_decoder_rejected_later_chunk_preserves_prior_commit():
+    decoder = IncrementalQuaternaryDecoder()
+    decoder.feed("[")
+    before = decoder.finish()
+
+    with pytest.raises(ValueError, match="позиции 2"):
+        decoder.feed("0x")
+
+    assert decoder.offset == 1
+    assert decoder.finish() == before
+
+    decoder.feed("01]")
+    assert decoder.finish().values() == ("[", "0", "1", "]")
+    assert [token.offset for token in decoder.finish().tokens] == [0, 1, 2, 3]
+
+
+def test_incremental_decoder_rejected_chunk_rolls_back_comment_state():
+    decoder = IncrementalQuaternaryDecoder()
+    decoder.feed("# comment")
+    before_offset = decoder.offset
+
+    with pytest.raises(ValueError, match="Недопустимый символ"):
+        decoder.feed("\n0x")
+
+    assert decoder.offset == before_offset
+    assert decoder.finish().tokens == ()
+
+    decoder.feed("\n01")
+    assert decoder.finish().values() == ("0", "1")
+    assert [token.offset for token in decoder.finish().tokens] == [
+        before_offset + 1,
+        before_offset + 2,
+    ]
+
+
 def test_deterministic_quaternary_serialization_round_trip():
     original = parse_raw_quaternary(" [ 0 1 ] # comment\n][")
     serialized = serialize_quaternary_anum(original, include_header=True)


### PR DESCRIPTION
Refs #428.

```repo-guard-yaml
change_type: fix
scope:
  - core/anum_parser.py
  - tests/test_anum_parser.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - core/anum_parser.py
  - tests/test_anum_parser.py
must_not_touch:
  - contracts/**
  - cutover/**
expected_effects:
  - transactional feed behavior
  - unchanged successful parsing
```
