### PR TITLE
TypeScript: add explicit enumerable read capability

### DIFF
--- a/ts/src/memory.ts
+++ b/ts/src/memory.ts
@@ -23,6 +23,15 @@ export interface ReadMemory {
   incoming(end: LinkHandle): readonly LinkHandle[];
 }
 
+/**
+ * Narrow opt-in capability for operations whose accepted result is the whole
+ * selected memory (for example an explicit all-links wildcard). Ordinary
+ * replay/checkers should continue to depend on ReadMemory only.
+ */
+export interface EnumerableReadMemory extends ReadMemory {
+  allLinks(): readonly LinkHandle[];
+}
+
 export interface WriteMemory extends ReadMemory {
   ensureRoot(): LinkHandle;
   ensureStartSelfClosed(end: LinkHandle): LinkHandle;
@@ -42,7 +51,7 @@ export class MemoryError extends Error {
   override readonly name = "MemoryError";
 }
 
-export class Memory implements WriteMemory {
+export class Memory implements WriteMemory, EnumerableReadMemory {
   private readonly owner = Symbol("mts.memory.owner");
   private readonly handles: InternalHandle[] = [];
   private readonly links: LinkPoles[] = [];
@@ -142,6 +151,12 @@ export class Memory implements WriteMemory {
   incoming(end: LinkHandle): readonly LinkHandle[] {
     const canonicalEnd = this.requireHandle(end);
     return [...(this.incomingIndex.get(canonicalEnd) ?? [])];
+  }
+
+  allLinks(): readonly LinkHandle[] {
+    // Return a frozen copy: enumeration exposes issued handles, never the
+    // mutable registry itself. Allocation order is iteration order only.
+    return Object.freeze([...this.handles]);
   }
 
   private allocateHandle(): InternalHandle {

--- a/ts/test/memory.test.ts
+++ b/ts/test/memory.test.ts
@@ -2,6 +2,7 @@ import {
   Memory,
   MemoryError,
   ensureRootBasis,
+  type EnumerableReadMemory,
   type LinkHandle,
   type ReadMemory,
 } from "../src/memory.js";
@@ -46,12 +47,28 @@ function observeOnly(
   return memory.linkCount;
 }
 
+const freshEnumerable: EnumerableReadMemory = new Memory();
+const freshLinks = freshEnumerable.allLinks();
+assertSame(freshLinks.length, 1, "fresh enumeration must contain only R");
+assertSame(freshLinks[0], freshEnumerable.root, "fresh enumeration must contain R");
+assert(Object.isFrozen(freshLinks), "enumeration result must be frozen");
+
 const memory = new Memory();
 const { R, O, C, L, U } = ensureRootBasis(memory);
 
 assertSame(memory.linkCount, 5, "root basis must contain exactly five Links");
 assertSame(memory.ensureRoot(), R, "ensureRoot must reuse R");
 assertSame(memory.ensure(R, R), R, "R -> R must resolve to R");
+
+const enumeratedBasis = memory.allLinks();
+assertSame(enumeratedBasis.length, memory.linkCount, "enumeration count must match linkCount");
+for (const ref of [R, O, C, L, U]) {
+  assertIncludes(enumeratedBasis, ref, "enumeration must contain every basis Link");
+}
+assertSame(new Set(enumeratedBasis).size, enumeratedBasis.length, "enumeration must not duplicate Links");
+const beforeEnumeration = memory.linkCount;
+assertSame(memory.allLinks().length, beforeEnumeration, "enumeration must be read-only");
+assertSame(memory.linkCount, beforeEnumeration, "enumeration must preserve linkCount");
 
 const rootPoles = memory.poles(R);
 assertSame(rootPoles.start, R, "R start must be R");
@@ -99,6 +116,10 @@ const loopPoles = memory.poles(loop);
 assertSame(loopPoles.start, L, "Loop(L) start must be L");
 assertSame(loopPoles.end, L, "Loop(L) end must be L");
 assertSame(memory.ensure(L, L), loop, "ordinary loop pair must be canonical");
+const afterLoop = memory.allLinks();
+assertSame(afterLoop.length, memory.linkCount, "new Link must appear once in enumeration");
+assertIncludes(afterLoop, loop, "enumeration must include newly materialized Link");
+assertSame(new Set(afterLoop).size, afterLoop.length, "same-pair reuse must not duplicate enumeration");
 
 const foreignRoot = new Memory().root;
 assertMemoryError(


### PR DESCRIPTION
Closes #500.

## What changed
- add a narrow opt-in `EnumerableReadMemory extends ReadMemory` capability with `allLinks()` instead of widening every trusted read-only consumer;
- make concrete `Memory` implement that capability directly from its canonical append-only handle registry;
- return a frozen copy, so callers cannot mutate the internal registry;
- preserve ordinary `ReadMemory` / `WriteMemory` surfaces and all existing pair/outgoing/incoming behavior;
- add tests for fresh-root enumeration, uniqueness, basis/new-link coverage, same-pair reuse, frozen result and linkCount invariance.

The iteration order is merely host allocation order; tests do not use it as semantic identity/order.

## Scope
Only `ts/src/memory.ts` and `ts/test/memory.test.ts` change. No new files, net +36 lines against budget +90, `behind_by=0` from exact accepted main `e89462e87e2665bab0d5818954392e6b7596620a`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.