### PR TITLE
Pre-TS: всегда запускать executable CI gates (#428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,34 +15,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code-changed: ${{ steps.changes.outputs.code }}
-      docs-changed: ${{ steps.changes.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Detect changes
-        id: changes
-        run: |
-          if git diff --name-only HEAD~1 2>/dev/null | grep -qE '\.(py|mtc|anum)$'; then
-            echo "code=true" >> $GITHUB_OUTPUT
-          else
-            echo "code=false" >> $GITHUB_OUTPUT
-          fi
-          if git diff --name-only HEAD~1 2>/dev/null | grep -qE '\.md$'; then
-            echo "docs=true" >> $GITHUB_OUTPUT
-          else
-            echo "docs=false" >> $GITHUB_OUTPUT
-          fi
-
   lint:
     runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.code-changed == 'true' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 
@@ -81,12 +55,11 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [detect-changes, lint, check-file-limits]
+    needs: [lint, check-file-limits]
     if: |
       always() &&
       !cancelled() &&
-      (needs.detect-changes.outputs.code-changed == 'true' || github.event_name == 'push') &&
-      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+      needs.lint.result == 'success' &&
       needs.check-file-limits.result == 'success'
     steps:
       - uses: actions/checkout@v4
@@ -107,8 +80,6 @@ jobs:
 
   validate-docs:
     runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.docs-changed == 'true' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fixes #439.
Refs #428.

```repo-guard-yaml
change_type: ci
scope:
  - .github/workflows/ci.yml
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 40
must_touch:
  - .github/workflows/ci.yml
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
expected_effects:
  - run ruff on every pull request
  - run pytest on every pull request
  - prevent contract-only changes from skipping executable gates
```

Упрощён conditional change detection: при текущем размере suite экономия не оправдывает риск пропуска semantic boundary checks. `validate-docs` также выполняется всегда; остальные repository gates сохранены.