### PR TITLE
Add read-only ANUM carrier convergence in TypeScript

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/anum-carrier.ts
+++ b/ts/src/anum-carrier.ts
@@ -1,0 +1,171 @@
+import {
+  executeAbits,
+  type Abit,
+  type StackAlgebra,
+  type StreamDenotation,
+} from "./anum.js";
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+} from "./memory.js";
+
+export type CarrierInputErrorCode =
+  | "invalid-vocabulary"
+  | "not-rooted-sequence"
+  | "non-abit";
+
+export interface AnumCarrierVocabulary {
+  readonly opening: LinkHandle;
+  readonly closing: LinkHandle;
+  readonly linked: LinkHandle;
+  readonly unlinked: LinkHandle;
+}
+
+export interface RootedSequence {
+  readonly values: readonly LinkHandle[];
+  readonly prefixes: readonly LinkHandle[];
+}
+
+export class CarrierInputError extends Error {
+  override readonly name: string = "CarrierInputError";
+
+  constructor(readonly code: CarrierInputErrorCode) {
+    super(code);
+  }
+}
+
+function invalidVocabulary(): never {
+  throw new CarrierInputError("invalid-vocabulary");
+}
+
+export function validateCarrierVocabulary(
+  memory: ReadMemory,
+  vocabulary: AnumCarrierVocabulary,
+): void {
+  const { root } = memory;
+  const handles = [
+    root,
+    vocabulary.opening,
+    vocabulary.closing,
+    vocabulary.linked,
+    vocabulary.unlinked,
+  ];
+  if (new Set(handles).size !== 5) {
+    invalidVocabulary();
+  }
+
+  try {
+    const opening = memory.poles(vocabulary.opening);
+    const closing = memory.poles(vocabulary.closing);
+    const linked = memory.poles(vocabulary.linked);
+    const unlinked = memory.poles(vocabulary.unlinked);
+
+    if (opening.start !== vocabulary.opening || opening.end !== root) {
+      invalidVocabulary();
+    }
+    if (closing.start !== root || closing.end !== vocabulary.closing) {
+      invalidVocabulary();
+    }
+    if (linked.start !== vocabulary.opening || linked.end !== vocabulary.closing) {
+      invalidVocabulary();
+    }
+    if (unlinked.start !== vocabulary.closing || unlinked.end !== vocabulary.opening) {
+      invalidVocabulary();
+    }
+  } catch (error) {
+    if (error instanceof CarrierInputError) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      invalidVocabulary();
+    }
+    throw error;
+  }
+}
+
+export function readRootedSequence(
+  memory: ReadMemory,
+  final: LinkHandle,
+): RootedSequence {
+  const { root } = memory;
+  if (final === root) {
+    return Object.freeze({
+      values: Object.freeze([]),
+      prefixes: Object.freeze([root]),
+    });
+  }
+
+  const reversedValues: LinkHandle[] = [];
+  const reversedPrefixes: LinkHandle[] = [final];
+  const visited = new Set<LinkHandle>();
+  let current = final;
+
+  try {
+    while (current !== root) {
+      if (visited.has(current)) {
+        throw new CarrierInputError("not-rooted-sequence");
+      }
+      visited.add(current);
+      const link = memory.poles(current);
+      reversedValues.push(link.end);
+      current = link.start;
+      reversedPrefixes.push(current);
+    }
+  } catch (error) {
+    if (error instanceof CarrierInputError) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      throw new CarrierInputError("not-rooted-sequence");
+    }
+    throw error;
+  }
+
+  return Object.freeze({
+    values: Object.freeze([...reversedValues].reverse()),
+    prefixes: Object.freeze([...reversedPrefixes].reverse()),
+  });
+}
+
+function decodeCarrierAbits(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: AnumCarrierVocabulary,
+): readonly Abit[] {
+  validateCarrierVocabulary(memory, vocabulary);
+  const sequence = readRootedSequence(memory, carrier);
+  const inverse = new Map<LinkHandle, Abit>([
+    [vocabulary.opening, "["],
+    [vocabulary.closing, "]"],
+    [vocabulary.linked, "1"],
+    [vocabulary.unlinked, "0"],
+  ]);
+
+  const result: Abit[] = [];
+  for (const value of sequence.values) {
+    const abit = inverse.get(value);
+    if (abit === undefined) {
+      throw new CarrierInputError("non-abit");
+    }
+    result.push(abit);
+  }
+  return Object.freeze(result);
+}
+
+export function decodeCarrierStream(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: AnumCarrierVocabulary,
+): string {
+  return decodeCarrierAbits(memory, carrier, vocabulary).join("");
+}
+
+export function deserializeCarrier<T>(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: AnumCarrierVocabulary,
+  algebra: StackAlgebra<T>,
+): StreamDenotation<T> {
+  return executeAbits(decodeCarrierAbits(memory, carrier, vocabulary), algebra);
+}

