### PR TITLE
TypeScript: port read-only relation replay

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/interpreter.ts
+++ b/ts/src/interpreter.ts
@@ -1,0 +1,211 @@
+import type { LinkHandle, ReadMemory } from "./memory.js";
+import {
+  replaySelectedSourceEvidence,
+  replaySourceSubselection,
+  type SourceFrontEndEvidence,
+  type SourceSubselectionEvidence,
+} from "./source.js";
+import { readContext } from "./state.js";
+import { readRequiredSingle, verifyHeader } from "./structural-readers.js";
+
+export interface RelationRoles {
+  readonly source: LinkHandle;
+  readonly sourceSelection: LinkHandle;
+  readonly formSequence: LinkHandle;
+  readonly dictionary: LinkHandle;
+  readonly grammar: LinkHandle;
+  readonly theory: LinkHandle;
+  readonly form: LinkHandle;
+  readonly beforeContext: LinkHandle;
+  readonly binding: LinkHandle;
+  readonly result: LinkHandle;
+  readonly afterContext: LinkHandle;
+}
+
+export interface RelationReplayEvidence {
+  readonly sourceEvidence: SourceFrontEndEvidence;
+  readonly act: LinkHandle;
+  readonly roles: RelationRoles;
+  readonly interpreter: LinkHandle;
+  readonly roleDictionary: LinkHandle;
+}
+
+export class InterpreterReplayError extends Error {
+  override readonly name = "InterpreterReplayError";
+
+  constructor(readonly code: "invalid-relation-evidence") {
+    super(code);
+  }
+}
+
+interface SelectedRelationEvidence {
+  readonly selectionSequence: LinkHandle;
+  readonly formSequence: LinkHandle;
+  readonly grammar: LinkHandle;
+  readonly theory: LinkHandle;
+  readonly form: LinkHandle;
+}
+
+function invalid(): never {
+  throw new InterpreterReplayError("invalid-relation-evidence");
+}
+
+function required(
+  memory: ReadMemory,
+  act: LinkHandle,
+  role: LinkHandle,
+): LinkHandle {
+  return readRequiredSingle(memory, act, role);
+}
+
+function replaySelectedRelation(
+  memory: ReadMemory,
+  evidence: RelationReplayEvidence,
+  selected: SelectedRelationEvidence,
+): LinkHandle {
+  const before = memory.linkCount;
+  const { roles, act, sourceEvidence } = evidence;
+
+  const source = required(memory, act, roles.source);
+  const sourceSelection = required(memory, act, roles.sourceSelection);
+  const formSequence = required(memory, act, roles.formSequence);
+  const dictionary = required(memory, act, roles.dictionary);
+  const grammar = required(memory, act, roles.grammar);
+  const theory = required(memory, act, roles.theory);
+  const form = required(memory, act, roles.form);
+  const beforeContextRef = required(memory, act, roles.beforeContext);
+  const binding = required(memory, act, roles.binding);
+  const result = required(memory, act, roles.result);
+  const afterContextRef = required(memory, act, roles.afterContext);
+
+  if (
+    source !== sourceEvidence.source ||
+    sourceSelection !== selected.selectionSequence ||
+    formSequence !== selected.formSequence ||
+    dictionary !== sourceEvidence.dictionary ||
+    grammar !== selected.grammar ||
+    theory !== selected.theory ||
+    form !== selected.form
+  ) {
+    invalid();
+  }
+
+  const beforeContext = readContext(memory, beforeContextRef);
+  if (binding !== beforeContext.current) {
+    invalid();
+  }
+
+  const formPoles = memory.poles(form);
+  const startSelfClosed = formPoles.start === form;
+  const endSelfClosed = formPoles.end === form;
+  if (startSelfClosed === endSelfClosed) {
+    // Exactly one pole must self-close. This rejects both ordinary complete
+    // forms and the unique fully self-closed root-like form.
+    invalid();
+  }
+
+  const resultPoles = memory.poles(result);
+  if (startSelfClosed) {
+    if (resultPoles.start !== binding || resultPoles.end !== formPoles.end) {
+      invalid();
+    }
+  } else if (resultPoles.start !== formPoles.start || resultPoles.end !== binding) {
+    invalid();
+  }
+
+  const afterContext = readContext(memory, afterContextRef);
+  if (
+    afterContext.parent !== beforeContext.parent ||
+    afterContext.current !== result
+  ) {
+    invalid();
+  }
+
+  verifyHeader(memory, act, {
+    interpreter: evidence.interpreter,
+    roleDictionary: evidence.roleDictionary,
+    afterContext: afterContextRef,
+  });
+
+  if (memory.linkCount !== before) {
+    invalid();
+  }
+  return result;
+}
+
+function normalizeReplay<T>(effect: () => T): T {
+  try {
+    return effect();
+  } catch (error) {
+    if (error instanceof InterpreterReplayError) {
+      throw error;
+    }
+    throw new InterpreterReplayError("invalid-relation-evidence");
+  }
+}
+
+export function replayRelationStep(
+  memory: ReadMemory,
+  byteRefs: readonly LinkHandle[],
+  evidence: RelationReplayEvidence,
+): LinkHandle {
+  return normalizeReplay(() => {
+    const before = memory.linkCount;
+    const forms = replaySelectedSourceEvidence(memory, byteRefs, evidence.sourceEvidence);
+    if (forms.length !== 1) {
+      invalid();
+    }
+    const form = forms[0];
+    if (form === undefined) {
+      invalid();
+    }
+
+    const result = replaySelectedRelation(memory, evidence, {
+      selectionSequence: evidence.sourceEvidence.selectionSequence,
+      formSequence: evidence.sourceEvidence.formSequence,
+      grammar: evidence.sourceEvidence.grammar,
+      theory: evidence.sourceEvidence.theory,
+      form,
+    });
+    if (memory.linkCount !== before) {
+      invalid();
+    }
+    return result;
+  });
+}
+
+export function replayRelationSubselectionStep(
+  memory: ReadMemory,
+  byteRefs: readonly LinkHandle[],
+  evidence: RelationReplayEvidence,
+  subselection: SourceSubselectionEvidence,
+): LinkHandle {
+  return normalizeReplay(() => {
+    const before = memory.linkCount;
+    const forms = replaySourceSubselection(
+      memory,
+      byteRefs,
+      evidence.sourceEvidence,
+      subselection,
+    );
+    if (forms.length !== 1) {
+      invalid();
+    }
+    const form = forms[0];
+    if (form === undefined) {
+      invalid();
+    }
+
+    const result = replaySelectedRelation(memory, evidence, {
+      selectionSequence: subselection.selectionSequence,
+      formSequence: subselection.formSequence,
+      grammar: subselection.grammar,
+      theory: subselection.theory,
+      form,
+    });
+    if (memory.linkCount !== before) {
+      invalid();
+    }
+    return result;
+  });
+}

