### PR TITLE
TypeScript: port explicit sequence materialization

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/sequence.ts
+++ b/ts/src/sequence.ts
@@ -1,4 +1,4 @@
-import type { LinkHandle, ReadMemory } from "./memory.js";
+import type { LinkHandle, ReadMemory, WriteMemory } from "./memory.js";
 
 export type SequenceItem =
   | { readonly kind: "atom"; readonly value: LinkHandle }
@@ -7,6 +7,20 @@ export type SequenceItem =
 export interface SequenceDescription {
   readonly root: LinkHandle;
   readonly items: readonly SequenceItem[];
+}
+
+export interface MaterializedEdge {
+  readonly ref: LinkHandle;
+  readonly start: LinkHandle;
+  readonly end: LinkHandle;
+}
+
+export interface SequenceMaterializationEffect {
+  readonly description: SequenceDescription;
+  readonly result: LinkHandle;
+  readonly created: readonly MaterializedEdge[];
+  readonly linkCountBefore: number;
+  readonly linkCountAfter: number;
 }
 
 export class SequenceReplayError extends Error {
@@ -33,6 +47,17 @@ function validateInputs(
   validateHandle(memory, closeForm);
   if (openForm === closeForm) invalid();
   for (const form of forms) validateHandle(memory, form);
+}
+
+function validateDescription(memory: ReadMemory, description: SequenceDescription): void {
+  if (description.root !== memory.root) invalid();
+  const visit = (items: readonly SequenceItem[]): void => {
+    for (const item of items) {
+      if (item.kind === "atom") validateHandle(memory, item.value);
+      else visit(item.items);
+    }
+  };
+  visit(description.items);
 }
 
 export function replayRootOpeningRestoration(
@@ -90,4 +115,97 @@ export function replayResolvedSequenceGrouping(
   if (stack.length !== 1) invalid();
   if (memory.linkCount !== before) invalid();
   return Object.freeze({ root: memory.root, items: Object.freeze(rootItems) });
+}
+
+function materializeItems(
+  memory: WriteMemory,
+  items: readonly SequenceItem[],
+  created: MaterializedEdge[],
+): LinkHandle {
+  const values = items.map((item) => item.kind === "atom"
+    ? item.value
+    : materializeItems(memory, item.items, created));
+  if (values.length === 0) return memory.root;
+  let result = values[0]!;
+  for (let index = 1; index < values.length; index += 1) {
+    const end = values[index]!;
+    const existing = memory.find(result, end);
+    const ref = memory.ensure(result, end);
+    if (existing !== undefined) {
+      if (ref !== existing) invalid();
+    } else {
+      created.push(Object.freeze({ ref, start: result, end }));
+    }
+    result = ref;
+  }
+  return result;
+}
+
+export function materializeSequence(
+  memory: WriteMemory,
+  description: SequenceDescription,
+): SequenceMaterializationEffect {
+  validateDescription(memory, description);
+  const linkCountBefore = memory.linkCount;
+  const created: MaterializedEdge[] = [];
+  const result = materializeItems(memory, description.items, created);
+  const linkCountAfter = memory.linkCount;
+  if (linkCountAfter !== linkCountBefore + created.length) invalid();
+  return Object.freeze({
+    description,
+    result,
+    created: Object.freeze(created),
+    linkCountBefore,
+    linkCountAfter,
+  });
+}
+
+function replayItems(memory: ReadMemory, items: readonly SequenceItem[]): LinkHandle {
+  const values = items.map((item) => item.kind === "atom"
+    ? item.value
+    : replayItems(memory, item.items));
+  if (values.length === 0) return memory.root;
+  let result = values[0]!;
+  for (let index = 1; index < values.length; index += 1) {
+    const ref = memory.find(result, values[index]!);
+    if (ref === undefined) invalid();
+    result = ref;
+  }
+  return result;
+}
+
+export function replaySequenceMaterialization(
+  memory: ReadMemory,
+  effect: SequenceMaterializationEffect,
+): LinkHandle {
+  const before = memory.linkCount;
+  validateDescription(memory, effect.description);
+  const required = new Set<LinkHandle>();
+  const collect = (items: readonly SequenceItem[]): LinkHandle => {
+    const values = items.map((item) => item.kind === "atom" ? item.value : collect(item.items));
+    if (values.length === 0) return memory.root;
+    let result = values[0]!;
+    for (let index = 1; index < values.length; index += 1) {
+      const ref = memory.find(result, values[index]!);
+      if (ref === undefined) invalid();
+      required.add(ref);
+      result = ref;
+    }
+    return result;
+  };
+  const result = collect(effect.description.items);
+  if (result !== effect.result) invalid();
+
+  const seen = new Set<LinkHandle>();
+  for (const edge of effect.created) {
+    validateHandle(memory, edge.ref);
+    if (seen.has(edge.ref) || !required.has(edge.ref)) invalid();
+    seen.add(edge.ref);
+    const poles = memory.poles(edge.ref);
+    if (poles.start !== edge.start || poles.end !== edge.end) invalid();
+    if (memory.find(edge.start, edge.end) !== edge.ref) invalid();
+  }
+  if (effect.linkCountAfter !== effect.linkCountBefore + effect.created.length) invalid();
+  if (memory.linkCount !== before) invalid();
+  return result;
 }

--- a/ts/test/sequence-materialization.test.ts
+++ b/ts/test/sequence-materialization.test.ts
@@ -1,0 +1,179 @@
+import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
+import {
+  SequenceReplayError,
+  materializeSequence,
+  replaySequenceMaterialization,
+  type SequenceDescription,
+  type SequenceItem,
+  type SequenceMaterializationEffect,
+} from "../src/sequence.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function reject(effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof SequenceReplayError, `expected SequenceReplayError, got ${String(error)}`);
+    same(error.code, "invalid-sequence-evidence", "sequence error code");
+    return;
+  }
+  throw new Error("expected invalid-sequence-evidence");
+}
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+const atom = (value: LinkHandle): SequenceItem => Object.freeze({ kind: "atom", value });
+const group = (...items: SequenceItem[]): SequenceItem => Object.freeze({ kind: "group", items: Object.freeze(items) });
+const description = (memory: Memory, ...items: SequenceItem[]): SequenceDescription =>
+  Object.freeze({ root: memory.root, items: Object.freeze(items) });
+
+{
+  const m = new Memory();
+  const [a, b, c] = anchors(m, 3);
+  assert(a && b && c, "fixture refs");
+
+  const empty = materializeSequence(m, description(m));
+  same(empty.result, m.root, "empty result root");
+  same(empty.created.length, 0, "empty creates");
+
+  const singleton = materializeSequence(m, description(m, atom(a)));
+  same(singleton.result, a, "singleton same link");
+  same(singleton.created.length, 0, "singleton creates");
+
+  const two = materializeSequence(m, description(m, atom(a), atom(b)));
+  same(two.created.length, 1, "two atom create count");
+  same(two.created[0]?.start, a, "two atom start");
+  same(two.created[0]?.end, b, "two atom end");
+  same(m.poles(two.result).start, a, "two atom result start");
+  same(m.poles(two.result).end, b, "two atom result end");
+
+  const reused = materializeSequence(m, description(m, atom(a), atom(b)));
+  same(reused.result, two.result, "existing pair reused");
+  same(reused.created.length, 0, "reused creates none");
+
+  const three = materializeSequence(m, description(m, atom(a), atom(b), atom(c)));
+  same(three.created.length, 1, "partial prefix creates suffix only");
+  same(three.created[0]?.start, two.result, "suffix starts at reused prefix");
+  same(three.created[0]?.end, c, "suffix end");
+}
+
+{
+  const m = new Memory();
+  const [a, b, c] = anchors(m, 3);
+  assert(a && b && c, "nested refs");
+  const nested = materializeSequence(m, description(m, group(atom(a), atom(b)), atom(c)));
+  same(nested.created.length, 2, "nested creates inner and outer");
+  same(nested.created[1]?.start, nested.created[0]?.ref, "nested result feeds outer fold");
+
+  const emptyNested = materializeSequence(m, description(m, group(), atom(c)));
+  same(emptyNested.created.length, 1, "empty group contributes root");
+  same(emptyNested.created[0]?.start, m.root, "empty group is root");
+  same(emptyNested.created[0]?.end, c, "empty group fold end");
+}
+
+{
+  const m = new Memory();
+  const [a, b] = anchors(m, 2);
+  assert(a && b, "reuse refs");
+  const effect = materializeSequence(m, description(m,
+    group(atom(a), atom(b)),
+    group(atom(a), atom(b)),
+  ));
+  same(effect.created.length, 2, "same nested pair created once plus outer self-pair");
+  same(effect.created[0]?.start, a, "nested first start");
+  same(effect.created[0]?.end, b, "nested first end");
+  same(effect.created[1]?.start, effect.created[0]?.ref, "outer starts with reused nested ref");
+  same(effect.created[1]?.end, effect.created[0]?.ref, "outer ends with reused nested ref");
+}
+
+{
+  const m = new Memory();
+  const foreignMemory = new Memory();
+  const [a] = anchors(m, 1);
+  const [foreign] = anchors(foreignMemory, 1);
+  assert(a && foreign, "foreign refs");
+  const before = m.linkCount;
+  reject(() => materializeSequence(m, Object.freeze({ root: foreignMemory.root, items: [atom(a)] })));
+  same(m.linkCount, before, "root mismatch no writes");
+  reject(() => materializeSequence(m, description(m, atom(a), atom(foreign))));
+  same(m.linkCount, before, "foreign atom no writes");
+}
+
+{
+  const m = new Memory();
+  const [a, b, c] = anchors(m, 3);
+  assert(a && b && c, "replay refs");
+  const effect = materializeSequence(m, description(m, atom(a), atom(b), atom(c)));
+  const before = m.linkCount;
+  same(replaySequenceMaterialization(m, effect), effect.result, "replay result");
+  same(m.linkCount, before, "replay read-only");
+
+  const forgedResult = Object.freeze({ ...effect, result: a });
+  reject(() => replaySequenceMaterialization(m, forgedResult));
+
+  const wrongPoles = Object.freeze({
+    ...effect,
+    created: Object.freeze([{ ...effect.created[0]!, start: c }]),
+    linkCountAfter: effect.linkCountBefore + 1,
+  });
+  reject(() => replaySequenceMaterialization(m, wrongPoles));
+
+  const duplicate = Object.freeze({
+    ...effect,
+    created: Object.freeze([effect.created[0]!, effect.created[0]!]),
+    linkCountAfter: effect.linkCountBefore + 2,
+  });
+  reject(() => replaySequenceMaterialization(m, duplicate));
+
+  const unrelated = m.ensure(a, c);
+  const unrelatedEffect = Object.freeze({
+    ...effect,
+    created: Object.freeze([{ ref: unrelated, start: a, end: c }]),
+    linkCountAfter: effect.linkCountBefore + 1,
+  });
+  reject(() => replaySequenceMaterialization(m, unrelatedEffect));
+}
+
+{
+  const m = new Memory();
+  const [a, b] = anchors(m, 2);
+  assert(a && b, "missing pair refs");
+  const fake: SequenceMaterializationEffect = Object.freeze({
+    description: description(m, atom(a), atom(b)),
+    result: a,
+    created: Object.freeze([]),
+    linkCountBefore: m.linkCount,
+    linkCountAfter: m.linkCount,
+  });
+  const before = m.linkCount;
+  reject(() => replaySequenceMaterialization(m, fake));
+  same(m.linkCount, before, "missing replay pair not materialized");
+}
+
+class Probe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined { return this.source.find(start, end); }
+  outgoing(): readonly LinkHandle[] { throw new Error("materialization replay must not scan outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("materialization replay must not scan incoming"); }
+}
+
+{
+  const m = new Memory();
+  const [a, b] = anchors(m, 2);
+  assert(a && b, "probe refs");
+  const effect = materializeSequence(m, description(m, atom(a), atom(b)));
+  same(replaySequenceMaterialization(new Probe(m), effect), effect.result, "ReadMemory replay");
+}


### PR DESCRIPTION
Closes #486.

## What changed
- extend `ts/src/sequence.ts` with `MaterializedEdge` / `SequenceMaterializationEffect`;
- implement explicit `materializeSequence(WriteMemory, description)` using canonical `find` + `ensure` left folds and recording only physically created pairs in operation order;
- preserve empty group => root, singleton => identity, nested results as ordinary outer fold values, and same-pair reuse;
- validate root/atom handles before semantic writes and require `linkCountAfter = linkCountBefore + created.length`;
- add read-only `replaySequenceMaterialization(ReadMemory, effect)` using only existing pairs through `find`, exact final result, created-edge poles/uniqueness/traversal membership, effect count invariant, and unchanged `linkCount`;
- do not add Python-style before/after snapshots, revisions, slots, scans, persistence adapters, or Memory changes.

## Scope
Only `ts/src/sequence.ts`, new `ts/test/sequence-materialization.test.ts`, and `ts/package.json` change. One new file, net +297 lines against budget +620, `behind_by=0` from exact accepted main `9c3f97d2b701ea4c7c34ee319defbda1e537605d`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.