### PR TITLE
TypeScript: port static ValueBundle elaboration

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/value-bundle.ts
+++ b/ts/src/value-bundle.ts
@@ -1,0 +1,305 @@
+import type { LinkHandle, ReadMemory } from "./memory.js";
+import { readRootedSequence } from "./rooted-sequence.js";
+
+export type OccurrencePath = readonly number[];
+export type BundleNodeKind =
+  | "bundle" | "definition" | "comparison" | "sequence" | "link"
+  | "unary" | "round" | "square" | "scalar" | "judgment";
+export type BundleRole = "ConstraintBundle" | "ValueBundle";
+export type ExpectedRole = "none" | "constraint" | "value" | "scalar" | "definition-rhs";
+
+export const BUNDLE_KIND_ORDER: readonly BundleNodeKind[] = Object.freeze([
+  "bundle", "definition", "comparison", "sequence", "link",
+  "unary", "round", "square", "scalar", "judgment",
+]);
+
+const FORM_KINDS = new Set<BundleNodeKind>([
+  "bundle", "sequence", "link", "unary", "round", "square", "scalar",
+]);
+
+export interface BundleRoleAt {
+  readonly path: OccurrencePath;
+  readonly role: BundleRole;
+}
+
+export interface BundleElaboration {
+  readonly roles: readonly BundleRoleAt[];
+}
+
+export interface ValueBundleVocabulary {
+  readonly startAnchor: LinkHandle;
+  readonly endAnchor: LinkHandle;
+  readonly kindSeed: LinkHandle;
+  readonly kindTags: readonly LinkHandle[];
+}
+
+export class ValueBundleReplayError extends Error {
+  override readonly name = "ValueBundleReplayError";
+  constructor(readonly code: "invalid-value-bundle-evidence") { super(code); }
+}
+
+export class BundleElaborationError extends Error {
+  override readonly name = "BundleElaborationError";
+  constructor(readonly code: string, readonly path: OccurrencePath) { super(`${code} at ${path.join(".")}`); }
+}
+
+function invalid(): never {
+  throw new ValueBundleReplayError("invalid-value-bundle-evidence");
+}
+
+function fail(code: string, path: OccurrencePath): never {
+  throw new BundleElaborationError(code, Object.freeze([...path]));
+}
+
+function sameValues(actual: readonly LinkHandle[], expected: readonly LinkHandle[]): boolean {
+  return actual.length === expected.length && actual.every((value, index) => value === expected[index]);
+}
+
+function validateVocabulary(memory: ReadMemory, vocabulary: ValueBundleVocabulary): void {
+  if (vocabulary.kindTags.length !== BUNDLE_KIND_ORDER.length) invalid();
+  const refs = [
+    vocabulary.startAnchor, vocabulary.endAnchor, vocabulary.kindSeed, ...vocabulary.kindTags,
+  ];
+  if (new Set(refs).size !== refs.length) invalid();
+  const start = memory.poles(vocabulary.startAnchor);
+  const end = memory.poles(vocabulary.endAnchor);
+  const seed = memory.poles(vocabulary.kindSeed);
+  if (start.start !== vocabulary.startAnchor || start.end !== memory.root) invalid();
+  if (end.start !== memory.root || end.end !== vocabulary.endAnchor) invalid();
+  if (seed.start !== vocabulary.startAnchor || seed.end !== vocabulary.endAnchor) invalid();
+  vocabulary.kindTags.forEach((tag, index) => {
+    const expected = Array<LinkHandle>(index + 1).fill(vocabulary.kindSeed);
+    if (!sameValues(readRootedSequence(memory, tag).values, expected)) invalid();
+  });
+}
+
+interface DecodedNode {
+  readonly kind: BundleNodeKind;
+  readonly children: readonly LinkHandle[];
+}
+
+function decodeNode(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: ValueBundleVocabulary,
+): DecodedNode {
+  const poles = memory.poles(carrier);
+  const index = vocabulary.kindTags.indexOf(poles.start);
+  if (index < 0) invalid();
+  const kind = BUNDLE_KIND_ORDER[index];
+  if (kind === undefined) invalid();
+  return Object.freeze({ kind, children: readRootedSequence(memory, poles.end).values });
+}
+
+function validateArity(kind: BundleNodeKind, children: readonly LinkHandle[]): void {
+  const exact: Partial<Record<BundleNodeKind, readonly number[]>> = {
+    definition: [2], comparison: [2], link: [2], unary: [1],
+    round: [0, 1], square: [0], scalar: [0], judgment: [0],
+  };
+  if (kind === "sequence" && children.length < 2) invalid();
+  const expected = exact[kind];
+  if (expected !== undefined && !expected.includes(children.length)) invalid();
+}
+
+type IntrinsicEvidence = "constraint" | "value" | "mixed" | undefined;
+
+function intrinsicBundleEvidence(
+  memory: ReadMemory,
+  children: readonly LinkHandle[],
+  vocabulary: ValueBundleVocabulary,
+  active: Set<LinkHandle>,
+): IntrinsicEvidence {
+  const evidence = new Set<"constraint" | "value">();
+  for (const child of children) {
+    if (active.has(child)) invalid();
+    active.add(child);
+    try {
+      const decoded = decodeNode(memory, child, vocabulary);
+      validateArity(decoded.kind, decoded.children);
+      if (decoded.kind === "bundle") {
+        const nested = intrinsicBundleEvidence(memory, decoded.children, vocabulary, active);
+        if (nested === "mixed") return "mixed";
+        if (nested !== undefined) evidence.add(nested);
+      } else if (decoded.kind === "comparison" || decoded.kind === "judgment") {
+        evidence.add("constraint");
+      } else if (FORM_KINDS.has(decoded.kind)) {
+        evidence.add("value");
+      } else {
+        fail("unsupported-bundle-item", []);
+      }
+      if (evidence.size > 1) return "mixed";
+    } finally {
+      active.delete(child);
+    }
+  }
+  return evidence.values().next().value;
+}
+
+function containsBundle(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: ValueBundleVocabulary,
+  active: Set<LinkHandle>,
+): boolean {
+  if (active.has(carrier)) invalid();
+  active.add(carrier);
+  try {
+    const decoded = decodeNode(memory, carrier, vocabulary);
+    validateArity(decoded.kind, decoded.children);
+    if (decoded.kind === "bundle") return true;
+    if (["sequence", "link", "unary"].includes(decoded.kind)) {
+      return decoded.children.some((child) => containsBundle(memory, child, vocabulary, active));
+    }
+    if (decoded.kind === "round" && decoded.children.length === 1) {
+      return containsBundle(memory, decoded.children[0]!, vocabulary, active);
+    }
+    return false;
+  } finally {
+    active.delete(carrier);
+  }
+}
+
+function elaborateBundle(
+  memory: ReadMemory,
+  children: readonly LinkHandle[],
+  vocabulary: ValueBundleVocabulary,
+  path: OccurrencePath,
+  expected: ExpectedRole,
+  roles: BundleRoleAt[],
+  active: Set<LinkHandle>,
+): void {
+  const evidence = intrinsicBundleEvidence(memory, children, vocabulary, new Set());
+  if (evidence === "mixed") fail("mixed-bundle-role-evidence", path);
+  if (expected === "scalar") fail("bundle-not-supported-in-scalar-operator", path);
+
+  let role: BundleRole;
+  if (expected === "definition-rhs") {
+    if (evidence === "value") fail("bundle-valued-definition-deferred", path);
+    role = "ConstraintBundle";
+  } else if (expected === "constraint") {
+    if (evidence === "value") fail("bundle-role-mismatch", path);
+    role = "ConstraintBundle";
+  } else if (expected === "value") {
+    if (evidence === "constraint") fail("bundle-role-mismatch", path);
+    role = "ValueBundle";
+  } else if (evidence === "constraint") {
+    role = "ConstraintBundle";
+  } else if (evidence === "value") {
+    role = "ValueBundle";
+  } else {
+    fail("ambiguous-empty-bundle-role", path);
+  }
+
+  if (role === "ValueBundle") {
+    for (const child of children) {
+      if (decodeNode(memory, child, vocabulary).kind === "bundle") {
+        fail("nested-value-bundle-not-supported", path);
+      }
+    }
+  }
+  roles.push(Object.freeze({ path: Object.freeze([...path]), role }));
+  const childExpected: ExpectedRole = role === "ConstraintBundle" ? "constraint" : "scalar";
+  children.forEach((child, index) => elaborateExpression(
+    memory, child, vocabulary, [...path, index], childExpected, roles, active,
+  ));
+}
+
+function elaborateExpression(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: ValueBundleVocabulary,
+  path: OccurrencePath,
+  expected: ExpectedRole,
+  roles: BundleRoleAt[],
+  active: Set<LinkHandle>,
+): void {
+  if (active.has(carrier)) invalid();
+  active.add(carrier);
+  try {
+    const { kind, children } = decodeNode(memory, carrier, vocabulary);
+    validateArity(kind, children);
+    if (kind === "bundle") {
+      elaborateBundle(memory, children, vocabulary, path, expected, roles, active);
+      return;
+    }
+    if (kind === "definition") {
+      if (["scalar", "value", "constraint"].includes(expected)) fail("expression-role-mismatch", path);
+      elaborateExpression(memory, children[0]!, vocabulary, [...path, 0], "scalar", roles, active);
+      elaborateExpression(memory, children[1]!, vocabulary, [...path, 1], "definition-rhs", roles, active);
+      return;
+    }
+    if (kind === "comparison") {
+      if (expected === "scalar") fail("expression-role-mismatch", path);
+      children.forEach((child, index) => elaborateExpression(
+        memory, child, vocabulary, [...path, index], "value", roles, active,
+      ));
+      return;
+    }
+    if (kind === "sequence") {
+      if (expected === "constraint") fail("expression-role-mismatch", path);
+      const hasBundle = children.some((child) => containsBundle(memory, child, vocabulary, new Set()));
+      if (expected === "scalar" && hasBundle) fail("bundle-not-supported-in-scalar-operator", path);
+      if (expected === "definition-rhs" && hasBundle) fail("bundle-valued-definition-deferred", path);
+      children.forEach((child, index) => elaborateExpression(
+        memory, child, vocabulary, [...path, index], "value", roles, active,
+      ));
+      return;
+    }
+    if (kind === "link") {
+      if (expected === "constraint") fail("expression-role-mismatch", path);
+      children.forEach((child, index) => elaborateExpression(
+        memory, child, vocabulary, [...path, index], "scalar", roles, active,
+      ));
+      return;
+    }
+    if (kind === "unary") {
+      if (expected === "constraint") fail("expression-role-mismatch", path);
+      elaborateExpression(memory, children[0]!, vocabulary, [...path, 0], "scalar", roles, active);
+      return;
+    }
+    if (kind === "round") {
+      if (expected === "constraint") fail("expression-role-mismatch", path);
+      if (children.length === 1) {
+        elaborateExpression(memory, children[0]!, vocabulary, [...path, 0], expected, roles, active);
+      }
+      return;
+    }
+    if (kind === "square" || kind === "scalar") {
+      if (expected === "constraint") fail("expression-role-mismatch", path);
+      return;
+    }
+    if (kind === "judgment") {
+      if (expected !== "constraint") fail("expression-role-mismatch", path);
+      return;
+    }
+    fail("unsupported-expression", path);
+  } finally {
+    active.delete(carrier);
+  }
+}
+
+export function elaborateBundleRoles(
+  memory: ReadMemory,
+  carrier: LinkHandle,
+  vocabulary: ValueBundleVocabulary,
+  entry: ExpectedRole = "none",
+): BundleElaboration {
+  const before = memory.linkCount;
+  try {
+    if (!["none", "constraint", "value", "scalar", "definition-rhs"].includes(entry)) invalid();
+    validateVocabulary(memory, vocabulary);
+    const roles: BundleRoleAt[] = [];
+    elaborateExpression(memory, carrier, vocabulary, [], entry, roles, new Set());
+    if (memory.linkCount !== before) invalid();
+    return Object.freeze({ roles: Object.freeze(roles) });
+  } catch (error) {
+    if (error instanceof BundleElaborationError || error instanceof ValueBundleReplayError) throw error;
+    throw new ValueBundleReplayError("invalid-value-bundle-evidence");
+  }
+}
+
+export function bundleRoleAt(elaboration: BundleElaboration, path: OccurrencePath): BundleRole | undefined {
+  return elaboration.roles.find((item) =>
+    item.path.length === path.length && item.path.every((part, index) => part === path[index])
+  )?.role;
+}

