### PR TITLE
TypeScript: M9d reference Node JSON backend

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js",
+    "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js",
     "check": "npm run typecheck && npm test"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
     "typescript": "5.9.3"
   }
 }

--- a/ts/src/node-json-backend.ts
+++ b/ts/src/node-json-backend.ts
@@ -1,0 +1,105 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { PersistentTopologyBackend, StoredDataset } from "./persistent-store.js";
+
+export class NodeJsonBackendError extends Error {
+  override readonly name = "NodeJsonBackendError";
+}
+
+function backendError(message: string, cause?: unknown): NodeJsonBackendError {
+  return new NodeJsonBackendError(message, cause === undefined ? undefined : { cause });
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code;
+}
+
+function serialize(dataset: StoredDataset): string {
+  const envelope = {
+    schema: dataset.schema,
+    lineage: dataset.lineage,
+    topology: {
+      schema: dataset.topology.schema,
+      root: dataset.topology.root,
+      links: dataset.topology.links.map(([start, end]) => [start, end]),
+    },
+  };
+  return `${JSON.stringify(envelope)}\n`;
+}
+
+export class NodeJsonFileBackend implements PersistentTopologyBackend {
+  private serial = 0;
+
+  constructor(readonly path: string) {
+    if (typeof path !== "string" || path.length === 0) throw backendError("invalid Node JSON backend path");
+  }
+
+  load(): StoredDataset | undefined {
+    let text: string;
+    try {
+      text = readFileSync(this.path, "utf8");
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) return undefined;
+      throw backendError("cannot read persistent JSON dataset", error);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw backendError("invalid persistent JSON dataset", error);
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw backendError("persistent JSON dataset must be an object");
+    }
+    return parsed as StoredDataset;
+  }
+
+  commit(dataset: StoredDataset): void {
+    const directory = dirname(this.path);
+    try {
+      mkdirSync(directory, { recursive: true });
+    } catch (error) {
+      throw backendError("cannot create persistent JSON directory", error);
+    }
+
+    const temporary = this.nextTemporaryPath(directory);
+    let descriptor: number | undefined;
+    try {
+      descriptor = openSync(temporary, "wx");
+      writeFileSync(descriptor, serialize(dataset), "utf8");
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = undefined;
+      this.replaceTemporary(temporary);
+    } catch (error) {
+      if (descriptor !== undefined) {
+        try { closeSync(descriptor); } catch { /* preserve primary failure */ }
+      }
+      try {
+        if (existsSync(temporary)) unlinkSync(temporary);
+      } catch { /* preserve primary failure */ }
+      if (error instanceof NodeJsonBackendError) throw error;
+      throw backendError("cannot commit persistent JSON dataset", error);
+    }
+  }
+
+  protected replaceTemporary(temporary: string): void {
+    renameSync(temporary, this.path);
+  }
+
+  private nextTemporaryPath(directory: string): string {
+    this.serial += 1;
+    return join(directory, `.${basename(this.path)}.${process.pid}.${this.serial}.tmp`);
+  }
+}

--- a/ts/test/node-json-backend.test.ts
+++ b/ts/test/node-json-backend.test.ts
@@ -23,7 +23,9 @@ function assertSame<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), message);
 }
 
