### PR TITLE
TypeScript: port exact Run replay

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {

--- a/ts/src/run.ts
+++ b/ts/src/run.ts
@@ -102,10 +102,11 @@ export function replayRun(
 ): readonly LinkHandle[] {
   const before = memory.linkCount;
   try {
-    verifyRunChain(memory, evidence);
-
     if (evidence.steps.length === 0) {
       if (evidence.runRoot !== memory.root) {
+        // Validate ownership before reporting the semantic root mismatch so a
+        // foreign/forged technical handle still fails at the Memory boundary.
+        memory.poles(evidence.runRoot);
         fail("empty-run-root-mismatch");
       }
       if (evidence.initialContext !== evidence.terminalContext) {
@@ -121,6 +122,8 @@ export function replayRun(
       }
       return Object.freeze([]);
     }
+
+    verifyRunChain(memory, evidence);
 
     const acts: LinkHandle[] = [];
     let previousAfter: LinkHandle | undefined;

--- a/ts/src/run.ts
+++ b/ts/src/run.ts
@@ -1,0 +1,184 @@
+import { MemoryError, type LinkHandle, type ReadMemory } from "./memory.js";
+import { StateError, readContext } from "./state.js";
+import {
+  StructuralReadError,
+  readActHeader,
+  readRequiredSingle,
+} from "./structural-readers.js";
+
+export interface RunStepSelection {
+  readonly act: LinkHandle;
+  readonly beforeRole: LinkHandle;
+  readonly afterRole: LinkHandle;
+}
+
+export interface RunEvidence {
+  readonly runRoot: LinkHandle;
+  readonly initialContext: LinkHandle;
+  readonly terminalContext: LinkHandle;
+  readonly steps: readonly RunStepSelection[];
+}
+
+export type RunReplayErrorCode =
+  | "invalid-run-evidence"
+  | "run-chain-ended-early"
+  | "run-chain-act-mismatch"
+  | "run-chain-extra-prefix"
+  | "invalid-step-before-field"
+  | "invalid-step-after-field"
+  | "invalid-step-before-context"
+  | "invalid-step-after-context"
+  | "step-header-after-context-mismatch"
+  | "initial-context-mismatch"
+  | "context-discontinuity"
+  | "terminal-context-mismatch"
+  | "empty-run-root-mismatch"
+  | "empty-run-context-change"
+  | "invalid-empty-run-context";
+
+export class RunReplayError extends Error {
+  override readonly name = "RunReplayError";
+
+  constructor(readonly code: RunReplayErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: RunReplayErrorCode): never {
+  throw new RunReplayError(code);
+}
+
+function verifyRunChain(memory: ReadMemory, evidence: RunEvidence): void {
+  let current = evidence.runRoot;
+  for (let index = evidence.steps.length - 1; index >= 0; index -= 1) {
+    const step = evidence.steps[index];
+    if (step === undefined) {
+      fail("invalid-run-evidence");
+    }
+    if (current === memory.root) {
+      fail("run-chain-ended-early");
+    }
+    const cell = memory.poles(current);
+    if (cell.end !== step.act) {
+      fail("run-chain-act-mismatch");
+    }
+    current = cell.start;
+  }
+  if (current !== memory.root) {
+    fail("run-chain-extra-prefix");
+  }
+}
+
+function readStepContext(
+  memory: ReadMemory,
+  step: RunStepSelection,
+  role: LinkHandle,
+  fieldError: RunReplayErrorCode,
+  contextError: RunReplayErrorCode,
+): LinkHandle {
+  let context: LinkHandle;
+  try {
+    context = readRequiredSingle(memory, step.act, role);
+  } catch (error) {
+    if (error instanceof StructuralReadError || error instanceof MemoryError) {
+      fail(fieldError);
+    }
+    throw error;
+  }
+  try {
+    readContext(memory, context);
+  } catch (error) {
+    if (error instanceof StateError || error instanceof MemoryError) {
+      fail(contextError);
+    }
+    throw error;
+  }
+  return context;
+}
+
+export function replayRun(
+  memory: ReadMemory,
+  evidence: RunEvidence,
+): readonly LinkHandle[] {
+  const before = memory.linkCount;
+  try {
+    verifyRunChain(memory, evidence);
+
+    if (evidence.steps.length === 0) {
+      if (evidence.runRoot !== memory.root) {
+        fail("empty-run-root-mismatch");
+      }
+      if (evidence.initialContext !== evidence.terminalContext) {
+        fail("empty-run-context-change");
+      }
+      try {
+        readContext(memory, evidence.initialContext);
+      } catch (error) {
+        if (error instanceof StateError || error instanceof MemoryError) {
+          fail("invalid-empty-run-context");
+        }
+        throw error;
+      }
+      return Object.freeze([]);
+    }
+
+    const acts: LinkHandle[] = [];
+    let previousAfter: LinkHandle | undefined;
+
+    evidence.steps.forEach((step, index) => {
+      const beforeContext = readStepContext(
+        memory,
+        step,
+        step.beforeRole,
+        "invalid-step-before-field",
+        "invalid-step-before-context",
+      );
+      const afterContext = readStepContext(
+        memory,
+        step,
+        step.afterRole,
+        "invalid-step-after-field",
+        "invalid-step-after-context",
+      );
+
+      let headerAfter: LinkHandle;
+      try {
+        headerAfter = readActHeader(memory, step.act).afterContext;
+      } catch (error) {
+        if (error instanceof StructuralReadError || error instanceof MemoryError) {
+          fail("invalid-run-evidence");
+        }
+        throw error;
+      }
+      if (headerAfter !== afterContext) {
+        fail("step-header-after-context-mismatch");
+      }
+
+      if (index === 0 && beforeContext !== evidence.initialContext) {
+        fail("initial-context-mismatch");
+      }
+      if (previousAfter !== undefined && beforeContext !== previousAfter) {
+        fail("context-discontinuity");
+      }
+      previousAfter = afterContext;
+      acts.push(step.act);
+    });
+
+    if (previousAfter !== evidence.terminalContext) {
+      fail("terminal-context-mismatch");
+    }
+    return Object.freeze(acts);
+  } catch (error) {
+    if (error instanceof RunReplayError) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      throw new RunReplayError("invalid-run-evidence");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new RunReplayError("invalid-run-evidence");
+    }
+  }
+}

--- a/ts/test/run.test.ts
+++ b/ts/test/run.test.ts
@@ -1,0 +1,237 @@
+import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
+import { defineContext } from "../src/state.js";
+import {
+  defineActField,
+  defineActHeader,
+} from "../src/structural-readers.js";
+import {
+  RunReplayError,
+  replayRun,
+  type RunEvidence,
+  type RunStepSelection,
+} from "../src/run.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), message);
+}
+
+function assertArraySame(
+  actual: readonly LinkHandle[],
+  expected: readonly LinkHandle[],
+  message: string,
+): void {
+  assert(actual.length === expected.length, `${message}: length`);
+  actual.forEach((value, index) => assertSame(value, expected[index], `${message}: ${index}`));
+}
+
+function assertRunError(code: RunReplayError["code"], effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof RunReplayError, `${code}: wrong error type`);
+    assertSame(error.code, code, `${code}: wrong code`);
+    return;
+  }
+  throw new Error(`${code}: expected RunReplayError`);
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly R: LinkHandle;
+  readonly interpreter: LinkHandle;
+  readonly roleDictionary: LinkHandle;
+  readonly beforeRole: LinkHandle;
+  readonly afterRole: LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, O, C, L, U } = ensureRootBasis(memory);
+  const interpreter = memory.ensure(L, R);
+  const roleDictionary = memory.ensure(U, R);
+  const beforeRole = memory.ensure(O, L);
+  const afterRole = memory.ensure(C, U);
+  return { memory, R, interpreter, roleDictionary, beforeRole, afterRole };
+}
+
+function context(fx: Fixture, seed: LinkHandle): LinkHandle {
+  const parent = fx.memory.ensure(seed, fx.R);
+  const current = fx.memory.ensure(fx.R, seed);
+  return defineContext(fx.memory, parent, current);
+}
+
+function step(
+  fx: Fixture,
+  before: LinkHandle,
+  after: LinkHandle,
+  options: {
+    readonly headerAfter?: LinkHandle;
+    readonly beforeRole?: LinkHandle;
+    readonly afterRole?: LinkHandle;
+  } = {},
+): RunStepSelection {
+  const beforeRole = options.beforeRole ?? fx.beforeRole;
+  const afterRole = options.afterRole ?? fx.afterRole;
+  const act = defineActHeader(
+    fx.memory,
+    fx.interpreter,
+    fx.roleDictionary,
+    options.headerAfter ?? after,
+  );
+  defineActField(fx.memory, act, beforeRole, before);
+  defineActField(fx.memory, act, afterRole, after);
+  return Object.freeze({ act, beforeRole, afterRole });
+}
+
+function run(
+  fx: Fixture,
+  steps: readonly RunStepSelection[],
+  initialContext: LinkHandle,
+  terminalContext: LinkHandle,
+): RunEvidence {
+  let runRoot = fx.R;
+  for (const selected of steps) runRoot = fx.memory.ensure(runRoot, selected.act);
+  return Object.freeze({
+    runRoot,
+    initialContext,
+    terminalContext,
+    steps: Object.freeze([...steps]),
+  });
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const k1 = context(fx, fx.afterRole);
+  const k2 = context(fx, fx.interpreter);
+  const s0 = step(fx, k0, k1);
+  const s1 = step(fx, k1, k2);
+  const evidence = run(fx, [s0, s1], k0, k2);
+  const before = fx.memory.linkCount;
+  assertArraySame(replayRun(fx.memory, evidence), [s0.act, s1.act], "linear run");
+  assertSame(fx.memory.linkCount, before, "linear replay must be read-only");
+  assertSame(fx.memory.find(k0, k2), undefined, "run must not create context shortcut");
+  assertRunError("run-chain-act-mismatch", () =>
+    replayRun(fx.memory, { ...evidence, steps: [s1, s0] }),
+  );
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const selected = step(fx, k0, k0);
+  const evidence = run(fx, [selected, selected], k0, k0);
+  const first = fx.memory.poles(evidence.runRoot).start;
+  assert(first !== fx.R, "repeated Act must have a distinct second run position");
+  assertSame(fx.memory.poles(first).end, selected.act, "first position selects same Act");
+  assertSame(fx.memory.poles(evidence.runRoot).end, selected.act, "second position selects same Act");
+  assertArraySame(replayRun(fx.memory, evidence), [selected.act, selected.act], "repeated Act");
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const k1 = context(fx, fx.afterRole);
+  const s0 = step(fx, k0, k1);
+  const s1 = step(fx, k1, k0);
+  assertArraySame(replayRun(fx.memory, run(fx, [s0, s1], k0, k0)), [s0.act, s1.act], "context return");
+
+  const branchContext = context(fx, fx.roleDictionary);
+  const branch = step(fx, k0, branchContext);
+  assert(branch.act !== s0.act, "branch must be structurally distinct");
+  assertArraySame(replayRun(fx.memory, run(fx, [s0], k0, k1)), [s0.act], "unselected branch");
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const k1 = context(fx, fx.afterRole);
+  const k2 = context(fx, fx.interpreter);
+  const s0 = step(fx, k0, k1);
+  const s1 = step(fx, k2, k0);
+  assertRunError("context-discontinuity", () => replayRun(fx.memory, run(fx, [s0, s1], k0, k0)));
+  assertRunError("initial-context-mismatch", () => replayRun(fx.memory, run(fx, [s0], k2, k1)));
+  assertRunError("terminal-context-mismatch", () => replayRun(fx.memory, run(fx, [s0], k0, k2)));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const k1 = context(fx, fx.afterRole);
+  const selected = step(fx, k0, k1);
+  const wrong = context(fx, fx.interpreter);
+  defineActField(fx.memory, selected.act, selected.beforeRole, wrong);
+  assertRunError("invalid-step-before-field", () => replayRun(fx.memory, run(fx, [selected], k0, k1)));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const k1 = context(fx, fx.afterRole);
+  const selected = step(fx, k0, k1);
+  const wrong = context(fx, fx.interpreter);
+  defineActField(fx.memory, selected.act, selected.afterRole, wrong);
+  assertRunError("invalid-step-after-field", () => replayRun(fx.memory, run(fx, [selected], k0, k1)));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const k1 = context(fx, fx.afterRole);
+  const wrongHeader = context(fx, fx.interpreter);
+  const selected = step(fx, k0, k1, { headerAfter: wrongHeader });
+  assertRunError("step-header-after-context-mismatch", () => replayRun(fx.memory, run(fx, [selected], k0, k1)));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const invalid = fx.memory.ensure(fx.beforeRole, fx.afterRole);
+  const beforeInvalid = step(fx, invalid, k0);
+  assertRunError("invalid-step-before-context", () => replayRun(fx.memory, run(fx, [beforeInvalid], invalid, k0)));
+
+  const afterInvalid = step(fx, k0, invalid);
+  assertRunError("invalid-step-after-context", () => replayRun(fx.memory, run(fx, [afterInvalid], k0, invalid)));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  assertArraySame(replayRun(fx.memory, run(fx, [], k0, k0)), [], "empty run identity");
+  const k1 = context(fx, fx.afterRole);
+  assertRunError("empty-run-context-change", () => replayRun(fx.memory, run(fx, [], k0, k1)));
+  const invalid = fx.memory.ensure(fx.beforeRole, fx.afterRole);
+  assertRunError("invalid-empty-run-context", () => replayRun(fx.memory, run(fx, [], invalid, invalid)));
+  assertRunError("empty-run-root-mismatch", () => replayRun(fx.memory, {
+    runRoot: fx.beforeRole,
+    initialContext: k0,
+    terminalContext: k0,
+    steps: [],
+  }));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const selected = step(fx, k0, k0);
+  const evidence = run(fx, [selected], k0, k0);
+  const extra = fx.memory.ensure(evidence.runRoot, fx.afterRole);
+  assertRunError("run-chain-extra-prefix", () => replayRun(fx.memory, { ...evidence, runRoot: extra }));
+  assertRunError("run-chain-ended-early", () => replayRun(fx.memory, { ...evidence, runRoot: fx.R }));
+}
+
+{
+  const fx = fixture();
+  const k0 = context(fx, fx.beforeRole);
+  const foreign = new Memory().root;
+  assertRunError("invalid-run-evidence", () => replayRun(fx.memory, {
+    runRoot: foreign,
+    initialContext: k0,
+    terminalContext: k0,
+    steps: [],
+  }));
+}

