### PR TITLE
Probe repo-guard negative contract parity

### DIFF
--- a/contracts/mts-conformance-v0.7.json
+++ b/contracts/mts-conformance-v0.7.json
@@ -1,9 +1,9 @@
 {
   "schema": "mts-conformance/v0.7",
   "status": "accepted",
-  "accepted": true,
+  "accepted": false,
   "issue": 403,
-  "contract": "mts-contract/v0.7",
+  "contract": "mts-contract/v0.6",
   "previousAcceptedRelease": {
     "contract": "mts-contract/v0.6",
     "conformance": "mts-conformance/v0.6",
@@ -28,7 +28,8 @@
     "tests/test_foundation_v2_cutover_gate.py",
     "tests/test_foundation_v2_c7_preflight.py",
     "tests/test_foundation_v2_c8_integrated.py",
-    "tests/test_repository_contract.py"
+    "tests/test_repository_contract.py",
+    "tests/repo-guard-negative-probe-missing.py"
   ],
   "integratedPath": [
     "root",
@@ -48,7 +49,8 @@
     "read-or-replay-materializes",
     "historical-female-F-or-F-male-projection-meaning",
     "root-as-fifth-abit",
-    "empty-group-rejected"
+    "empty-group-rejected",
+    "repo-guard-negative-probe-missing-vector"
   ],
   "versionedSurfaces": {
     "anum": "anum-deserialization/v0.4",


### PR DESCRIPTION
Fixes #461
Parent: #446.

Evidence-only negative parity probe. **DO NOT MERGE.** This PR intentionally contains invalid current conformance data solely to demonstrate that the trusted base repo-guard policy blocks migrated generic release-governance invariants. It will be closed unmerged immediately after diagnostics are captured.

```repo-guard-yaml
change_type: governance
scope:
  - contracts/mts-conformance-v0.7.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 4
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - contracts/mts-conformance-v0.7.json
must_not_touch:
  - repo-policy.json
  - contracts/mts-contract-v0.7.json
  - cutover/**
  - core/**
  - tests/**
  - ts/**
  - docs/**
  - .github/workflows/**
expected_effects:
  - verify blocking diagnostics for intentionally invalid generic release topology
```