--- a/ts/test/value-bundle-elaboration.test.ts
+++ b/ts/test/value-bundle-elaboration.test.ts
@@ -1,0 +1,222 @@
+import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
+import {
+  BUNDLE_KIND_ORDER,
+  BundleElaborationError,
+  ValueBundleReplayError,
+  bundleRoleAt,
+  elaborateBundleRoles,
+  type BundleNodeKind,
+  type ExpectedRole,
+  type ValueBundleVocabulary,
+} from "../src/value-bundle.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function rejectCode(effect: () => unknown, code: string, path: readonly number[]): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof BundleElaborationError, `expected BundleElaborationError, got ${String(error)}`);
+    same(error.code, code, "bundle elaboration error code");
+    same(error.path.join(","), path.join(","), "bundle elaboration error path");
+    return;
+  }
+  throw new Error(`expected ${code}`);
+}
+function rejectReplay(effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof ValueBundleReplayError, `expected ValueBundleReplayError, got ${String(error)}`);
+    return;
+  }
+  throw new Error("expected invalid value bundle evidence");
+}
+
+function fixture() {
+  const memory = new Memory();
+  const startAnchor = memory.ensureStartSelfClosed(memory.root);
+  const endAnchor = memory.ensureEndSelfClosed(memory.root);
+  const kindSeed = memory.ensure(startAnchor, endAnchor);
+  let current = memory.root;
+  const kindTags: LinkHandle[] = [];
+  for (const _kind of BUNDLE_KIND_ORDER) {
+    current = memory.ensure(current, kindSeed);
+    kindTags.push(current);
+  }
+  const vocabulary: ValueBundleVocabulary = Object.freeze({
+    startAnchor, endAnchor, kindSeed, kindTags: Object.freeze(kindTags),
+  });
+  const fold = (values: readonly LinkHandle[]): LinkHandle => {
+    let prefix = memory.root;
+    for (const value of values) prefix = memory.ensure(prefix, value);
+    return prefix;
+  };
+  const node = (kind: BundleNodeKind, ...children: LinkHandle[]): LinkHandle => {
+    const tag = kindTags[BUNDLE_KIND_ORDER.indexOf(kind)];
+    assert(tag, `missing tag ${kind}`);
+    return memory.ensure(tag, fold(children));
+  };
+  const scalar = (): LinkHandle => node("scalar");
+  const bundle = (...children: LinkHandle[]): LinkHandle => node("bundle", ...children);
+  const comparison = (left: LinkHandle, right: LinkHandle): LinkHandle => node("comparison", left, right);
+  return { memory, vocabulary, node, scalar, bundle, comparison, fold };
+}
+
+function role(
+  carrierFactory: (f: ReturnType<typeof fixture>) => LinkHandle,
+  expected: "ConstraintBundle" | "ValueBundle",
+  entry: ExpectedRole = "none",
+  path: readonly number[] = [],
+): void {
+  const f = fixture();
+  const carrier = carrierFactory(f);
+  const before = f.memory.linkCount;
+  same(bundleRoleAt(elaborateBundleRoles(f.memory, carrier, f.vocabulary, entry), path), expected, "bundle role");
+  same(f.memory.linkCount, before, "elaboration read-only");
+}
+
+role(
+  (f) => f.bundle(f.comparison(f.scalar(), f.scalar()), f.comparison(f.scalar(), f.scalar())),
+  "ConstraintBundle",
+);
+role((f) => f.bundle(f.scalar(), f.scalar()), "ValueBundle");
+role((f) => f.bundle(), "ConstraintBundle", "constraint");
+role((f) => f.comparison(f.bundle(), f.scalar()), "ValueBundle", "none", [0]);
+role((f) => f.node("definition", f.scalar(), f.bundle()), "ConstraintBundle", "none", [1]);
+
+{
+  const f = fixture();
+  rejectCode(
+    () => elaborateBundleRoles(
+      f.memory,
+      f.bundle(f.scalar(), f.comparison(f.scalar(), f.scalar())),
+      f.vocabulary,
+    ),
+    "mixed-bundle-role-evidence", [],
+  );
+}
+{
+  const f = fixture();
+  rejectCode(
+    () => elaborateBundleRoles(f.memory, f.bundle(f.bundle()), f.vocabulary),
+    "ambiguous-empty-bundle-role", [],
+  );
+}
+{
+  const f = fixture();
+  rejectCode(
+    () => elaborateBundleRoles(
+      f.memory,
+      f.comparison(f.bundle(f.bundle(f.scalar(), f.scalar())), f.scalar()),
+      f.vocabulary,
+    ),
+    "nested-value-bundle-not-supported", [0],
+  );
+}
+{
+  const f = fixture();
+  rejectCode(
+    () => elaborateBundleRoles(f.memory, f.bundle(f.scalar(), f.scalar()), f.vocabulary, "constraint"),
+    "bundle-role-mismatch", [],
+  );
+}
+{
+  const f = fixture();
+  rejectCode(
+    () => elaborateBundleRoles(
+      f.memory,
+      f.node("definition", f.scalar(), f.bundle(f.scalar(), f.scalar())),
+      f.vocabulary,
+    ),
+    "bundle-valued-definition-deferred", [1],
+  );
+}
+for (const kind of ["link", "unary"] as const) {
+  const f = fixture();
+  const carrier = kind === "link"
+    ? f.node("link", f.bundle(f.scalar(), f.scalar()), f.scalar())
+    : f.node("unary", f.bundle(f.scalar(), f.scalar()));
+  rejectCode(
+    () => elaborateBundleRoles(f.memory, carrier, f.vocabulary),
+    "bundle-not-supported-in-scalar-operator", [0],
+  );
+}
+{
+  const f = fixture();
+  const carrier = f.node(
+    "link",
+    f.node("sequence", f.scalar(), f.bundle(f.scalar(), f.scalar())),
+    f.scalar(),
+  );
+  rejectCode(
+    () => elaborateBundleRoles(f.memory, carrier, f.vocabulary),
+    "bundle-not-supported-in-scalar-operator", [0],
+  );
+}
+
+{
+  const f = fixture();
+  rejectReplay(() => elaborateBundleRoles(f.memory, f.node("comparison", f.scalar()), f.vocabulary));
+  rejectReplay(() => elaborateBundleRoles(f.memory, f.node("sequence", f.scalar()), f.vocabulary));
+  rejectReplay(() => elaborateBundleRoles(f.memory, f.node("scalar", f.scalar()), f.vocabulary));
+}
+
+{
+  const f = fixture();
+  rejectReplay(() => elaborateBundleRoles(f.memory, f.scalar(), Object.freeze({
+    ...f.vocabulary,
+    kindTags: Object.freeze(f.vocabulary.kindTags.slice(0, -1)),
+  })));
+  const aliases = [...f.vocabulary.kindTags];
+  aliases[1] = aliases[0]!;
+  rejectReplay(() => elaborateBundleRoles(f.memory, f.scalar(), Object.freeze({
+    ...f.vocabulary,
+    kindTags: Object.freeze(aliases),
+  })));
+}
+
+{
+  const f = fixture();
+  const other = new Memory();
+  const foreign = other.ensureStartSelfClosed(other.root);
+  const tags = [...f.vocabulary.kindTags];
+  tags[0] = foreign;
+  rejectReplay(() => elaborateBundleRoles(f.memory, f.scalar(), Object.freeze({
+    ...f.vocabulary,
+    kindTags: Object.freeze(tags),
+  })));
+}
+
+{
+  const f = fixture();
+  const shared = f.bundle();
+  const carrier = f.comparison(shared, shared);
+  const result = elaborateBundleRoles(f.memory, carrier, f.vocabulary);
+  same(bundleRoleAt(result, [0]), "ValueBundle", "shared subtree first path role");
+  same(bundleRoleAt(result, [1]), "ValueBundle", "shared subtree second path role");
+}
+
+class Probe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("static ValueBundle replay must not use find"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("static ValueBundle replay must not use outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("static ValueBundle replay must not use incoming"); }
+}
+
+{
+  const f = fixture();
+  const carrier = f.bundle(f.scalar(), f.scalar());
+  const before = f.memory.linkCount;
+  same(
+    bundleRoleAt(elaborateBundleRoles(new Probe(f.memory), carrier, f.vocabulary), []),
+    "ValueBundle",
+    "ReadMemory-only elaboration",
+  );
+  same(f.memory.linkCount, before, "probe leaves linkCount unchanged");
+}


### PR DESCRIPTION
Closes #496.

## What changed
- add `ts/src/value-bundle.ts` with the accepted fixed kind vocabulary, rooted structural validation and compact checker-side role/path types;
- port static ValueBundle role elaboration from rooted skeleton Links only, using `ReadMemory.poles` + existing `readRootedSequence`;
- preserve accepted expected-role propagation, intrinsic constraint/value evidence, mixed/ambiguous/nested/deferred role failures, sequence containment checks and exact node arities;
- preserve shared-subtree occurrence paths without treating paths or handles as semantic copies;
- expose only structural elaboration/result helpers; no resolved bundle values/query semantics yet;
- add no AST/parser/interpreter/AnumMemory dependency, no scans, no materialization and no changes to Memory/rooted-sequence.

## Scope
Only new `ts/src/value-bundle.ts`, new `ts/test/value-bundle-elaboration.test.ts`, and `ts/package.json` change. Two new files, net +526 lines against budget +760, `behind_by=0` from exact accepted main `fb89a6f53c9bc44fec72f41106f8350f13c5654e`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.