--- a/ts/src/interpreter.ts
+++ b/ts/src/interpreter.ts
@@ -32,10 +32,7 @@ export interface RelationReplayEvidence {
 
 export class InterpreterReplayError extends Error {
   override readonly name = "InterpreterReplayError";
-
-  constructor(readonly code: "invalid-relation-evidence") {
-    super(code);
-  }
+  constructor(readonly code: "invalid-relation-evidence") { super(code); }
 }
 
 interface SelectedRelationEvidence {
@@ -50,14 +47,6 @@ function invalid(): never {
   throw new InterpreterReplayError("invalid-relation-evidence");
 }
 
-function required(
-  memory: ReadMemory,
-  act: LinkHandle,
-  role: LinkHandle,
-): LinkHandle {
-  return readRequiredSingle(memory, act, role);
-}
-
 function replaySelectedRelation(
   memory: ReadMemory,
   evidence: RelationReplayEvidence,
@@ -65,71 +54,49 @@ function replaySelectedRelation(
 ): LinkHandle {
   const before = memory.linkCount;
   const { roles, act, sourceEvidence } = evidence;
-
-  const source = required(memory, act, roles.source);
-  const sourceSelection = required(memory, act, roles.sourceSelection);
-  const formSequence = required(memory, act, roles.formSequence);
-  const dictionary = required(memory, act, roles.dictionary);
-  const grammar = required(memory, act, roles.grammar);
-  const theory = required(memory, act, roles.theory);
-  const form = required(memory, act, roles.form);
-  const beforeContextRef = required(memory, act, roles.beforeContext);
-  const binding = required(memory, act, roles.binding);
-  const result = required(memory, act, roles.result);
-  const afterContextRef = required(memory, act, roles.afterContext);
-
+  const field = (role: LinkHandle) => readRequiredSingle(memory, act, role);
+  const source = field(roles.source);
+  const sourceSelection = field(roles.sourceSelection);
+  const formSequence = field(roles.formSequence);
+  const dictionary = field(roles.dictionary);
+  const grammar = field(roles.grammar);
+  const theory = field(roles.theory);
+  const form = field(roles.form);
+  const beforeContextRef = field(roles.beforeContext);
+  const binding = field(roles.binding);
+  const result = field(roles.result);
+  const afterContextRef = field(roles.afterContext);
   if (
     source !== sourceEvidence.source ||
     sourceSelection !== selected.selectionSequence ||
     formSequence !== selected.formSequence ||
     dictionary !== sourceEvidence.dictionary ||
-    grammar !== selected.grammar ||
-    theory !== selected.theory ||
-    form !== selected.form
-  ) {
-    invalid();
-  }
+    grammar !== selected.grammar || theory !== selected.theory || form !== selected.form
+  ) invalid();
 
   const beforeContext = readContext(memory, beforeContextRef);
-  if (binding !== beforeContext.current) {
-    invalid();
-  }
+  if (binding !== beforeContext.current) invalid();
 
   const formPoles = memory.poles(form);
   const startSelfClosed = formPoles.start === form;
   const endSelfClosed = formPoles.end === form;
-  if (startSelfClosed === endSelfClosed) {
-    // Exactly one pole must self-close. This rejects both ordinary complete
-    // forms and the unique fully self-closed root-like form.
-    invalid();
-  }
+  // Exactly one self-closed pole is the accepted relation form. This also
+  // excludes both ordinary complete forms and the fully self-closed root.
+  if (startSelfClosed === endSelfClosed) invalid();
 
   const resultPoles = memory.poles(result);
   if (startSelfClosed) {
-    if (resultPoles.start !== binding || resultPoles.end !== formPoles.end) {
-      invalid();
-    }
-  } else if (resultPoles.start !== formPoles.start || resultPoles.end !== binding) {
-    invalid();
-  }
+    if (resultPoles.start !== binding || resultPoles.end !== formPoles.end) invalid();
+  } else if (resultPoles.start !== formPoles.start || resultPoles.end !== binding) invalid();
 
   const afterContext = readContext(memory, afterContextRef);
-  if (
-    afterContext.parent !== beforeContext.parent ||
-    afterContext.current !== result
-  ) {
-    invalid();
-  }
-
+  if (afterContext.parent !== beforeContext.parent || afterContext.current !== result) invalid();
   verifyHeader(memory, act, {
     interpreter: evidence.interpreter,
     roleDictionary: evidence.roleDictionary,
     afterContext: afterContextRef,
   });
-
-  if (memory.linkCount !== before) {
-    invalid();
-  }
+  if (memory.linkCount !== before) invalid();
   return result;
 }
 
@@ -137,9 +104,7 @@ function normalizeReplay<T>(effect: () => T): T {
   try {
     return effect();
   } catch (error) {
-    if (error instanceof InterpreterReplayError) {
-      throw error;
-    }
+    if (error instanceof InterpreterReplayError) throw error;
     throw new InterpreterReplayError("invalid-relation-evidence");
   }
 }
@@ -152,14 +117,8 @@ export function replayRelationStep(
   return normalizeReplay(() => {
     const before = memory.linkCount;
     const forms = replaySelectedSourceEvidence(memory, byteRefs, evidence.sourceEvidence);
-    if (forms.length !== 1) {
-      invalid();
-    }
-    const form = forms[0];
-    if (form === undefined) {
-      invalid();
-    }
-
+    const form = forms.length === 1 ? forms[0] : undefined;
+    if (form === undefined) invalid();
     const result = replaySelectedRelation(memory, evidence, {
       selectionSequence: evidence.sourceEvidence.selectionSequence,
       formSequence: evidence.sourceEvidence.formSequence,
@@ -167,9 +126,7 @@ export function replayRelationStep(
       theory: evidence.sourceEvidence.theory,
       form,
     });
-    if (memory.linkCount !== before) {
-      invalid();
-    }
+    if (memory.linkCount !== before) invalid();
     return result;
   });
 }
@@ -182,20 +139,9 @@ export function replayRelationSubselectionStep(
 ): LinkHandle {
   return normalizeReplay(() => {
     const before = memory.linkCount;
-    const forms = replaySourceSubselection(
-      memory,
-      byteRefs,
-      evidence.sourceEvidence,
-      subselection,
-    );
-    if (forms.length !== 1) {
-      invalid();
-    }
-    const form = forms[0];
-    if (form === undefined) {
-      invalid();
-    }
-
+    const forms = replaySourceSubselection(memory, byteRefs, evidence.sourceEvidence, subselection);
+    const form = forms.length === 1 ? forms[0] : undefined;
+    if (form === undefined) invalid();
     const result = replaySelectedRelation(memory, evidence, {
       selectionSequence: subselection.selectionSequence,
       formSequence: subselection.formSequence,
@@ -203,9 +149,7 @@ export function replayRelationSubselectionStep(
       theory: subselection.theory,
       form,
     });
-    if (memory.linkCount !== before) {
-      invalid();
-    }
+    if (memory.linkCount !== before) invalid();
     return result;
   });
 }

--- a/ts/test/interpreter-relation.test.ts
+++ b/ts/test/interpreter-relation.test.ts
@@ -1,0 +1,450 @@
+import {
+  InterpreterReplayError,
+  replayRelationStep,
+  replayRelationSubselectionStep,
+  type RelationReplayEvidence,
+  type RelationRoles,
+} from "../src/interpreter.js";
+import {
+  buildSelectedSourceEvidence,
+  defineSourceForm,
+  materializeSourceContent,
+  type SelectedSegmentSpec,
+  type SourceFrontEndEvidence,
+  type SourceSubselectionEvidence,
+} from "../src/source.js";
+import {
+  defineDictionaryEffect,
+  defineDictionaryScope,
+} from "../src/dictionary.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectReplayError(effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof InterpreterReplayError, `expected InterpreterReplayError, got ${String(error)}`);
+    assertSame(error.code, "invalid-relation-evidence", "relation error code");
+    return;
+  }
+  throw new Error("expected InterpreterReplayError");
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+function fold(memory: Memory, values: readonly LinkHandle[]): LinkHandle {
+  let current = memory.root;
+  for (const value of values) current = memory.ensure(current, value);
+  return current;
+}
+
+function spec(
+  start: number,
+  end: number,
+  form: LinkHandle,
+  dictionaryOccurrence: LinkHandle,
+): SelectedSegmentSpec {
+  return Object.freeze({ start, end, form, dictionaryOccurrence });
+}
+
+interface SourceFixture {
+  readonly evidence: SourceFrontEndEvidence;
+  readonly byteRefs: readonly LinkHandle[];
+}
+
+function sourceFixture(
+  memory: Memory,
+  forms: readonly LinkHandle[],
+): SourceFixture {
+  const byteRefs = anchors(memory, 256);
+  const [grammar, theory] = anchors(memory, 2);
+  assert(byteRefs.length === 256 && grammar !== undefined && theory !== undefined, "source fixture refs");
+
+  let history = memory.root;
+  let dictionary = defineDictionaryScope(memory, memory.root, history);
+  const occurrences: LinkHandle[] = [];
+  const bytes = new Uint8Array(forms.length);
+  for (let index = 0; index < forms.length; index += 1) {
+    const form = forms[index];
+    assert(form !== undefined, "source form");
+    const value = 0x61 + index;
+    bytes[index] = value;
+    const effect = defineDictionaryEffect(
+      memory,
+      dictionary,
+      memory.root,
+      history,
+      materializeSourceContent(memory, byteRefs, new Uint8Array([value])),
+      form,
+    );
+    occurrences.push(effect.occurrence);
+    history = effect.historyAfter;
+    dictionary = effect.afterScope;
+  }
+
+  const source = defineSourceForm(memory, materializeSourceContent(memory, byteRefs, bytes));
+  const evidence = buildSelectedSourceEvidence(
+    memory,
+    byteRefs,
+    source,
+    forms.map((form, index) => spec(index, index + 1, form, occurrences[index]!)),
+    { dictionary, grammar, theory },
+  );
+  return Object.freeze({ evidence, byteRefs: Object.freeze(byteRefs) });
+}
+
+function relationRoles(memory: Memory): RelationRoles {
+  const refs = anchors(memory, 11);
+  assert(refs.length === 11, "relation role refs");
+  return Object.freeze({
+    source: refs[0]!,
+    sourceSelection: refs[1]!,
+    formSequence: refs[2]!,
+    dictionary: refs[3]!,
+    grammar: refs[4]!,
+    theory: refs[5]!,
+    form: refs[6]!,
+    beforeContext: refs[7]!,
+    binding: refs[8]!,
+    result: refs[9]!,
+    afterContext: refs[10]!,
+  });
+}
+
+interface RelationActOptions {
+  readonly sourceEvidence: SourceFrontEndEvidence;
+  readonly selected: {
+    readonly selectionSequence: LinkHandle;
+    readonly formSequence: LinkHandle;
+    readonly grammar: LinkHandle;
+    readonly theory: LinkHandle;
+    readonly form: LinkHandle;
+  };
+  readonly roles: RelationRoles;
+  readonly interpreter: LinkHandle;
+  readonly roleDictionary: LinkHandle;
+  readonly beforeContext: LinkHandle;
+  readonly binding: LinkHandle;
+  readonly result: LinkHandle;
+  readonly afterContext: LinkHandle;
+  readonly headerInterpreter?: LinkHandle;
+  readonly headerRoleDictionary?: LinkHandle;
+  readonly headerAfterContext?: LinkHandle;
+  readonly omitResult?: boolean;
+  readonly extraResult?: LinkHandle;
+}
+
+function relationAct(memory: Memory, options: RelationActOptions): RelationReplayEvidence {
+  const act = defineActHeader(
+    memory,
+    options.headerInterpreter ?? options.interpreter,
+    options.headerRoleDictionary ?? options.roleDictionary,
+    options.headerAfterContext ?? options.afterContext,
+  );
+  const fields: readonly [LinkHandle, LinkHandle][] = [
+    [options.roles.source, options.sourceEvidence.source],
+    [options.roles.sourceSelection, options.selected.selectionSequence],
+    [options.roles.formSequence, options.selected.formSequence],
+    [options.roles.dictionary, options.sourceEvidence.dictionary],
+    [options.roles.grammar, options.selected.grammar],
+    [options.roles.theory, options.selected.theory],
+    [options.roles.form, options.selected.form],
+    [options.roles.beforeContext, options.beforeContext],
+    [options.roles.binding, options.binding],
+    [options.roles.afterContext, options.afterContext],
+  ];
+  for (const [role, value] of fields) defineActField(memory, act, role, value);
+  if (!options.omitResult) defineActField(memory, act, options.roles.result, options.result);
+  if (options.extraResult !== undefined) defineActField(memory, act, options.roles.result, options.extraResult);
+  return Object.freeze({
+    sourceEvidence: options.sourceEvidence,
+    act,
+    roles: options.roles,
+    interpreter: options.interpreter,
+    roleDictionary: options.roleDictionary,
+  });
+}
+
+function fullSelected(evidence: SourceFrontEndEvidence, form: LinkHandle) {
+  return Object.freeze({
+    selectionSequence: evidence.selectionSequence,
+    formSequence: evidence.formSequence,
+    grammar: evidence.grammar,
+    theory: evidence.theory,
+    form,
+  });
+}
+
+class ReadOnlyProbe implements ReadMemory {
+  outgoingCalls = 0;
+
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("relation replay must not use find"); }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.outgoingCalls += 1;
+    return this.source.outgoing(start);
+  }
+  incoming(): readonly LinkHandle[] { throw new Error("relation replay must not use incoming"); }
+}
+
+function validRelation(
+  formFactory: (memory: Memory, fixed: LinkHandle) => LinkHandle,
+  resultFactory: (memory: Memory, binding: LinkHandle, fixed: LinkHandle) => LinkHandle,
+) {
+  const memory = new Memory();
+  const [fixed, parent, binding, interpreter, roleDictionary] = anchors(memory, 5);
+  assert(fixed && parent && binding && interpreter && roleDictionary, "relation fixture refs");
+  const form = formFactory(memory, fixed);
+  const source = sourceFixture(memory, [form]);
+  const roles = relationRoles(memory);
+  const beforeContext = defineContext(memory, parent, binding);
+  const result = resultFactory(memory, binding, fixed);
+  const afterContext = defineContext(memory, parent, result);
+  const evidence = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result,
+    afterContext,
+  });
+  const before = memory.linkCount;
+  const probe = new ReadOnlyProbe(memory);
+  assertSame(replayRelationStep(probe, source.byteRefs, evidence), result, "relation result");
+  assertSame(memory.linkCount, before, "relation replay must be read-only");
+  assert(probe.outgoingCalls > 0, "act fields must use indexed outgoing(act)");
+  return { memory, source, roles, form, fixed, parent, binding, interpreter, roleDictionary, beforeContext, result, afterContext };
+}
+
+validRelation(
+  (memory, fixed) => memory.ensureStartSelfClosed(fixed),
+  (memory, binding, fixed) => memory.ensure(binding, fixed),
+);
+validRelation(
+  (memory, fixed) => memory.ensureEndSelfClosed(fixed),
+  (memory, binding, fixed) => memory.ensure(fixed, binding),
+);
+
+{
+  const { memory, source, roles, form, parent, binding, interpreter, roleDictionary, beforeContext, afterContext } = validRelation(
+    (target, fixed) => target.ensureStartSelfClosed(fixed),
+    (target, selectedBinding, fixed) => target.ensure(selectedBinding, fixed),
+  );
+  const [other] = anchors(memory, 1);
+  assert(other, "negative fixture ref");
+  const wrongResult = memory.ensure(other, binding);
+  const forged = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result: wrongResult,
+    afterContext,
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, forged));
+
+  const wrongBinding = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding: other,
+    result: wrongResult,
+    afterContext,
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, wrongBinding));
+
+  const changedParentContext = defineContext(memory, other, wrongResult);
+  const changedParent = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result: wrongResult,
+    afterContext: changedParentContext,
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, changedParent));
+
+  for (const header of [
+    { headerInterpreter: other },
+    { headerRoleDictionary: other },
+    { headerAfterContext: beforeContext },
+  ]) {
+    const forgedHeader = relationAct(memory, {
+      sourceEvidence: source.evidence,
+      selected: fullSelected(source.evidence, form),
+      roles,
+      interpreter,
+      roleDictionary,
+      beforeContext,
+      binding,
+      result: wrongResult,
+      afterContext,
+      ...header,
+    });
+    expectReplayError(() => replayRelationStep(memory, source.byteRefs, forgedHeader));
+  }
+
+  const missingResult = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result: wrongResult,
+    afterContext,
+    omitResult: true,
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, missingResult));
+
+  const secondResult = memory.ensure(binding, other);
+  const multipleResult = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result: wrongResult,
+    afterContext,
+    extraResult: secondResult,
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, multipleResult));
+
+  const forgedSource: SourceFrontEndEvidence = Object.freeze({
+    ...source.evidence,
+    grammarMembership: memory.ensure(source.evidence.grammar, other),
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, Object.freeze({ ...forged, sourceEvidence: forgedSource })));
+
+  // Keep the original fixture parent live in this block and prove no implicit context selection exists.
+  assert(parent !== other, "explicit parent fixture must be distinct");
+}
+
+for (const makeForm of [
+  (memory: Memory, left: LinkHandle, right: LinkHandle) => memory.ensure(left, right),
+  (memory: Memory) => memory.root,
+]) {
+  const memory = new Memory();
+  const [left, right, parent, binding, interpreter, roleDictionary] = anchors(memory, 6);
+  assert(left && right && parent && binding && interpreter && roleDictionary, "invalid-form refs");
+  const form = makeForm(memory, left, right);
+  const source = sourceFixture(memory, [form]);
+  const roles = relationRoles(memory);
+  const beforeContext = defineContext(memory, parent, binding);
+  const result = memory.ensure(binding, right);
+  const afterContext = defineContext(memory, parent, result);
+  const evidence = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: fullSelected(source.evidence, form),
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result,
+    afterContext,
+  });
+  expectReplayError(() => replayRelationStep(memory, source.byteRefs, evidence));
+}
+
+{
+  const memory = new Memory();
+  const [fixed, otherForm, parent, binding, interpreter, roleDictionary] = anchors(memory, 6);
+  assert(fixed && otherForm && parent && binding && interpreter && roleDictionary, "subselection refs");
+  const form = memory.ensureStartSelfClosed(fixed);
+  const source = sourceFixture(memory, [otherForm, form]);
+  const roles = relationRoles(memory);
+  const segment = source.evidence.segments[1]!;
+  const selectionSequence = fold(memory, [segment.selection]);
+  const formSequence = fold(memory, [form]);
+  const subselection: SourceSubselectionEvidence = Object.freeze({
+    startSegment: 1,
+    endSegment: 2,
+    selectionSequence,
+    formSequence,
+    grammar: source.evidence.grammar,
+    theory: source.evidence.theory,
+    grammarMembership: memory.ensure(source.evidence.grammar, formSequence),
+    theoryMembership: memory.ensure(source.evidence.theory, formSequence),
+  });
+  const beforeContext = defineContext(memory, parent, binding);
+  const result = memory.ensure(binding, fixed);
+  const afterContext = defineContext(memory, parent, result);
+  const evidence = relationAct(memory, {
+    sourceEvidence: source.evidence,
+    selected: { selectionSequence, formSequence, grammar: subselection.grammar, theory: subselection.theory, form },
+    roles,
+    interpreter,
+    roleDictionary,
+    beforeContext,
+    binding,
+    result,
+    afterContext,
+  });
+  const before = memory.linkCount;
+  assertSame(
+    replayRelationSubselectionStep(memory, source.byteRefs, evidence, subselection),
+    result,
+    "single relation subselection",
+  );
+  assertSame(memory.linkCount, before, "subselection relation replay must be read-only");
+
+  const all: SourceSubselectionEvidence = Object.freeze({
+    startSegment: 0,
+    endSegment: 2,
+    selectionSequence: source.evidence.selectionSequence,
+    formSequence: source.evidence.formSequence,
+    grammar: source.evidence.grammar,
+    theory: source.evidence.theory,
+    grammarMembership: source.evidence.grammarMembership,
+    theoryMembership: source.evidence.theoryMembership,
+  });
+  expectReplayError(() => replayRelationSubselectionStep(memory, source.byteRefs, evidence, all));
+
+  const forged: SourceSubselectionEvidence = Object.freeze({
+    ...subselection,
+    formSequence: source.evidence.formSequence,
+  });
+  expectReplayError(() => replayRelationSubselectionStep(memory, source.byteRefs, evidence, forged));
+}


### PR DESCRIPTION
Closes #481.

## What changed
- add a small read-only `interpreter.ts` relation replay layer;
- derive all semantic relation values from structural act role fields instead of duplicating Python DTO payload;
- keep only expected interpreter/role-dictionary plus source evidence and selected act as host evidence;
- support whole-source and trusted source-subselection relation replay through one shared verifier;
- accept exactly one self-closed pole, verify the already-existing result topology, preserve context parent/current invariants, and never materialize a missing result;
- cover start/end self-closed parity, malformed forms/results/contexts/headers/cardinality/source evidence, trusted subselection, and a ReadMemory probe with unchanged linkCount.

## Scope
Only `ts/src/interpreter.ts`, `ts/test/interpreter-relation.test.ts`, and `ts/package.json` are changed. Two new files, net +605 lines (budget +620), `behind_by=0` against M5-complete main `6521df4cf5ddb666c6f2d60e762ced548314369b`.

## Validation
Keep draft until CI is fully green. Then re-check main/race guard and `behind_by=0`, mark ready, require the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on the exact merge SHA.