### PR TITLE
TypeScript: M10b source/state differential coverage

### DIFF
--- a/differential/fixtures-v0.7.json
+++ b/differential/fixtures-v0.7.json
@@ -20,6 +20,16 @@
     {"id":"persistence-basis-loop-reopen","category":"persistence","input":{"operation":"basis-loop-reopen"}},
     {"id":"persistence-same-pair","category":"persistence","input":{"operation":"same-pair"}},
     {"id":"persistence-second-root","category":"persistence","input":{"operation":"open-topology","root":0,"links":[[0,0],[1,1]]}},
-    {"id":"persistence-id-cycle","category":"persistence","input":{"operation":"open-topology","root":0,"links":[[0,0],[2,0],[1,0]]}}
+    {"id":"persistence-id-cycle","category":"persistence","input":{"operation":"open-topology","root":0,"links":[[0,0],[2,0],[1,0]]}},
+
+    {"id":"source-empty","category":"source","input":{"operation":"round-trip","bytes":[]}},
+    {"id":"source-ascii","category":"source","input":{"operation":"round-trip","bytes":[97,98]}},
+    {"id":"source-utf8-arrow","category":"source","input":{"operation":"round-trip","bytes":[97,226,159,188,98]}},
+    {"id":"source-invalid-vocabulary","category":"source","input":{"operation":"invalid-vocabulary","bytes":[97]}},
+
+    {"id":"state-context","category":"state","input":{"operation":"context"}},
+    {"id":"state-representative-default","category":"state","input":{"operation":"representative-default"}},
+    {"id":"state-representative-binding","category":"state","input":{"operation":"representative-binding"}},
+    {"id":"state-representative-conflict","category":"state","input":{"operation":"representative-conflict"}}
   ]
 }

--- a/differential/python_oracle.py
+++ b/differential/python_oracle.py
@@ -13,7 +13,22 @@ if str(ROOT) not in sys.path:
 
 from core.anum_protocol import StreamError, deserialize_stream
 from core.foundation_v2_persistent import JsonLinkStore, PERSISTENT_SCHEMA, PersistentStoreError
-from core.rooted_link_network import LinkNetwork, LinkNetworkBuilder, LinkNetworkError, NetworkSnapshot
+from core.foundation_v2_source import SourceFrontEndBuilder, SourceReplayError
+from core.foundation_v2_state import (
+    RepresentativeConflictError,
+    current_of_context,
+    define_context,
+    define_local_representative_binding,
+    local_representative_resolution,
+    parent_of_context,
+)
+from core.rooted_link_network import (
+    LinkNetwork,
+    LinkNetworkBuilder,
+    LinkNetworkError,
+    NetworkSnapshot,
+    read_rooted_sequence,
+)
 
 
 FROZEN_ORACLE_SHA = "ef42d91a868bbc5b7004acc325006ad27db3bb68"
@@ -24,6 +39,8 @@ FROZEN_BLOBS = {
     "core/anum_parser.py": "a92d32f39032b841b8bbbec72ddd0bb81326610c",
     "core/foundation_v2_persistent.py": "af7e97eaea9e01cb313dc264f44f040f0f00997c",
     "core/foundation_v2_materialization.py": "ff894030ec06f15acb8530cda8fe2143ecabbed3",
+    "core/foundation_v2_source.py": "12c764f2ab0d7b2b98078cccb6325d0663be5996",
+    "core/foundation_v2_state.py": "70e7ae5eece7f347d0879ba73edc3477cf91f8b7",
 }
 
 
@@ -184,6 +201,120 @@ def run_persistence(case: dict) -> dict:
     return {"id": case["id"], "accepted": True, "observable": observable}
 
 
