### PR TITLE
TypeScript: port rooted Direct Deixis replay

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/direct-deixis.ts
+++ b/ts/src/direct-deixis.ts
@@ -1,0 +1,125 @@
+import type { LinkHandle, ReadMemory } from "./memory.js";
+import { readRootedSequence } from "./rooted-sequence.js";
+
+export type DeicticPole = "start" | "end";
+
+export interface DeicticOccurrence {
+  readonly path: readonly number[];
+  readonly up: number;
+  readonly pole: DeicticPole;
+}
+
+export interface DirectDeixisVocabulary {
+  readonly nodeTag: LinkHandle;
+  readonly opaqueTag: LinkHandle;
+  readonly pronounTag: LinkHandle;
+  readonly upStep: LinkHandle;
+  readonly startPole: LinkHandle;
+  readonly endPole: LinkHandle;
+}
+
+export class DirectDeixisReplayError extends Error {
+  override readonly name = "DirectDeixisReplayError";
+  constructor(readonly code: "invalid-direct-deixis-evidence") { super(code); }
+}
+
+function invalid(): never {
+  throw new DirectDeixisReplayError("invalid-direct-deixis-evidence");
+}
+
+function expectPoles(
+  memory: ReadMemory,
+  ref: LinkHandle,
+  start: LinkHandle,
+  end: LinkHandle,
+): void {
+  const poles = memory.poles(ref);
+  if (poles.start !== start || poles.end !== end) invalid();
+}
+
+function validateVocabulary(memory: ReadMemory, vocabulary: DirectDeixisVocabulary): void {
+  const refs = [
+    vocabulary.nodeTag,
+    vocabulary.opaqueTag,
+    vocabulary.pronounTag,
+    vocabulary.upStep,
+    vocabulary.startPole,
+    vocabulary.endPole,
+  ];
+  if (new Set(refs).size !== refs.length) invalid();
+  try {
+    expectPoles(memory, vocabulary.startPole, vocabulary.startPole, memory.root);
+    expectPoles(memory, vocabulary.endPole, memory.root, vocabulary.endPole);
+    expectPoles(memory, vocabulary.nodeTag, vocabulary.startPole, vocabulary.endPole);
+    expectPoles(memory, vocabulary.opaqueTag, vocabulary.endPole, vocabulary.startPole);
+    expectPoles(memory, vocabulary.pronounTag, vocabulary.nodeTag, vocabulary.opaqueTag);
+    expectPoles(memory, vocabulary.upStep, vocabulary.opaqueTag, vocabulary.nodeTag);
+  } catch (error) {
+    if (error instanceof DirectDeixisReplayError) throw error;
+    invalid();
+  }
+}
+
+function decodePronoun(
+  memory: ReadMemory,
+  metadata: LinkHandle,
+  vocabulary: DirectDeixisVocabulary,
+): { readonly up: number; readonly pole: DeicticPole } {
+  const values = readRootedSequence(memory, metadata).values;
+  if (values.length === 0) invalid();
+  const marker = values[values.length - 1];
+  const pole: DeicticPole = marker === vocabulary.startPole
+    ? "start"
+    : marker === vocabulary.endPole
+      ? "end"
+      : invalid();
+  for (let index = 0; index < values.length - 1; index += 1) {
+    if (values[index] !== vocabulary.upStep) invalid();
+  }
+  return Object.freeze({ up: values.length - 1, pole });
+}
+
+export function analyzeDirectDeixisCarrier(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: DirectDeixisVocabulary,
+): readonly DeicticOccurrence[] {
+  const before = memory.linkCount;
+  try {
+    validateVocabulary(memory, vocabulary);
+    const occurrences: DeicticOccurrence[] = [];
+    const active = new Set<LinkHandle>();
+
+    const visit = (current: LinkHandle, path: readonly number[]): void => {
+      if (active.has(current)) invalid();
+      active.add(current);
+      try {
+        const poles = memory.poles(current);
+        if (poles.start === vocabulary.opaqueTag) {
+          if (poles.end !== memory.root) invalid();
+          return;
+        }
+        if (poles.start === vocabulary.pronounTag) {
+          const metadata = decodePronoun(memory, poles.end, vocabulary);
+          occurrences.push(Object.freeze({ path: Object.freeze([...path]), ...metadata }));
+          return;
+        }
+        if (poles.start === vocabulary.nodeTag) {
+          const children = readRootedSequence(memory, poles.end).values;
+          children.forEach((child, index) => visit(child, [...path, index]));
+          return;
+        }
+        invalid();
+      } finally {
+        active.delete(current);
+      }
+    };
+
+    visit(carrier, []);
+    if (memory.linkCount !== before) invalid();
+    return Object.freeze(occurrences);
+  } catch (error) {
+    if (error instanceof DirectDeixisReplayError) throw error;
+    throw new DirectDeixisReplayError("invalid-direct-deixis-evidence");
+  }
+}

