### PR TITLE
Implement generic ANUM raw stack semantics in TypeScript

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/anum.ts
+++ b/ts/src/anum.ts
@@ -1,0 +1,237 @@
+export type Abit = "[" | "]" | "1" | "0";
+export type StackOperation = "OPEN" | "CLOSE" | "VALUE";
+export type StreamErrorCode = "unexpected-close" | "unclosed-open" | "non-abit";
+
+export interface AnumToken {
+  readonly abit: Abit;
+  readonly offset: number;
+}
+
+export interface AnumForm {
+  readonly tokens: readonly AnumToken[];
+}
+
+export interface StackAlgebra<T> {
+  readonly root: T;
+  readonly linked: T;
+  readonly unlinked: T;
+  link(start: T, end: T): T;
+}
+
+export interface StreamDenotation<T> {
+  readonly denotation: T;
+  readonly resolvedValues: readonly T[];
+  readonly operations: readonly StackOperation[];
+}
+
+export class StreamError extends Error {
+  override readonly name = "StreamError";
+
+  constructor(readonly code: StreamErrorCode) {
+    super(code);
+  }
+}
+
+export class QuaternaryDecodeError extends StreamError {
+  override readonly name = "QuaternaryDecodeError";
+
+  constructor(
+    readonly offset: number,
+    readonly symbol: string,
+  ) {
+    super("non-abit");
+    this.message = `non-abit at code-point offset ${offset}: ${JSON.stringify(symbol)}`;
+  }
+}
+
+function isAbit(symbol: string): symbol is Abit {
+  return symbol === "[" || symbol === "]" || symbol === "1" || symbol === "0";
+}
+
+function isPythonWhitespace(symbol: string): boolean {
+  const code = symbol.codePointAt(0);
+  if (code === undefined) {
+    return false;
+  }
+  return (
+    (code >= 0x09 && code <= 0x0d) ||
+    (code >= 0x1c && code <= 0x20) ||
+    code === 0x85 ||
+    code === 0xa0 ||
+    code === 0x1680 ||
+    (code >= 0x2000 && code <= 0x200a) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    code === 0x202f ||
+    code === 0x205f ||
+    code === 0x3000
+  );
+}
+
+export class IncrementalQuaternaryDecoder {
+  private committedOffset = 0;
+  private inComment = false;
+  private readonly committedTokens: AnumToken[] = [];
+
+  get offset(): number {
+    return this.committedOffset;
+  }
+
+  feed(chunk: string): readonly AnumToken[] {
+    const emitted: AnumToken[] = [];
+    let nextCommentState = this.inComment;
+    let consumedCodePoints = 0;
+
+    // `for...of` идёт по Unicode code points. Счётчик отделён от UTF-16
+    // индексов JS, чтобы observable offsets совпадали с Python str iteration.
+    for (const symbol of chunk) {
+      const absoluteOffset = this.committedOffset + consumedCodePoints;
+      consumedCodePoints += 1;
+
+      if (nextCommentState) {
+        if (symbol === "\r" || symbol === "\n") {
+          nextCommentState = false;
+        }
+        continue;
+      }
+      if (symbol === "#") {
+        nextCommentState = true;
+        continue;
+      }
+      if (isPythonWhitespace(symbol)) {
+        continue;
+      }
+      if (!isAbit(symbol)) {
+        // До этой точки меняется только локальное состояние: rejected chunk
+        // не коммитит tokens, offset или comment state.
+        throw new QuaternaryDecodeError(absoluteOffset, symbol);
+      }
+      emitted.push(Object.freeze({ abit: symbol, offset: absoluteOffset }));
+    }
+
+    this.committedTokens.push(...emitted);
+    this.inComment = nextCommentState;
+    this.committedOffset += consumedCodePoints;
+    return Object.freeze([...emitted]);
+  }
+
+  finish(): AnumForm {
+    return Object.freeze({ tokens: Object.freeze([...this.committedTokens]) });
+  }
+}
+
+export function parseRawQuaternary(text: string): AnumForm {
+  const decoder = new IncrementalQuaternaryDecoder();
+  decoder.feed(text);
+  return decoder.finish();
+}
+
+export function normalizeRawForm(form: AnumForm): string {
+  return form.tokens.map((token) => token.abit).join("");
+}
+
+interface Frame<T> {
+  started: boolean;
+  current: T;
+}
+
+function append<T>(frame: Frame<T>, value: T, algebra: StackAlgebra<T>): void {
+  if (!frame.started) {
+    frame.current = value;
+    frame.started = true;
+    return;
+  }
+  frame.current = algebra.link(frame.current, value);
+}
+
+export function executeAbits<T>(
+  abits: Iterable<Abit>,
+  algebra: StackAlgebra<T>,
+): StreamDenotation<T> {
+  const frames: Frame<T>[] = [{ started: false, current: algebra.root }];
+  const resolvedValues: T[] = [];
+  const operations: StackOperation[] = [];
+
+  for (const abit of abits) {
+    if (abit === "[") {
+      frames.push({ started: false, current: algebra.root });
+      operations.push("OPEN");
+      continue;
+    }
+    if (abit === "]") {
+      if (frames.length === 1) {
+        throw new StreamError("unexpected-close");
+      }
+      const inner = frames.pop();
+      const parent = frames[frames.length - 1];
+      if (inner === undefined || parent === undefined) {
+        throw new Error("internal ANUM stack invariant violated");
+      }
+      const returned = inner.started
+        ? algebra.link(algebra.root, inner.current)
+        : algebra.root;
+      append(parent, returned, algebra);
+      operations.push("CLOSE");
+      continue;
+    }
+
+    const value = abit === "1" ? algebra.linked : algebra.unlinked;
+    const current = frames[frames.length - 1];
+    if (current === undefined) {
+      throw new Error("internal ANUM stack invariant violated");
+    }
+    resolvedValues.push(value);
+    append(current, value, algebra);
+    operations.push("VALUE");
+  }
+
+  if (frames.length !== 1) {
+    throw new StreamError("unclosed-open");
+  }
+  const rootFrame = frames[0];
+  if (rootFrame === undefined) {
+    throw new Error("internal ANUM stack invariant violated");
+  }
+  return Object.freeze({
+    denotation: rootFrame.started ? rootFrame.current : algebra.root,
+    resolvedValues: Object.freeze([...resolvedValues]),
+    operations: Object.freeze([...operations]),
+  });
+}
+
+export function deserializeAnum<T>(
+  form: AnumForm,
+  algebra: StackAlgebra<T>,
+): StreamDenotation<T> {
+  return executeAbits(form.tokens.map((token) => token.abit), algebra);
+}
+
+export function deserializeStream<T>(
+  source: string,
+  algebra: StackAlgebra<T>,
+): StreamDenotation<T> {
+  const abits: Abit[] = [];
+  for (const symbol of source) {
+    if (!isAbit(symbol)) {
+      throw new StreamError("non-abit");
+    }
+    abits.push(symbol);
+  }
+  return executeAbits(abits, algebra);
+}
+
+export function semanticLink(start: string, end: string): string {
+  if (start === "R" && end === "R") return "R";
+  if (start === "O" && end === "R") return "O";
+  if (start === "R" && end === "C") return "C";
+  if (start === "O" && end === "C") return "L";
+  if (start === "C" && end === "O") return "U";
+  return `(${start}⟼${end})`;
+}
+
+export const symbolicStackAlgebra: StackAlgebra<string> = Object.freeze({
+  root: "R",
+  linked: "L",
+  unlinked: "U",
+  link: semanticLink,
+});