+def byte_vocabulary(builder: LinkNetworkBuilder, root):
+    refs = {}
+    current = root
+    for value in range(256):
+        current = builder.ensure_start_self_closed(current)
+        refs[value] = current
+    return refs
+
+
+def run_source(case: dict) -> dict:
+    operation = case["input"]["operation"]
+    builder = LinkNetworkBuilder()
+    root = builder.ensure_root()
+    if operation == "invalid-vocabulary":
+        try:
+            SourceFrontEndBuilder(builder, root, {})
+        except SourceReplayError:
+            return {"id": case["id"], "accepted": False, "error": "invalid-source"}
+        raise RuntimeError("invalid source vocabulary was unexpectedly accepted")
+
+    refs = byte_vocabulary(builder, root)
+    front_end = SourceFrontEndBuilder(builder, root, refs)
+    data = bytes(case["input"]["bytes"])
+    content = front_end.content_ref(data)
+    repeated_content = front_end.content_ref(data)
+    source = front_end.source_occurrence(data)
+    repeated_source = front_end.source_occurrence(data)
+    network = builder.freeze(root)
+    before = network.snapshot()
+    sequence = read_rooted_sequence(network, content)
+    inverse = {ref: value for value, ref in refs.items()}
+    decoded = [inverse[value] for value in sequence.values]
+    source_link = network.link(source.source)
+    after = network.snapshot()
+    return {
+        "id": case["id"],
+        "accepted": True,
+        "observable": {
+            "bytes": decoded,
+            "contentIsRoot": content is root,
+            "contentReused": repeated_content is content,
+            "sourceReused": repeated_source.source is source.source,
+            "sourceStartSelfClosed": source_link.start is source.source and source_link.end is content,
+            "readOnlyCountStable": len(before.links) == len(after.links),
+        },
+    }
+
+
+def state_basis(builder: LinkNetworkBuilder):
+    root = builder.ensure_root()
+    opening = builder.ensure_start_self_closed(root)
+    closing = builder.ensure_end_self_closed(root)
+    linked = builder.ensure(opening, closing)
+    unlinked = builder.ensure(closing, opening)
+    return root, opening, closing, linked, unlinked
+
+
+def run_state(case: dict) -> dict:
+    operation = case["input"]["operation"]
+    builder = LinkNetworkBuilder()
+    root, opening, closing, linked, unlinked = state_basis(builder)
+    context = define_context(builder, opening, closing)
+
+    if operation == "context":
+        repeated = define_context(builder, opening, closing)
+        network = builder.freeze(root)
+        before = network.snapshot()
+        parent = parent_of_context(network, context)
+        current = current_of_context(network, context)
+        after = network.snapshot()
+        observable = {
+            "parentMatches": parent is opening,
+            "currentMatches": current is closing,
+            "contextReused": repeated is context,
+            "readOnlyCountStable": len(before.links) == len(after.links),
+        }
+    elif operation == "representative-default":
+        network = builder.freeze(root)
+        before = network.snapshot()
+        resolution = local_representative_resolution(network, context, linked)
+        after = network.snapshot()
+        observable = {
+            "representativeMatches": resolution.representative is linked,
+            "bindingCount": len(resolution.bindings),
+            "readOnlyCountStable": len(before.links) == len(after.links),
+        }
+    elif operation == "representative-binding":
+        _pair, binding = define_local_representative_binding(builder, context, linked, unlinked)
+        _pair2, repeated = define_local_representative_binding(builder, context, linked, unlinked)
+        network = builder.freeze(root)
+        before = network.snapshot()
+        resolution = local_representative_resolution(network, context, linked)
+        after = network.snapshot()
+        observable = {
+            "representativeMatches": resolution.representative is unlinked,
+            "bindingCount": len(resolution.bindings),
+            "bindingReused": repeated is binding,
+            "readOnlyCountStable": len(before.links) == len(after.links),
+        }
+    elif operation == "representative-conflict":
+        define_local_representative_binding(builder, context, linked, opening)
+        define_local_representative_binding(builder, context, linked, closing)
+        network = builder.freeze(root)
+        try:
+            local_representative_resolution(network, context, linked)
+        except RepresentativeConflictError:
+            return {"id": case["id"], "accepted": False, "error": "representative-conflict"}
+        raise RuntimeError("representative conflict was unexpectedly accepted")
+    else:
+        raise RuntimeError(f"unknown state operation: {operation}")
+
+    return {"id": case["id"], "accepted": True, "observable": observable}
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         raise SystemExit("usage: python_oracle.py FIXTURES.json")
@@ -198,6 +329,10 @@ def main() -> int:
             results.append(run_anum(case))
         elif category == "persistence":
             results.append(run_persistence(case))