--- a/ts/test/run.test.ts
+++ b/ts/test/run.test.ts
@@ -219,8 +219,9 @@ function run(
   const k0 = context(fx, fx.beforeRole);
   const selected = step(fx, k0, k0);
   const evidence = run(fx, [selected], k0, k0);
-  const extra = fx.memory.ensure(evidence.runRoot, fx.afterRole);
-  assertRunError("run-chain-extra-prefix", () => replayRun(fx.memory, { ...evidence, runRoot: extra }));
+  const extraPrefix = fx.memory.ensure(fx.R, fx.afterRole);
+  const forgedRoot = fx.memory.ensure(extraPrefix, selected.act);
+  assertRunError("run-chain-extra-prefix", () => replayRun(fx.memory, { ...evidence, runRoot: forgedRoot }));
   assertRunError("run-chain-ended-early", () => replayRun(fx.memory, { ...evidence, runRoot: fx.R }));
 }
 


### PR DESCRIPTION
Closes #503.

## What changed
- add `ts/src/run.ts` with read-only exact Run replay over the structural chain `R -> Act_0 -> ... -> Act_n`;
- keep host evidence minimal: each selected step contains only `act`, `beforeRole`, `afterRole`; exact before/after contexts are recovered through `readRequiredSingle` instead of duplicated DTO fields;
- validate recovered contexts with existing `readContext` and require the actual Act header `afterContext` to match the structural after field;
- enforce exact initial/adjacent/terminal context continuity, empty-Run identity, exact run-chain ordering, early/extra-prefix rejection, repeated-Act occurrence semantics and fail-closed foreign/malformed handles;
- preserve `linkCount` and never materialize or infer context shortcuts;
- reuse accepted `state.ts` + `structural-readers.ts` unchanged; no parser/AST/proof/search/transitivity semantics.

## Scope
Only new `ts/src/run.ts`, new `ts/test/run.test.ts`, and `ts/package.json` change. Two new files, net ~421 lines against budget +470, `behind_by=0` from exact accepted main `5f9e9ade5ed3995dfe6087486232880a5b9e4674`.

## Validation
Keep draft until CI is fully green. Then repeat main/race guard, require `behind_by=0` and mergeability, mark ready, wait for the separate non-draft blocking repo-guard, merge with expected head SHA, and verify post-merge CI on exact main SHA.