### PR TITLE
TypeScript: add canonical source byte content and source form

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/source.ts
+++ b/ts/src/source.ts
@@ -1,0 +1,132 @@
+import {
+  type LinkHandle,
+  type ReadMemory,
+  type WriteMemory,
+} from "./memory.js";
+import {
+  RootedSequenceError,
+  readRootedSequence,
+} from "./rooted-sequence.js";
+
+export type SourceErrorCode =
+  | "invalid-byte-vocabulary"
+  | "invalid-source-content"
+  | "invalid-source";
+
+export interface SourceContent {
+  readonly bytes: Uint8Array;
+  readonly prefixes: readonly LinkHandle[];
+}
+
+export class SourceError extends Error {
+  override readonly name: string = "SourceError";
+
+  constructor(readonly code: SourceErrorCode) {
+    super(code);
+  }
+}
+
+function byteVocabulary(
+  memory: ReadMemory,
+  byteRefs: readonly LinkHandle[],
+): ReadonlyMap<LinkHandle, number> {
+  if (byteRefs.length !== 256 || new Set(byteRefs).size !== 256) {
+    throw new SourceError("invalid-byte-vocabulary");
+  }
+
+  const inverse = new Map<LinkHandle, number>();
+  for (let value = 0; value < byteRefs.length; value += 1) {
+    const ref = byteRefs[value];
+    if (ref === undefined) {
+      throw new SourceError("invalid-byte-vocabulary");
+    }
+    try {
+      memory.poles(ref);
+    } catch {
+      throw new SourceError("invalid-byte-vocabulary");
+    }
+    inverse.set(ref, value);
+  }
+  return inverse;
+}
+
+export function materializeSourceContent(
+  memory: WriteMemory,
+  byteRefs: readonly LinkHandle[],
+  bytes: Uint8Array,
+): LinkHandle {
+  byteVocabulary(memory, byteRefs);
+  let current = memory.root;
+  for (const value of bytes) {
+    const byteRef = byteRefs[value];
+    if (byteRef === undefined) {
+      throw new SourceError("invalid-byte-vocabulary");
+    }
+    current = memory.ensure(current, byteRef);
+  }
+  return current;
+}
+
+export function readSourceContent(
+  memory: ReadMemory,
+  byteRefs: readonly LinkHandle[],
+  content: LinkHandle,
+): SourceContent {
+  const inverse = byteVocabulary(memory, byteRefs);
+  let sequence;
+  try {
+    sequence = readRootedSequence(memory, content);
+  } catch (error) {
+    if (error instanceof RootedSequenceError) {
+      throw new SourceError("invalid-source-content");
+    }
+    throw error;
+  }
+
+  const bytes = new Uint8Array(sequence.values.length);
+  for (let index = 0; index < sequence.values.length; index += 1) {
+    const value = sequence.values[index];
+    if (value === undefined) {
+      throw new SourceError("invalid-source-content");
+    }
+    const byte = inverse.get(value);
+    if (byte === undefined) {
+      throw new SourceError("invalid-source-content");
+    }
+    bytes[index] = byte;
+  }
+
+  return Object.freeze({
+    bytes,
+    prefixes: Object.freeze([...sequence.prefixes]),
+  });
+}
+
+export function defineSourceForm(
+  memory: WriteMemory,
+  content: LinkHandle,
+): LinkHandle {
+  try {
+    return memory.ensureStartSelfClosed(content);
+  } catch {
+    throw new SourceError("invalid-source-content");
+  }
+}
+
+export function readSourceForm(
+  memory: ReadMemory,
+  source: LinkHandle,
+): LinkHandle {
+  try {
+    const link = memory.poles(source);
+    if (link.start !== source) {
+      throw new SourceError("invalid-source");
+    }
+    return link.end;
+  } catch (error) {
+    if (error instanceof SourceError) {
+      throw error;
+    }
+    throw new SourceError("invalid-source");
+  }
+}