--- a/ts/src/anum.ts
+++ b/ts/src/anum.ts
@@ -25,7 +25,7 @@ export interface StreamDenotation<T> {
 }
 
 export class StreamError extends Error {
-  override readonly name = "StreamError";
+  override readonly name: string = "StreamError";
 
   constructor(readonly code: StreamErrorCode) {
     super(code);
@@ -33,7 +33,7 @@ export class StreamError extends Error {
 }
 
 export class QuaternaryDecodeError extends StreamError {
-  override readonly name = "QuaternaryDecodeError";
+  override readonly name: string = "QuaternaryDecodeError";
 
   constructor(
     readonly offset: number,

--- a/ts/test/anum.test.ts
+++ b/ts/test/anum.test.ts
@@ -1,0 +1,183 @@
+import {
+  IncrementalQuaternaryDecoder,
+  QuaternaryDecodeError,
+  StreamError,
+  deserializeAnum,
+  deserializeStream,
+  executeAbits,
+  normalizeRawForm,
+  parseRawQuaternary,
+  symbolicStackAlgebra,
+  type StackAlgebra,
+  type StackOperation,
+} from "../src/anum.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectStreamError(effect: () => unknown, code: StreamError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StreamError, `expected StreamError, got ${String(error)}`);
+    assertSame(error.code, code, "stream error code");
+    return;
+  }
+  throw new Error(`expected StreamError(${code})`);
+}
+
+function expectDecodeError(effect: () => unknown, offset: number): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof QuaternaryDecodeError, `expected decode error, got ${String(error)}`);
+    assertSame(error.code, "non-abit", "decode error code");
+    assertSame(error.offset, offset, "portable code-point offset");
+    return;
+  }
+  throw new Error(`expected QuaternaryDecodeError at ${offset}`);
+}
+
+interface ValidVector {
+  readonly id: string;
+  readonly source: string;
+  readonly expectedDenotation: string;
+  readonly expectedResolvedValues?: readonly string[];
+  readonly expectedDistinctRootRefs?: readonly string[];
+  readonly expectedOperations: readonly StackOperation[];
+}
+
+const validVectors: readonly ValidVector[] = [
+  { id: "empty-stream-is-root", source: "", expectedDenotation: "R", expectedOperations: [] },
+  { id: "single-one-is-L", source: "1", expectedDenotation: "L", expectedResolvedValues: ["L"], expectedOperations: ["VALUE"] },
+  { id: "flat-pair-left-fold", source: "10", expectedDenotation: "(L⟼U)", expectedResolvedValues: ["L", "U"], expectedOperations: ["VALUE", "VALUE"] },
+  { id: "empty-group-is-root", source: "[]", expectedDenotation: "R", expectedResolvedValues: [], expectedOperations: ["OPEN", "CLOSE"] },
+  { id: "two-empty-groups-collapse-to-root", source: "[][]", expectedDenotation: "R", expectedResolvedValues: [], expectedOperations: ["OPEN", "CLOSE", "OPEN", "CLOSE"] },
+  { id: "nonempty-group-root-wraps-inner-result", source: "[10]", expectedDenotation: "(R⟼(L⟼U))", expectedResolvedValues: ["L", "U"], expectedOperations: ["OPEN", "VALUE", "VALUE", "CLOSE"] },
+  { id: "group-result-is-one-parent-value", source: "1[10]", expectedDenotation: "(L⟼(R⟼(L⟼U)))", expectedResolvedValues: ["L", "L", "U"], expectedOperations: ["VALUE", "OPEN", "VALUE", "VALUE", "CLOSE"] },
+  { id: "nested-root-wrap", source: "[[10]]", expectedDenotation: "(R⟼(R⟼(L⟼U)))", expectedResolvedValues: ["L", "U"], expectedOperations: ["OPEN", "OPEN", "VALUE", "VALUE", "CLOSE", "CLOSE"] },
+  { id: "repeated-position-reuses-semantic-L", source: "1110", expectedDenotation: "(((L⟼L)⟼L)⟼U)", expectedResolvedValues: ["L", "L", "L", "U"], expectedDistinctRootRefs: ["L", "U"], expectedOperations: ["VALUE", "VALUE", "VALUE", "VALUE"] },
+];
+
+for (const vector of validVectors) {
+  const result = deserializeStream(vector.source, symbolicStackAlgebra);
+  assertSame(result.denotation, vector.expectedDenotation, `${vector.id} denotation`);
+  assertDeepEqual(result.operations, vector.expectedOperations, `${vector.id} operations`);
+  if (vector.expectedResolvedValues !== undefined) {
+    assertDeepEqual(result.resolvedValues, vector.expectedResolvedValues, `${vector.id} values`);
+  }
+  if (vector.expectedDistinctRootRefs !== undefined) {
+    assertDeepEqual(
+      [...new Set(result.resolvedValues)].sort(),
+      [...vector.expectedDistinctRootRefs].sort(),
+      `${vector.id} distinct values`,
+    );
+  }
+}
+
+for (const vector of [
+  { source: "]", error: "unexpected-close" },
+  { source: "1]", error: "unexpected-close" },
+  { source: "[", error: "unclosed-open" },
+  { source: "[1", error: "unclosed-open" },
+  { source: "2", error: "non-abit" },
+] as const) {
+  expectStreamError(
+    () => deserializeStream(vector.source, symbolicStackAlgebra),
+    vector.error,
+  );
+}
+
+for (const source of ["", "[]", "1", "10", "[1]", "[[]]", "1110"]) {
+  assertDeepEqual(
+    deserializeAnum(parseRawQuaternary(source), symbolicStackAlgebra),
+    deserializeStream(source, symbolicStackAlgebra),
+    `parsed/raw parity for ${source}`,
+  );
+}
+
+assertSame(deserializeStream("[][]", symbolicStackAlgebra).denotation, "R", "empty groups collapse to R");
+expectStreamError(() => deserializeStream("R", symbolicStackAlgebra), "non-abit");
+expectDecodeError(() => parseRawQuaternary("R"), 0);
+
+const numericAlgebra: StackAlgebra<number> = {
+  root: 0,
+  linked: 1,
+  unlinked: 2,
+  link: (start, end) => start === 0 && end === 0 ? 0 : start * 100 + end + 10,
+};
+assertSame(executeAbits(["[", "1", "0", "]"], numericAlgebra).denotation, 122, "stack engine must be generic over result type");
+
+const commented = parseRawQuaternary("  [ 0 1 ]  # byte shell\n][");
+assertSame(normalizeRawForm(commented), "[01]][", "comments and whitespace are lexical only");
+assertDeepEqual(commented.tokens.map((token) => token.offset), [2, 4, 6, 8, 24, 25], "Python-compatible offsets");
+
+const streamedText = " [0# comment spans\n1] ][ [[ ]] ";
+const batch = parseRawQuaternary(streamedText);
+const streamedDecoder = new IncrementalQuaternaryDecoder();
+for (const chunk of [" [0# com", "ment spans", "\n1] ", "][ [", "[ ]", "] "]) {
+  streamedDecoder.feed(chunk);
+}
+const streamed = streamedDecoder.finish();
+assertSame(normalizeRawForm(streamed), normalizeRawForm(batch), "batch/incremental values must match");
+assertDeepEqual(streamed.tokens.map((token) => token.offset), batch.tokens.map((token) => token.offset), "batch/incremental offsets must match");
+
+const rejected = new IncrementalQuaternaryDecoder();
+expectDecodeError(() => rejected.feed("[0x"), 2);
+assertSame(rejected.offset, 0, "rejected first chunk must roll back offset");
+assertDeepEqual(rejected.finish().tokens, [], "rejected first chunk must roll back tokens");
+rejected.feed("[01]");
+assertDeepEqual(rejected.finish().tokens.map((token) => token.offset), [0, 1, 2, 3], "retry offsets");
+
+const later = new IncrementalQuaternaryDecoder();
+later.feed("[");
+expectDecodeError(() => later.feed("0x"), 2);
+assertSame(later.offset, 1, "rejected later chunk preserves prior offset");
+later.feed("01]");
+assertSame(normalizeRawForm(later.finish()), "[01]", "retry after later rejection");
+
+const commentRollback = new IncrementalQuaternaryDecoder();
+commentRollback.feed("# comment");
+const commentOffset = commentRollback.offset;
+expectDecodeError(() => commentRollback.feed("\n0x"), commentOffset + 2);
+assertSame(commentRollback.offset, commentOffset, "rejected chunk rolls back comment transition");
+commentRollback.feed("\n01");
+assertDeepEqual(commentRollback.finish().tokens.map((token) => token.offset), [commentOffset + 1, commentOffset + 2], "comment retry offsets");
+
+const astralBefore = parseRawQuaternary("#😀\n1");
+assertDeepEqual(astralBefore.tokens.map((token) => token.offset), [3], "astral code point before abit counts once");
+
+const astralInvalid = new IncrementalQuaternaryDecoder();
+expectDecodeError(() => astralInvalid.feed("1😀"), 1);
+assertSame(astralInvalid.offset, 0, "astral rejection rolls back valid prefix in same chunk");
+assertDeepEqual(astralInvalid.finish().tokens, [], "astral rejection rolls back tokens");
+
+const astralChunks = new IncrementalQuaternaryDecoder();
+astralChunks.feed("#😀");
+assertSame(astralChunks.offset, 2, "astral comment chunk uses code-point length");
+astralChunks.feed("\n1");
+assertDeepEqual(astralChunks.finish().tokens.map((token) => token.offset), [3], "astral chunk boundary preserves absolute offset");
+
+const astralRetry = new IncrementalQuaternaryDecoder();
+astralRetry.feed("#😀");
+expectDecodeError(() => astralRetry.feed("\n0😀"), 4);
+assertSame(astralRetry.offset, 2, "failed astral feed rolls back offset");
+assertDeepEqual(astralRetry.finish().tokens, [], "failed astral feed rolls back tokens");
+astralRetry.feed("\n01");
+assertDeepEqual(astralRetry.finish().tokens.map((token) => token.offset), [3, 4], "astral retry preserves portable offsets");
+
+const pythonSeparator = parseRawQuaternary("\u001c1");
+assertDeepEqual(pythonSeparator.tokens.map((token) => token.offset), [1], "Python control separator is whitespace");
+expectDecodeError(() => parseRawQuaternary("\ufeff1"), 0);


