### PR TITLE
Extract generic rooted sequence reader from ANUM carrier

### DIFF
--- a/ts/src/anum-carrier.ts
+++ b/ts/src/anum-carrier.ts
@@ -9,6 +9,10 @@ import {
   type LinkHandle,
   type ReadMemory,
 } from "./memory.js";
+import {
+  RootedSequenceError,
+  readRootedSequence,
+} from "./rooted-sequence.js";
 
 export type CarrierInputErrorCode =
   | "invalid-vocabulary"
@@ -20,11 +24,6 @@ export interface AnumCarrierVocabulary {
   readonly closing: LinkHandle;
   readonly linked: LinkHandle;
   readonly unlinked: LinkHandle;
-}
-
-export interface RootedSequence {
-  readonly values: readonly LinkHandle[];
-  readonly prefixes: readonly LinkHandle[];
 }
 
 export class CarrierInputError extends Error {
@@ -84,57 +83,23 @@ export function validateCarrierVocabulary(
   }
 }
 
-export function readRootedSequence(
-  memory: ReadMemory,
-  final: LinkHandle,
-): RootedSequence {
-  const { root } = memory;
-  if (final === root) {
-    return Object.freeze({
-      values: Object.freeze([]),
-      prefixes: Object.freeze([root]),
-    });
-  }
-
-  const reversedValues: LinkHandle[] = [];
-  const reversedPrefixes: LinkHandle[] = [final];
-  const visited = new Set<LinkHandle>();
-  let current = final;
-
-  try {
-    while (current !== root) {
-      if (visited.has(current)) {
-        throw new CarrierInputError("not-rooted-sequence");
-      }
-      visited.add(current);
-      const link = memory.poles(current);
-      reversedValues.push(link.end);
-      current = link.start;
-      reversedPrefixes.push(current);
-    }
-  } catch (error) {
-    if (error instanceof CarrierInputError) {
-      throw error;
-    }
-    if (error instanceof MemoryError) {
-      throw new CarrierInputError("not-rooted-sequence");
-    }
-    throw error;
-  }
-
-  return Object.freeze({
-    values: Object.freeze([...reversedValues].reverse()),
-    prefixes: Object.freeze([...reversedPrefixes].reverse()),
-  });
-}
-
 function decodeCarrierAbits(
   memory: ReadMemory,
   carrier: LinkHandle,
   vocabulary: AnumCarrierVocabulary,
 ): readonly Abit[] {
   validateCarrierVocabulary(memory, vocabulary);
-  const sequence = readRootedSequence(memory, carrier);
+
+  let sequence;
+  try {
+    sequence = readRootedSequence(memory, carrier);
+  } catch (error) {
+    if (error instanceof RootedSequenceError) {
+      throw new CarrierInputError("not-rooted-sequence");
+    }
+    throw error;
+  }
+
   const inverse = new Map<LinkHandle, Abit>([
     [vocabulary.opening, "["],
     [vocabulary.closing, "]"],

--- a/ts/src/rooted-sequence.ts
+++ b/ts/src/rooted-sequence.ts
@@ -1,0 +1,62 @@
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+} from "./memory.js";
+
+export interface RootedSequence {
+  readonly values: readonly LinkHandle[];
+  readonly prefixes: readonly LinkHandle[];
+}
+
+export class RootedSequenceError extends Error {
+  override readonly name: string = "RootedSequenceError";
+
+  constructor(readonly code: "not-rooted-sequence") {
+    super(code);
+  }
+}
+
+export function readRootedSequence(
+  memory: ReadMemory,
+  final: LinkHandle,
+): RootedSequence {
+  const { root } = memory;
+  if (final === root) {
+    return Object.freeze({
+      values: Object.freeze([]),
+      prefixes: Object.freeze([root]),
+    });
+  }
+
+  const reversedValues: LinkHandle[] = [];
+  const reversedPrefixes: LinkHandle[] = [final];
+  const visited = new Set<LinkHandle>();
+  let current = final;
+
+  try {
+    while (current !== root) {
+      if (visited.has(current)) {
+        throw new RootedSequenceError("not-rooted-sequence");
+      }
+      visited.add(current);
+      const link = memory.poles(current);
+      reversedValues.push(link.end);
+      current = link.start;
+      reversedPrefixes.push(current);
+    }
+  } catch (error) {
+    if (error instanceof RootedSequenceError) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      throw new RootedSequenceError("not-rooted-sequence");
+    }
+    throw error;
+  }
+
+  return Object.freeze({
+    values: Object.freeze([...reversedValues].reverse()),
+    prefixes: Object.freeze([...reversedPrefixes].reverse()),
+  });
+}

--- a/ts/test/anum-carrier.test.ts
+++ b/ts/test/anum-carrier.test.ts
@@ -2,9 +2,12 @@ import {
   CarrierInputError,
   decodeCarrierStream,
   deserializeCarrier,
-  readRootedSequence,
   type AnumCarrierVocabulary,
 } from "../src/anum-carrier.js";
+import {
+  RootedSequenceError,
+  readRootedSequence,
+} from "../src/rooted-sequence.js";
 import {
   StreamError,
   deserializeStream,
@@ -41,6 +44,17 @@ function expectCarrierError(effect: () => unknown, code: CarrierInputError["code
     return;
   }
   throw new Error(`expected CarrierInputError(${code})`);
+}
+
+function expectRootedSequenceError(effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof RootedSequenceError, `expected RootedSequenceError, got ${String(error)}`);
+    assertSame(error.code, "not-rooted-sequence", "rooted-sequence error code");
+    return;
+  }
+  throw new Error("expected RootedSequenceError(not-rooted-sequence)");
 }
 
 function expectStreamError(effect: () => unknown, code: StreamError["code"]): void {
@@ -107,8 +121,9 @@ function fixture(): Fixture {
 
   assert(openingCarrier !== vocabulary.opening, "carrier '[' is distinct from vocabulary O");
   assertSame(decodeCarrierStream(read, openingCarrier, vocabulary), "[", "explicit '[' carrier");
+  expectRootedSequenceError(() => readRootedSequence(read, vocabulary.opening));
   expectCarrierError(
-    () => readRootedSequence(read, vocabulary.opening),
+    () => decodeCarrierStream(read, vocabulary.opening, vocabulary),
     "not-rooted-sequence",
   );
   assertSame(memory.linkCount, before, "rooted sequence reads must not materialize");
@@ -117,11 +132,7 @@ function fixture(): Fixture {
 {
   const { read, vocabulary, carrier } = fixture();
   assertSame(decodeCarrierStream(read, carrier("0"), vocabulary), "0", "single zero carrier");
-  assertSame(
-    carrier("]["),
-    vocabulary.unlinked,
-    "canonical U can have explicit carrier role for ][",
-  );
+  assertSame(carrier("]["), vocabulary.unlinked, "canonical U can have explicit carrier role for ][");
   assertSame(
     decodeCarrierStream(read, vocabulary.unlinked, vocabulary),
     "][",
@@ -150,10 +161,7 @@ for (const vector of [
 ] as const) {
   const { read, vocabulary, carrier } = fixture();
   const selected = carrier(vector.source);
-  expectStreamError(
-    () => deserializeStream(vector.source, symbolicStackAlgebra),
-    vector.error,
-  );
+  expectStreamError(() => deserializeStream(vector.source, symbolicStackAlgebra), vector.error);
   expectStreamError(
     () => deserializeCarrier(read, selected, vocabulary, symbolicStackAlgebra),
     vector.error,
@@ -165,10 +173,7 @@ for (const vector of [
   const other = memory.ensureStartSelfClosed(vocabulary.linked);
   const carrier = memory.ensure(root, other);
   const before = memory.linkCount;
-  expectCarrierError(
-    () => decodeCarrierStream(read, carrier, vocabulary),
-    "non-abit",
-  );
+  expectCarrierError(() => decodeCarrierStream(read, carrier, vocabulary), "non-abit");
   assertSame(memory.linkCount, before, "non-abit rejection must not materialize");
 }
 
@@ -186,10 +191,7 @@ for (const vector of [
 {
   const { read, vocabulary, root } = fixture();
   const foreignRoot = new Memory().root;
-  const foreign: AnumCarrierVocabulary = {
-    ...vocabulary,
-    opening: foreignRoot,
-  };
+  const foreign: AnumCarrierVocabulary = { ...vocabulary, opening: foreignRoot };
   expectCarrierError(() => decodeCarrierStream(read, root, foreign), "invalid-vocabulary");
 }
 


### PR DESCRIPTION
Fixes #472
Parent: #430.

This semantics-neutral refactor starts from accepted M5b main `b64d0717bf82220f912aaa704eda4f970df57dbe` and extracts the finite R-rooted start-history traversal before source content becomes its second consumer.

Changes:
- new generic `ts/src/rooted-sequence.ts` owns the single `readRootedSequence(ReadMemory, final)` implementation;
- `R` stays the empty sequence with prefixes `[R]`;
- repeated non-root handles / foreign handles fail `RootedSequenceError("not-rooted-sequence")`;
- `anum-carrier` delegates to the generic reader and explicitly maps that structural failure back to the accepted `CarrierInputError("not-rooted-sequence")`;
- existing carrier raw parity/no-materialization semantics are unchanged;
- carrier tests now prove both the generic structural error and the preserved external carrier error.

Net production/test growth is small because the old carrier-local traversal is removed. No Python core, contracts, cutover, docs, workflows, Memory, ANUM stack, state or dictionary semantics changed.

```repo-guard-yaml
change_type: refactor
scope:
  - ts/src/rooted-sequence.ts
  - ts/src/anum-carrier.ts
  - ts/test/anum-carrier.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 120
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/rooted-sequence.ts
  - ts/src/anum-carrier.ts
must_not_touch:
  - core/**
  - contracts/**
  - cutover/**
  - docs/**
  - .github/workflows/**
  - ts/src/memory.ts
  - ts/src/anum.ts
  - ts/src/structural-readers.ts
  - ts/src/state.ts
  - ts/src/dictionary.ts
expected_effects:
  - extract one generic read-only R-rooted sequence primitive
  - preserve ANUM carrier observable semantics exactly
  - avoid duplicate traversal in upcoming source-content migration
```

Draft CI first proves all TS/Python semantics unchanged; ready mode then runs blocking repo-guard.