--- a/ts/test/source.test.ts
+++ b/ts/test/source.test.ts
@@ -1,0 +1,151 @@
+import {
+  defineSourceForm,
+  materializeSourceContent,
+  readSourceContent,
+  readSourceForm,
+  SourceError,
+} from "../src/source.js";
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectSourceError(effect: () => unknown, code: SourceError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof SourceError, `expected SourceError, got ${String(error)}`);
+    assertSame(error.code, code, "source error code");
+    return;
+  }
+  throw new Error(`expected SourceError(${code})`);
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+class ChainOnlyProbe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("source reads must not use find"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("source reads must not use outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("source reads must not use incoming"); }
+}
+
+const memory = new Memory();
+const vocabularyAndFixtures = anchors(memory, 260);
+const byteRefs = vocabularyAndFixtures.slice(0, 256);
+const nonByte = vocabularyAndFixtures[256];
+const other = vocabularyAndFixtures[257];
+assert(byteRefs.length === 256 && nonByte !== undefined && other !== undefined, "fixture anchors must exist");
+
+{
+  const before = memory.linkCount;
+  const empty = materializeSourceContent(memory, byteRefs, new Uint8Array());
+  assertSame(empty, memory.root, "empty source content must be root");
+  const read = readSourceContent(new ChainOnlyProbe(memory), byteRefs, empty);
+  assertDeepEqual(Array.from(read.bytes), [], "empty bytes");
+  assertDeepEqual(read.prefixes, [memory.root], "empty prefixes");
+  assertSame(memory.linkCount, before, "empty source read must not materialize");
+}
+
+const utf8 = new Uint8Array([0x61, 0xe2, 0x9f, 0xbc, 0x62]);
+const content = materializeSourceContent(memory, byteRefs, utf8);
+assertSame(
+  materializeSourceContent(memory, byteRefs, new Uint8Array(utf8)),
+  content,
+  "equal bytes must reuse canonical content",
+);
+
+{
+  const before = memory.linkCount;
+  const read = readSourceContent(new ChainOnlyProbe(memory), byteRefs, content);
+  assertDeepEqual(Array.from(read.bytes), Array.from(utf8), "source bytes round-trip exactly");
+  assertSame(read.prefixes[0], memory.root, "source prefixes start at root");
+  assertSame(read.prefixes.at(-1), content, "source prefixes end at content");
+  assertSame(read.prefixes.length, utf8.length + 1, "one prefix per byte boundary");
+  assertSame(memory.linkCount, before, "source content read must not materialize");
+}
+
+const source = defineSourceForm(memory, content);
+assertSame(defineSourceForm(memory, content), source, "same content must reuse canonical source form");
+{
+  const before = memory.linkCount;
+  assertSame(readSourceForm(new ChainOnlyProbe(memory), source), content, "source form payload");
+  assertSame(memory.linkCount, before, "source form read must not materialize");
+}
+
+const distinctContent = materializeSourceContent(memory, byteRefs, new Uint8Array([0x61, 0x62]));
+const distinctSource = defineSourceForm(memory, distinctContent);
+assert(distinctContent !== content, "different bytes must have different content");
+assert(distinctSource !== source, "different content must have different source form");
+
+const nonByteContent = memory.ensure(memory.root, nonByte);
+expectSourceError(
+  () => readSourceContent(memory, byteRefs, nonByteContent),
+  "invalid-source-content",
+);
+
+const cyclicContent = memory.ensureStartSelfClosed(other);
+expectSourceError(
+  () => readSourceContent(memory, byteRefs, cyclicContent),
+  "invalid-source-content",
+);
+
+const foreign = new Memory();
+expectSourceError(
+  () => readSourceContent(memory, byteRefs, foreign.root),
+  "invalid-source-content",
+);
+expectSourceError(
+  () => defineSourceForm(memory, foreign.root),
+  "invalid-source-content",
+);
+
+const ordinary = memory.ensure(nonByte, other);
+expectSourceError(() => readSourceForm(memory, ordinary), "invalid-source");
+expectSourceError(() => readSourceForm(memory, foreign.root), "invalid-source");
+
+expectSourceError(
+  () => materializeSourceContent(memory, byteRefs.slice(0, 255), new Uint8Array([0])),
+  "invalid-byte-vocabulary",
+);
+const duplicatedVocabulary = [...byteRefs];
+duplicatedVocabulary[255] = duplicatedVocabulary[0]!;
+expectSourceError(
+  () => readSourceContent(memory, duplicatedVocabulary, content),
+  "invalid-byte-vocabulary",
+);
+const foreignVocabulary = [...byteRefs];
+foreignVocabulary[255] = foreign.root;
+expectSourceError(
+  () => readSourceContent(memory, foreignVocabulary, content),
+  "invalid-byte-vocabulary",
+);


### PR DESCRIPTION
Fixes #474
Parent: #430.

This M5c slice ports only the accepted source-content substrate and canonical source form on top of the generic rooted-sequence reader merged in #473.

Changes:
- `ts/src/source.ts`:
  - exact 256-entry distinct byte vocabulary boundary;
  - `materializeSourceContent(WriteMemory, byteRefs, Uint8Array)` folds bytes from `R`;
  - `readSourceContent(ReadMemory, byteRefs, content)` delegates traversal to `readRootedSequence`, returns exact bytes + prefixes and rejects non-byte/malformed content;
  - `defineSourceForm` preserves `S = S -> content` via `ensureStartSelfClosed`;
  - `readSourceForm` verifies the start-self-closed source topology read-only;
  - stable portable `SourceError` codes.
- `ts/test/source.test.ts` covers empty/UTF-8 bytes, canonical reuse, distinct content, read-only chain-only probe, non-byte/cyclic/foreign content, malformed source and invalid vocabularies.
- `ts/package.json` only appends the new source test to the existing TypeScript test command.

No segmentation, dictionary replay, grammar/theory evidence, source-offset semantics or M6 work is included. No existing Memory/ANUM/state/dictionary/rooted-sequence production file is modified.

Draft CI must prove strict TS + Python oracle parity first. Only after full draft green will this PR be marked ready for the separate blocking repo-guard run.