### PR TITLE
TypeScript: port read-only sequence grouping

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/sequence.ts
+++ b/ts/src/sequence.ts
@@ -1,0 +1,93 @@
+import type { LinkHandle, ReadMemory } from "./memory.js";
+
+export type SequenceItem =
+  | { readonly kind: "atom"; readonly value: LinkHandle }
+  | { readonly kind: "group"; readonly items: readonly SequenceItem[] };
+
+export interface SequenceDescription {
+  readonly root: LinkHandle;
+  readonly items: readonly SequenceItem[];
+}
+
+export class SequenceReplayError extends Error {
+  override readonly name = "SequenceReplayError";
+  constructor(readonly code: "invalid-sequence-evidence") { super(code); }
+}
+
+function invalid(): never {
+  throw new SequenceReplayError("invalid-sequence-evidence");
+}
+
+function validateHandle(memory: ReadMemory, link: LinkHandle): void {
+  try { memory.poles(link); }
+  catch { invalid(); }
+}
+
+function validateInputs(
+  memory: ReadMemory,
+  forms: readonly LinkHandle[],
+  openForm: LinkHandle,
+  closeForm: LinkHandle,
+): void {
+  validateHandle(memory, openForm);
+  validateHandle(memory, closeForm);
+  if (openForm === closeForm) invalid();
+  for (const form of forms) validateHandle(memory, form);
+}
+
+export function replayRootOpeningRestoration(
+  memory: ReadMemory,
+  forms: readonly LinkHandle[],
+  openForm: LinkHandle,
+  closeForm: LinkHandle,
+): readonly LinkHandle[] {
+  const before = memory.linkCount;
+  validateInputs(memory, forms, openForm, closeForm);
+  if (forms.length === 0 || forms[0] !== openForm) return forms;
+
+  let balance = 0;
+  let minimum = 0;
+  for (const form of forms) {
+    if (form === openForm) balance += 1;
+    else if (form === closeForm) balance -= 1;
+    minimum = Math.min(minimum, balance);
+  }
+  const result = minimum < 0
+    ? Object.freeze([...Array<LinkHandle>(-minimum).fill(openForm), ...forms])
+    : forms;
+  if (memory.linkCount !== before) invalid();
+  return result;
+}
+
+export function replayResolvedSequenceGrouping(
+  memory: ReadMemory,
+  forms: readonly LinkHandle[],
+  openForm: LinkHandle,
+  closeForm: LinkHandle,
+): SequenceDescription {
+  const before = memory.linkCount;
+  validateInputs(memory, forms, openForm, closeForm);
+
+  const rootItems: SequenceItem[] = [];
+  const stack: SequenceItem[][] = [rootItems];
+  for (const form of forms) {
+    if (form === openForm) {
+      stack.push([]);
+      continue;
+    }
+    if (form === closeForm) {
+      if (stack.length === 1) invalid();
+      const items = stack.pop();
+      if (items === undefined) invalid();
+      stack[stack.length - 1]!.push(Object.freeze({
+        kind: "group" as const,
+        items: Object.freeze(items),
+      }));
+      continue;
+    }
+    stack[stack.length - 1]!.push(Object.freeze({ kind: "atom" as const, value: form }));
+  }
+  if (stack.length !== 1) invalid();
+  if (memory.linkCount !== before) invalid();
+  return Object.freeze({ root: memory.root, items: Object.freeze(rootItems) });
+}

