### PR TITLE
Add canonical context and indexed local representatives in TypeScript

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/state.ts
+++ b/ts/src/state.ts
@@ -1,0 +1,145 @@
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+  type WriteMemory,
+} from "./memory.js";
+
+export type StateErrorCode = "invalid-context" | "representative-conflict";
+
+export interface ContextState {
+  readonly parent: LinkHandle;
+  readonly current: LinkHandle;
+}
+
+export interface LocalRepresentativeResolution {
+  readonly member: LinkHandle;
+  readonly representative: LinkHandle;
+  readonly bindings: readonly LinkHandle[];
+}
+
+export class StateError extends Error {
+  override readonly name: string = "StateError";
+
+  constructor(readonly code: StateErrorCode) {
+    super(code);
+  }
+}
+
+export function defineContext(
+  memory: WriteMemory,
+  parent: LinkHandle,
+  current: LinkHandle,
+): LinkHandle {
+  const payload = memory.ensure(parent, current);
+  return memory.ensureStartSelfClosed(payload);
+}
+
+export function readContext(
+  memory: ReadMemory,
+  context: LinkHandle,
+): ContextState {
+  try {
+    const contextLink = memory.poles(context);
+    if (contextLink.start !== context) {
+      throw new StateError("invalid-context");
+    }
+    const payload = memory.poles(contextLink.end);
+    return Object.freeze({ parent: payload.start, current: payload.end });
+  } catch (error) {
+    if (error instanceof StateError) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      throw new StateError("invalid-context");
+    }
+    throw error;
+  }
+}
+
+export function parentOfContext(
+  memory: ReadMemory,
+  context: LinkHandle,
+): LinkHandle {
+  return readContext(memory, context).parent;
+}
+
+export function currentOfContext(
+  memory: ReadMemory,
+  context: LinkHandle,
+): LinkHandle {
+  return readContext(memory, context).current;
+}
+
+export function defineLocalRepresentativeBinding(
+  memory: WriteMemory,
+  context: LinkHandle,
+  member: LinkHandle,
+  representative: LinkHandle,
+): LinkHandle {
+  const pair = memory.ensure(member, representative);
+  return memory.ensure(context, pair);
+}
+
+export function localRepresentativeResolution(
+  memory: ReadMemory,
+  context: LinkHandle,
+  member: LinkHandle,
+): LocalRepresentativeResolution {
+  // Validation is explicit and also guarantees that `outgoing(context)` is a
+  // query over an issued handle in this Memory.
+  readContext(memory, context);
+
+  const matches: Array<{
+    readonly binding: LinkHandle;
+    readonly representative: LinkHandle;
+  }> = [];
+
+  // Python scanned every Link. The indexed Memory already exposes precisely the
+  // candidate attachments whose start pole is the selected context.
+  for (const binding of memory.outgoing(context)) {
+    if (binding === context) {
+      continue;
+    }
+    const attachment = memory.poles(binding);
+    if (attachment.start !== context) {
+      continue;
+    }
+    const pair = memory.poles(attachment.end);
+    if (pair.start === member) {
+      matches.push({ binding, representative: pair.end });
+    }
+  }
+
+  if (matches.length === 0) {
+    return Object.freeze({
+      member,
+      representative: member,
+      bindings: Object.freeze([]),
+    });
+  }
+
+  const representatives = new Set(matches.map((match) => match.representative));
+  if (representatives.size !== 1) {
+    throw new StateError("representative-conflict");
+  }
+
+  const representative = matches[0]?.representative;
+  if (representative === undefined) {
+    throw new Error("internal representative resolution invariant violated");
+  }
+
+  return Object.freeze({
+    member,
+    representative,
+    bindings: Object.freeze(matches.map((match) => match.binding)),
+  });
+}
+
+export function localRepresentative(
+  memory: ReadMemory,
+  context: LinkHandle,
+  member: LinkHandle,
+): LinkHandle {
+  return localRepresentativeResolution(memory, context, member).representative;
+}

