### PR TITLE
Add scoped dictionary parent/history semantics in TypeScript

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/dictionary.ts
+++ b/ts/src/dictionary.ts
@@ -1,0 +1,204 @@
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+  type WriteMemory,
+} from "./memory.js";
+
+export type DictionaryErrorCode =
+  | "invalid-scope"
+  | "scope-parent-cycle"
+  | "local-history-cycle"
+  | "invalid-predecessor-snapshot"
+  | "local-form-conflict"
+  | "source-not-visible"
+  | "visible-form-mismatch"
+  | "occurrence-not-visible";
+
+export interface DictionaryScope {
+  readonly parentScope: LinkHandle;
+  readonly localHistory: LinkHandle;
+}
+
+export interface DictionaryEffectRefs {
+  readonly entry: LinkHandle;
+  readonly occurrence: LinkHandle;
+  readonly historyAfter: LinkHandle;
+  readonly afterScope: LinkHandle;
+}
+
+export interface ScopedDictionaryResolution {
+  readonly scope: LinkHandle;
+  readonly form: LinkHandle;
+  readonly occurrences: readonly LinkHandle[];
+}
+
+export class DictionaryError extends Error {
+  override readonly name: string = "DictionaryError";
+
+  constructor(readonly code: DictionaryErrorCode) {
+    super(code);
+  }
+}
+
+export function defineDictionaryScope(
+  memory: WriteMemory,
+  parentScope: LinkHandle,
+  localHistory: LinkHandle,
+): LinkHandle {
+  const payload = memory.ensure(parentScope, localHistory);
+  return memory.ensureStartSelfClosed(payload);
+}
+
+export function readDictionaryScope(
+  memory: ReadMemory,
+  dictionary: LinkHandle,
+): DictionaryScope {
+  if (dictionary === memory.root) {
+    throw new DictionaryError("invalid-scope");
+  }
+
+  try {
+    const scope = memory.poles(dictionary);
+    if (scope.start !== dictionary) {
+      throw new DictionaryError("invalid-scope");
+    }
+    const payload = memory.poles(scope.end);
+    return Object.freeze({
+      parentScope: payload.start,
+      localHistory: payload.end,
+    });
+  } catch (error) {
+    if (error instanceof DictionaryError) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      throw new DictionaryError("invalid-scope");
+    }
+    throw error;
+  }
+}
+
+export function defineDictionaryEffect(
+  memory: WriteMemory,
+  beforeScope: LinkHandle,
+  parentScope: LinkHandle,
+  historyBefore: LinkHandle,
+  sourceContent: LinkHandle,
+  form: LinkHandle,
+): DictionaryEffectRefs {
+  const entry = memory.ensure(sourceContent, form);
+  const occurrence = memory.ensure(beforeScope, entry);
+  const historyAfter = memory.ensure(historyBefore, occurrence);
+  const afterScope = defineDictionaryScope(memory, parentScope, historyAfter);
+  return Object.freeze({ entry, occurrence, historyAfter, afterScope });
+}
+
+interface LocalMatch {
+  readonly occurrence: LinkHandle;
+  readonly form: LinkHandle;
+}
+
+function localDictionaryMatches(
+  memory: ReadMemory,
+  parentScope: LinkHandle,
+  localHistory: LinkHandle,
+  sourceContent: LinkHandle,
+): readonly LocalMatch[] {
+  const matches: LocalMatch[] = [];
+  const visitedHistory = new Set<LinkHandle>();
+  let history = localHistory;
+
+  while (history !== memory.root) {
+    if (visitedHistory.has(history)) {
+      throw new DictionaryError("local-history-cycle");
+    }
+    visitedHistory.add(history);
+
+    const cell = memory.poles(history);
+    const previousHistory = cell.start;
+    const occurrence = cell.end;
+    const occurrenceLink = memory.poles(occurrence);
+    const beforeScope = occurrenceLink.start;
+    const entryRef = occurrenceLink.end;
+
+    const before = readDictionaryScope(memory, beforeScope);
+    if (
+      before.parentScope !== parentScope ||
+      before.localHistory !== previousHistory
+    ) {
+      throw new DictionaryError("invalid-predecessor-snapshot");
+    }
+
+    const entry = memory.poles(entryRef);
+    if (entry.start === sourceContent) {
+      matches.push(Object.freeze({ occurrence, form: entry.end }));
+    }
+    history = previousHistory;
+  }
+
+  return Object.freeze(matches);
+}
+
+export function lookupScopedDictionary(
+  memory: ReadMemory,
+  dictionary: LinkHandle,
+  sourceContent: LinkHandle,
+): ScopedDictionaryResolution | undefined {
+  const visitedScopes = new Set<LinkHandle>();
+  let currentScope = dictionary;
+
+  while (currentScope !== memory.root) {
+    if (visitedScopes.has(currentScope)) {
+      throw new DictionaryError("scope-parent-cycle");
+    }
+    visitedScopes.add(currentScope);
+
+    const scope = readDictionaryScope(memory, currentScope);
+    const local = localDictionaryMatches(
+      memory,
+      scope.parentScope,
+      scope.localHistory,
+      sourceContent,
+    );
+
+    if (local.length > 0) {
+      const forms = new Set(local.map((match) => match.form));
+      if (forms.size !== 1) {
+        throw new DictionaryError("local-form-conflict");
+      }
+      const form = local[0]?.form;
+      if (form === undefined) {
+        throw new Error("internal dictionary resolution invariant violated");
+      }
+      return Object.freeze({
+        scope: currentScope,
+        form,
+        occurrences: Object.freeze(local.map((match) => match.occurrence)),
+      });
+    }
+
+    currentScope = scope.parentScope;
+  }
+
+  return undefined;
+}
+
+export function verifyVisibleDictionaryOccurrence(
+  memory: ReadMemory,
+  dictionary: LinkHandle,
+  occurrence: LinkHandle,
+  sourceContent: LinkHandle,
+  form: LinkHandle,
+): void {
+  const resolution = lookupScopedDictionary(memory, dictionary, sourceContent);
+  if (resolution === undefined) {
+    throw new DictionaryError("source-not-visible");
+  }
+  if (resolution.form !== form) {
+    throw new DictionaryError("visible-form-mismatch");
+  }
+  if (!resolution.occurrences.includes(occurrence)) {
+    throw new DictionaryError("occurrence-not-visible");
+  }
+}

