### PR TITLE
Pre-TS: исправить lifecycle blocking repo-guard (#439)

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -2,7 +2,7 @@ name: repo-guard policy check
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ["**"]
 
 permissions:
@@ -27,7 +27,7 @@ jobs:
           mode: check-pr
           enforcement: blocking
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Publish repo-guard summary
         if: always()


### PR DESCRIPTION
Fixes #439.
Refs #428.

```repo-guard-yaml
change_type: ci
scope:
  - .github/workflows/repo-guard.yml
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 10
must_touch:
  - .github/workflows/repo-guard.yml
must_not_touch:
  - repo-policy.json
  - core/**
  - contracts/**
  - cutover/**
expected_effects:
  - run blocking repo-guard when a PR is reopened
  - run blocking repo-guard when a draft PR becomes ready for review
  - preserve linked-issue GovernanceGrant lookup
```

Также использован штатный `${{ github.token }}` вместо эквивалентного `${{ secrets.GITHUB_TOKEN }}` для `GH_TOKEN`; permissions остаются read-only.