--- a/ts/test/state.test.ts
+++ b/ts/test/state.test.ts
@@ -1,0 +1,185 @@
+import {
+  StateError,
+  currentOfContext,
+  defineContext,
+  defineLocalRepresentativeBinding,
+  localRepresentative,
+  localRepresentativeResolution,
+  parentOfContext,
+  readContext,
+} from "../src/state.js";
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectStateError(effect: () => unknown, code: StateError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StateError, `expected StateError, got ${String(error)}`);
+    assertSame(error.code, code, "state error code");
+    return;
+  }
+  throw new Error(`expected StateError(${code})`);
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+class IndexedContextProbe implements ReadMemory {
+  outgoingCalls = 0;
+
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle {
+    return this.source.root;
+  }
+
+  get linkCount(): number {
+    return this.source.linkCount;
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    return this.source.poles(link);
+  }
+
+  find(): LinkHandle | undefined {
+    throw new Error("local representative resolution must not use pair lookup");
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.outgoingCalls += 1;
+    return this.source.outgoing(start);
+  }
+
+  incoming(): readonly LinkHandle[] {
+    throw new Error("local representative resolution must not use incoming scan");
+  }
+}
+
+const memory = new Memory();
+const [
+  parent,
+  current,
+  otherParent,
+  otherCurrent,
+  member,
+  representativeOne,
+  representativeTwo,
+  otherMember,
+  otherRepresentative,
+  ordinaryLeft,
+  ordinaryRight,
+] = anchors(memory, 11);
+
+assert(
+  parent !== undefined &&
+  current !== undefined &&
+  otherParent !== undefined &&
+  otherCurrent !== undefined &&
+  member !== undefined &&
+  representativeOne !== undefined &&
+  representativeTwo !== undefined &&
+  otherMember !== undefined &&
+  otherRepresentative !== undefined &&
+  ordinaryLeft !== undefined &&
+  ordinaryRight !== undefined,
+  "fixture anchors must exist",
+);
+
+const context = defineContext(memory, parent, current);
+const sameContext = defineContext(memory, parent, current);
+assertSame(sameContext, context, "same parent/current must reuse canonical context");
+
+const otherContext = defineContext(memory, otherParent, otherCurrent);
+assert(otherContext !== context, "different explicit context must remain distinct");
+
+const beforeContextReads = memory.linkCount;
+assertDeepEqual(readContext(memory, context), { parent, current }, "context payload");
+assertSame(parentOfContext(memory, context), parent, "context parent");
+assertSame(currentOfContext(memory, context), current, "context current");
+assertSame(currentOfContext(memory, otherContext), otherCurrent, "no ambient context stack");
+assertSame(memory.linkCount, beforeContextReads, "context reads must not materialize");
+
+const ordinary = memory.ensure(ordinaryLeft, ordinaryRight);
+expectStateError(() => readContext(memory, ordinary), "invalid-context");
+const foreignContext = defineContext(new Memory(), new Memory().root, new Memory().root);
+expectStateError(() => readContext(memory, foreignContext), "invalid-context");
+
+const fallback = localRepresentativeResolution(memory, context, member);
+assertSame(fallback.member, member, "fallback member");
+assertSame(fallback.representative, member, "missing binding falls back to member");
+assertDeepEqual(fallback.bindings, [], "fallback has no binding evidence");
+assertSame(localRepresentative(memory, context, member), member, "fallback convenience reader");
+
+const bindingOne = defineLocalRepresentativeBinding(
+  memory,
+  context,
+  member,
+  representativeOne,
+);
+const repeatedBinding = defineLocalRepresentativeBinding(
+  memory,
+  context,
+  member,
+  representativeOne,
+);
+assertSame(repeatedBinding, bindingOne, "same representative binding must be canonical");
+
+const unrelatedBinding = defineLocalRepresentativeBinding(
+  memory,
+  context,
+  otherMember,
+  otherRepresentative,
+);
+assert(unrelatedBinding !== bindingOne, "unrelated binding must remain distinct");
+
+const probe = new IndexedContextProbe(memory);
+const resolved = localRepresentativeResolution(probe, context, member);
+assertSame(probe.outgoingCalls, 1, "resolution must use one indexed outgoing(context) query");
+assertSame(resolved.member, member, "resolved member");
+assertSame(resolved.representative, representativeOne, "resolved representative");
+assertDeepEqual(resolved.bindings, [bindingOne], "exact matching binding evidence");
+assertSame(localRepresentative(memory, context, member), representativeOne, "representative convenience reader");
+
+// Topology elsewhere in Memory must not affect the indexed context-local result.
+let noise = otherRepresentative;
+for (let index = 0; index < 40; index += 1) {
+  noise = memory.ensureStartSelfClosed(noise);
+}
+const beforeResolutionReads = memory.linkCount;
+const stillResolved = localRepresentativeResolution(memory, context, member);
+assertSame(stillResolved.representative, representativeOne, "unrelated topology is irrelevant");
+assertDeepEqual(stillResolved.bindings, [bindingOne], "unrelated topology does not add bindings");
+assertSame(memory.linkCount, beforeResolutionReads, "representative reads must not materialize");
+
+defineLocalRepresentativeBinding(memory, context, member, representativeTwo);
+expectStateError(
+  () => localRepresentativeResolution(memory, context, member),
+  "representative-conflict",
+);

