### PR TITLE
TypeScript: port selected source front-end evidence replay

### DIFF
--- a/ts/src/source.ts
+++ b/ts/src/source.ts
@@ -4,6 +4,10 @@ import {
   type WriteMemory,
 } from "./memory.js";
 import {
+  DictionaryError,
+  verifyVisibleDictionaryOccurrence,
+} from "./dictionary.js";
+import {
   RootedSequenceError,
   readRootedSequence,
 } from "./rooted-sequence.js";
@@ -11,11 +15,44 @@ import {
 export type SourceErrorCode =
   | "invalid-byte-vocabulary"
   | "invalid-source-content"
-  | "invalid-source";
+  | "invalid-source"
+  | "invalid-selected-partition"
+  | "invalid-source-evidence"
+  | "invalid-dictionary-evidence"
+  | "invalid-admission-evidence";
 
 export interface SourceContent {
   readonly bytes: Uint8Array;
   readonly prefixes: readonly LinkHandle[];
+}
+
+export interface SelectedSegmentSpec {
+  readonly start: number;
+  readonly end: number;
+  readonly form: LinkHandle;
+  readonly dictionaryOccurrence: LinkHandle;
+}
+
+export interface SelectedSegmentEvidence extends SelectedSegmentSpec {
+  readonly sliceContent: LinkHandle;
+  readonly span: LinkHandle;
+  readonly sliceEvidence: LinkHandle;
+  readonly lexeme: LinkHandle;
+  readonly resolution: LinkHandle;
+  readonly selection: LinkHandle;
+}
+
+export interface SourceFrontEndEvidence {
+  readonly content: LinkHandle;
+  readonly source: LinkHandle;
+  readonly dictionary: LinkHandle;
+  readonly grammar: LinkHandle;
+  readonly theory: LinkHandle;
+  readonly segments: readonly SelectedSegmentEvidence[];
+  readonly selectionSequence: LinkHandle;
+  readonly formSequence: LinkHandle;
+  readonly grammarMembership: LinkHandle;
+  readonly theoryMembership: LinkHandle;
 }
 
 export class SourceError extends Error {
@@ -129,4 +166,246 @@ export function readSourceForm(
     }
     throw new SourceError("invalid-source");
   }
+}
+
+function validatePartition(
+  byteLength: number,
+  segments: readonly Pick<SelectedSegmentSpec, "start" | "end">[],
+): void {
+  if (segments.length === 0) {
+    if (byteLength !== 0) {
+      throw new SourceError("invalid-selected-partition");
+    }
+    return;
+  }
+
+  let expectedStart = 0;
+  for (const segment of segments) {
+    if (
+      !Number.isInteger(segment.start) ||
+      !Number.isInteger(segment.end) ||
+      segment.start !== expectedStart ||
+      segment.end <= segment.start ||
+      segment.end > byteLength
+    ) {
+      throw new SourceError("invalid-selected-partition");
+    }
+    expectedStart = segment.end;
+  }
+  if (expectedStart !== byteLength) {
+    throw new SourceError("invalid-selected-partition");
+  }
+}
+
+function fold(memory: WriteMemory, values: readonly LinkHandle[]): LinkHandle {
+  let current = memory.root;
+  for (const value of values) {
+    current = memory.ensure(current, value);
+  }
+  return current;
+}
+
+export function buildSelectedSourceEvidence(
+  memory: WriteMemory,
+  byteRefs: readonly LinkHandle[],
+  source: LinkHandle,
+  specs: readonly SelectedSegmentSpec[],
+  options: {
+    readonly dictionary: LinkHandle;
+    readonly grammar: LinkHandle;
+    readonly theory: LinkHandle;
+  },
+): SourceFrontEndEvidence {
+  const content = readSourceForm(memory, source);
+  const sourceContent = readSourceContent(memory, byteRefs, content);
+  validatePartition(sourceContent.bytes.length, specs);
+
+  const segments: SelectedSegmentEvidence[] = [];
+  for (const spec of specs) {
+    const startPrefix = sourceContent.prefixes[spec.start];
+    const endPrefix = sourceContent.prefixes[spec.end];
+    if (startPrefix === undefined || endPrefix === undefined) {
+      throw new SourceError("invalid-selected-partition");
+    }
+    const sliceContent = materializeSourceContent(
+      memory,
+      byteRefs,
+      sourceContent.bytes.slice(spec.start, spec.end),
+    );
+    const span = memory.ensure(startPrefix, endPrefix);
+    const sliceEvidence = memory.ensure(span, sliceContent);
+    const lexeme = memory.ensure(source, sliceEvidence);
+    const resolution = memory.ensure(lexeme, spec.form);
+    const selection = memory.ensure(spec.dictionaryOccurrence, resolution);
+    segments.push(Object.freeze({
+      ...spec,
+      sliceContent,
+      span,
+      sliceEvidence,
+      lexeme,
+      resolution,
+      selection,
+    }));
+  }
+
+  const selectionSequence = fold(memory, segments.map((segment) => segment.selection));
+  const formSequence = fold(memory, segments.map((segment) => segment.form));
+  const grammarMembership = memory.ensure(options.grammar, formSequence);
+  const theoryMembership = memory.ensure(options.theory, formSequence);
+
+  return Object.freeze({
+    content,
+    source,
+    dictionary: options.dictionary,
+    grammar: options.grammar,
+    theory: options.theory,
+    segments: Object.freeze(segments),
+    selectionSequence,
+    formSequence,
+    grammarMembership,
+    theoryMembership,
+  });
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function verifyFold(
+  memory: ReadMemory,
+  final: LinkHandle,
+  values: readonly LinkHandle[],
+): void {
+  try {
+    const sequence = readRootedSequence(memory, final);
+    if (
+      sequence.values.length !== values.length ||
+      sequence.values.some((value, index) => value !== values[index])
+    ) {
+      throw new SourceError("invalid-source-evidence");
+    }
+  } catch (error) {
+    if (error instanceof SourceError) {
+      throw error;
+    }
+    if (error instanceof RootedSequenceError) {
+      throw new SourceError("invalid-source-evidence");
+    }
+    throw error;
+  }
+}
+
+function verifyMembership(
+  memory: ReadMemory,
+  membership: LinkHandle,
+  container: LinkHandle,
+  value: LinkHandle,
+): void {
+  try {
+    const link = memory.poles(membership);
+    if (link.start !== container || link.end !== value) {
+      throw new SourceError("invalid-admission-evidence");
+    }
+  } catch (error) {
+    if (error instanceof SourceError) {
+      throw error;
+    }
+    throw new SourceError("invalid-admission-evidence");
+  }
+}
+
+export function replaySelectedSourceEvidence(
+  memory: ReadMemory,
+  byteRefs: readonly LinkHandle[],
+  evidence: SourceFrontEndEvidence,
+): readonly LinkHandle[] {
+  const before = memory.linkCount;
+  const content = readSourceForm(memory, evidence.source);
+  if (content !== evidence.content) {
+    throw new SourceError("invalid-source-evidence");
+  }
+  const sourceContent = readSourceContent(memory, byteRefs, evidence.content);
+  validatePartition(sourceContent.bytes.length, evidence.segments);
+
+  const forms: LinkHandle[] = [];
+  const selections: LinkHandle[] = [];
+  for (const segment of evidence.segments) {
+    const startPrefix = sourceContent.prefixes[segment.start];
+    const endPrefix = sourceContent.prefixes[segment.end];
+    if (startPrefix === undefined || endPrefix === undefined) {
+      throw new SourceError("invalid-source-evidence");
+    }
+
+    const slice = readSourceContent(memory, byteRefs, segment.sliceContent);
+    if (!sameBytes(slice.bytes, sourceContent.bytes.slice(segment.start, segment.end))) {
+      throw new SourceError("invalid-source-evidence");
+    }
+
+    try {
+      const span = memory.poles(segment.span);
+      const sliceEvidence = memory.poles(segment.sliceEvidence);
+      const lexeme = memory.poles(segment.lexeme);
+      const resolution = memory.poles(segment.resolution);
+      if (span.start !== startPrefix || span.end !== endPrefix) {
+        throw new SourceError("invalid-source-evidence");
+      }
+      if (sliceEvidence.start !== segment.span || sliceEvidence.end !== segment.sliceContent) {
+        throw new SourceError("invalid-source-evidence");
+      }
+      if (lexeme.start !== evidence.source || lexeme.end !== segment.sliceEvidence) {
+        throw new SourceError("invalid-source-evidence");
+      }
+      if (resolution.start !== segment.lexeme || resolution.end !== segment.form) {
+        throw new SourceError("invalid-source-evidence");
+      }
+    } catch (error) {
+      if (error instanceof SourceError) {
+        throw error;
+      }
+      throw new SourceError("invalid-source-evidence");
+    }
+
+    try {
+      verifyVisibleDictionaryOccurrence(
+        memory,
+        evidence.dictionary,
+        segment.dictionaryOccurrence,
+        segment.sliceContent,
+        segment.form,
+      );
+    } catch (error) {
+      if (error instanceof DictionaryError) {
+        throw new SourceError("invalid-dictionary-evidence");
+      }
+      throw error;
+    }
+
+    try {
+      const selection = memory.poles(segment.selection);
+      if (
+        selection.start !== segment.dictionaryOccurrence ||
+        selection.end !== segment.resolution
+      ) {
+        throw new SourceError("invalid-source-evidence");
+      }
+    } catch (error) {
+      if (error instanceof SourceError) {
+        throw error;
+      }
+      throw new SourceError("invalid-source-evidence");
+    }
+
+    forms.push(segment.form);
+    selections.push(segment.selection);
+  }
+
+  verifyFold(memory, evidence.selectionSequence, selections);
+  verifyFold(memory, evidence.formSequence, forms);
+  verifyMembership(memory, evidence.grammarMembership, evidence.grammar, evidence.formSequence);
+  verifyMembership(memory, evidence.theoryMembership, evidence.theory, evidence.formSequence);
+
+  if (memory.linkCount !== before) {
+    throw new SourceError("invalid-source-evidence");
+  }
+  return Object.freeze(forms);
 }

--- a/ts/test/source.test.ts
+++ b/ts/test/source.test.ts
@@ -1,10 +1,18 @@
 import {
+  buildSelectedSourceEvidence,
   defineSourceForm,
   materializeSourceContent,
   readSourceContent,
   readSourceForm,
+  replaySelectedSourceEvidence,
   SourceError,
+  type SelectedSegmentSpec,
+  type SourceFrontEndEvidence,
 } from "../src/source.js";
+import {
+  defineDictionaryEffect,
+  defineDictionaryScope,
+} from "../src/dictionary.js";
 import {
   Memory,
   type LinkHandle,
@@ -149,3 +157,231 @@ expectSourceError(
   () => readSourceContent(memory, foreignVocabulary, content),
   "invalid-byte-vocabulary",
 );
+
+interface DictionaryFixture {
+  readonly dictionary: LinkHandle;
+  readonly occurrences: readonly LinkHandle[];
+}
+
+function dictionaryWith(
+  target: Memory,
+  vocabulary: readonly LinkHandle[],
+  mappings: readonly (readonly [Uint8Array, LinkHandle])[],
+): DictionaryFixture {
+  const root = target.root;
+  let history = root;
+  let dictionary = defineDictionaryScope(target, root, history);
+  const occurrences: LinkHandle[] = [];
+  for (const [bytes, form] of mappings) {
+    const effect = defineDictionaryEffect(
+      target,
+      dictionary,
+      root,
+      history,
+      materializeSourceContent(target, vocabulary, bytes),
+      form,
+    );
+    occurrences.push(effect.occurrence);
+    history = effect.historyAfter;
+    dictionary = effect.afterScope;
+  }
+  return Object.freeze({ dictionary, occurrences: Object.freeze(occurrences) });
+}
+
+function spec(
+  start: number,
+  end: number,
+  form: LinkHandle,
+  dictionaryOccurrence: LinkHandle,
+): SelectedSegmentSpec {
+  return Object.freeze({ start, end, form, dictionaryOccurrence });
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 264);
+  const bytes = refs.slice(0, 256);
+  const [formA, formArrow, formB, grammar, theory] = refs.slice(256, 261);
+  assert(
+    bytes.length === 256 && formA !== undefined && formArrow !== undefined &&
+    formB !== undefined && grammar !== undefined && theory !== undefined,
+    "front-end fixture refs",
+  );
+  const raw = new Uint8Array([0x61, 0xe2, 0x9f, 0xbc, 0x62]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, raw));
+  const dictionary = dictionaryWith(target, bytes, [
+    [new Uint8Array([0x61]), formA],
+    [new Uint8Array([0xe2, 0x9f, 0xbc]), formArrow],
+    [new Uint8Array([0x62]), formB],
+  ]);
+  const evidence = buildSelectedSourceEvidence(
+    target,
+    bytes,
+    sourceForm,
+    [
+      spec(0, 1, formA, dictionary.occurrences[0]!),
+      spec(1, 4, formArrow, dictionary.occurrences[1]!),
+      spec(4, 5, formB, dictionary.occurrences[2]!),
+    ],
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+
+  const before = target.linkCount;
+  assertDeepEqual(
+    replaySelectedSourceEvidence(new ChainOnlyProbe(target), bytes, evidence),
+    [formA, formArrow, formB],
+    "multibyte arrow is one caller-selected segment",
+  );
+  assertSame(target.linkCount, before, "front-end replay must be read-only");
+  assertSame(evidence.segments[1]?.start, 1, "arrow start byte coordinate");
+  assertSame(evidence.segments[1]?.end, 4, "arrow end byte coordinate");
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 262);
+  const bytes = refs.slice(0, 256);
+  const [formOne, formTwo, grammar, theory] = refs.slice(256, 260);
+  assert(bytes.length === 256 && formOne && formTwo && grammar && theory, "dictionary fixture refs");
+  const raw = new Uint8Array([0x78]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, raw));
+  const one = dictionaryWith(target, bytes, [[raw, formOne]]);
+  const two = dictionaryWith(target, bytes, [[raw, formTwo]]);
+  const evidenceOne = buildSelectedSourceEvidence(
+    target, bytes, sourceForm, [spec(0, 1, formOne, one.occurrences[0]!)],
+    { dictionary: one.dictionary, grammar, theory },
+  );
+  const evidenceTwo = buildSelectedSourceEvidence(
+    target, bytes, sourceForm, [spec(0, 1, formTwo, two.occurrences[0]!)],
+    { dictionary: two.dictionary, grammar, theory },
+  );
+  assertSame(evidenceOne.content, evidenceTwo.content, "same bytes share content");
+  assertSame(evidenceOne.source, evidenceTwo.source, "same bytes share source form");
+  assertDeepEqual(replaySelectedSourceEvidence(target, bytes, evidenceOne), [formOne], "dictionary one");
+  assertDeepEqual(replaySelectedSourceEvidence(target, bytes, evidenceTwo), [formTwo], "dictionary two");
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 265);
+  const bytes = refs.slice(0, 256);
+  const [left, right, grammar, theory, unrelated] = refs.slice(256, 261);
+  assert(bytes.length === 256 && left && right && grammar && theory && unrelated, "semantic form fixture refs");
+  const existingForm = target.ensure(left, right);
+  const raw = new Uint8Array([0x78]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, raw));
+  const dictionary = dictionaryWith(target, bytes, [[raw, existingForm]]);
+  const evidence = buildSelectedSourceEvidence(
+    target, bytes, sourceForm, [spec(0, 1, existingForm, dictionary.occurrences[0]!)],
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+  assertSame(replaySelectedSourceEvidence(target, bytes, evidence)[0], existingForm, "existing Link is direct resolved form");
+
+  const forgedSpan = target.ensureStartSelfClosed(unrelated);
+  const forgedSpanEvidence: SourceFrontEndEvidence = Object.freeze({
+    ...evidence,
+    segments: Object.freeze([
+      Object.freeze({ ...evidence.segments[0]!, span: forgedSpan }),
+    ]),
+  });
+  expectSourceError(
+    () => replaySelectedSourceEvidence(target, bytes, forgedSpanEvidence),
+    "invalid-source-evidence",
+  );
+
+  const forgedGrammar: SourceFrontEndEvidence = Object.freeze({
+    ...evidence,
+    grammarMembership: target.ensure(grammar, unrelated),
+  });
+  expectSourceError(
+    () => replaySelectedSourceEvidence(target, bytes, forgedGrammar),
+    "invalid-admission-evidence",
+  );
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 264);
+  const bytes = refs.slice(0, 256);
+  const [formA, formB, formAB, grammar, theory] = refs.slice(256, 261);
+  assert(bytes.length === 256 && formA && formB && formAB && grammar && theory, "ambiguous fixture refs");
+  const a = new Uint8Array([0x61]);
+  const b = new Uint8Array([0x62]);
+  const ab = new Uint8Array([0x61, 0x62]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, ab));
+  const dictionary = dictionaryWith(target, bytes, [[a, formA], [b, formB], [ab, formAB]]);
+  const split = buildSelectedSourceEvidence(
+    target, bytes, sourceForm,
+    [spec(0, 1, formA, dictionary.occurrences[0]!), spec(1, 2, formB, dictionary.occurrences[1]!)],
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+  const whole = buildSelectedSourceEvidence(
+    target, bytes, sourceForm,
+    [spec(0, 2, formAB, dictionary.occurrences[2]!)],
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+  assertDeepEqual(replaySelectedSourceEvidence(target, bytes, split), [formA, formB], "split segmentation");
+  assertDeepEqual(replaySelectedSourceEvidence(target, bytes, whole), [formAB], "whole segmentation");
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 264);
+  const bytes = refs.slice(0, 256);
+  const [formX, formY, grammar, theory] = refs.slice(256, 260);
+  assert(bytes.length === 256 && formX && formY && grammar && theory, "history fixture refs");
+  const x = new Uint8Array([0x78]);
+  const y = new Uint8Array([0x79]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, x));
+  const dictionary = dictionaryWith(target, bytes, [[x, formX], [y, formY]]);
+  const evidence = buildSelectedSourceEvidence(
+    target, bytes, sourceForm, [spec(0, 1, formX, dictionary.occurrences[0]!)],
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+  assertDeepEqual(replaySelectedSourceEvidence(target, bytes, evidence), [formX], "earlier visible occurrence remains valid");
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 266);
+  const bytes = refs.slice(0, 256);
+  const [form, otherForm, grammar, theory] = refs.slice(256, 260);
+  assert(bytes.length === 256 && form && otherForm && grammar && theory, "foreign dictionary fixture refs");
+  const x = new Uint8Array([0x78]);
+  const y = new Uint8Array([0x79]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, x));
+  const primary = dictionaryWith(target, bytes, [[x, form]]);
+  const structurallyOther = dictionaryWith(target, bytes, [[y, otherForm], [x, form]]);
+  const evidence = buildSelectedSourceEvidence(
+    target,
+    bytes,
+    sourceForm,
+    [spec(0, 1, form, structurallyOther.occurrences[1]!)],
+    { dictionary: primary.dictionary, grammar, theory },
+  );
+  expectSourceError(
+    () => replaySelectedSourceEvidence(target, bytes, evidence),
+    "invalid-dictionary-evidence",
+  );
+}
+
+{
+  const target = new Memory();
+  const refs = anchors(target, 260);
+  const bytes = refs.slice(0, 256);
+  const [form, grammar, theory] = refs.slice(256, 259);
+  assert(bytes.length === 256 && form && grammar && theory, "partition fixture refs");
+  const ab = new Uint8Array([0x61, 0x62]);
+  const sourceForm = defineSourceForm(target, materializeSourceContent(target, bytes, ab));
+  const dictionary = dictionaryWith(target, bytes, [[new Uint8Array([0x62]), form]]);
+  expectSourceError(
+    () => buildSelectedSourceEvidence(
+      target,
+      bytes,
+      sourceForm,
+      [spec(1, 2, form, dictionary.occurrences[0]!)],
+      { dictionary: dictionary.dictionary, grammar, theory },
+    ),
+    "invalid-selected-partition",
+  );
+}