--- a/ts/test/dictionary.test.ts
+++ b/ts/test/dictionary.test.ts
@@ -1,0 +1,226 @@
+import {
+  DictionaryError,
+  defineDictionaryEffect,
+  defineDictionaryScope,
+  lookupScopedDictionary,
+  readDictionaryScope,
+  verifyVisibleDictionaryOccurrence,
+} from "../src/dictionary.js";
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectDictionaryError(
+  effect: () => unknown,
+  code: DictionaryError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof DictionaryError, `expected DictionaryError, got ${String(error)}`);
+    assertSame(error.code, code, "dictionary error code");
+    return;
+  }
+  throw new Error(`expected DictionaryError(${code})`);
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+class ChainOnlyProbe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("dictionary lookup must not use find"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("dictionary lookup must not use outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("dictionary lookup must not use incoming"); }
+}
+
+const memory = new Memory();
+const [sourceX, sourceY, formOne, formTwo, parentY, childX, unrelated, wrongHistory] = anchors(memory, 8);
+assert(
+  sourceX !== undefined && sourceY !== undefined && formOne !== undefined &&
+  formTwo !== undefined && parentY !== undefined && childX !== undefined &&
+  unrelated !== undefined && wrongHistory !== undefined,
+  "fixture anchors must exist",
+);
+const root = memory.root;
+
+const base = defineDictionaryScope(memory, root, root);
+assertSame(defineDictionaryScope(memory, root, root), base, "empty scope must be canonical");
+assertDeepEqual(
+  readDictionaryScope(memory, base),
+  { parentScope: root, localHistory: root },
+  "empty scope payload",
+);
+expectDictionaryError(() => readDictionaryScope(memory, root), "invalid-scope");
+const ordinary = memory.ensure(sourceX, sourceY);
+expectDictionaryError(() => readDictionaryScope(memory, ordinary), "invalid-scope");
+
+const first = defineDictionaryEffect(memory, base, root, root, sourceX, formOne);
+assertDeepEqual(memory.poles(first.entry), { start: sourceX, end: formOne }, "entry topology");
+assertDeepEqual(memory.poles(first.occurrence), { start: base, end: first.entry }, "occurrence topology");
+assertDeepEqual(memory.poles(first.historyAfter), { start: root, end: first.occurrence }, "history append topology");
+assertDeepEqual(
+  readDictionaryScope(memory, first.afterScope),
+  { parentScope: root, localHistory: first.historyAfter },
+  "after-scope selects appended history",
+);
+
+const beforeReads = memory.linkCount;
+const firstResolution = lookupScopedDictionary(new ChainOnlyProbe(memory), first.afterScope, sourceX);
+assert(firstResolution !== undefined, "first definition must resolve");
+assertSame(firstResolution.form, formOne, "first resolved form");
+assertDeepEqual(firstResolution.occurrences, [first.occurrence], "first occurrence evidence");
+verifyVisibleDictionaryOccurrence(memory, first.afterScope, first.occurrence, sourceX, formOne);
+assertSame(memory.linkCount, beforeReads, "dictionary reads must not materialize");
+
+const secondSame = defineDictionaryEffect(
+  memory, first.afterScope, root, first.historyAfter, sourceX, formOne,
+);
+const repeated = lookupScopedDictionary(memory, secondSame.afterScope, sourceX);
+assert(repeated !== undefined, "repeated definition must resolve");
+assertSame(repeated.form, formOne, "repeated same form remains one semantic form");
+assertDeepEqual(
+  repeated.occurrences,
+  [secondSame.occurrence, first.occurrence],
+  "repeated definitions preserve newest-to-oldest structural events",
+);
+
+const conflicting = defineDictionaryEffect(
+  memory, first.afterScope, root, first.historyAfter, sourceX, formTwo,
+);
+expectDictionaryError(
+  () => lookupScopedDictionary(memory, conflicting.afterScope, sourceX),
+  "local-form-conflict",
+);
+
+const independentOther = defineDictionaryEffect(memory, base, root, root, sourceX, formTwo);
+assertSame(lookupScopedDictionary(memory, first.afterScope, sourceX)?.form, formOne, "first independent scope");
+assertSame(lookupScopedDictionary(memory, independentOther.afterScope, sourceX)?.form, formTwo, "second independent scope");
+
+const parentX = first;
+const parentSecond = defineDictionaryEffect(
+  memory,
+  parentX.afterScope,
+  root,
+  parentX.historyAfter,
+  sourceY,
+  parentY,
+);
+const childBase = defineDictionaryScope(memory, parentSecond.afterScope, root);
+const child = defineDictionaryEffect(
+  memory,
+  childBase,
+  parentSecond.afterScope,
+  root,
+  sourceX,
+  childX,
+);
+assertSame(lookupScopedDictionary(memory, child.afterScope, sourceX)?.form, childX, "child shadows parent");
+assertSame(lookupScopedDictionary(memory, child.afterScope, sourceY)?.form, parentY, "missing child name falls through");
+assertSame(lookupScopedDictionary(memory, child.afterScope, unrelated), undefined, "missing name stays absent");
+
+const unreachableHistory = memory.ensureStartSelfClosed(unrelated);
+const unreachableBase = defineDictionaryScope(memory, root, unreachableHistory);
+const unreachable = defineDictionaryEffect(
+  memory,
+  unreachableBase,
+  root,
+  unreachableHistory,
+  sourceY,
+  formTwo,
+);
+expectDictionaryError(
+  () => verifyVisibleDictionaryOccurrence(memory, base, unreachable.occurrence, sourceY, formTwo),
+  "source-not-visible",
+);
+expectDictionaryError(
+  () => verifyVisibleDictionaryOccurrence(memory, first.afterScope, first.occurrence, sourceX, formTwo),
+  "visible-form-mismatch",
+);
+expectDictionaryError(
+  () => verifyVisibleDictionaryOccurrence(memory, first.afterScope, independentOther.occurrence, sourceX, formOne),
+  "occurrence-not-visible",
+);
+
+const wrongBefore = defineDictionaryScope(memory, root, wrongHistory);
+const forgedOccurrence = memory.ensure(wrongBefore, first.entry);
+const forgedHistory = memory.ensure(root, forgedOccurrence);
+const forgedScope = defineDictionaryScope(memory, root, forgedHistory);
+expectDictionaryError(
+  () => lookupScopedDictionary(memory, forgedScope, sourceX),
+  "invalid-predecessor-snapshot",
+);
+
+function fake(): LinkHandle {
+  return Object.freeze({}) as LinkHandle;
+}
+
+class FakeReadMemory implements ReadMemory {
+  constructor(
+    readonly root: LinkHandle,
+    private readonly topology: ReadonlyMap<LinkHandle, LinkPoles>,
+  ) {}
+
+  get linkCount(): number { return this.topology.size; }
+  poles(link: LinkHandle): LinkPoles {
+    const poles = this.topology.get(link);
+    if (poles === undefined) throw new Error("missing fake link");
+    return poles;
+  }
+  find(): LinkHandle | undefined { throw new Error("fake dictionary must not search"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("fake dictionary must not scan outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("fake dictionary must not scan incoming"); }
+}
+
+{
+  const R = fake(), d1 = fake(), d2 = fake(), p1 = fake(), p2 = fake(), source = fake();
+  const cyclic = new FakeReadMemory(R, new Map([
+    [d1, { start: d1, end: p1 }],
+    [p1, { start: d2, end: R }],
+    [d2, { start: d2, end: p2 }],
+    [p2, { start: d1, end: R }],
+  ]));
+  expectDictionaryError(() => lookupScopedDictionary(cyclic, d1, source), "scope-parent-cycle");
+}
+
+{
+  const R = fake(), d = fake(), payload = fake(), history = fake();
+  const occurrence = fake(), entry = fake(), source = fake(), form = fake();
+  const cyclic = new FakeReadMemory(R, new Map([
+    [d, { start: d, end: payload }],
+    [payload, { start: R, end: history }],
+    [history, { start: history, end: occurrence }],
+    [occurrence, { start: d, end: entry }],
+    [entry, { start: source, end: form }],
+  ]));
+  expectDictionaryError(() => lookupScopedDictionary(cyclic, d, source), "local-history-cycle");
+}


### PR DESCRIPTION
Fixes #470
Parent: #430 (M5)

M5b starts from accepted M5a main `268742e0a87d68abad12d911cb61a57f071ccd54` and ports only scoped dictionary structural state; source/interpreter/colon replay remains separate.

Implemented:
- canonical `D = D -> (parentScope -> localHistory)` construction;
- root `R` remains a sentinel, not a concrete scope;
- exact `defineDictionaryEffect` topology for entry, occurrence, history append and after-scope;
- lookup walks only selected scope-parent and local-history chains via `ReadMemory.poles`;
- exact predecessor-snapshot validation: occurrence `beforeScope` must have the same parent and exact previous history selected by the history cell;
- repeated identical local definitions preserve newest-to-oldest structural occurrences;
- distinct forms in one local history fail `local-form-conflict` rather than last-write-wins;
- child scope shadows parent, missing child name falls through;
- globally existing but unreachable occurrences are not visible;
- visible-form and selected-occurrence verification fail closed;
- parent/history cycles fail closed;
- test probe forbids `find`, `outgoing` and `incoming`, proving no whole-memory/index search is used;
- read operations preserve `linkCount`.

No accepted M2-M5a production files, Python core, contracts, cutover, docs or workflows changed.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/dictionary.ts
  - ts/test/dictionary.test.ts
  - ts/package.json
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 500
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/dictionary.ts
  - ts/test/dictionary.test.ts
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
  - docs/**
  - .github/workflows/**
  - ts/src/memory.ts
  - ts/src/anum.ts
  - ts/src/anum-carrier.ts
  - ts/src/structural-readers.ts
  - ts/src/state.ts
expected_effects:
  - add exact scoped dictionary parent/history semantics in TypeScript
  - preserve lexical shadowing and predecessor-snapshot integrity
  - avoid whole-memory search and last-write-wins behavior
```

Draft CI first proves strict TypeScript + all prior TS slices + frozen Python oracle; then ready mode runs blocking repo-guard.