--- a/ts/test/state.test.ts
+++ b/ts/test/state.test.ts
@@ -128,7 +128,10 @@ assertSame(memory.linkCount, beforeContextReads, "context reads must not materia
 
 const ordinary = memory.ensure(ordinaryLeft, ordinaryRight);
 expectStateError(() => readContext(memory, ordinary), "invalid-context");
-const foreignContext = defineContext(new Memory(), new Memory().root, new Memory().root);
+const foreignMemory = new Memory();
+const foreignParent = foreignMemory.ensureStartSelfClosed(foreignMemory.root);
+const foreignCurrent = foreignMemory.ensureEndSelfClosed(foreignMemory.root);
+const foreignContext = defineContext(foreignMemory, foreignParent, foreignCurrent);
 expectStateError(() => readContext(memory, foreignContext), "invalid-context");
 
 const fallback = localRepresentativeResolution(memory, context, member);


### PR DESCRIPTION
Fixes #468
Parent: #430 (M5)

M5a starts from accepted M4a main `9a000a00354f8d44d437416c615a883b0ee72998` and ports only explicit Context plus local representative state semantics.

Implemented:
- `defineContext(WriteMemory, parent, current)` as canonical `K = K -> (parent -> current)`;
- `readContext`, `parentOfContext`, `currentOfContext` over `ReadMemory` only;
- non-start-self-closed and foreign context handles fail closed as `invalid-context`;
- `defineLocalRepresentativeBinding(WriteMemory, context, member, representative)` as `context -> (member -> representative)`;
- `localRepresentativeResolution(ReadMemory, ...)` validates context and inspects only indexed `outgoing(context)`;
- no binding falls back to the member itself;
- one distinct representative returns exact binding evidence;
- repeated identical binding is canonical;
- distinct representatives for one member/context fail `representative-conflict`;
- unrelated context-local and global topology does not affect the result;
- test probe forbids `find`/`incoming` and proves exactly one `outgoing(context)` query;
- read operations preserve `linkCount` and there is no ambient context/session state.

No Python core, contracts, cutover, docs, workflows, Memory/ANUM/structural-reader production files changed.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/state.ts
  - ts/test/state.test.ts
  - ts/package.json
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 360
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/state.ts
  - ts/test/state.test.ts
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
  - docs/**
  - .github/workflows/**
  - ts/src/memory.ts
  - ts/src/anum.ts
  - ts/src/anum-carrier.ts
  - ts/src/structural-readers.ts
expected_effects:
  - add explicit canonical Context state semantics in TypeScript
  - replace Python full-network representative lookup with indexed outgoing(context)
  - preserve local representative fallback and conflict behavior
```

Draft CI first proves strict TypeScript + all accepted M2-M4 suites + frozen Python oracle; ready mode then runs the active blocking repo-guard policy.