### PR DESCRIPTION
Fixes #447
Parent: #430 (M3)

M3a starts from the accepted post-governance baseline `63a2936126ccddd38e23d9c1ef57eef07605723b` and implements only raw/effect-free ANUM v0.4 semantics.

Implemented:
- generic `StackAlgebra<T>` with one OPEN/CLOSE/VALUE engine independent of host result type;
- symbolic string algebra reproducing accepted root-basis denotations;
- strict compact stream rejection with portable `unexpected-close`, `unclosed-open`, `non-abit` codes;
- separate raw lexical decoder that ignores comments/Python whitespace but never treats root `R` as an abit;
- transactional incremental `feed(chunk)` — rejected chunks commit no tokens, offsets or comment-state changes;
- explicit Unicode code-point offsets via `for...of`, never UTF-16 `string.length` indexing;
- Python-compatible whitespace classification rather than JS `\s`;
- all 9 accepted valid and 5 invalid ANUM v0.4 raw vectors;
- batch/incremental parity and rollback tests;
- non-BMP offset/rollback/chunk-boundary regressions;
- existing Memory test remains in the TS test command.

No carrier migration, Memory integration, Python semantic core, contracts, cutover or workflows are changed in this slice.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/anum.ts
  - ts/test/anum.test.ts
  - ts/package.json
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 500
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/anum.ts
  - ts/test/anum.test.ts
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
  - .github/workflows/**
expected_effects:
  - implement generic effect-free ANUM v0.4 raw stack semantics
  - preserve transactional incremental lexical parsing
  - preserve Python-compatible Unicode code-point source offsets
  - reproduce accepted positive and negative raw vectors exactly
```

Draft CI will prove strict TS + frozen Python oracle first; then the PR will be marked ready for the active repo-guard base-policy gate.