### PR TITLE
TypeScript: port resolved ValueBundle semantics

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/value-bundle.ts
+++ b/ts/src/value-bundle.ts
@@ -1,4 +1,8 @@
-import type { LinkHandle, ReadMemory } from "./memory.js";
+import type {
+  EnumerableReadMemory,
+  LinkHandle,
+  ReadMemory,
+} from "./memory.js";
 import { readRootedSequence } from "./rooted-sequence.js";
 
 export type OccurrencePath = readonly number[];
@@ -32,6 +36,24 @@ export interface ValueBundleVocabulary {
   readonly kindSeed: LinkHandle;
   readonly kindTags: readonly LinkHandle[];
 }
+
+export interface ResolvedOccurrence {
+  readonly path: OccurrencePath;
+  readonly link: LinkHandle;
+}
+
+export interface LinkValue {
+  readonly kind: "link";
+  readonly link: LinkHandle;
+}
+
+export interface BundleValue {
+  readonly kind: "bundle";
+  readonly links: ReadonlySet<LinkHandle>;
+  readonly occurrences: readonly ResolvedOccurrence[];
+}
+
+export type MtsValue = LinkValue | BundleValue;
 
 export class ValueBundleReplayError extends Error {
   override readonly name = "ValueBundleReplayError";
@@ -302,4 +324,114 @@ export function bundleRoleAt(elaboration: BundleElaboration, path: OccurrencePat
   return elaboration.roles.find((item) =>
     item.path.length === path.length && item.path.every((part, index) => part === path[index])
   )?.role;
+}
+
+function validatedOccurrence(
+  memory: ReadMemory,
+  occurrence: ResolvedOccurrence,
+): ResolvedOccurrence {
+  if (
+    typeof occurrence !== "object" || occurrence === null ||
+    !Array.isArray(occurrence.path)
+  ) invalid();
+  memory.poles(occurrence.link);
+  return Object.freeze({
+    path: Object.freeze([...occurrence.path]),
+    link: occurrence.link,
+  });
+}
+
+function bundleValue(
+  links: Iterable<LinkHandle>,
+  occurrences: readonly ResolvedOccurrence[] = [],
+): BundleValue {
+  return Object.freeze({
+    kind: "bundle" as const,
+    links: new Set(links) as ReadonlySet<LinkHandle>,
+    occurrences: Object.freeze([...occurrences]),
+  });
+}
+
+export function resolveFlatBundle(
+  memory: ReadMemory,
+  occurrences: readonly ResolvedOccurrence[],
+): BundleValue {
+  const before = memory.linkCount;
+  try {
+    if (!Array.isArray(occurrences)) invalid();
+    const resolved = occurrences.map((occurrence) => validatedOccurrence(memory, occurrence));
+    const result = bundleValue(resolved.map((occurrence) => occurrence.link), resolved);
+    if (memory.linkCount !== before) invalid();
+    return result;
+  } catch (error) {
+    if (error instanceof ValueBundleReplayError) throw error;
+    throw new ValueBundleReplayError("invalid-value-bundle-evidence");
+  }
+}
+
+export function valuesEqual(left: MtsValue, right: MtsValue): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "link" && right.kind === "link") return left.link === right.link;
+  if (left.kind !== "bundle" || right.kind !== "bundle") return false;
+  if (left.links.size !== right.links.size) return false;
+  for (const link of left.links) {
+    if (!right.links.has(link)) return false;
+  }
+  return true;
+}
+
+function validateValue(memory: ReadMemory, value: MtsValue): void {
+  if (value.kind === "link") {
+    memory.poles(value.link);
+    return;
+  }
+  if (value.kind !== "bundle") invalid();
+  for (const link of value.links) memory.poles(link);
+  for (const occurrence of value.occurrences) validatedOccurrence(memory, occurrence);
+}
+
+function endpointDomain(value: MtsValue): ReadonlySet<LinkHandle> | undefined {
+  if (value.kind === "link") return new Set([value.link]);
+  return value.links.size === 0 ? undefined : value.links;
+}
+
+export function expandResolvedBundleQuery(
+  memory: EnumerableReadMemory,
+  left: MtsValue,
+  right: MtsValue,
+): BundleValue {
+  const before = memory.linkCount;
+  try {
+    if (left.kind !== "bundle" && right.kind !== "bundle") invalid();
+    validateValue(memory, left);
+    validateValue(memory, right);
+    const leftDomain = endpointDomain(left);
+    const rightDomain = endpointDomain(right);
+    const found = new Set<LinkHandle>();
+
+    if (leftDomain === undefined && rightDomain === undefined) {
+      for (const ref of memory.allLinks()) found.add(ref);
+    } else if (leftDomain === undefined) {
+      for (const end of rightDomain!) {
+        for (const ref of memory.incoming(end)) found.add(ref);
+      }
+    } else if (rightDomain === undefined) {
+      for (const start of leftDomain) {
+        for (const ref of memory.outgoing(start)) found.add(ref);
+      }
+    } else {
+      for (const start of leftDomain) {
+        for (const end of rightDomain) {
+          const ref = memory.find(start, end);
+          if (ref !== undefined) found.add(ref);
+        }
+      }
+    }
+
+    if (memory.linkCount !== before) invalid();
+    return bundleValue(found);
+  } catch (error) {
+    if (error instanceof ValueBundleReplayError) throw error;
+    throw new ValueBundleReplayError("invalid-value-bundle-evidence");
+  }
 }