+        elif category == "source":
+            results.append(run_source(case))
+        elif category == "state":
+            results.append(run_state(case))
         else:
             raise RuntimeError(f"unknown differential category: {category}")
     json.dump(results, sys.stdout, sort_keys=True, separators=(",", ":"))

--- a/ts/test/differential.test.ts
+++ b/ts/test/differential.test.ts
@@ -6,7 +6,7 @@ import {
   deserializeStream,
   symbolicStackAlgebra,
 } from "../src/anum.js";
-import { Memory, ensureRootBasis } from "../src/memory.js";
+import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
 import {
   PersistenceTopologyError,
   STORAGE_TOPOLOGY_SCHEMA,
@@ -20,6 +20,20 @@ import {
   type PersistentTopologyBackend,
   type StoredDataset,
 } from "../src/persistent-store.js";
+import {
+  SourceError,
+  defineSourceForm,
+  materializeSourceContent,
+  readSourceContent,
+  readSourceForm,
+} from "../src/source.js";
+import {
+  StateError,
+  defineContext,
+  defineLocalRepresentativeBinding,
+  localRepresentativeResolution,
+  readContext,
+} from "../src/state.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -28,7 +42,7 @@ function assert(condition: unknown, message: string): asserts condition {
 type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 interface DifferentialCase {
   readonly id: string;
-  readonly category: "topology" | "anum" | "persistence";
+  readonly category: "topology" | "anum" | "persistence" | "source" | "state";
   readonly input: Record<string, Json>;
 }
 interface Corpus {
@@ -212,6 +226,137 @@ function runPersistence(test: DifferentialCase): Result {
   }
 }
 
+function byteVocabulary(memory: Memory): readonly LinkHandle[] {
+  const refs: LinkHandle[] = [];
+  let current = memory.root;
+  for (let value = 0; value < 256; value += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    refs.push(current);
+  }
+  return Object.freeze(refs);
+}
+
+function sourceBytes(input: Record<string, Json>): Uint8Array {
+  const raw = input.bytes;
+  assert(Array.isArray(raw), "source fixture needs byte array");
+  const values = raw.map((value) => {
+    assert(typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 255, "invalid source byte fixture");
+    return value;
+  });
+  return new Uint8Array(values);
+}
+
+function runSource(test: DifferentialCase): Result {
+  const operation = test.input.operation;
+  assert(typeof operation === "string", "source fixture needs operation");
+  const memory = new Memory();
+  const bytes = sourceBytes(test.input);
+  if (operation === "invalid-vocabulary") {
+    try {
+      materializeSourceContent(memory, [], bytes);
+    } catch (error) {
+      if (error instanceof SourceError) return { id: test.id, accepted: false, error: "invalid-source" };
+      throw error;
+    }
+    throw new Error("invalid source vocabulary was unexpectedly accepted");
+  }
+  if (operation !== "round-trip") throw new Error(`unknown source fixture operation: ${operation}`);
+
+  const refs = byteVocabulary(memory);
+  const content = materializeSourceContent(memory, refs, bytes);
+  const repeatedContent = materializeSourceContent(memory, refs, bytes);
+  const source = defineSourceForm(memory, content);
+  const repeatedSource = defineSourceForm(memory, content);
+  const before = memory.linkCount;
+  const decoded = readSourceContent(memory, refs, content);
+  const selectedContent = readSourceForm(memory, source);
+  const sourcePoles = memory.poles(source);
+  const after = memory.linkCount;
+  assert(selectedContent === content, "source fixture selected unexpected content");
+  return {
+    id: test.id,
+    accepted: true,
+    observable: {
+      bytes: [...decoded.bytes],
+      contentIsRoot: content === memory.root,
+      contentReused: repeatedContent === content,
+      sourceReused: repeatedSource === source,
+      sourceStartSelfClosed: sourcePoles.start === source && sourcePoles.end === content,
+      readOnlyCountStable: before === after,
+    },
+  };
+}
+
+function runState(test: DifferentialCase): Result {
+  const operation = test.input.operation;
+  assert(typeof operation === "string", "state fixture needs operation");
+  const memory = new Memory();
+  const { O, C, L, U } = ensureRootBasis(memory);
+  const context = defineContext(memory, O, C);
+
+  if (operation === "context") {
+    const repeated = defineContext(memory, O, C);
+    const before = memory.linkCount;
+    const state = readContext(memory, context);
+    const after = memory.linkCount;
+    return {
+      id: test.id,
+      accepted: true,
+      observable: {
+        parentMatches: state.parent === O,
+        currentMatches: state.current === C,
+        contextReused: repeated === context,
+        readOnlyCountStable: before === after,
+      },
+    };
+  }
+  if (operation === "representative-default") {
+    const before = memory.linkCount;
+    const resolution = localRepresentativeResolution(memory, context, L);
+    const after = memory.linkCount;
+    return {
+      id: test.id,
+      accepted: true,
+      observable: {
+        representativeMatches: resolution.representative === L,
+        bindingCount: resolution.bindings.length,
+        readOnlyCountStable: before === after,
+      },
+    };
+  }
+  if (operation === "representative-binding") {
+    const binding = defineLocalRepresentativeBinding(memory, context, L, U);
+    const repeated = defineLocalRepresentativeBinding(memory, context, L, U);
+    const before = memory.linkCount;
+    const resolution = localRepresentativeResolution(memory, context, L);
+    const after = memory.linkCount;
+    return {
+      id: test.id,
+      accepted: true,
+      observable: {
+        representativeMatches: resolution.representative === U,
+        bindingCount: resolution.bindings.length,
+        bindingReused: repeated === binding,
+        readOnlyCountStable: before === after,
+      },
+    };
+  }
+  if (operation === "representative-conflict") {
+    defineLocalRepresentativeBinding(memory, context, L, O);
+    defineLocalRepresentativeBinding(memory, context, L, C);
+    try {
+      localRepresentativeResolution(memory, context, L);
+    } catch (error) {
+      if (error instanceof StateError && error.code === "representative-conflict") {
+        return { id: test.id, accepted: false, error: "representative-conflict" };
+      }
+      throw error;
+    }
+    throw new Error("representative conflict was unexpectedly accepted");
+  }
+  throw new Error(`unknown state fixture operation: ${operation}`);
+}
+
 const repoRoot = resolve(process.cwd(), "..");
 const fixturePath = resolve(repoRoot, "differential/fixtures-v0.7.json");
 const corpus = JSON.parse(readFileSync(fixturePath, "utf8")) as Corpus;
@@ -228,7 +373,9 @@ const expected = JSON.parse(python.stdout) as Result[];
 const actual = corpus.cases.map((test) => {
   if (test.category === "topology") return runTopology(test);
   if (test.category === "anum") return runAnum(test);
-  return runPersistence(test);
+  if (test.category === "persistence") return runPersistence(test);
+  if (test.category === "source") return runSource(test);
+  return runState(test);
 });
 
 assert(expected.length === actual.length, "differential result cardinality mismatch");


### PR DESCRIPTION
Closes #519.

Extends the accepted M10 differential protocol in-place: the existing host-neutral fixture corpus, frozen Python adapter and TypeScript exact comparator now cover canonical source byte-content/source forms plus context and local representative semantics, including representative conflict. The freeze guard is expanded to the frozen source/state Python owner blobs. No new files and no semantic/core changes.

Diff is +292 net within the +520 budget, based on exact accepted main `271699467b608241202df97986ffa7bc3740a1a9`, with `behind_by=0`. Keep draft until the full Python↔TypeScript differential CI is green, then apply the standard race/repo-guard/expected-head/post-merge gates.