### PR TITLE
Pre-TS: ужесточить persistent JSON boundary (#428)

### DIFF
--- a/core/foundation_v2_persistent.py
+++ b/core/foundation_v2_persistent.py
@@ -51,12 +51,24 @@ class PersistentStoreError(ValueError):
     """Persistent canonical-link store operation or evidence is invalid."""
 
 
+def _is_storage_coordinate(value: object) -> bool:
+    """Return whether ``value`` is a strict integer storage coordinate."""
+
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 @dataclass(frozen=True, order=True)
 class PersistentLinkId:
     """Dataset-local storage coordinate; never semantic MTS identity."""
 
     lineage: str
     local: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lineage, str) or not self.lineage:
+            raise PersistentStoreError("invalid persistent lineage id")
+        if not _is_storage_coordinate(self.local) or self.local < 0:
+            raise PersistentStoreError("invalid persistent link id")
 
 
 @dataclass(frozen=True)
@@ -166,6 +178,8 @@ class JsonLinkStore:
             raw = json.loads(target.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise PersistentStoreError("cannot open persistent dataset") from exc
+        if not isinstance(raw, dict):
+            raise PersistentStoreError("invalid persistent dataset object")
         if raw.get("schema") != PERSISTENT_SCHEMA:
             raise PersistentStoreError("unsupported persistent dataset schema")
         lineage = raw.get("lineage")
@@ -173,7 +187,7 @@ class JsonLinkStore:
         links_raw = raw.get("links")
         if not isinstance(lineage, str) or not lineage:
             raise PersistentStoreError("invalid persistent lineage id")
-        if not isinstance(root, int):
+        if not _is_storage_coordinate(root):
             raise PersistentStoreError("invalid persistent root id")
         if not isinstance(links_raw, list):
             raise PersistentStoreError("invalid persistent links")
@@ -182,7 +196,7 @@ class JsonLinkStore:
             if (
                 not isinstance(pair, list)
                 or len(pair) != 2
-                or not all(isinstance(value, int) for value in pair)
+                or not all(_is_storage_coordinate(value) for value in pair)
             ):
                 raise PersistentStoreError("invalid persistent link pair")
             links.append((pair[0], pair[1]))
@@ -202,17 +216,26 @@ class JsonLinkStore:
         target.parent.mkdir(parents=True, exist_ok=True)
         if not isinstance(snapshot, PersistentSnapshot):
             raise PersistentStoreError("expected persistent snapshot")
+        if not isinstance(snapshot.lineage, str) or not snapshot.lineage:
+            raise PersistentStoreError("invalid snapshot lineage")
+        if not isinstance(snapshot.root, PersistentLinkId):
+            raise PersistentStoreError("invalid snapshot root")
+        cls._validate_snapshot_id(snapshot.root, snapshot.lineage)
+        if not isinstance(snapshot.links, tuple):
+            raise PersistentStoreError("invalid snapshot links")
+        for item in snapshot.links:
+            if (
+                not isinstance(item, tuple)
+                or len(item) != 3
+                or not all(isinstance(value, PersistentLinkId) for value in item)
+            ):
+                raise PersistentStoreError("invalid snapshot link")
+            for value in item:
+                cls._validate_snapshot_id(value, snapshot.lineage)
 
         ordered = sorted(snapshot.links, key=lambda item: item[0].local)
         if [item[0].local for item in ordered] != list(range(len(ordered))):
             raise PersistentStoreError("snapshot local ids must be dense for import")
-        for ref, start, end in ordered:
-            if (
-                ref.lineage != snapshot.lineage
-                or start.lineage != snapshot.lineage
-                or end.lineage != snapshot.lineage
-            ):
-                raise PersistentStoreError("snapshot mixes storage lineages")
         if snapshot.root.lineage != snapshot.lineage:
             raise PersistentStoreError("snapshot root belongs to another lineage")
 
@@ -409,6 +432,8 @@ class JsonLinkStore:
         """Reconstruct canonical runtime topology with fresh technical handles."""
 
         self._require_open()
+        if count is not None and not _is_storage_coordinate(count):
+            raise PersistentStoreError("invalid runtime prefix count")
         selected_count = len(self._links) if count is None else count
         if selected_count <= self._root_local or selected_count > len(self._links):
             raise PersistentStoreError("invalid runtime prefix count")
@@ -442,6 +467,10 @@ class JsonLinkStore:
         """Reconstruct before/after runtime states in one technical runtime scope."""
 
         self._require_open()
+        if not _is_storage_coordinate(before_count) or not _is_storage_coordinate(
+            after_count
+        ):
+            raise PersistentStoreError("invalid persistent materialization range")
         if (
             before_count <= self._root_local
             or after_count < before_count
@@ -491,6 +520,8 @@ class JsonLinkStore:
             return self._validate_id(endpoint), False
         if not isinstance(endpoint, BatchRef):
             raise PersistentStoreError("invalid batch endpoint")
+        if not _is_storage_coordinate(endpoint.index):
+            raise PersistentStoreError("invalid batch reference")
         if endpoint.index < 0 or endpoint.index > current_index:
             raise PersistentStoreError(
                 "batch forward reference cannot create semantic distinction"
@@ -505,15 +536,27 @@ class JsonLinkStore:
         self._validate_links(self._links, self._root_local)
 
     @staticmethod
+    def _validate_snapshot_id(ref: PersistentLinkId, lineage: str) -> int:
+        if not isinstance(ref, PersistentLinkId):
+            raise PersistentStoreError("invalid snapshot link id")
+        if ref.lineage != lineage:
+            raise PersistentStoreError("snapshot mixes storage lineages")
+        if not _is_storage_coordinate(ref.local) or ref.local < 0:
+            raise PersistentStoreError("invalid snapshot link id")
+        return ref.local
+
+    @staticmethod
     def _validate_links(links: list[tuple[int, int]], root_local: int) -> None:
         if not links:
             raise PersistentStoreError("persistent dataset cannot be empty")
+        if not _is_storage_coordinate(root_local):
+            raise PersistentStoreError("persistent root is out of range")
         if root_local < 0 or root_local >= len(links):
             raise PersistentStoreError("persistent root is out of range")
         for start, end in links:
             if (
-                not isinstance(start, int)
-                or not isinstance(end, int)
+                not _is_storage_coordinate(start)
+                or not _is_storage_coordinate(end)
                 or start < 0
                 or start >= len(links)
                 or end < 0
@@ -564,6 +607,8 @@ class JsonLinkStore:
             raise PersistentStoreError("expected persistent link id")
         if ref.lineage != self._lineage:
             raise PersistentStoreError("foreign persistent dataset lineage")
+        if not _is_storage_coordinate(ref.local):
+            raise PersistentStoreError("persistent link id is out of range")
         if ref.local < 0 or ref.local >= len(self._links):
             raise PersistentStoreError("persistent link id is out of range")
         return ref.local

--- a/tests/test_mts_foundation_v2_persistent.py
+++ b/tests/test_mts_foundation_v2_persistent.py
@@ -16,6 +16,7 @@ from core.foundation_v2_persistent import (
     PersistentSequenceAtom,
     PersistentSequenceDescription,
     PersistentSequenceGroup,
+    PersistentSnapshot,
     PersistentStoreError,
     materialize_persistent_sequence,
     replay_persistent_sequence_materialization,
@@ -39,6 +40,15 @@ def _local_topology(store: JsonLinkStore):
         (ref.local, start.local, end.local)
         for ref, start, end in store.snapshot().links
     )
+
+
+def _unsafe_persistent_id(lineage: str, local: object) -> PersistentLinkId:
+    """Construct invalid test evidence without public constructor validation."""
+
+    ref = object.__new__(PersistentLinkId)
+    object.__setattr__(ref, "lineage", lineage)
+    object.__setattr__(ref, "local", local)
+    return ref
 
 
 def test_create_starts_with_unique_root_and_root_pair_is_idempotent(tmp_path) -> None:
@@ -229,6 +239,105 @@ def test_open_rejects_duplicate_pair_second_root_and_unrooted_cycle(tmp_path) ->
         )
         with pytest.raises(PersistentStoreError, match="canonical|rooted"):
             JsonLinkStore.open(path)
+
+
+@pytest.mark.parametrize("payload", [[], 42, None])
+def test_open_rejects_non_object_json_fail_closed(tmp_path, payload) -> None:
+    path = tmp_path / "invalid-shape.json"
+    before = json.dumps(payload).encode("utf-8")
+    path.write_bytes(before)
+
+    with pytest.raises(PersistentStoreError, match="dataset object"):
+        JsonLinkStore.open(path)
+
+    assert path.read_bytes() == before
+
+
+def test_open_rejects_bool_root_coordinate(tmp_path) -> None:
+    path = tmp_path / "invalid-root.json"
+    payload = {
+        "schema": PERSISTENT_SCHEMA,
+        "lineage": "bad-root",
+        "root": True,
+        "links": [[0, 0]],
+    }
+    before = json.dumps(payload).encode("utf-8")
+    path.write_bytes(before)
+
+    with pytest.raises(PersistentStoreError, match="root id"):
+        JsonLinkStore.open(path)
+
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("links", [[[True, 0]], [[0, False]]])
+def test_open_rejects_bool_endpoint_coordinate(tmp_path, links) -> None:
+    path = tmp_path / "invalid-endpoint.json"
+    payload = {
+        "schema": PERSISTENT_SCHEMA,
+        "lineage": "bad-endpoint",
+        "root": 0,
+        "links": links,
+    }
+    before = json.dumps(payload).encode("utf-8")
+    path.write_bytes(before)
+
+    with pytest.raises(PersistentStoreError, match="link pair"):
+        JsonLinkStore.open(path)
+
+    assert path.read_bytes() == before
+
+
+def test_persistent_link_id_rejects_bool_local_coordinate() -> None:
+    with pytest.raises(PersistentStoreError, match="link id"):
+        PersistentLinkId("lineage", True)
+
+
+def test_runtime_boundaries_reject_bool_coordinates(tmp_path) -> None:
+    store = JsonLinkStore.create(tmp_path / "apamemory.json")
+
+    with pytest.raises(PersistentStoreError, match="runtime prefix count"):
+        store.runtime_network(count=True)
+    with pytest.raises(PersistentStoreError, match="materialization range"):
+        store.runtime_materialization_lineage(True, 1)
+
+
+def test_batch_bool_reference_rejects_without_state_change(tmp_path) -> None:
+    path = tmp_path / "apamemory.json"
+    store = JsonLinkStore.create(path)
+    before = store.snapshot()
+    file_before = path.read_bytes()
+
+    with pytest.raises(PersistentStoreError, match="batch reference"):
+        store.materialize_batch((BatchLink(BatchRef(True), store.root),))
+
+    assert store.snapshot() == before
+    assert path.read_bytes() == file_before
+
+
+def test_import_rejects_bool_storage_coordinates_without_creating_file(tmp_path) -> None:
+    lineage = "snapshot"
+    root = PersistentLinkId(lineage, 0)
+    bad_root = _unsafe_persistent_id(lineage, True)
+    bad_endpoint = _unsafe_persistent_id(lineage, False)
+
+    cases = (
+        PersistentSnapshot(
+            lineage=lineage,
+            root=bad_root,
+            links=((bad_root, bad_root, bad_root),),
+        ),
+        PersistentSnapshot(
+            lineage=lineage,
+            root=root,
+            links=((root, bad_endpoint, root),),
+        ),
+    )
+    for index, snapshot in enumerate(cases):
+        target = tmp_path / f"imported-{index}.json"
+        with pytest.raises(PersistentStoreError, match="snapshot link id"):
+            JsonLinkStore.import_topology(target, snapshot)
+        assert not target.exists()
 
 
 def test_json_payload_contains_only_storage_coordinates(tmp_path) -> None:


### PR DESCRIPTION
Refs #428.

```repo-guard-yaml
change_type: fix
scope:
  - core/foundation_v2_persistent.py
  - tests/test_mts_foundation_v2_persistent.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 180
must_touch:
  - core/foundation_v2_persistent.py
  - tests/test_mts_foundation_v2_persistent.py
must_not_touch:
  - contracts/**
  - cutover/**
expected_effects:
  - fail closed on malformed persistent JSON shape
  - reject bool storage coordinates
  - preserve valid reopen behavior
  - preserve state on rejected writes and imports
```