--- a/ts/test/value-bundle-resolved.test.ts
+++ b/ts/test/value-bundle-resolved.test.ts
@@ -1,0 +1,179 @@
+import {
+  Memory,
+  type EnumerableReadMemory,
+  type LinkHandle,
+  type LinkPoles,
+} from "../src/memory.js";
+import {
+  ValueBundleReplayError,
+  expandResolvedBundleQuery,
+  resolveFlatBundle,
+  valuesEqual,
+  type BundleValue,
+  type LinkValue,
+  type MtsValue,
+  type ResolvedOccurrence,
+} from "../src/value-bundle.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function setSame(actual: ReadonlySet<LinkHandle>, expected: readonly LinkHandle[], message: string): void {
+  same(actual.size, new Set(expected).size, `${message}: size`);
+  for (const ref of expected) assert(actual.has(ref), `${message}: missing expected Link`);
+}
+function reject(effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof ValueBundleReplayError, `expected ValueBundleReplayError, got ${String(error)}`);
+    same(error.code, "invalid-value-bundle-evidence", "ValueBundle error code");
+    return;
+  }
+  throw new Error("expected invalid-value-bundle-evidence");
+}
+function occurrence(path: readonly number[], link: LinkHandle): ResolvedOccurrence {
+  return Object.freeze({ path: Object.freeze([...path]), link });
+}
+function scalar(link: LinkHandle): LinkValue {
+  return Object.freeze({ kind: "link", link });
+}
+function bundle(memory: Memory, ...links: LinkHandle[]): BundleValue {
+  return resolveFlatBundle(memory, links.map((link, index) => occurrence([index], link)));
+}
+
+{
+  const m = new Memory();
+  const a = m.ensureEndSelfClosed(m.root);
+  const b = m.ensure(a, m.root);
+  const before = m.linkCount;
+  const value = resolveFlatBundle(m, [occurrence([0], a), occurrence([1], b), occurrence([2], a)]);
+  setSame(value.links, [a, b], "resolved bundle deduplicates extensional set");
+  same(value.occurrences.length, 3, "resolved bundle preserves duplicate occurrences");
+  same(value.occurrences[0]?.path.join(","), "0", "first occurrence path");
+  same(value.occurrences[2]?.path.join(","), "2", "duplicate occurrence path");
+  same(m.linkCount, before, "resolveFlatBundle is read-only");
+
+  const reordered = resolveFlatBundle(m, [occurrence([9], b), occurrence([8], a)]);
+  assert(valuesEqual(value, reordered), "bundle equality is extensional and order-insensitive");
+  const duplicateOnly = resolveFlatBundle(m, [occurrence([0], a), occurrence([1], a)]);
+  const singleton = resolveFlatBundle(m, [occurrence([0], a)]);
+  assert(valuesEqual(duplicateOnly, singleton), "duplicate occurrences are equality-idempotent");
+  assert(!valuesEqual(value, singleton), "different bundle sets are unequal");
+  assert(valuesEqual(scalar(a), scalar(a)), "same scalar Link is equal");
+  assert(!valuesEqual(scalar(a), scalar(b)), "different scalar Links are unequal");
+  assert(!valuesEqual(singleton, scalar(a)), "singleton bundle never coerces to scalar");
+}
+
+{
+  const m = new Memory();
+  const foreign = new Memory().root;
+  reject(() => resolveFlatBundle(m, [occurrence([0], foreign)]));
+  same(m.linkCount, 1, "foreign occurrence never materializes a guess");
+}
+
+interface ExpansionFixture {
+  readonly memory: Memory;
+  readonly root: LinkHandle;
+  readonly one: LinkHandle;
+  readonly two: LinkHandle;
+  readonly three: LinkHandle;
+}
+function expansionFixture(): ExpansionFixture {
+  const memory = new Memory();
+  const root = memory.root;
+  const one = memory.ensureEndSelfClosed(root);
+  const two = memory.ensure(one, root);
+  const three = memory.ensure(one, one);
+  same(memory.linkCount, 4, "expansion fixture must have four Links");
+  return { memory, root, one, two, three };
+}
+
+{
+  const f = expansionFixture();
+  const before = f.memory.linkCount;
+  const cases: readonly [string, MtsValue, MtsValue, readonly LinkHandle[]][] = [
+    ["single-to-bundle", scalar(f.root), bundle(f.memory, f.root, f.one), [f.root, f.one]],
+    ["bundle-to-single", bundle(f.memory, f.root, f.one), scalar(f.one), [f.one, f.three]],
+    ["cartesian-existing", bundle(f.memory, f.root, f.one), bundle(f.memory, f.root, f.one), [f.root, f.one, f.two, f.three]],
+    ["outgoing-wildcard", scalar(f.root), bundle(f.memory), [f.root, f.one]],
+    ["incoming-wildcard", bundle(f.memory), scalar(f.one), [f.one, f.three]],
+    ["all-links-wildcard", bundle(f.memory), bundle(f.memory), [f.root, f.one, f.two, f.three]],
+    ["missing-pair-no-realize", scalar(f.root), bundle(f.memory, f.two), []],
+  ];
+  for (const [id, left, right, expected] of cases) {
+    const value = expandResolvedBundleQuery(f.memory, left, right);
+    setSame(value.links, expected, id);
+    same(value.occurrences.length, 0, `${id}: query result has no source occurrences`);
+    same(f.memory.linkCount, before, `${id}: query is read-only`);
+  }
+}
+
+class QueryProbe implements EnumerableReadMemory {
+  findCalls = 0;
+  outgoingCalls = 0;
+  incomingCalls = 0;
+  allLinksCalls = 0;
+  constructor(private readonly source: Memory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    this.findCalls += 1;
+    return this.source.find(start, end);
+  }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.outgoingCalls += 1;
+    return this.source.outgoing(start);
+  }
+  incoming(end: LinkHandle): readonly LinkHandle[] {
+    this.incomingCalls += 1;
+    return this.source.incoming(end);
+  }
+  allLinks(): readonly LinkHandle[] {
+    this.allLinksCalls += 1;
+    return this.source.allLinks();
+  }
+}
+
+{
+  const f = expansionFixture();
+  const exact = new QueryProbe(f.memory);
+  expandResolvedBundleQuery(exact, bundle(f.memory, f.root, f.one), bundle(f.memory, f.root, f.one));
+  same(exact.findCalls, 4, "Cartesian query uses exact pair index");
+  same(exact.outgoingCalls, 0, "Cartesian query does not use outgoing wildcard");
+  same(exact.incomingCalls, 0, "Cartesian query does not use incoming wildcard");
+  same(exact.allLinksCalls, 0, "Cartesian query does not enumerate all Links");
+
+  const outgoing = new QueryProbe(f.memory);
+  expandResolvedBundleQuery(outgoing, scalar(f.root), bundle(f.memory));
+  same(outgoing.outgoingCalls, 1, "right wildcard uses outgoing index");
+  same(outgoing.allLinksCalls, 0, "one-sided wildcard does not enumerate all Links");
+
+  const incoming = new QueryProbe(f.memory);
+  expandResolvedBundleQuery(incoming, bundle(f.memory), scalar(f.one));
+  same(incoming.incomingCalls, 1, "left wildcard uses incoming index");
+  same(incoming.allLinksCalls, 0, "one-sided wildcard does not enumerate all Links");
+
+  const all = new QueryProbe(f.memory);
+  expandResolvedBundleQuery(all, bundle(f.memory), bundle(f.memory));
+  same(all.allLinksCalls, 1, "double wildcard uses explicit enumeration capability once");
+  same(all.findCalls, 0, "double wildcard does not reconstruct memory by pair scans");
+}
+
+{
+  const f = expansionFixture();
+  reject(() => expandResolvedBundleQuery(f.memory, scalar(f.root), scalar(f.one)));
+  reject(() => expandResolvedBundleQuery(
+    f.memory,
+    { kind: "bundle", links: new Set([new Memory().root]), occurrences: [] },
+    scalar(f.one),
+  ));
+  reject(() => expandResolvedBundleQuery(
+    f.memory,
+    { kind: "mystery" } as unknown as MtsValue,
+    bundle(f.memory),
+  ));
+}