-function assertThrows(effect: () => unknown, type: typeof Error, message: string): void {
+type ErrorClass = abstract new (...args: any[]) => Error;
+
+function assertThrows(effect: () => unknown, type: ErrorClass, message: string): void {
   try {
     effect();
   } catch (error) {

--- a/ts/test/node-json-backend.test.ts
+++ b/ts/test/node-json-backend.test.ts
@@ -1,0 +1,158 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NodeJsonBackendError, NodeJsonFileBackend } from "../src/node-json-backend.js";
+import { PersistentStore, PersistentStoreError } from "../src/persistent-store.js";
+import {
+  materializePersistentSequence,
+  replayPersistentSequenceMaterialization,
+} from "../src/persistent-sequence.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), message);
+}
+
+function assertThrows(effect: () => unknown, type: typeof Error, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof type, `${message}: wrong error type`);
+    return;
+  }
+  throw new Error(`${message}: expected error`);
+}
+
+function withTemp(run: (directory: string) => void): void {
+  const directory = mkdtempSync(join(tmpdir(), "mts-node-json-"));
+  try { run(directory); }
+  finally { rmSync(directory, { recursive: true, force: true }); }
+}
+
+function basis(store: PersistentStore) {
+  const R = store.root;
+  const O = store.materializeStartSelfClosed(R);
+  const C = store.materializeEndSelfClosed(R);
+  const L = store.materialize(O, C);
+  const U = store.materialize(C, O);
+  return { R, O, C, L, U };
+}
+
+class FailingReplaceBackend extends NodeJsonFileBackend {
+  failNextReplace = false;
+
+  protected override replaceTemporary(temporary: string): void {
+    if (this.failNextReplace) {
+      this.failNextReplace = false;
+      throw new Error("injected pre-rename failure");
+    }
+    super.replaceTemporary(temporary);
+  }
+}
+
+withTemp((directory) => {
+  const path = join(directory, "store.json");
+  const backend = new NodeJsonFileBackend(path);
+  assertSame(backend.load(), undefined, "missing file is an empty backend");
+  const store = PersistentStore.create(backend, "file-lineage");
+  assert(existsSync(path), "create writes the reference file");
+  assertSame(store.count, 1, "fresh file store contains root only");
+
+  const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  assert(Object.keys(raw).sort().join(",") === "lineage,schema,topology", "file envelope contains only accepted fields");
+  const topology = raw.topology as Record<string, unknown>;
+  assert(Object.keys(topology).sort().join(",") === "links,root,schema", "topology contains no indexes or runtime handles");
+});
+
+withTemp((directory) => {
+  const path = join(directory, "store.json");
+  const store = PersistentStore.create(new NodeJsonFileBackend(path), "reopen-lineage");
+  const { O, C, L } = basis(store);
+  const loop = store.materialize(L, L);
+  const count = store.count;
+
+  const reopened = PersistentStore.open(new NodeJsonFileBackend(path));
+  assertSame(reopened.lineage, "reopen-lineage", "reopen preserves storage lineage");
+  assertSame(reopened.count, count, "reopen preserves topology cardinality");
+  const links = reopened.allLinks();
+  const rO = links[O.local]!;
+  const rC = links[C.local]!;
+  const rL = links[L.local]!;
+  assertSame(reopened.find(rO, rC)?.local, rL.local, "same pair survives reopen");
+  assertSame(reopened.materialize(rO, rC).local, rL.local, "same pair remains idempotent after reopen");
+  assertSame(reopened.poles(links[loop.local]!)[0].local, rL.local, "ordinary loop survives reopen");
+});
+
+withTemp((directory) => {
+  const path = join(directory, "store.json");
+  const store = PersistentStore.create(new NodeJsonFileBackend(path), "sequence-file-lineage");
+  const { O, C } = basis(store);
+  const a = store.materialize(O, O);
+  const b = store.materialize(C, C);
+  const evidence = materializePersistentSequence(store, {
+    root: store.root,
+    items: [
+      { kind: "atom", value: a },
+      { kind: "atom", value: b },
+      { kind: "atom", value: O },
+    ],
+  });
+  const reopened = PersistentStore.open(new NodeJsonFileBackend(path));
+  assertSame(replayPersistentSequenceMaterialization(reopened, evidence).local, evidence.result.local, "persistent sequence evidence replays after file reopen");
+});
+
+withTemp((directory) => {
+  const path = join(directory, "bad.json");
+  const malformed = "{bad json\n";
+  writeFileSync(path, malformed, "utf8");
+  const before = readFileSync(path);
+  assertThrows(() => new NodeJsonFileBackend(path).load(), NodeJsonBackendError, "malformed JSON rejects");
+  assert(readFileSync(path).equals(before), "malformed JSON is not rewritten");
+
+  writeFileSync(path, "[]\n", "utf8");
+  const nonObject = readFileSync(path);
+  assertThrows(() => new NodeJsonFileBackend(path).load(), NodeJsonBackendError, "non-object JSON rejects");
+  assert(readFileSync(path).equals(nonObject), "non-object JSON is not rewritten");
+});
+
+withTemp((directory) => {
+  const path = join(directory, "invalid-topology.json");
+  const payload = JSON.stringify({
+    schema: "mts-persistent-dataset/v0.1",
+    lineage: "bad-lineage",
+    topology: {
+      schema: "mts-storage-topology/v0.1",
+      root: 0,
+      links: [[0, 0], [1, 1]],
+    },
+  }) + "\n";
+  writeFileSync(path, payload, "utf8");
+  const before = readFileSync(path);
+  assertThrows(() => PersistentStore.open(new NodeJsonFileBackend(path)), PersistentStoreError, "invalid topology fails in canonical store validator");
+  assert(readFileSync(path).equals(before), "invalid topology open is read-only");
+});
+
+withTemp((directory) => {
+  const path = join(directory, "atomic.json");
+  const backend = new FailingReplaceBackend(path);
+  const store = PersistentStore.create(backend, "atomic-lineage");
+  const { O } = basis(store);
+  const beforeBytes = readFileSync(path);
+  const beforeCount = store.count;
+  backend.failNextReplace = true;
+  assertThrows(() => store.materialize(O, O), NodeJsonBackendError, "pre-rename failure surfaces through backend error");
+  assertSame(store.count, beforeCount, "failed file commit does not publish live store candidate");
+  assert(readFileSync(path).equals(beforeBytes), "pre-rename failure preserves exact previous target bytes");
+  const leftovers = readdirSync(directory).filter((name) => name.startsWith(".atomic.json.") && name.endsWith(".tmp"));
+  assertSame(leftovers.length, 0, "failed replace cleans temporary file");
+});


### PR DESCRIPTION
Closes #515.

Adds a Node-only `PersistentTopologyBackend` implementation with deterministic JSON envelope, fsync + same-directory temporary replacement, cleanup on failure, clean reopen coverage, persistent sequence replay after reopen, and injected pre-rename failure atomicity. Semantic `Memory`, `PersistentStore`, and sequence code are unchanged. `@types/node` is dev-only.

Diff is +264 net within the +520 budget, based on exact accepted main `01b55f9181e0bf30b62a066ab3b700a45b3c01e5`, with `behind_by=0`. Keep draft until CI is fully green, then apply the standard race/repo-guard/expected-head/post-merge gates.