--- a/ts/test/direct-deixis.test.ts
+++ b/ts/test/direct-deixis.test.ts
@@ -1,0 +1,151 @@
+import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
+import {
+  DirectDeixisReplayError,
+  analyzeDirectDeixisCarrier,
+  type DeicticPole,
+  type DirectDeixisVocabulary,
+} from "../src/direct-deixis.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function reject(effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof DirectDeixisReplayError, `expected DirectDeixisReplayError, got ${String(error)}`);
+    same(error.code, "invalid-direct-deixis-evidence", "direct deixis error code");
+    return;
+  }
+  throw new Error("expected invalid-direct-deixis-evidence");
+}
+
+function fixture() {
+  const memory = new Memory();
+  const startPole = memory.ensureStartSelfClosed(memory.root);
+  const endPole = memory.ensureEndSelfClosed(memory.root);
+  const nodeTag = memory.ensure(startPole, endPole);
+  const opaqueTag = memory.ensure(endPole, startPole);
+  const pronounTag = memory.ensure(nodeTag, opaqueTag);
+  const upStep = memory.ensure(opaqueTag, nodeTag);
+  const vocabulary: DirectDeixisVocabulary = Object.freeze({
+    nodeTag, opaqueTag, pronounTag, upStep, startPole, endPole,
+  });
+  const fold = (values: readonly LinkHandle[]): LinkHandle => {
+    let current = memory.root;
+    for (const value of values) current = memory.ensure(current, value);
+    return current;
+  };
+  const opaque = (): LinkHandle => memory.ensure(opaqueTag, memory.root);
+  const pronoun = (up: number, pole: DeicticPole): LinkHandle => {
+    const marker = pole === "start" ? startPole : endPole;
+    return memory.ensure(pronounTag, fold([...Array<LinkHandle>(up).fill(upStep), marker]));
+  };
+  const node = (...children: LinkHandle[]): LinkHandle => memory.ensure(nodeTag, fold(children));
+  return { memory, vocabulary, fold, opaque, pronoun, node };
+}
+
+{
+  const f = fixture();
+  const carrier = f.node(
+    f.node(f.pronoun(0, "start")),
+    f.node(f.pronoun(2, "end")),
+    f.opaque(),
+  );
+  const before = f.memory.linkCount;
+  const result = analyzeDirectDeixisCarrier(f.memory, carrier, f.vocabulary);
+  same(result.length, 2, "occurrence count");
+  same(result[0]?.path.join(","), "0,0", "first path");
+  same(result[0]?.up, 0, "first up");
+  same(result[0]?.pole, "start", "first pole");
+  same(result[1]?.path.join(","), "1,0", "second path");
+  same(result[1]?.up, 2, "second up");
+  same(result[1]?.pole, "end", "second pole");
+  same(f.memory.linkCount, before, "analysis read-only");
+}
+
+{
+  const f = fixture();
+  const pronoun = f.pronoun(1, "end");
+  const shared = f.node(pronoun);
+  const carrier = f.node(shared, shared);
+  const result = analyzeDirectDeixisCarrier(f.memory, carrier, f.vocabulary);
+  same(result.length, 2, "shared subtree occurrence count");
+  same(result[0]?.path.join(","), "0,0", "shared first path");
+  same(result[1]?.path.join(","), "1,0", "shared second path");
+  same(result[0]?.up, 1, "shared first up");
+  same(result[1]?.pole, "end", "shared second pole");
+}
+
+{
+  const f = fixture();
+  const deeplyGrouped = f.node(f.node(f.node(f.pronoun(2, "start"))), f.opaque());
+  const result = analyzeDirectDeixisCarrier(f.memory, deeplyGrouped, f.vocabulary);
+  same(result[0]?.path.join(","), "0,0,0", "grouping remains structural path");
+}
+
+{
+  const f = fixture();
+  const result = analyzeDirectDeixisCarrier(f.memory, f.opaque(), f.vocabulary);
+  same(result.length, 0, "opaque carrier has no implication/occurrence");
+}
+
+{
+  const f = fixture();
+  const badOpaque = f.memory.ensure(f.vocabulary.opaqueTag, f.vocabulary.startPole);
+  reject(() => analyzeDirectDeixisCarrier(f.memory, badOpaque, f.vocabulary));
+
+  const emptyMetadata = f.memory.ensure(f.vocabulary.pronounTag, f.memory.root);
+  reject(() => analyzeDirectDeixisCarrier(f.memory, emptyMetadata, f.vocabulary));
+
+  const invalidMarker = f.memory.ensure(
+    f.vocabulary.pronounTag,
+    f.fold([f.vocabulary.nodeTag]),
+  );
+  reject(() => analyzeDirectDeixisCarrier(f.memory, invalidMarker, f.vocabulary));
+
+  const nonUpPrefix = f.memory.ensure(
+    f.vocabulary.pronounTag,
+    f.fold([f.vocabulary.opaqueTag, f.vocabulary.startPole]),
+  );
+  reject(() => analyzeDirectDeixisCarrier(f.memory, nonUpPrefix, f.vocabulary));
+
+  const malformedNode = f.memory.ensure(f.vocabulary.nodeTag, f.vocabulary.startPole);
+  reject(() => analyzeDirectDeixisCarrier(f.memory, malformedNode, f.vocabulary));
+}
+
+{
+  const f = fixture();
+  reject(() => analyzeDirectDeixisCarrier(f.memory, f.opaque(), Object.freeze({
+    ...f.vocabulary,
+    endPole: f.vocabulary.startPole,
+  })));
+
+  const other = new Memory();
+  const foreign = other.ensureStartSelfClosed(other.root);
+  reject(() => analyzeDirectDeixisCarrier(f.memory, f.opaque(), Object.freeze({
+    ...f.vocabulary,
+    startPole: foreign,
+  })));
+}
+
+class Probe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("direct deixis must not use find"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("direct deixis must not use outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("direct deixis must not use incoming"); }
+}
+
+{
+  const f = fixture();
+  const carrier = f.node(f.pronoun(1, "start"), f.opaque());
+  const before = f.memory.linkCount;
+  const result = analyzeDirectDeixisCarrier(new Probe(f.memory), carrier, f.vocabulary);
+  same(result.length, 1, "ReadMemory probe result");
+  same(f.memory.linkCount, before, "ReadMemory probe no writes");
+}


### PR DESCRIPTION
Closes #495.

## What changed
- add `ts/src/direct-deixis.ts` with compact Direct Deixis vocabulary and portable `(path, up, pole)` occurrence result;
- validate all six rooted vocabulary Links by exact topology and distinctness;
- analyze OPAQUE/NODE/PRONOUN carriers read-only using only `ReadMemory.poles` and the existing generic `readRootedSequence`;
- preserve structural occurrence paths, shared-subtree multiple occurrences, ordered traversal and active-cycle guard;
- decode pronoun metadata as zero-or-more exact `upStep` followed by one exact start/end pole;
- reject malformed carrier/vocabulary/metadata/rooted sequences and foreign handles fail-closed;
- add no production builder, parser/AST dependency, scans, hidden context, source offsets or materialization.

## Scope
Only new `ts/src/direct-deixis.ts`, new `ts/test/direct-deixis.test.ts`, and `ts/package.json` change. Two new files, net +275 lines against budget +520, `behind_by=0` from exact accepted main `ce5a87989c2fd70d0d1f3ebad144e550e2a70d5a`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.