### PR DESCRIPTION
Fixes #476
Parent: #430.

M5d ports the remaining accepted caller-selected source front-end evidence on top of M5c source content and M5b scoped dictionary.

Scope is intentionally only `ts/src/source.ts` + `ts/test/source.test.ts` (net +515, within #476 budget 520).

Implemented:
- exact segment topology: sliceContent, prefix span, slice evidence, lexeme, resolution, dictionary-occurrence selection;
- exact R-rooted selection/form folds;
- direct grammar/theory memberships to the selected form sequence;
- builder validates only contiguous full byte partition and materializes caller-selected evidence; it does not choose segmentation or verify dictionary visibility;
- trusted replay validates source/content, exact byte slice + prefix span, topology, selected dictionary occurrence visibility through existing `verifyVisibleDictionaryOccurrence`, ordered folds and G/T memberships;
- replay accepts ReadMemory only and verifies linkCount stability;
- no parser/tokenizer/longest-match/global Memory scan/M6/research semantics.

Parity regressions include multibyte arrow as one selected byte slice, same source under distinct dictionaries, existing Link as form, split-vs-whole ambiguous segmentation, earlier visible occurrence under later snapshot, forged span, structurally other dictionary occurrence, forged admission and partial partition rejection.

Draft until strict TS + frozen Python suite are green. Then require a separate non-draft blocking repo-guard run before merge.