--- a/ts/test/sequence-grouping.test.ts
+++ b/ts/test/sequence-grouping.test.ts
@@ -1,0 +1,130 @@
+import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
+import {
+  SequenceReplayError,
+  replayResolvedSequenceGrouping,
+  replayRootOpeningRestoration,
+  type SequenceItem,
+} from "../src/sequence.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function reject(effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof SequenceReplayError, `expected SequenceReplayError, got ${String(error)}`);
+    same(error.code, "invalid-sequence-evidence", "sequence error code");
+    return;
+  }
+  throw new Error("expected invalid-sequence-evidence");
+}
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+function atom(item: SequenceItem | undefined, value: LinkHandle, message: string): void {
+  assert(item?.kind === "atom", `${message}: expected atom`);
+  same(item.value, value, `${message}: value`);
+}
+function group(item: SequenceItem | undefined, length: number, message: string): readonly SequenceItem[] {
+  assert(item?.kind === "group", `${message}: expected group`);
+  same(item.items.length, length, `${message}: length`);
+  return item.items;
+}
+
+{
+  const m = new Memory();
+  const [open, close, a, b, c] = anchors(m, 5);
+  assert(open && close && a && b && c, "fixture refs");
+  const before = m.linkCount;
+
+  const empty = replayResolvedSequenceGrouping(m, [], open, close);
+  same(empty.root, m.root, "empty root");
+  same(empty.items.length, 0, "empty items");
+
+  const flat = replayResolvedSequenceGrouping(m, [a, b], open, close);
+  atom(flat.items[0], a, "flat a");
+  atom(flat.items[1], b, "flat b");
+
+  const nested = replayResolvedSequenceGrouping(m, [open, a, b, close, c], open, close);
+  const nestedItems = group(nested.items[0], 2, "nested group");
+  atom(nestedItems[0], a, "nested a");
+  atom(nestedItems[1], b, "nested b");
+  atom(nested.items[1], c, "nested tail");
+
+  const emptyNested = replayResolvedSequenceGrouping(m, [open, close], open, close);
+  group(emptyNested.items[0], 0, "empty nested group");
+
+  const deep = replayResolvedSequenceGrouping(m, [open, a, open, b, close, close], open, close);
+  const outer = group(deep.items[0], 2, "outer group");
+  atom(outer[0], a, "outer atom");
+  const inner = group(outer[1], 1, "inner group");
+  atom(inner[0], b, "inner atom");
+
+  same(m.linkCount, before, "grouping must be read-only");
+}
+
+{
+  const m = new Memory();
+  const [open, close, a] = anchors(m, 3);
+  assert(open && close && a, "fixture refs");
+  reject(() => replayResolvedSequenceGrouping(m, [close], open, close));
+  reject(() => replayResolvedSequenceGrouping(m, [open, a], open, close));
+  reject(() => replayResolvedSequenceGrouping(m, [a], open, open));
+}
+
+{
+  const m = new Memory();
+  const [open, close, a] = anchors(m, 3);
+  assert(open && close && a, "fixture refs");
+  const before = m.linkCount;
+  const balanced = [open, a, close] as const;
+  same(replayRootOpeningRestoration(m, balanced, open, close), balanced, "balanced unchanged identity");
+
+  const deficit = replayRootOpeningRestoration(m, [open, close, close], open, close);
+  same(deficit.length, 4, "restored length");
+  same(deficit[0], open, "restored repeated opening");
+  same(deficit[1], open, "original opening retained");
+
+  const ineligible = [a, close] as const;
+  same(replayRootOpeningRestoration(m, ineligible, open, close), ineligible, "non-leading open unchanged");
+  same(m.linkCount, before, "restoration must be read-only");
+}
+
+{
+  const left = new Memory();
+  const right = new Memory();
+  const [open, close, a] = anchors(left, 3);
+  const [foreign] = anchors(right, 1);
+  assert(open && close && a && foreign, "foreign refs");
+  reject(() => replayResolvedSequenceGrouping(left, [foreign], open, close));
+  reject(() => replayRootOpeningRestoration(left, [open, foreign], open, close));
+  reject(() => replayResolvedSequenceGrouping(left, [a], foreign, close));
+}
+
+class Probe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("sequence replay must not use find"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("sequence replay must not use outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("sequence replay must not use incoming"); }
+}
+
+{
+  const m = new Memory();
+  const [open, close, a] = anchors(m, 3);
+  assert(open && close && a, "probe refs");
+  const probe = new Probe(m);
+  replayResolvedSequenceGrouping(probe, [open, a, close], open, close);
+  replayRootOpeningRestoration(probe, [open, close, close], open, close);
+}


### PR DESCRIPTION
Closes #485.

## What changed
- add new read-only `ts/src/sequence.ts` with explicit `SequenceItem` / `SequenceDescription` host checker representation;
- implement root-opening restoration using only explicit selected `openForm`/`closeForm` identity and repeated uses of the same opening Link;
- implement resolved sequence grouping with nested host groups, valid empty groups, exact unexpected-close/missing-close rejection, and root `R` on the description;
- validate issued handles through `ReadMemory.poles`, preserve `linkCount`, and perform no pair lookup, scan, or materialization;
- cover empty/flat/nested/deep/empty-group cases, delimiter failures, restoration balance/deficit/ineligible cases, foreign handles, and a ReadMemory probe that forbids find/outgoing/incoming.

## Scope
Only new `ts/src/sequence.ts`, new `ts/test/sequence-grouping.test.ts`, and `ts/package.json` change. Two new files, net +222 lines against budget +470, `behind_by=0` from exact accepted main `e5bffe694d70096765a517926af86bde92fd9310`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.