--- a/ts/test/anum-carrier.test.ts
+++ b/ts/test/anum-carrier.test.ts
@@ -1,0 +1,203 @@
+import {
+  CarrierInputError,
+  decodeCarrierStream,
+  deserializeCarrier,
+  readRootedSequence,
+  type AnumCarrierVocabulary,
+} from "../src/anum-carrier.js";
+import {
+  StreamError,
+  deserializeStream,
+  symbolicStackAlgebra,
+} from "../src/anum.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+  type ReadMemory,
+} from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectCarrierError(effect: () => unknown, code: CarrierInputError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof CarrierInputError, `expected CarrierInputError, got ${String(error)}`);
+    assertSame(error.code, code, "carrier error code");
+    return;
+  }
+  throw new Error(`expected CarrierInputError(${code})`);
+}
+
+function expectStreamError(effect: () => unknown, code: StreamError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StreamError, `expected StreamError, got ${String(error)}`);
+    assertSame(error.code, code, "stream error code");
+    return;
+  }
+  throw new Error(`expected StreamError(${code})`);
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly read: ReadMemory;
+  readonly vocabulary: AnumCarrierVocabulary;
+  readonly root: LinkHandle;
+  carrier(source: string): LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, O, C, L, U } = ensureRootBasis(memory);
+  const vocabulary: AnumCarrierVocabulary = Object.freeze({
+    opening: O,
+    closing: C,
+    linked: L,
+    unlinked: U,
+  });
+  const values = new Map<string, LinkHandle>([
+    ["[", O],
+    ["]", C],
+    ["1", L],
+    ["0", U],
+  ]);
+
+  return {
+    memory,
+    read: memory,
+    vocabulary,
+    root: R,
+    carrier(source: string): LinkHandle {
+      let current = R;
+      for (const symbol of source) {
+        const value = values.get(symbol);
+        if (value === undefined) throw new Error(`invalid fixture symbol: ${symbol}`);
+        current = memory.ensure(current, value);
+      }
+      return current;
+    },
+  };
+}
+
+{
+  const { memory, read, vocabulary, root, carrier } = fixture();
+  const openingCarrier = carrier("[");
+  const before = memory.linkCount;
+
+  assertDeepEqual(readRootedSequence(read, root).values, [], "R is empty rooted sequence");
+  const closingSequence = readRootedSequence(read, vocabulary.closing);
+  assertDeepEqual(closingSequence.values, [vocabulary.closing], "C contributes one closing value");
+  assertDeepEqual(closingSequence.prefixes, [root, vocabulary.closing], "C rooted prefixes");
+
+  assert(openingCarrier !== vocabulary.opening, "carrier '[' is distinct from vocabulary O");
+  assertSame(decodeCarrierStream(read, openingCarrier, vocabulary), "[", "explicit '[' carrier");
+  expectCarrierError(
+    () => readRootedSequence(read, vocabulary.opening),
+    "not-rooted-sequence",
+  );
+  assertSame(memory.linkCount, before, "rooted sequence reads must not materialize");
+}
+
+{
+  const { read, vocabulary, carrier } = fixture();
+  assertSame(decodeCarrierStream(read, carrier("0"), vocabulary), "0", "single zero carrier");
+  assertSame(
+    carrier("]["),
+    vocabulary.unlinked,
+    "canonical U can have explicit carrier role for ][",
+  );
+  assertSame(
+    decodeCarrierStream(read, vocabulary.unlinked, vocabulary),
+    "][",
+    "explicit carrier role must win over vocabulary-value role",
+  );
+}
+
+const validSources = ["", "1", "10", "[]", "[][]", "[10]", "1[10]", "[[10]]", "1110"];
+for (const source of validSources) {
+  const { memory, read, vocabulary, carrier } = fixture();
+  const selected = carrier(source);
+  const before = memory.linkCount;
+  const raw = deserializeStream(source, symbolicStackAlgebra);
+  const fromCarrier = deserializeCarrier(read, selected, vocabulary, symbolicStackAlgebra);
+
+  assertSame(decodeCarrierStream(read, selected, vocabulary), source, `carrier source parity: ${source}`);
+  assertDeepEqual(fromCarrier, raw, `carrier denotation parity: ${source}`);
+  assertSame(memory.linkCount, before, `carrier path is read-only: ${source}`);
+}
+
+for (const vector of [
+  { source: "]", error: "unexpected-close" },
+  { source: "1]", error: "unexpected-close" },
+  { source: "[", error: "unclosed-open" },
+  { source: "[1", error: "unclosed-open" },
+] as const) {
+  const { read, vocabulary, carrier } = fixture();
+  const selected = carrier(vector.source);
+  expectStreamError(
+    () => deserializeStream(vector.source, symbolicStackAlgebra),
+    vector.error,
+  );
+  expectStreamError(
+    () => deserializeCarrier(read, selected, vocabulary, symbolicStackAlgebra),
+    vector.error,
+  );
+}
+
+{
+  const { memory, read, vocabulary, root } = fixture();
+  const other = memory.ensureStartSelfClosed(vocabulary.linked);
+  const carrier = memory.ensure(root, other);
+  const before = memory.linkCount;
+  expectCarrierError(
+    () => decodeCarrierStream(read, carrier, vocabulary),
+    "non-abit",
+  );
+  assertSame(memory.linkCount, before, "non-abit rejection must not materialize");
+}
+
+{
+  const { read, vocabulary, root } = fixture();
+  const wrong: AnumCarrierVocabulary = {
+    opening: vocabulary.closing,
+    closing: vocabulary.opening,
+    linked: vocabulary.linked,
+    unlinked: vocabulary.unlinked,
+  };
+  expectCarrierError(() => decodeCarrierStream(read, root, wrong), "invalid-vocabulary");
+}
+
+{
+  const { read, vocabulary, root } = fixture();
+  const foreignRoot = new Memory().root;
+  const foreign: AnumCarrierVocabulary = {
+    ...vocabulary,
+    opening: foreignRoot,
+  };
+  expectCarrierError(() => decodeCarrierStream(read, root, foreign), "invalid-vocabulary");
+}
+
+{
+  const { memory, read, vocabulary, root } = fixture();
+  const before = memory.linkCount;
+  assertSame(decodeCarrierStream(read, root, vocabulary), "", "R is empty carrier");
+  assertSame(decodeCarrierStream(read, vocabulary.closing, vocabulary), "]", "C is canonical ] carrier");
+  assertSame(decodeCarrierStream(read, vocabulary.unlinked, vocabulary), "][", "U is canonical ][ carrier");
+  assertSame(memory.linkCount, before, "structural carrier cases are read-only");
+}