### PR DESCRIPTION
Closes #497.

## What changed
- extend `ts/src/value-bundle.ts` with compact resolved occurrence, scalar LinkValue and extensional BundleValue host values;
- add `resolveFlatBundle(ReadMemory, occurrences)`: validate each occurrence independently, preserve ordered provenance, deduplicate only the semantic Link set, never write;
- add pure tagged `valuesEqual`: exact Link identity for scalar values, extensional set equality for bundles, no scalar/singleton-bundle coercion;
- add `expandResolvedBundleQuery(EnumerableReadMemory, left, right)` with indexed read-only paths:
  - exact domains -> `find(start,end)`;
  - right wildcard -> `outgoing(start)`;
  - left wildcard -> `incoming(end)`;
  - double wildcard -> explicit `allLinks()` capability from #500;
- missing pairs are omitted and never materialized;
- query results have extensional links only, with no invented source occurrences;
- cover accepted equality/duplicate/provenance/foreign/missing-pair and all expansion modes, plus a capability probe proving all-links enumeration is used only for the double wildcard.

## Scope
Only `ts/src/value-bundle.ts`, new `ts/test/value-bundle-resolved.test.ts`, and `ts/package.json` change. One new file, net +311 lines against budget +620, `behind_by=0` from exact accepted main `c5adb4ead969f6188d4418e2464ed729214af527`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.