### PR TITLE
Remove Python duplicates of active repo-guard contract governance

### DIFF
--- a/tests/test_repository_contract.py
+++ b/tests/test_repository_contract.py
@@ -20,7 +20,6 @@ PREVIOUS_CONTRACT = ROOT / "contracts/mts-contract-v0.6.json"
 PREVIOUS_CONFORMANCE = ROOT / "contracts/mts-conformance-v0.6.json"
 CURRENT_CONTRACT = ROOT / "contracts/mts-contract-v0.7.json"
 CURRENT_CONFORMANCE = ROOT / "contracts/mts-conformance-v0.7.json"
-C8_GATE = ROOT / "tests/test_foundation_v2_c8_integrated.py"
 ACTIVE_THEORY = {"Основания МТС.md", "Система аксиом МТС.md"}
 ACTIVE_SPECS = {
     "Формальная нотация МТС.md",
@@ -182,11 +181,8 @@ def test_c9_acceptance_selects_exactly_mts_v07_as_current() -> None:
     assert acceptance["decision"] == "ACCEPT_MTS_V0_7"
     assert acceptance["versionDecision"]["previousAcceptedVersion"] == "mts-contract/v0.6"
     assert acceptance["versionDecision"]["acceptedVersion"] == "mts-contract/v0.7"
-    assert acceptance["current"] == {
-        "contract": "contracts/mts-contract-v0.7.json",
-        "conformance": "contracts/mts-conformance-v0.7.json",
-        "publicFacade": "core/foundation_v2.py",
-    }
+    assert set(acceptance["current"]) == {"contract", "conformance", "publicFacade"}
+    assert acceptance["current"]["publicFacade"] == "core/foundation_v2.py"
     assert acceptance["acceptance"] == {
         "foundationV2Accepted": True,
         "cutoverPerformed": True,
@@ -197,28 +193,21 @@ def test_c9_acceptance_selects_exactly_mts_v07_as_current() -> None:
     }
 
 
-def test_v07_contract_and_conformance_are_accepted_and_cross_linked() -> None:
+def test_v07_release_metadata_matches_accepted_semantic_version() -> None:
     contract = load(CURRENT_CONTRACT)
     conformance = load(CURRENT_CONFORMANCE)
     assert contract["schema"] == "mts-contract/v0.7"
-    assert contract["status"] == "accepted"
-    assert contract["accepted"] is True
     assert contract["acceptedMtsVersion"] == contract["schema"]
-    assert contract["conformanceCorpus"] == "contracts/mts-conformance-v0.7.json"
     assert contract["currentPointer"] == "cutover/foundation-v2-c9-acceptance-v0.1.json"
     assert conformance["schema"] == "mts-conformance/v0.7"
-    assert conformance["status"] == "accepted"
-    assert conformance["accepted"] is True
-    assert conformance["contract"] == contract["schema"]
     assert conformance["acceptance"]["acceptedMtsVersion"] == contract["schema"]
     assert conformance["acceptance"]["foundationV2Accepted"] is True
     assert conformance["acceptance"]["downstreamRepinAllowed"] is True
 
 
-def test_v07_owns_only_existing_post_c7_runtime_files() -> None:
+def test_v07_owners_exclude_deleted_historical_runtime_files() -> None:
     contract = load(CURRENT_CONTRACT)
     for role, path in contract["owners"].items():
-        assert (ROOT / path).is_file(), (role, path)
         assert path not in DELETED_HISTORICAL_PATHS, (role, path)
     live_strings = set(strings(contract)) | set(strings(load(CURRENT_CONFORMANCE)))
     assert not (DELETED_HISTORICAL_PATHS & live_strings)
@@ -262,7 +251,6 @@ def test_v07_versioned_leaf_boundaries_match_completed_p3_decisions() -> None:
 
 def test_v07_requires_the_green_c8_integrated_gate() -> None:
     conformance = load(CURRENT_CONFORMANCE)
-    assert C8_GATE.is_file()
     assert "tests/test_foundation_v2_c8_integrated.py" in conformance["requiredExecutableGates"]
     assert "tests/test_repository_contract.py" in conformance["requiredExecutableGates"]
     assert conformance["c7"] == {
@@ -277,8 +265,6 @@ def test_v07_requires_the_green_c8_integrated_gate() -> None:
         "requiredNegativeVectorsPassed": True,
         "compatibilityRuntimeUsed": False,
     }
-    for path in conformance["requiredExecutableGates"]:
-        assert (ROOT / path).is_file(), path
 
 
 def test_v06_remains_previous_release_evidence_not_current_pointer() -> None:
@@ -286,12 +272,9 @@ def test_v06_remains_previous_release_evidence_not_current_pointer() -> None:
     previous_conformance = load(PREVIOUS_CONFORMANCE)
     acceptance = load(ACCEPTANCE)
     assert previous_contract["schema"] == "mts-contract/v0.6"
-    assert previous_contract["accepted"] is True
     assert previous_conformance["schema"] == "mts-conformance/v0.6"
-    assert previous_conformance["accepted"] is True
     assert acceptance["previousReleaseEvidence"]["immutable"] is True
     assert acceptance["previousReleaseEvidence"]["liveRuntimeSelectable"] is False
-    assert acceptance["current"]["contract"] != "contracts/mts-contract-v0.6.json"
 
 
 def test_contract_directory_contains_exactly_previous_and_current_release_pairs() -> None:


### PR DESCRIPTION
Fixes #459
Parent: #446

R5b removes only repository-governance assertions that are now enforced by the trusted R5a base policy (`6bd4de1e2b853be656019e057a3796896145f0db`).

Removed duplication:
- current v0.7 `status`/`accepted`, contract→conformance path and contract-id cross-link assertions;
- per-owner physical file existence loop;
- direct C8 gate file existence and generic `requiredExecutableGates` path-existence loop;
- previous v0.6 `accepted` booleans and redundant current-not-v0.6 check;
- acceptance current contract/conformance path values now enforced by the base macro.

Retained in Python:
- exact MTS version/schema identities where repo-guard only proves pair consistency;
- `acceptedMtsVersion`, `currentPointer`, public facade identity;
- candidate/history semantics;
- immutable/non-live previous-release semantics;
- rooted identity, four-abit, read-vs-materialize semantics;
- versioned leaf boundaries;
- exact C7/C8 semantic evidence;
- required semantic gate membership;
- deleted historical-runtime vetoes;
- negative-vector execution (untouched in its executable test).

```repo-guard-yaml
change_type: refactor
scope:
  - tests/test_repository_contract.py
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - tests/test_repository_contract.py
must_not_touch:
  - repo-policy.json
  - contracts/**
  - cutover/**
  - core/**
  - ts/**
  - docs/**
  - .github/workflows/**
expected_effects:
  - remove only Python assertions duplicated by active repo-guard contract governance
  - retain MTS semantic and historical-domain assertions in Python
  - prove parity because the R5a policy is now the trusted base for this PR
```

Draft CI first verifies the remaining Python/TS behavior. Then the PR will be marked ready so the active base repo-guard policy itself proves the migrated generic constraints on the same diff.