### PR TITLE
Activate repo-guard contract governance for MTS v0.7

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -4,6 +4,135 @@
   "enforcement": {
     "mode": "blocking"
   },
+  "integration": {
+    "workflows": [
+      {
+        "id": "project-ci",
+        "kind": "github_actions",
+        "path": ".github/workflows/ci.yml",
+        "role": "ci_gate",
+        "expect": {
+          "events": [
+            "pull_request"
+          ],
+          "enforcement": "blocking",
+          "disallow": [
+            "continue_on_error"
+          ]
+        }
+      }
+    ]
+  },
+  "contract_conformance": {
+    "current": {
+      "contract": {
+        "path": "contracts/mts-contract-v0.7.json",
+        "format": "json"
+      },
+      "conformance": {
+        "path": "contracts/mts-conformance-v0.7.json",
+        "format": "json"
+      }
+    },
+    "previous": {
+      "contract": {
+        "path": "contracts/mts-contract-v0.6.json",
+        "format": "json"
+      },
+      "conformance": {
+        "path": "contracts/mts-conformance-v0.6.json",
+        "format": "json"
+      }
+    },
+    "pair_fields": {
+      "contract_id": "/schema",
+      "conformance_contract_id": "/contract",
+      "contract_conformance_path": "/conformanceCorpus",
+      "contract_status": "/status",
+      "conformance_status": "/status",
+      "contract_accepted": "/accepted",
+      "conformance_accepted": "/accepted"
+    },
+    "accepted_state": {
+      "status": "accepted",
+      "accepted": true
+    },
+    "acceptance": {
+      "document": {
+        "path": "cutover/foundation-v2-c9-acceptance-v0.1.json",
+        "format": "json"
+      },
+      "current_contract_path": "/current/contract",
+      "current_conformance_path": "/current/conformance"
+    },
+    "required_paths": [
+      {
+        "document": "current.contract",
+        "pointer": "/owners",
+        "projection": "object_values"
+      },
+      {
+        "document": "current.conformance",
+        "pointer": "/requiredExecutableGates",
+        "projection": "array_items"
+      },
+      {
+        "document": "acceptance",
+        "pointer": "/current",
+        "projection": "object_values"
+      }
+    ],
+    "cochange": [
+      "current.contract",
+      "current.conformance",
+      "acceptance"
+    ],
+    "control_paths": [
+      "contracts/mts-contract-v*.json",
+      "contracts/mts-conformance-v*.json",
+      "cutover/foundation-v2-c9-acceptance-v*.json"
+    ]
+  },
+  "evidence_bindings": [
+    {
+      "id": "required-gates-covered-by-project-ci",
+      "kind": "workflow_path_coverage",
+      "source": {
+        "document": "contract-conformance.current.conformance",
+        "pointer": "/requiredExecutableGates",
+        "projection": "array_items",
+        "type": "repository_path_set"
+      },
+      "workflow": "project-ci",
+      "covers": [
+        "tests/**"
+      ]
+    },
+    {
+      "id": "negative-vectors-have-test-evidence",
+      "kind": "anchor_value_coverage",
+      "source": {
+        "document": "contract-conformance.current.conformance",
+        "pointer": "/requiredNegativeVectors",
+        "projection": "array_items",
+        "type": "string_set"
+      },
+      "target_anchor_type": "negative_vector_test"
+    }
+  ],
+  "anchors": {
+    "types": {
+      "negative_vector_test": {
+        "sources": [
+          {
+            "kind": "regex",
+            "glob": "tests/**",
+            "pattern": "executed\\.add\\(\"([^\"]+)\"\\)"
+          }
+        ]
+      }
+    }
+  },
   "paths": {
     "forbidden": [
       "legacy/**",


### PR DESCRIPTION
Fixes #457
Parent: #446

## Что включено

`repo-policy.json` теперь декларативно описывает текущую release topology без MTS-specific логики в repo-guard core:

- current: `mts-contract-v0.7` ↔ `mts-conformance-v0.7`;
- previous immutable evidence: v0.6 pair;
- acceptance pointer: `foundation-v2-c9-acceptance-v0.1.json`;
- accepted/status/cross-link checks через `contract_conformance` macro;
- owner paths, executable gate paths и acceptance current paths через generic `referenced_paths_exist`;
- current contract+conformance+acceptance меняются атомарно;
- stable governance patterns защищают future versioned release artifacts;
- `.github/workflows/ci.yml` объявлен generic blocking `ci_gate`;
- `/requiredExecutableGates` статически привязан к `tests/**` coverage этого workflow;
- `/requiredNegativeVectors` привязан к обычным regex anchors из существующего executable test evidence.

## Trust boundary

repo-guard не исполняет команды из contract/conformance JSON, не знает Python/pytest и не интерпретирует смысл negative-vector IDs. Domain execution и MTS semantics остаются в существующих тестах.

R5a намеренно **не удаляет** assertions из `tests/test_repository_contract.py`: head policy этого PR ещё не является base policy для собственного `check-pr`. Удаление дублированных generic assertions будет отдельным R5b после merge/post-merge green.

Первый ready-run подтвердил proposed head policy полностью: 37/37 checks green. Единственный red был explicit governance-review delta `/` из-за добавления `anchors`, который пока не участвует в monotonic Constraint Program. Linked issue #457 теперь явно разрешает только этот root delta.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 220
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - core/**
  - tests/**
  - ts/**
  - docs/**
  - .github/workflows/**
expected_effects:
  - activate generic contract-conformance release governance for accepted MTS v0.7
  - bind declared executable gates to existing blocking CI without executing contract-controlled commands
  - bind declared negative-vector ids to ordinary test evidence anchors
```

Head SHA не менялся после green draft CI; повторный ready-run должен проверить обновлённую governance authorization на том же policy diff.