### PR TITLE
Pre-TS: converter boundary fixes (#428)

### DIFF
--- a/converters/anum_cli.py
+++ b/converters/anum_cli.py
@@ -9,7 +9,7 @@ from core.anum_protocol import deserialize_anum, validate_anum
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Инструменты текущего потока ANUM v0.3")
+    parser = argparse.ArgumentParser(description="Инструменты текущего потока ANUM v0.4")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     parse_parser = subparsers.add_parser("parse", help="Лексически разобрать *.anum")
@@ -23,7 +23,7 @@ def main(argv: list[str] | None = None) -> int:
 
     deserialize_parser = subparsers.add_parser(
         "deserialize",
-        help="Выполнить чистую десериализацию ANUM v0.3",
+        help="Выполнить чистую десериализацию ANUM v0.4",
     )
     deserialize_parser.add_argument("file")
 

--- a/converters/anum_to_text.py
+++ b/converters/anum_to_text.py
@@ -101,16 +101,16 @@ def extract_char_anums(anum: str) -> list:
 
 
 def anum_to_char(abits: str) -> str:
-    """Конвертация ачисла одного символа в UTF-8 символ.
+    """Конвертация ачисла одного символа в один UTF-8 символ.
 
     Args:
         abits: Строка абитов ('1' и '0'), кратная 8 по длине.
 
     Returns:
-        Декодированный UTF-8 символ.
+        Ровно один декодированный UTF-8 символ.
 
     Raises:
-        ValueError: При некорректной длине или содержимом.
+        ValueError: При некорректной длине, UTF-8 или числе символов.
     """
     if len(abits) % 8 != 0:
         raise ValueError(
@@ -119,7 +119,15 @@ def anum_to_char(abits: str) -> str:
     byte_values = []
     for i in range(0, len(abits), 8):
         byte_values.append(abits_to_byte(abits[i:i+8]))
-    return bytes(byte_values).decode('utf-8')
+    try:
+        char = bytes(byte_values).decode('utf-8')
+    except UnicodeDecodeError as exc:
+        raise ValueError('Ачисло символа содержит некорректную UTF-8 последовательность') from exc
+    if len(char) != 1:
+        raise ValueError(
+            f'Ожидается ровно один UTF-8 символ, декодировано: {len(char)}'
+        )
+    return char
 
 
 def anum_to_text(anum: str) -> str:
@@ -150,7 +158,7 @@ def anum_to_text_verbose(anum: str) -> list:
         byte_values = []
         for i in range(0, len(abits), 8):
             byte_values.append(abits_to_byte(abits[i:i+8]))
-        char = bytes(byte_values).decode('utf-8')
+        char = anum_to_char(abits)
         entry = {
             'anum': f'[{abits}]',
             'abits': abits,

--- a/converters/text_to_anum.py
+++ b/converters/text_to_anum.py
@@ -32,7 +32,12 @@ def byte_to_abits(byte_val: int) -> str:
 
     Returns:
         Строка из 8 символов '1' и '0'.
+
+    Raises:
+        ValueError: Если значение не является целым байтом 0–255.
     """
+    if type(byte_val) is not int or not 0 <= byte_val <= 255:
+        raise ValueError(f'Ожидается значение байта 0–255, получено: {byte_val!r}')
     binary = format(byte_val, '08b')
     return ''.join('1' if bit == '1' else '0' for bit in binary)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -17,7 +17,8 @@ from converters.text_to_anum import (
     byte_to_abits, char_to_anum, text_to_anum, text_to_anum_verbose
 )
 from converters.anum_to_text import (
-    abits_to_byte, extract_char_anums, anum_to_char, anum_to_text
+    abits_to_byte, extract_char_anums, anum_to_char, anum_to_text,
+    anum_to_text_verbose
 )
 from converters.ascii_unicode import (
     unicode_to_ascii, ascii_to_unicode, abits_to_aprover, aprover_to_abits
@@ -40,6 +41,16 @@ class TestByteToAbits(unittest.TestCase):
     def test_ascii_a(self):
         # a = 0x61 = 01100001
         self.assertEqual(byte_to_abits(0x61), '01100001')
+
+    def test_rejects_out_of_byte_range(self):
+        for value in (-1, 256):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    byte_to_abits(value)
+
+    def test_rejects_bool_as_byte(self):
+        with self.assertRaises(ValueError):
+            byte_to_abits(True)
 
 
 class TestAbitsToByteRoundtrip(unittest.TestCase):
@@ -114,6 +125,28 @@ class TestTextToAnumRoundtrip(unittest.TestCase):
     def test_spaces_and_punctuation(self):
         text = 'hello, world!'
         self.assertEqual(anum_to_text(text_to_anum(text)), text)
+
+
+class TestAnumToCharBoundary(unittest.TestCase):
+    """Тесты явной границы одного UTF-8 символа."""
+
+    def test_rejects_empty_character_payload(self):
+        with self.assertRaises(ValueError):
+            anum_to_char('')
+
+    def test_rejects_two_characters_in_one_group(self):
+        abits = byte_to_abits(ord('A')) + byte_to_abits(ord('B'))
+        with self.assertRaises(ValueError):
+            anum_to_char(abits)
+
+    def test_verbose_rejects_two_characters_with_domain_error(self):
+        abits = byte_to_abits(ord('A')) + byte_to_abits(ord('B'))
+        with self.assertRaises(ValueError):
+            anum_to_text_verbose(f'[{abits}]')
+
+    def test_rejects_invalid_utf8_with_domain_error(self):
+        with self.assertRaises(ValueError):
+            anum_to_char('11111111')
 
 
 class TestExtractCharAnums(unittest.TestCase):


### PR DESCRIPTION
Refs #428.

```repo-guard-yaml
change_type: fix
scope:
  - converters/anum_cli.py
  - converters/text_to_anum.py
  - converters/anum_to_text.py
  - tests/test_converters.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - converters/anum_cli.py
  - converters/text_to_anum.py
  - converters/anum_to_text.py
  - tests/test_converters.py
must_not_touch:
  - contracts/**
  - cutover/**
expected_effects:
  - update CLI version wording
  - validate converter input domains
  - preserve valid UTF-8 round trips
```
