### PR TITLE
Add indexed structural Act readers in TypeScript

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/structural-readers.ts
+++ b/ts/src/structural-readers.ts
@@ -1,0 +1,101 @@
+import type { LinkHandle, ReadMemory } from "./memory.js";
+
+export type StructuralReadErrorCode =
+  | "invalid-act-header"
+  | "missing-required-field"
+  | "multiple-field-values"
+  | "act-header-mismatch";
+
+export interface ActHeader {
+  readonly interpreter: LinkHandle;
+  readonly roleDictionary: LinkHandle;
+  readonly afterContext: LinkHandle;
+}
+
+export class StructuralReadError extends Error {
+  override readonly name: string = "StructuralReadError";
+
+  constructor(readonly code: StructuralReadErrorCode) {
+    super(code);
+  }
+}
+
+export function readActHeader(
+  memory: ReadMemory,
+  act: LinkHandle,
+): ActHeader {
+  const actLink = memory.poles(act);
+  if (actLink.start !== act) {
+    throw new StructuralReadError("invalid-act-header");
+  }
+
+  const header = memory.poles(actLink.end);
+  const roleAndContext = memory.poles(header.end);
+  return Object.freeze({
+    interpreter: header.start,
+    roleDictionary: roleAndContext.start,
+    afterContext: roleAndContext.end,
+  });
+}
+
+export function readOptionalMany(
+  memory: ReadMemory,
+  act: LinkHandle,
+  role: LinkHandle,
+): readonly LinkHandle[] {
+  const values: LinkHandle[] = [];
+
+  // ReadMemory exposes the indexed outgoing surface directly. This avoids the
+  // Python-era whole-network scan and keeps the reader independent of storage.
+  for (const attachment of memory.outgoing(act)) {
+    if (attachment === act) {
+      // A is start-self-closed, therefore A itself is in outgoing(A), but it is
+      // the header carrier rather than a role-field attachment.
+      continue;
+    }
+    const attachmentLink = memory.poles(attachment);
+    if (attachmentLink.start !== act) {
+      continue;
+    }
+    const field = memory.poles(attachmentLink.end);
+    if (field.start === role) {
+      values.push(field.end);
+    }
+  }
+
+  return Object.freeze(values);
+}
+
+export function readRequiredSingle(
+  memory: ReadMemory,
+  act: LinkHandle,
+  role: LinkHandle,
+): LinkHandle {
+  const values = readOptionalMany(memory, act, role);
+  if (values.length === 0) {
+    throw new StructuralReadError("missing-required-field");
+  }
+  if (values.length !== 1) {
+    throw new StructuralReadError("multiple-field-values");
+  }
+  const value = values[0];
+  if (value === undefined) {
+    throw new Error("internal structural reader cardinality invariant violated");
+  }
+  return value;
+}
+
+export function verifyHeader(
+  memory: ReadMemory,
+  act: LinkHandle,
+  expected: ActHeader,
+): void {
+  const actual = readActHeader(memory, act);
+  if (
+    actual.interpreter !== expected.interpreter ||
+    actual.roleDictionary !== expected.roleDictionary ||
+    actual.afterContext !== expected.afterContext
+  ) {
+    throw new StructuralReadError("act-header-mismatch");
+  }
+}

