### PR TITLE
Repin repo-guard to accepted v2 governance boundary

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@b3a2c0c60631a4aaba38100c28fb6535e13fe018
+        uses: netkeep80/repo-guard@85a2e3c61223497c3fc601c670aa15b99ecc870f
         with:
           mode: check-pr
           enforcement: blocking


### PR DESCRIPTION
Fixes #448

## Что изменено

`.github/workflows/repo-guard.yml` перепривязан с прежнего immutable SHA на принятый post-R4 boundary:

`netkeep80/repo-guard@85a2e3c61223497c3fc601c670aa15b99ecc870f`

Это отдельный consumer-cutover перед #446. В этом PR не добавляется contract/conformance policy и не меняется MTS runtime/теория.

## Проверенный scope

- `repo-policy.json` не использует старый integration/trace DSL, поэтому миграция policy здесь не нужна;
- локального `--contract`/compatibility alias не найдено;
- accepted v0.7 contract/conformance/cutover artifacts не меняются;
- Python oracle и уже принятый TypeScript Memory kernel остаются без изменений.

```repo-guard-yaml
change_type: ci
scope:
  - .github/workflows/repo-guard.yml
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - .github/workflows/repo-guard.yml
must_not_touch:
  - repo-policy.json
  - contracts/**
  - cutover/**
  - core/**
  - tests/**
  - ts/**
  - docs/**
expected_effects:
  - pin anum_docs to the accepted repo-guard v2 contract-conformance governance boundary
  - preserve MTS v0.7 semantics and all executable runtimes unchanged
```

После draft CI PR будет переведён в ready, чтобы именно новый pin выполнил blocking `check-pr` перед merge.