### PR DESCRIPTION
Fixes #464
Parent: #430 (M3)

M3b starts from accepted M3a main `b8336fe0de371f6003e375bd4e69b630282ca7c9` and adds only the existing-carrier transport for `anum-deserialization/v0.4`.

Implemented:
- production carrier API accepts `ReadMemory` only;
- finite R-rooted start-history reader with cycle rejection;
- explicit root/O/C/L/U vocabulary validation;
- portable carrier errors `invalid-vocabulary`, `not-rooted-sequence`, `non-abit`;
- carrier values decode to the four abits and delegate to the **existing M3a `executeAbits`** engine;
- no `ensure*` or materialization call exists in the production carrier path;
- all 9 accepted valid raw sources reproduce exact carrier source + denotation;
- applicable invalid raw vectors preserve the same stack error code through carrier;
- exact structural cases `R -> ""`, `C -> "]"`, `U -> "]["`;
- explicit-role regression: carrier `"]["` is canonical U while single `0` carrier is structurally different;
- non-rooted O, non-abit sequence value, wrong vocabulary and foreign handle fail closed;
- runtime `linkCount` is unchanged across carrier decode/deserialization.

`ts/src/anum.ts`, Python core, contracts, cutover, docs and workflows are untouched.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/anum-carrier.ts
  - ts/test/anum-carrier.test.ts
  - ts/package.json
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 420
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/anum-carrier.ts
  - ts/test/anum-carrier.test.ts
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
  - docs/**
  - .github/workflows/**
  - ts/src/anum.ts
expected_effects:
  - add read-only existing-carrier transport for ANUM v0.4
  - reuse the single accepted M3a stack machine for raw and carrier input
  - preserve explicit carrier-role and no-materialization boundaries
```

Draft CI first proves strict TypeScript + frozen Python oracle; then the PR will be marked ready for the active repo-guard base-policy gate.