--- a/ts/test/structural-readers.test.ts
+++ b/ts/test/structural-readers.test.ts
@@ -1,0 +1,198 @@
+import {
+  StructuralReadError,
+  readActHeader,
+  readOptionalMany,
+  readRequiredSingle,
+  verifyHeader,
+} from "../src/structural-readers.js";
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectStructuralError(
+  effect: () => unknown,
+  code: StructuralReadError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralReadError, `expected StructuralReadError, got ${String(error)}`);
+    assertSame(error.code, code, "structural error code");
+    return;
+  }
+  throw new Error(`expected StructuralReadError(${code})`);
+}
+
+function nextAnchor(memory: Memory, previous: LinkHandle): LinkHandle {
+  return memory.ensureStartSelfClosed(previous);
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = nextAnchor(memory, current);
+    result.push(current);
+  }
+  return result;
+}
+
+function defineActHeader(
+  memory: Memory,
+  interpreter: LinkHandle,
+  roleDictionary: LinkHandle,
+  afterContext: LinkHandle,
+): LinkHandle {
+  const roleAndContext = memory.ensure(roleDictionary, afterContext);
+  const header = memory.ensure(interpreter, roleAndContext);
+  return memory.ensureStartSelfClosed(header);
+}
+
+function defineActField(
+  memory: Memory,
+  act: LinkHandle,
+  role: LinkHandle,
+  value: LinkHandle,
+): LinkHandle {
+  const field = memory.ensure(role, value);
+  return memory.ensure(act, field);
+}
+
+class IndexedReadProbe implements ReadMemory {
+  outgoingCalls = 0;
+
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle {
+    return this.source.root;
+  }
+
+  get linkCount(): number {
+    return this.source.linkCount;
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    return this.source.poles(link);
+  }
+
+  find(): LinkHandle | undefined {
+    throw new Error("structural reader must not use pair search");
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.outgoingCalls += 1;
+    return this.source.outgoing(start);
+  }
+
+  incoming(): readonly LinkHandle[] {
+    throw new Error("structural reader must not use incoming scan");
+  }
+}
+
+const memory = new Memory();
+const [
+  interpreter,
+  roleDictionary,
+  afterContext,
+  roleSource,
+  roleTheory,
+  roleMany,
+  source,
+  theory,
+  valueOne,
+  valueTwo,
+  mismatch,
+] = anchors(memory, 11);
+
+assert(
+  interpreter !== undefined &&
+  roleDictionary !== undefined &&
+  afterContext !== undefined &&
+  roleSource !== undefined &&
+  roleTheory !== undefined &&
+  roleMany !== undefined &&
+  source !== undefined &&
+  theory !== undefined &&
+  valueOne !== undefined &&
+  valueTwo !== undefined &&
+  mismatch !== undefined,
+  "fixture anchors must exist",
+);
+
+const act = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+defineActField(memory, act, roleSource, source);
+defineActField(memory, act, roleTheory, theory);
+defineActField(memory, act, roleMany, valueOne);
+defineActField(memory, act, roleMany, valueTwo);
+
+// Repeating the same semantic attachment does not manufacture another field.
+const repeatedOne = defineActField(memory, act, roleSource, source);
+const repeatedTwo = defineActField(memory, act, roleSource, source);
+assertSame(repeatedOne, repeatedTwo, "same act/role/value attachment must be canonical");
+
+// Add unrelated topology to prove role reads are local to indexed outgoing(A).
+let noise = mismatch;
+for (let index = 0; index < 40; index += 1) {
+  noise = memory.ensureStartSelfClosed(noise);
+}
+const beforeReads = memory.linkCount;
+
+const header = readActHeader(memory, act);
+assertSame(header.interpreter, interpreter, "act interpreter");
+assertSame(header.roleDictionary, roleDictionary, "act role dictionary");
+assertSame(header.afterContext, afterContext, "act after-context");
+verifyHeader(memory, act, { interpreter, roleDictionary, afterContext });
+expectStructuralError(
+  () => verifyHeader(memory, act, { interpreter: mismatch, roleDictionary, afterContext }),
+  "act-header-mismatch",
+);
+
+const probe = new IndexedReadProbe(memory);
+assertDeepEqual(readOptionalMany(probe, act, roleSource), [source], "one role value");
+assertSame(probe.outgoingCalls, 1, "role lookup must use indexed outgoing(act) once");
+assertDeepEqual(readOptionalMany(memory, act, roleTheory), [theory], "second role value");
+assertDeepEqual(readOptionalMany(memory, act, mismatch), [], "missing optional role");
+assertDeepEqual(
+  readOptionalMany(memory, act, roleMany),
+  [valueOne, valueTwo],
+  "distinct values remain structurally visible",
+);
+
+assertSame(readRequiredSingle(memory, act, roleSource), source, "required single role");
+expectStructuralError(
+  () => readRequiredSingle(memory, act, mismatch),
+  "missing-required-field",
+);
+expectStructuralError(
+  () => readRequiredSingle(memory, act, roleMany),
+  "multiple-field-values",
+);
+
+const ordinary = memory.ensure(interpreter, theory);
+expectStructuralError(() => readActHeader(memory, ordinary), "invalid-act-header");
+
+assertSame(memory.linkCount, beforeReads + 1, "only explicit fixture construction may add a link");
+const afterOrdinaryConstruction = memory.linkCount;
+readActHeader(memory, act);
+readOptionalMany(memory, act, roleSource);
+readRequiredSingle(memory, act, roleTheory);
+verifyHeader(memory, act, { interpreter, roleDictionary, afterContext });
+assertSame(memory.linkCount, afterOrdinaryConstruction, "structural readers must be read-only");


### PR DESCRIPTION
Fixes #466
Parent: #430 (M4)

M4a starts from accepted M3 main `6547e8d08dc05596c018108a6408702122010ac4` and adds only generic structural Act readers before any interpreter/proof DTO migration.

Implemented:
- `readActHeader(memory, act)` for exact `A = A -> (I -> (D_roles -> K_after))` topology;
- `readOptionalMany(memory, act, role)` using indexed `ReadMemory.outgoing(act)`;
- `readRequiredSingle(...)` with fail-closed missing/ambiguous cardinality;
- `verifyHeader(...)` for exact already-selected interpreter/role-dictionary/after-context handles;
- production API accepts `ReadMemory` only;
- no role-name resolution, semantic search, inference or materialization;
- repeated identical attachment remains one canonical Link while distinct role values remain visible;
- non-act shapes, missing fields, multiple values and header mismatches reject;
- test probe forbids pair/incoming lookup and confirms one indexed outgoing call;
- unrelated topology does not affect role reads;
- `linkCount` remains unchanged across all production reads.

No Python core, contracts, cutover, docs, workflows, Memory or ANUM production files changed.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/structural-readers.ts
  - ts/test/structural-readers.test.ts
  - ts/package.json
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 360
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/structural-readers.ts
  - ts/test/structural-readers.test.ts
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
  - docs/**
  - .github/workflows/**
  - ts/src/memory.ts
  - ts/src/anum.ts
  - ts/src/anum-carrier.ts
expected_effects:
  - add indexed read-only structural Act readers
  - avoid full-network scans and Python Evidence DTO porting
  - establish reusable exact header and role-field verification primitives
```

Draft CI first proves strict TypeScript + existing M2/M3 suites + frozen Python oracle; then ready mode will run blocking repo-guard.