### PR TITLE
TypeScript: M10c dictionary/source-evidence differential coverage

### DIFF
--- a/differential/fixtures-v0.7.json
+++ b/differential/fixtures-v0.7.json
@@ -30,6 +30,21 @@
     {"id":"state-context","category":"state","input":{"operation":"context"}},
     {"id":"state-representative-default","category":"state","input":{"operation":"representative-default"}},
     {"id":"state-representative-binding","category":"state","input":{"operation":"representative-binding"}},
-    {"id":"state-representative-conflict","category":"state","input":{"operation":"representative-conflict"}}
+    {"id":"state-representative-conflict","category":"state","input":{"operation":"representative-conflict"}},
+
+    {"id":"dictionary-single","category":"dictionary","input":{"operation":"single"}},
+    {"id":"dictionary-parent","category":"dictionary","input":{"operation":"parent-visible"}},
+    {"id":"dictionary-shadow","category":"dictionary","input":{"operation":"shadow"}},
+    {"id":"dictionary-conflict","category":"dictionary","input":{"operation":"conflict"}},
+    {"id":"dictionary-root-sentinel","category":"dictionary","input":{"operation":"root-sentinel"}},
+    {"id":"dictionary-forged-occurrence","category":"dictionary","input":{"operation":"forged-occurrence"}},
+
+    {"id":"selection-single","category":"selection","input":{"operation":"selected","bytes":[97],"segments":[[0,1,0]]}},
+    {"id":"selection-multi","category":"selection","input":{"operation":"selected","bytes":[97,98],"segments":[[0,1,0],[1,2,1]]}},
+    {"id":"selection-utf8-slice","category":"selection","input":{"operation":"selected","bytes":[97,226,159,188,98],"segments":[[0,1,0],[1,4,1],[4,5,2]]}},
+    {"id":"selection-dictionary-choice","category":"selection","input":{"operation":"dictionary-choice","bytes":[120]}},
+    {"id":"selection-gap","category":"selection","input":{"operation":"invalid-partition","bytes":[97,98],"segments":[[0,1,0]]}},
+    {"id":"selection-overlap","category":"selection","input":{"operation":"invalid-partition","bytes":[97,98],"segments":[[0,2,0],[1,2,1]]}},
+    {"id":"selection-forged-resolution","category":"selection","input":{"operation":"forged-resolution","bytes":[97]}}
   ]
 }

--- a/differential/python_oracle.py
+++ b/differential/python_oracle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import hashlib
 import json
 from pathlib import Path
@@ -13,14 +14,25 @@ if str(ROOT) not in sys.path:
 
 from core.anum_protocol import StreamError, deserialize_stream
 from core.foundation_v2_persistent import JsonLinkStore, PERSISTENT_SCHEMA, PersistentStoreError
-from core.foundation_v2_source import SourceFrontEndBuilder, SourceReplayError
+from core.foundation_v2_source import (
+    SegmentSpec,
+    SourceFrontEndBuilder,
+    SourceReplayError,
+    replay_source_front_end,
+)
 from core.foundation_v2_state import (
+    DictionaryConflictError,
+    DictionaryLookupError,
     RepresentativeConflictError,
     current_of_context,
     define_context,
+    define_dictionary_effect,
+    define_dictionary_scope,
     define_local_representative_binding,
     local_representative_resolution,
+    lookup_scoped_dictionary,
     parent_of_context,
+    verify_visible_dictionary_occurrence,
 )
 from core.rooted_link_network import (
     LinkNetwork,
@@ -53,11 +65,7 @@ def git_blob_sha(path: Path) -> str:
 def verify_freeze(corpus: dict) -> None:
     if corpus.get("pythonOracleSha") != FROZEN_ORACLE_SHA:
         raise RuntimeError("differential corpus does not select the frozen Python oracle")
-    changed = [
-        relative
-        for relative, expected in FROZEN_BLOBS.items()
-        if git_blob_sha(ROOT / relative) != expected
-    ]
+    changed = [relative for relative, expected in FROZEN_BLOBS.items() if git_blob_sha(ROOT / relative) != expected]
     if changed:
         raise RuntimeError("frozen Python oracle drift: " + ", ".join(changed))
 
@@ -70,8 +78,7 @@ def topology_basis_loop() -> dict:
     linked = builder.ensure(opening, closing)
     builder.ensure(closing, opening)
     builder.ensure(linked, linked)
-    network = builder.freeze(root)
-    snapshot = network.snapshot()
+    snapshot = builder.freeze(root).snapshot()
     return {"root": snapshot.root, "links": [list(pair) for pair in snapshot.links]}
 
 
@@ -86,53 +93,29 @@ def topology_same_pair() -> dict:
     network = builder.freeze(root)
     count = len(network.refs)
     snapshot = network.snapshot()
-    return {
-        "root": snapshot.root,
-        "links": [list(pair) for pair in snapshot.links],
-        "countBefore": count,
-        "countAfter": count,
-        "reused": reused is linked,
-    }
+    return {"root": snapshot.root, "links": [list(pair) for pair in snapshot.links], "countBefore": count, "countAfter": count, "reused": reused is linked}
 
 
 def run_topology(case: dict) -> dict:
     operation = case["input"]["operation"]
     try:
-        if operation == "basis-loop":
-            observable = topology_basis_loop()
-        elif operation == "same-pair":
-            observable = topology_same_pair()
+        if operation == "basis-loop": observable = topology_basis_loop()
+        elif operation == "same-pair": observable = topology_same_pair()
         elif operation == "restore":
             raw = case["input"]
-            network = LinkNetwork.from_snapshot(
-                NetworkSnapshot(
-                    links=tuple(tuple(pair) for pair in raw["links"]),
-                    root=raw["root"],
-                )
-            )
+            network = LinkNetwork.from_snapshot(NetworkSnapshot(links=tuple(tuple(pair) for pair in raw["links"]), root=raw["root"]))
             snapshot = network.snapshot()
             observable = {"root": snapshot.root, "links": [list(pair) for pair in snapshot.links]}
-        else:
-            raise RuntimeError(f"unknown topology operation: {operation}")
+        else: raise RuntimeError(f"unknown topology operation: {operation}")
     except LinkNetworkError:
         return {"id": case["id"], "accepted": False, "error": "invalid-topology"}
     return {"id": case["id"], "accepted": True, "observable": observable}
 
 
 def run_anum(case: dict) -> dict:
-    try:
-        result = deserialize_stream(case["input"]["source"])
-    except StreamError as exc:
-        return {"id": case["id"], "accepted": False, "error": exc.code}
-    return {
-        "id": case["id"],
-        "accepted": True,
-        "observable": {
-            "denotation": result.denotation,
-            "resolvedValues": list(result.resolved_values),
-            "operations": list(result.operations),
-        },
-    }
+    try: result = deserialize_stream(case["input"]["source"])
+    except StreamError as exc: return {"id": case["id"], "accepted": False, "error": exc.code}
+    return {"id": case["id"], "accepted": True, "observable": {"denotation": result.denotation, "resolvedValues": list(result.resolved_values), "operations": list(result.operations)}}
 
 
 def persistent_basis(store: JsonLinkStore):
@@ -146,10 +129,7 @@ def persistent_basis(store: JsonLinkStore):
 
 def persistent_topology(store: JsonLinkStore) -> dict:
     snapshot = store.snapshot()
-    return {
-        "root": snapshot.root.local,
-        "links": [[start.local, end.local] for _ref, start, end in snapshot.links],
-    }
+    return {"root": snapshot.root.local, "links": [[start.local, end.local] for _ref, start, end in snapshot.links]}
 
 
 def run_persistence(case: dict) -> dict:
@@ -159,186 +139,178 @@ def run_persistence(case: dict) -> dict:
             path = Path(directory) / "store.json"
             if operation == "open-topology":
                 raw = case["input"]
-                path.write_text(
-                    json.dumps(
-                        {
-                            "schema": PERSISTENT_SCHEMA,
-                            "lineage": "differential-lineage",
-                            "root": raw["root"],
-                            "links": raw["links"],
-                        },
-                        separators=(",", ":"),
-                    )
-                    + "\n",
-                    encoding="utf-8",
-                )
+                path.write_text(json.dumps({"schema": PERSISTENT_SCHEMA, "lineage": "differential-lineage", "root": raw["root"], "links": raw["links"]}, separators=(",", ":")) + "\n", encoding="utf-8")
                 store = JsonLinkStore.open(path)
                 observable = persistent_topology(store)
             else:
                 store = JsonLinkStore.create(path)
-                if operation == "root":
-                    observable = persistent_topology(store)
+                if operation == "root": observable = persistent_topology(store)
                 elif operation == "basis-loop-reopen":
                     _root, _opening, _closing, linked = persistent_basis(store)
-                    store.materialize(linked, linked)
-                    store.close()
-                    reopened = JsonLinkStore.open(path)
-                    observable = persistent_topology(reopened)
+                    store.materialize(linked, linked); store.close()
+                    observable = persistent_topology(JsonLinkStore.open(path))
                 elif operation == "same-pair":
                     _root, opening, closing, linked = persistent_basis(store)
-                    before = store.count
-                    reused = store.materialize(opening, closing)
-                    observable = {
-                        **persistent_topology(store),
-                        "countBefore": before,
-                        "countAfter": store.count,
-                        "reused": reused == linked,
-                    }
-                else:
-                    raise RuntimeError(f"unknown persistence operation: {operation}")
+                    before = store.count; reused = store.materialize(opening, closing)
+                    observable = {**persistent_topology(store), "countBefore": before, "countAfter": store.count, "reused": reused == linked}
+                else: raise RuntimeError(f"unknown persistence operation: {operation}")
     except PersistentStoreError:
         return {"id": case["id"], "accepted": False, "error": "invalid-topology"}
     return {"id": case["id"], "accepted": True, "observable": observable}
 
 
 def byte_vocabulary(builder: LinkNetworkBuilder, root):
-    refs = {}
-    current = root
+    refs = {}; current = root
     for value in range(256):
-        current = builder.ensure_start_self_closed(current)
-        refs[value] = current
+        current = builder.ensure_start_self_closed(current); refs[value] = current
     return refs
+
+
+def next_anchor(builder: LinkNetworkBuilder, current):
+    return builder.ensure_start_self_closed(current)
 
 
 def run_source(case: dict) -> dict:
     operation = case["input"]["operation"]
-    builder = LinkNetworkBuilder()
-    root = builder.ensure_root()
+    builder = LinkNetworkBuilder(); root = builder.ensure_root()
     if operation == "invalid-vocabulary":
-        try:
-            SourceFrontEndBuilder(builder, root, {})
-        except SourceReplayError:
-            return {"id": case["id"], "accepted": False, "error": "invalid-source"}
+        try: SourceFrontEndBuilder(builder, root, {})
+        except SourceReplayError: return {"id": case["id"], "accepted": False, "error": "invalid-source"}
         raise RuntimeError("invalid source vocabulary was unexpectedly accepted")
-
-    refs = byte_vocabulary(builder, root)
-    front_end = SourceFrontEndBuilder(builder, root, refs)
-    data = bytes(case["input"]["bytes"])
-    content = front_end.content_ref(data)
-    repeated_content = front_end.content_ref(data)
-    source = front_end.source_occurrence(data)
-    repeated_source = front_end.source_occurrence(data)
-    network = builder.freeze(root)
-    before = network.snapshot()
-    sequence = read_rooted_sequence(network, content)
-    inverse = {ref: value for value, ref in refs.items()}
-    decoded = [inverse[value] for value in sequence.values]
-    source_link = network.link(source.source)
-    after = network.snapshot()
-    return {
-        "id": case["id"],
-        "accepted": True,
-        "observable": {
-            "bytes": decoded,
-            "contentIsRoot": content is root,
-            "contentReused": repeated_content is content,
-            "sourceReused": repeated_source.source is source.source,
-            "sourceStartSelfClosed": source_link.start is source.source and source_link.end is content,
-            "readOnlyCountStable": len(before.links) == len(after.links),
-        },
-    }
+    refs = byte_vocabulary(builder, root); front_end = SourceFrontEndBuilder(builder, root, refs)
+    data = bytes(case["input"]["bytes"]); content = front_end.content_ref(data); repeated_content = front_end.content_ref(data)
+    source = front_end.source_occurrence(data); repeated_source = front_end.source_occurrence(data); network = builder.freeze(root)
+    before = network.snapshot(); sequence = read_rooted_sequence(network, content); inverse = {ref: value for value, ref in refs.items()}
+    decoded = [inverse[value] for value in sequence.values]; source_link = network.link(source.source); after = network.snapshot()
+    return {"id": case["id"], "accepted": True, "observable": {"bytes": decoded, "contentIsRoot": content is root, "contentReused": repeated_content is content, "sourceReused": repeated_source.source is source.source, "sourceStartSelfClosed": source_link.start is source.source and source_link.end is content, "readOnlyCountStable": len(before.links) == len(after.links)}}
 
 
 def state_basis(builder: LinkNetworkBuilder):
-    root = builder.ensure_root()
-    opening = builder.ensure_start_self_closed(root)
-    closing = builder.ensure_end_self_closed(root)
-    linked = builder.ensure(opening, closing)
-    unlinked = builder.ensure(closing, opening)
+    root = builder.ensure_root(); opening = builder.ensure_start_self_closed(root); closing = builder.ensure_end_self_closed(root)
+    linked = builder.ensure(opening, closing); unlinked = builder.ensure(closing, opening)
     return root, opening, closing, linked, unlinked
 
 
 def run_state(case: dict) -> dict:
-    operation = case["input"]["operation"]
-    builder = LinkNetworkBuilder()
-    root, opening, closing, linked, unlinked = state_basis(builder)
+    operation = case["input"]["operation"]; builder = LinkNetworkBuilder(); root, opening, closing, linked, unlinked = state_basis(builder)
     context = define_context(builder, opening, closing)
-
     if operation == "context":
-        repeated = define_context(builder, opening, closing)
-        network = builder.freeze(root)
-        before = network.snapshot()
-        parent = parent_of_context(network, context)
-        current = current_of_context(network, context)
-        after = network.snapshot()
-        observable = {
-            "parentMatches": parent is opening,
-            "currentMatches": current is closing,
-            "contextReused": repeated is context,
-            "readOnlyCountStable": len(before.links) == len(after.links),
-        }
+        repeated = define_context(builder, opening, closing); network = builder.freeze(root); before = network.snapshot()
+        parent = parent_of_context(network, context); current = current_of_context(network, context); after = network.snapshot()
+        observable = {"parentMatches": parent is opening, "currentMatches": current is closing, "contextReused": repeated is context, "readOnlyCountStable": len(before.links) == len(after.links)}
     elif operation == "representative-default":
-        network = builder.freeze(root)
-        before = network.snapshot()
-        resolution = local_representative_resolution(network, context, linked)
-        after = network.snapshot()
-        observable = {
-            "representativeMatches": resolution.representative is linked,
-            "bindingCount": len(resolution.bindings),
-            "readOnlyCountStable": len(before.links) == len(after.links),
-        }
+        network = builder.freeze(root); before = network.snapshot(); resolution = local_representative_resolution(network, context, linked); after = network.snapshot()
+        observable = {"representativeMatches": resolution.representative is linked, "bindingCount": len(resolution.bindings), "readOnlyCountStable": len(before.links) == len(after.links)}
     elif operation == "representative-binding":
-        _pair, binding = define_local_representative_binding(builder, context, linked, unlinked)
-        _pair2, repeated = define_local_representative_binding(builder, context, linked, unlinked)
-        network = builder.freeze(root)
-        before = network.snapshot()
-        resolution = local_representative_resolution(network, context, linked)
-        after = network.snapshot()
-        observable = {
-            "representativeMatches": resolution.representative is unlinked,
-            "bindingCount": len(resolution.bindings),
-            "bindingReused": repeated is binding,
-            "readOnlyCountStable": len(before.links) == len(after.links),
-        }
+        _pair, binding = define_local_representative_binding(builder, context, linked, unlinked); _pair2, repeated = define_local_representative_binding(builder, context, linked, unlinked)
+        network = builder.freeze(root); before = network.snapshot(); resolution = local_representative_resolution(network, context, linked); after = network.snapshot()
+        observable = {"representativeMatches": resolution.representative is unlinked, "bindingCount": len(resolution.bindings), "bindingReused": repeated is binding, "readOnlyCountStable": len(before.links) == len(after.links)}
     elif operation == "representative-conflict":
-        define_local_representative_binding(builder, context, linked, opening)
-        define_local_representative_binding(builder, context, linked, closing)
-        network = builder.freeze(root)
-        try:
-            local_representative_resolution(network, context, linked)
-        except RepresentativeConflictError:
-            return {"id": case["id"], "accepted": False, "error": "representative-conflict"}
+        define_local_representative_binding(builder, context, linked, opening); define_local_representative_binding(builder, context, linked, closing); network = builder.freeze(root)
+        try: local_representative_resolution(network, context, linked)
+        except RepresentativeConflictError: return {"id": case["id"], "accepted": False, "error": "representative-conflict"}
         raise RuntimeError("representative conflict was unexpectedly accepted")
-    else:
-        raise RuntimeError(f"unknown state operation: {operation}")
-
+    else: raise RuntimeError(f"unknown state operation: {operation}")
     return {"id": case["id"], "accepted": True, "observable": observable}
 
 
+def dictionary_fixture():
+    builder = LinkNetworkBuilder(); root, opening, closing, linked, unlinked = state_basis(builder)
+    content = builder.ensure(linked, linked); form_one = next_anchor(builder, unlinked); form_two = next_anchor(builder, form_one)
+    return builder, root, content, form_one, form_two, opening
+
+
+def run_dictionary(case: dict) -> dict:
+    operation = case["input"]["operation"]; builder, root, content, form_one, form_two, forged = dictionary_fixture()
+    if operation == "root-sentinel":
+        network = builder.freeze(root)
+        try: lookup_scoped_dictionary(network, root, content)
+        except DictionaryLookupError: return {"id": case["id"], "accepted": False, "error": "invalid-dictionary"}
+        raise RuntimeError("root dictionary sentinel was unexpectedly accepted")
+
+    scope = define_dictionary_scope(builder, root, root)
+    first = define_dictionary_effect(builder, scope, root, root, content, form_one)
+    repeated = define_dictionary_effect(builder, scope, root, root, content, form_one)
+    selected = first.after_scope; expected_form = form_one; expected_occurrence = first.occurrence
+    if operation == "parent-visible":
+        selected = define_dictionary_scope(builder, first.after_scope, root)
+    elif operation == "shadow":
+        child = define_dictionary_scope(builder, first.after_scope, root)
+        second = define_dictionary_effect(builder, child, first.after_scope, root, content, form_two)
+        selected = second.after_scope; expected_form = form_two; expected_occurrence = second.occurrence
+    elif operation == "conflict":
+        second = define_dictionary_effect(builder, first.after_scope, root, first.history_after, content, form_two)
+        network = builder.freeze(root)
+        try: lookup_scoped_dictionary(network, second.after_scope, content)
+        except DictionaryConflictError: return {"id": case["id"], "accepted": False, "error": "local-form-conflict"}
+        raise RuntimeError("dictionary local conflict was unexpectedly accepted")
+    elif operation not in ("single", "forged-occurrence"):
+        raise RuntimeError(f"unknown dictionary operation: {operation}")
+
+    network = builder.freeze(root); before = network.snapshot(); resolution = lookup_scoped_dictionary(network, selected, content)
+    if resolution is None: raise RuntimeError("dictionary fixture did not resolve")
+    if operation == "forged-occurrence":
+        try: verify_visible_dictionary_occurrence(network, selected, forged, content, expected_form)
+        except DictionaryLookupError: return {"id": case["id"], "accepted": False, "error": "invalid-dictionary-evidence"}
+        raise RuntimeError("forged dictionary occurrence was unexpectedly accepted")
+    verify_visible_dictionary_occurrence(network, selected, expected_occurrence, content, expected_form); after = network.snapshot()
+    return {"id": case["id"], "accepted": True, "observable": {"formMatches": resolution.form is expected_form, "occurrenceVisible": expected_occurrence in resolution.occurrences, "occurrenceCount": len(resolution.occurrences), "effectReused": repeated == first, "readOnlyCountStable": len(before.links) == len(after.links)}}
+
+
+def selection_fixture(builder, root, data, segments):
+    refs = byte_vocabulary(builder, root); front_end = SourceFrontEndBuilder(builder, root, refs); source = front_end.source_occurrence(data)
+    cursor = refs[255]; forms = []
+    for _ in segments:
+        cursor = next_anchor(builder, cursor); forms.append(cursor)
+    grammar = next_anchor(builder, cursor); theory = next_anchor(builder, grammar)
+    dictionary = define_dictionary_scope(builder, root, root); history = root; specs = []
+    for start, end, form_index in segments:
+        slice_content = front_end.content_ref(data[start:end]); form = forms[form_index]
+        effect = define_dictionary_effect(builder, dictionary, root, history, slice_content, form)
+        dictionary = effect.after_scope; history = effect.history_after
+        specs.append(SegmentSpec(start, end, form, effect.occurrence))
+    return refs, front_end, source, forms, dictionary, grammar, theory, specs
+
+
+def run_selection(case: dict) -> dict:
+    operation = case["input"]["operation"]; data = bytes(case["input"]["bytes"]); builder = LinkNetworkBuilder(); root = builder.ensure_root()
+    if operation == "dictionary-choice":
+        refs = byte_vocabulary(builder, root); front_end = SourceFrontEndBuilder(builder, root, refs); source = front_end.source_occurrence(data); content = front_end.content_ref(data)
+        cursor = refs[255]; form_one = next_anchor(builder, cursor); form_two = next_anchor(builder, form_one); grammar = next_anchor(builder, form_two); theory = next_anchor(builder, grammar)
+        d1 = define_dictionary_scope(builder, root, root); e1 = define_dictionary_effect(builder, d1, root, root, content, form_one)
+        d2 = define_dictionary_scope(builder, root, root); e2 = define_dictionary_effect(builder, d2, root, root, content, form_two)
+        ev1 = front_end.build_selected_evidence(source, (SegmentSpec(0, len(data), form_one, e1.occurrence),), dictionary=e1.after_scope, grammar=grammar, theory=theory)
+        ev2 = front_end.build_selected_evidence(source, (SegmentSpec(0, len(data), form_two, e2.occurrence),), dictionary=e2.after_scope, grammar=grammar, theory=theory)
+        network = builder.freeze(root); before = network.snapshot(); r1 = replay_source_front_end(network, ev1, refs); r2 = replay_source_front_end(network, ev2, refs); after = network.snapshot()
+        return {"id": case["id"], "accepted": True, "observable": {"firstMatches": r1 == (form_one,), "secondMatches": r2 == (form_two,), "formsDistinct": form_one is not form_two, "sourceShared": ev1.source is ev2.source, "contentShared": ev1.content is ev2.content, "readOnlyCountStable": len(before.links) == len(after.links)}}
+
+    segments = [tuple(item) for item in case["input"].get("segments", [[0, len(data), 0]])]
+    refs, front_end, source, forms, dictionary, grammar, theory, specs = selection_fixture(builder, root, data, segments)
+    if operation == "invalid-partition":
+        try: front_end.build_selected_evidence(source, tuple(specs), dictionary=dictionary, grammar=grammar, theory=theory)
+        except SourceReplayError: return {"id": case["id"], "accepted": False, "error": "invalid-selected-partition"}
+        raise RuntimeError("invalid selected partition was unexpectedly accepted")
+    evidence = front_end.build_selected_evidence(source, tuple(specs), dictionary=dictionary, grammar=grammar, theory=theory)
+    if operation == "forged-resolution":
+        evidence = replace(evidence, segments=(replace(evidence.segments[0], resolution=root),))
+    network = builder.freeze(root); before = network.snapshot()
+    try: resolved = replay_source_front_end(network, evidence, refs)
+    except SourceReplayError:
+        if operation == "forged-resolution": return {"id": case["id"], "accepted": False, "error": "invalid-source-evidence"}
+        raise
+    after = network.snapshot(); expected = tuple(forms[index] for _start, _end, index in segments)
+    return {"id": case["id"], "accepted": True, "observable": {"formCount": len(resolved), "formsMatchExpected": resolved == expected, "readOnlyCountStable": len(before.links) == len(after.links)}}
+
+
 def main() -> int:
-    if len(sys.argv) != 2:
-        raise SystemExit("usage: python_oracle.py FIXTURES.json")
-    corpus = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-    verify_freeze(corpus)
-    results = []
+    if len(sys.argv) != 2: raise SystemExit("usage: python_oracle.py FIXTURES.json")
+    corpus = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")); verify_freeze(corpus); results = []
+    runners = {"topology": run_topology, "anum": run_anum, "persistence": run_persistence, "source": run_source, "state": run_state, "dictionary": run_dictionary, "selection": run_selection}
     for case in corpus["cases"]:
-        category = case["category"]
-        if category == "topology":
-            results.append(run_topology(case))
-        elif category == "anum":
-            results.append(run_anum(case))
-        elif category == "persistence":
-            results.append(run_persistence(case))
-        elif category == "source":
-            results.append(run_source(case))
-        elif category == "state":
-            results.append(run_state(case))
-        else:
-            raise RuntimeError(f"unknown differential category: {category}")
-    json.dump(results, sys.stdout, sort_keys=True, separators=(",", ":"))
-    sys.stdout.write("\n")
-    return 0
+        runner = runners.get(case["category"])
+        if runner is None: raise RuntimeError(f"unknown differential category: {case['category']}")
+        results.append(runner(case))
+    json.dump(results, sys.stdout, sort_keys=True, separators=(",", ":")); sys.stdout.write("\n"); return 0
 
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+if __name__ == "__main__": raise SystemExit(main())

--- a/differential/python_oracle.py
+++ b/differential/python_oracle.py
@@ -32,6 +32,7 @@ from core.foundation_v2_state import (
     local_representative_resolution,
     lookup_scoped_dictionary,
     parent_of_context,
+    read_dictionary_scope,
     verify_visible_dictionary_occurrence,
 )
 from core.rooted_link_network import (
@@ -215,7 +216,7 @@ def run_state(case: dict) -> dict:
 
 
 def dictionary_fixture():
-    builder = LinkNetworkBuilder(); root, opening, closing, linked, unlinked = state_basis(builder)
+    builder = LinkNetworkBuilder(); root, opening, _closing, linked, unlinked = state_basis(builder)
     content = builder.ensure(linked, linked); form_one = next_anchor(builder, unlinked); form_two = next_anchor(builder, form_one)
     return builder, root, content, form_one, form_two, opening
 
@@ -224,7 +225,7 @@ def run_dictionary(case: dict) -> dict:
     operation = case["input"]["operation"]; builder, root, content, form_one, form_two, forged = dictionary_fixture()
     if operation == "root-sentinel":
         network = builder.freeze(root)
-        try: lookup_scoped_dictionary(network, root, content)
+        try: read_dictionary_scope(network, root)
         except DictionaryLookupError: return {"id": case["id"], "accepted": False, "error": "invalid-dictionary"}
         raise RuntimeError("root dictionary sentinel was unexpectedly accepted")
 

--- a/ts/test/differential.test.ts
+++ b/ts/test/differential.test.ts
@@ -1,11 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import {
-  StreamError,
-  deserializeStream,
-  symbolicStackAlgebra,
-} from "../src/anum.js";
+import { StreamError, deserializeStream, symbolicStackAlgebra } from "../src/anum.js";
 import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
 import {
   PersistenceTopologyError,
@@ -22,10 +18,14 @@ import {
 } from "../src/persistent-store.js";
 import {
   SourceError,
+  buildSelectedSourceEvidence,
   defineSourceForm,
   materializeSourceContent,
   readSourceContent,
   readSourceForm,
+  replaySelectedSourceEvidence,
+  type SelectedSegmentSpec,
+  type SourceFrontEndEvidence,
 } from "../src/source.js";
 import {
   StateError,
@@ -34,6 +34,14 @@ import {
   localRepresentativeResolution,
   readContext,
 } from "../src/state.js";
+import {
+  DictionaryError,
+  defineDictionaryEffect,
+  defineDictionaryScope,
+  lookupScopedDictionary,
+  readDictionaryScope,
+  verifyVisibleDictionaryOccurrence,
+} from "../src/dictionary.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -42,7 +50,7 @@ function assert(condition: unknown, message: string): asserts condition {
 type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 interface DifferentialCase {
   readonly id: string;
-  readonly category: "topology" | "anum" | "persistence" | "source" | "state";
+  readonly category: "topology" | "anum" | "persistence" | "source" | "state" | "dictionary" | "selection";
   readonly input: Record<string, Json>;
 }
 interface Corpus {
@@ -61,9 +69,7 @@ interface Result {
 function canonical(value: Json): Json {
   if (Array.isArray(value)) return value.map(canonical);
   if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, item]) => [key, canonical(item)]),
-    );
+    return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => [key, canonical(item)]));
   }
   return value;
 }
@@ -86,8 +92,7 @@ function storageImage(input: Record<string, Json>): StorageTopologyImage {
     root,
     links: links.map((pair) => {
       assert(Array.isArray(pair) && pair.length === 2, "invalid topology pair fixture");
-      const start = pair[0];
-      const end = pair[1];
+      const start = pair[0]; const end = pair[1];
       assert(typeof start === "number" && typeof end === "number", "invalid topology coordinates fixture");
       return [start, end] as const;
     }),
@@ -99,54 +104,28 @@ function runTopology(test: DifferentialCase): Result {
   assert(typeof operation === "string", "topology fixture needs operation");
   try {
     if (operation === "basis-loop") {
-      const memory = new Memory();
-      const { L } = ensureRootBasis(memory);
-      memory.ensure(L, L);
+      const memory = new Memory(); const { L } = ensureRootBasis(memory); memory.ensure(L, L);
       return { id: test.id, accepted: true, observable: topologyObservable(memory) };
     }
     if (operation === "same-pair") {
-      const memory = new Memory();
-      const { O, C, L } = ensureRootBasis(memory);
-      const before = memory.linkCount;
-      const reused = memory.ensure(O, C);
-      return {
-        id: test.id,
-        accepted: true,
-        observable: {
-          ...(topologyObservable(memory) as Record<string, Json>),
-          countBefore: before,
-          countAfter: memory.linkCount,
-          reused: reused === L,
-        },
-      };
+      const memory = new Memory(); const { O, C, L } = ensureRootBasis(memory); const before = memory.linkCount; const reused = memory.ensure(O, C);
+      return { id: test.id, accepted: true, observable: { ...(topologyObservable(memory) as Record<string, Json>), countBefore: before, countAfter: memory.linkCount, reused: reused === L } };
     }
     if (operation === "restore") {
-      const restored = restoreTopology(storageImage(test.input));
-      return { id: test.id, accepted: true, observable: topologyObservable(restored) };
+      return { id: test.id, accepted: true, observable: topologyObservable(restoreTopology(storageImage(test.input))) };
     }
     throw new Error(`unknown topology fixture operation: ${operation}`);
   } catch (error) {
-    if (error instanceof PersistenceTopologyError) {
-      return { id: test.id, accepted: false, error: "invalid-topology" };
-    }
+    if (error instanceof PersistenceTopologyError) return { id: test.id, accepted: false, error: "invalid-topology" };
     throw error;
   }
 }
 
 function runAnum(test: DifferentialCase): Result {
-  const source = test.input.source;
-  assert(typeof source === "string", "ANUM fixture needs source");
+  const source = test.input.source; assert(typeof source === "string", "ANUM fixture needs source");
   try {
     const result = deserializeStream(source, symbolicStackAlgebra);
-    return {
-      id: test.id,
-      accepted: true,
-      observable: {
-        denotation: result.denotation,
-        resolvedValues: [...result.resolvedValues],
-        operations: [...result.operations],
-      },
-    };
+    return { id: test.id, accepted: true, observable: { denotation: result.denotation, resolvedValues: [...result.resolvedValues], operations: [...result.operations] } };
   } catch (error) {
     if (error instanceof StreamError) return { id: test.id, accepted: false, error: error.code };
     throw error;
@@ -156,205 +135,178 @@ function runAnum(test: DifferentialCase): Result {
 function cloneDataset(dataset: StoredDataset): StoredDataset {
   return JSON.parse(JSON.stringify(dataset)) as StoredDataset;
 }
-
 class MemoryBackend implements PersistentTopologyBackend {
   constructor(public dataset?: StoredDataset) {}
   load(): StoredDataset | undefined { return this.dataset === undefined ? undefined : cloneDataset(this.dataset); }
   commit(dataset: StoredDataset): void { this.dataset = cloneDataset(dataset); }
 }
-
 function persistentBasis(store: PersistentStore) {
-  const root = store.root;
-  const opening = store.materializeStartSelfClosed(root);
-  const closing = store.materializeEndSelfClosed(root);
-  const linked = store.materialize(opening, closing);
-  store.materialize(closing, opening);
-  return { root, opening, closing, linked };
+  const root = store.root; const opening = store.materializeStartSelfClosed(root); const closing = store.materializeEndSelfClosed(root);
+  const linked = store.materialize(opening, closing); store.materialize(closing, opening); return { root, opening, closing, linked };
 }
-
 function persistentTopology(store: PersistentStore): Json {
   const topology = store.snapshot().topology;
   return { root: topology.root, links: topology.links.map(([start, end]) => [start, end]) };
 }
-
 function runPersistence(test: DifferentialCase): Result {
-  const operation = test.input.operation;
-  assert(typeof operation === "string", "persistence fixture needs operation");
+  const operation = test.input.operation; assert(typeof operation === "string", "persistence fixture needs operation");
   try {
     if (operation === "open-topology") {
-      const backend = new MemoryBackend({
-        schema: "mts-persistent-dataset/v0.1",
-        lineage: "differential-lineage",
-        topology: storageImage(test.input),
-      });
-      const store = PersistentStore.open(backend);
+      const store = PersistentStore.open(new MemoryBackend({ schema: "mts-persistent-dataset/v0.1", lineage: "differential-lineage", topology: storageImage(test.input) }));
       return { id: test.id, accepted: true, observable: persistentTopology(store) };
     }
-
-    const backend = new MemoryBackend();
-    const store = PersistentStore.create(backend, "differential-lineage");
-    if (operation === "root") {
-      return { id: test.id, accepted: true, observable: persistentTopology(store) };
-    }
+    const backend = new MemoryBackend(); const store = PersistentStore.create(backend, "differential-lineage");
+    if (operation === "root") return { id: test.id, accepted: true, observable: persistentTopology(store) };
     if (operation === "basis-loop-reopen") {
-      const { linked } = persistentBasis(store);
-      store.materialize(linked, linked);
-      const reopened = PersistentStore.open(backend);
-      return { id: test.id, accepted: true, observable: persistentTopology(reopened) };
+      const { linked } = persistentBasis(store); store.materialize(linked, linked);
+      return { id: test.id, accepted: true, observable: persistentTopology(PersistentStore.open(backend)) };
     }
     if (operation === "same-pair") {
-      const { opening, closing, linked } = persistentBasis(store);
-      const before = store.count;
-      const reused = store.materialize(opening, closing);
-      return {
-        id: test.id,
-        accepted: true,
-        observable: {
-          ...(persistentTopology(store) as Record<string, Json>),
-          countBefore: before,
-          countAfter: store.count,
-          reused: reused.local === linked.local,
-        },
-      };
+      const { opening, closing, linked } = persistentBasis(store); const before = store.count; const reused = store.materialize(opening, closing);
+      return { id: test.id, accepted: true, observable: { ...(persistentTopology(store) as Record<string, Json>), countBefore: before, countAfter: store.count, reused: reused.local === linked.local } };
     }
     throw new Error(`unknown persistence fixture operation: ${operation}`);
   } catch (error) {
-    if (error instanceof PersistentStoreError) {
-      return { id: test.id, accepted: false, error: "invalid-topology" };
-    }
+    if (error instanceof PersistentStoreError) return { id: test.id, accepted: false, error: "invalid-topology" };
     throw error;
   }
 }
 
 function byteVocabulary(memory: Memory): readonly LinkHandle[] {
-  const refs: LinkHandle[] = [];
-  let current = memory.root;
-  for (let value = 0; value < 256; value += 1) {
-    current = memory.ensureStartSelfClosed(current);
-    refs.push(current);
-  }
+  const refs: LinkHandle[] = []; let current = memory.root;
+  for (let value = 0; value < 256; value += 1) { current = memory.ensureStartSelfClosed(current); refs.push(current); }
   return Object.freeze(refs);
 }
-
 function sourceBytes(input: Record<string, Json>): Uint8Array {
-  const raw = input.bytes;
-  assert(Array.isArray(raw), "source fixture needs byte array");
-  const values = raw.map((value) => {
-    assert(typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 255, "invalid source byte fixture");
-    return value;
-  });
-  return new Uint8Array(values);
+  const raw = input.bytes; assert(Array.isArray(raw), "source fixture needs byte array");
+  return new Uint8Array(raw.map((value) => { assert(typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 255, "invalid source byte fixture"); return value; }));
 }
-
 function runSource(test: DifferentialCase): Result {
-  const operation = test.input.operation;
-  assert(typeof operation === "string", "source fixture needs operation");
-  const memory = new Memory();
-  const bytes = sourceBytes(test.input);
+  const operation = test.input.operation; assert(typeof operation === "string", "source fixture needs operation"); const memory = new Memory(); const bytes = sourceBytes(test.input);
   if (operation === "invalid-vocabulary") {
-    try {
-      materializeSourceContent(memory, [], bytes);
-    } catch (error) {
-      if (error instanceof SourceError) return { id: test.id, accepted: false, error: "invalid-source" };
-      throw error;
-    }
+    try { materializeSourceContent(memory, [], bytes); }
+    catch (error) { if (error instanceof SourceError) return { id: test.id, accepted: false, error: "invalid-source" }; throw error; }
     throw new Error("invalid source vocabulary was unexpectedly accepted");
   }
   if (operation !== "round-trip") throw new Error(`unknown source fixture operation: ${operation}`);
-
-  const refs = byteVocabulary(memory);
-  const content = materializeSourceContent(memory, refs, bytes);
-  const repeatedContent = materializeSourceContent(memory, refs, bytes);
-  const source = defineSourceForm(memory, content);
-  const repeatedSource = defineSourceForm(memory, content);
-  const before = memory.linkCount;
-  const decoded = readSourceContent(memory, refs, content);
-  const selectedContent = readSourceForm(memory, source);
-  const sourcePoles = memory.poles(source);
-  const after = memory.linkCount;
+  const refs = byteVocabulary(memory); const content = materializeSourceContent(memory, refs, bytes); const repeatedContent = materializeSourceContent(memory, refs, bytes);
+  const source = defineSourceForm(memory, content); const repeatedSource = defineSourceForm(memory, content); const before = memory.linkCount;
+  const decoded = readSourceContent(memory, refs, content); const selectedContent = readSourceForm(memory, source); const sourcePoles = memory.poles(source); const after = memory.linkCount;
   assert(selectedContent === content, "source fixture selected unexpected content");
-  return {
-    id: test.id,
-    accepted: true,
-    observable: {
-      bytes: [...decoded.bytes],
-      contentIsRoot: content === memory.root,
-      contentReused: repeatedContent === content,
-      sourceReused: repeatedSource === source,
-      sourceStartSelfClosed: sourcePoles.start === source && sourcePoles.end === content,
-      readOnlyCountStable: before === after,
-    },
-  };
+  return { id: test.id, accepted: true, observable: { bytes: [...decoded.bytes], contentIsRoot: content === memory.root, contentReused: repeatedContent === content, sourceReused: repeatedSource === source, sourceStartSelfClosed: sourcePoles.start === source && sourcePoles.end === content, readOnlyCountStable: before === after } };
 }
 
 function runState(test: DifferentialCase): Result {
-  const operation = test.input.operation;
-  assert(typeof operation === "string", "state fixture needs operation");
-  const memory = new Memory();
-  const { O, C, L, U } = ensureRootBasis(memory);
-  const context = defineContext(memory, O, C);
-
+  const operation = test.input.operation; assert(typeof operation === "string", "state fixture needs operation"); const memory = new Memory(); const { O, C, L, U } = ensureRootBasis(memory); const context = defineContext(memory, O, C);
   if (operation === "context") {
-    const repeated = defineContext(memory, O, C);
-    const before = memory.linkCount;
-    const state = readContext(memory, context);
-    const after = memory.linkCount;
-    return {
-      id: test.id,
-      accepted: true,
-      observable: {
-        parentMatches: state.parent === O,
-        currentMatches: state.current === C,
-        contextReused: repeated === context,
-        readOnlyCountStable: before === after,
-      },
-    };
+    const repeated = defineContext(memory, O, C); const before = memory.linkCount; const state = readContext(memory, context); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { parentMatches: state.parent === O, currentMatches: state.current === C, contextReused: repeated === context, readOnlyCountStable: before === after } };
   }
   if (operation === "representative-default") {
-    const before = memory.linkCount;
-    const resolution = localRepresentativeResolution(memory, context, L);
-    const after = memory.linkCount;
-    return {
-      id: test.id,
-      accepted: true,
-      observable: {
-        representativeMatches: resolution.representative === L,
-        bindingCount: resolution.bindings.length,
-        readOnlyCountStable: before === after,
-      },
-    };
+    const before = memory.linkCount; const resolution = localRepresentativeResolution(memory, context, L); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { representativeMatches: resolution.representative === L, bindingCount: resolution.bindings.length, readOnlyCountStable: before === after } };
   }
   if (operation === "representative-binding") {
-    const binding = defineLocalRepresentativeBinding(memory, context, L, U);
-    const repeated = defineLocalRepresentativeBinding(memory, context, L, U);
-    const before = memory.linkCount;
-    const resolution = localRepresentativeResolution(memory, context, L);
-    const after = memory.linkCount;
-    return {
-      id: test.id,
-      accepted: true,
-      observable: {
-        representativeMatches: resolution.representative === U,
-        bindingCount: resolution.bindings.length,
-        bindingReused: repeated === binding,
-        readOnlyCountStable: before === after,
-      },
-    };
+    const binding = defineLocalRepresentativeBinding(memory, context, L, U); const repeated = defineLocalRepresentativeBinding(memory, context, L, U); const before = memory.linkCount;
+    const resolution = localRepresentativeResolution(memory, context, L); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { representativeMatches: resolution.representative === U, bindingCount: resolution.bindings.length, bindingReused: repeated === binding, readOnlyCountStable: before === after } };
   }
   if (operation === "representative-conflict") {
-    defineLocalRepresentativeBinding(memory, context, L, O);
-    defineLocalRepresentativeBinding(memory, context, L, C);
-    try {
-      localRepresentativeResolution(memory, context, L);
-    } catch (error) {
-      if (error instanceof StateError && error.code === "representative-conflict") {
-        return { id: test.id, accepted: false, error: "representative-conflict" };
-      }
-      throw error;
-    }
+    defineLocalRepresentativeBinding(memory, context, L, O); defineLocalRepresentativeBinding(memory, context, L, C);
+    try { localRepresentativeResolution(memory, context, L); }
+    catch (error) { if (error instanceof StateError && error.code === "representative-conflict") return { id: test.id, accepted: false, error: "representative-conflict" }; throw error; }
     throw new Error("representative conflict was unexpectedly accepted");
   }
   throw new Error(`unknown state fixture operation: ${operation}`);
+}
+
+function runDictionary(test: DifferentialCase): Result {
+  const operation = test.input.operation; assert(typeof operation === "string", "dictionary fixture needs operation");
+  const memory = new Memory(); const { O, L, U } = ensureRootBasis(memory); const content = memory.ensure(L, L); const formOne = memory.ensureStartSelfClosed(U); const formTwo = memory.ensureStartSelfClosed(formOne);
+  if (operation === "root-sentinel") {
+    try { readDictionaryScope(memory, memory.root); }
+    catch (error) { if (error instanceof DictionaryError) return { id: test.id, accepted: false, error: "invalid-dictionary" }; throw error; }
+    throw new Error("root dictionary sentinel was unexpectedly accepted");
+  }
+  const scope = defineDictionaryScope(memory, memory.root, memory.root); const first = defineDictionaryEffect(memory, scope, memory.root, memory.root, content, formOne);
+  const repeated = defineDictionaryEffect(memory, scope, memory.root, memory.root, content, formOne);
+  let selected = first.afterScope; let expectedForm = formOne; let expectedOccurrence = first.occurrence;
+  if (operation === "parent-visible") selected = defineDictionaryScope(memory, first.afterScope, memory.root);
+  else if (operation === "shadow") {
+    const child = defineDictionaryScope(memory, first.afterScope, memory.root); const second = defineDictionaryEffect(memory, child, first.afterScope, memory.root, content, formTwo);
+    selected = second.afterScope; expectedForm = formTwo; expectedOccurrence = second.occurrence;
+  } else if (operation === "conflict") {
+    const second = defineDictionaryEffect(memory, first.afterScope, memory.root, first.historyAfter, content, formTwo);
+    try { lookupScopedDictionary(memory, second.afterScope, content); }
+    catch (error) { if (error instanceof DictionaryError && error.code === "local-form-conflict") return { id: test.id, accepted: false, error: "local-form-conflict" }; throw error; }
+    throw new Error("dictionary local conflict was unexpectedly accepted");
+  } else if (operation !== "single" && operation !== "forged-occurrence") throw new Error(`unknown dictionary operation: ${operation}`);
+  const before = memory.linkCount; const resolution = lookupScopedDictionary(memory, selected, content); assert(resolution !== undefined, "dictionary fixture did not resolve");
+  if (operation === "forged-occurrence") {
+    try { verifyVisibleDictionaryOccurrence(memory, selected, O, content, expectedForm); }
+    catch (error) { if (error instanceof DictionaryError) return { id: test.id, accepted: false, error: "invalid-dictionary-evidence" }; throw error; }
+    throw new Error("forged dictionary occurrence was unexpectedly accepted");
+  }
+  verifyVisibleDictionaryOccurrence(memory, selected, expectedOccurrence, content, expectedForm); const after = memory.linkCount;
+  const effectReused = repeated.entry === first.entry && repeated.occurrence === first.occurrence && repeated.historyAfter === first.historyAfter && repeated.afterScope === first.afterScope;
+  return { id: test.id, accepted: true, observable: { formMatches: resolution.form === expectedForm, occurrenceVisible: resolution.occurrences.includes(expectedOccurrence), occurrenceCount: resolution.occurrences.length, effectReused, readOnlyCountStable: before === after } };
+}
+
+type SegmentTuple = readonly [number, number, number];
+function segmentTuples(input: Record<string, Json>, byteLength: number): readonly SegmentTuple[] {
+  const raw = input.segments ?? [[0, byteLength, 0]];
+  assert(Array.isArray(raw), "selection fixture needs segments");
+  return raw.map((item) => {
+    assert(Array.isArray(item) && item.length === 3, "invalid selection segment fixture");
+    const [start, end, form] = item; assert(typeof start === "number" && typeof end === "number" && typeof form === "number", "invalid selection segment values");
+    return [start, end, form] as const;
+  });
+}
+function selectedFixture(memory: Memory, bytes: Uint8Array, segments: readonly SegmentTuple[]) {
+  const refs = byteVocabulary(memory); const content = materializeSourceContent(memory, refs, bytes); const source = defineSourceForm(memory, content);
+  let cursor = refs[255]!; const forms: LinkHandle[] = [];
+  for (let index = 0; index < segments.length; index += 1) { cursor = memory.ensureStartSelfClosed(cursor); forms.push(cursor); }
+  const grammar = memory.ensureStartSelfClosed(cursor); const theory = memory.ensureStartSelfClosed(grammar);
+  let dictionary = defineDictionaryScope(memory, memory.root, memory.root); let history = memory.root; const specs: SelectedSegmentSpec[] = [];
+  for (const [start, end, formIndex] of segments) {
+    const form = forms[formIndex]; assert(form !== undefined, "selection form index out of range");
+    const sliceContent = materializeSourceContent(memory, refs, bytes.slice(start, end)); const effect = defineDictionaryEffect(memory, dictionary, memory.root, history, sliceContent, form);
+    dictionary = effect.afterScope; history = effect.historyAfter; specs.push(Object.freeze({ start, end, form, dictionaryOccurrence: effect.occurrence }));
+  }
+  return { refs, source, forms: Object.freeze(forms), dictionary, grammar, theory, specs: Object.freeze(specs) };
+}
+function runSelection(test: DifferentialCase): Result {
+  const operation = test.input.operation; assert(typeof operation === "string", "selection fixture needs operation"); const bytes = sourceBytes(test.input); const memory = new Memory();
+  if (operation === "dictionary-choice") {
+    const refs = byteVocabulary(memory); const content = materializeSourceContent(memory, refs, bytes); const source = defineSourceForm(memory, content); let cursor = refs[255]!;
+    const formOne = memory.ensureStartSelfClosed(cursor); const formTwo = memory.ensureStartSelfClosed(formOne); const grammar = memory.ensureStartSelfClosed(formTwo); const theory = memory.ensureStartSelfClosed(grammar);
+    const d1 = defineDictionaryScope(memory, memory.root, memory.root); const e1 = defineDictionaryEffect(memory, d1, memory.root, memory.root, content, formOne);
+    const d2 = defineDictionaryScope(memory, memory.root, memory.root); const e2 = defineDictionaryEffect(memory, d2, memory.root, memory.root, content, formTwo);
+    const ev1 = buildSelectedSourceEvidence(memory, refs, source, [{ start: 0, end: bytes.length, form: formOne, dictionaryOccurrence: e1.occurrence }], { dictionary: e1.afterScope, grammar, theory });
+    const ev2 = buildSelectedSourceEvidence(memory, refs, source, [{ start: 0, end: bytes.length, form: formTwo, dictionaryOccurrence: e2.occurrence }], { dictionary: e2.afterScope, grammar, theory });
+    const before = memory.linkCount; const r1 = replaySelectedSourceEvidence(memory, refs, ev1); const r2 = replaySelectedSourceEvidence(memory, refs, ev2); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { firstMatches: r1.length === 1 && r1[0] === formOne, secondMatches: r2.length === 1 && r2[0] === formTwo, formsDistinct: formOne !== formTwo, sourceShared: ev1.source === ev2.source, contentShared: ev1.content === ev2.content, readOnlyCountStable: before === after } };
+  }
+  const segments = segmentTuples(test.input, bytes.length); const fixture = selectedFixture(memory, bytes, segments);
+  if (operation === "invalid-partition") {
+    try { buildSelectedSourceEvidence(memory, fixture.refs, fixture.source, fixture.specs, { dictionary: fixture.dictionary, grammar: fixture.grammar, theory: fixture.theory }); }
+    catch (error) { if (error instanceof SourceError) return { id: test.id, accepted: false, error: "invalid-selected-partition" }; throw error; }
+    throw new Error("invalid selected partition was unexpectedly accepted");
+  }
+  let evidence = buildSelectedSourceEvidence(memory, fixture.refs, fixture.source, fixture.specs, { dictionary: fixture.dictionary, grammar: fixture.grammar, theory: fixture.theory });
+  if (operation === "forged-resolution") {
+    const first = evidence.segments[0]; assert(first !== undefined, "forged fixture requires first segment");
+    evidence = Object.freeze({ ...evidence, segments: Object.freeze([Object.freeze({ ...first, resolution: memory.root }), ...evidence.segments.slice(1)]) }) as SourceFrontEndEvidence;
+  } else if (operation !== "selected") throw new Error(`unknown selection operation: ${operation}`);
+  const before = memory.linkCount;
+  try {
+    const resolved = replaySelectedSourceEvidence(memory, fixture.refs, evidence); const after = memory.linkCount;
+    const expected = segments.map(([, , index]) => fixture.forms[index]);
+    return { id: test.id, accepted: true, observable: { formCount: resolved.length, formsMatchExpected: resolved.every((form, index) => form === expected[index]), readOnlyCountStable: before === after } };
+  } catch (error) {
+    if (operation === "forged-resolution" && error instanceof SourceError) return { id: test.id, accepted: false, error: "invalid-source-evidence" };
+    throw error;
+  }
 }
 
 const repoRoot = resolve(process.cwd(), "..");
@@ -362,28 +314,21 @@ const fixturePath = resolve(repoRoot, "differential/fixtures-v0.7.json");
 const corpus = JSON.parse(readFileSync(fixturePath, "utf8")) as Corpus;
 assert(corpus.schema === "mts-differential-fixtures/v0.1", "unexpected differential fixture schema");
 assert(corpus.contract === "mts-contract/v0.7", "differential fixtures must select accepted v0.7 contract");
-
-const python = spawnSync("python3", ["differential/python_oracle.py", "differential/fixtures-v0.7.json"], {
-  cwd: repoRoot,
-  encoding: "utf8",
-});
+const python = spawnSync("python3", ["differential/python_oracle.py", "differential/fixtures-v0.7.json"], { cwd: repoRoot, encoding: "utf8" });
 assert(python.status === 0, `frozen Python oracle adapter failed: ${python.stderr || python.stdout}`);
 const expected = JSON.parse(python.stdout) as Result[];
-
-const actual = corpus.cases.map((test) => {
-  if (test.category === "topology") return runTopology(test);
-  if (test.category === "anum") return runAnum(test);
-  if (test.category === "persistence") return runPersistence(test);
-  if (test.category === "source") return runSource(test);
-  return runState(test);
-});
-
+const runners: Record<DifferentialCase["category"], (test: DifferentialCase) => Result> = {
+  topology: runTopology,
+  anum: runAnum,
+  persistence: runPersistence,
+  source: runSource,
+  state: runState,
+  dictionary: runDictionary,
+  selection: runSelection,
+};
+const actual = corpus.cases.map((test) => runners[test.category](test));
 assert(expected.length === actual.length, "differential result cardinality mismatch");
 expected.forEach((pythonResult, index) => {
-  const tsResult = actual[index];
-  assert(tsResult !== undefined, `missing TS result at ${index}`);
-  assert(
-    sameJson(pythonResult as unknown as Json, tsResult as unknown as Json),
-    `differential mismatch for ${pythonResult.id}: Python=${JSON.stringify(pythonResult)} TS=${JSON.stringify(tsResult)}`,
-  );
+  const tsResult = actual[index]; assert(tsResult !== undefined, `missing TS result at ${index}`);
+  assert(sameJson(pythonResult as unknown as Json, tsResult as unknown as Json), `differential mismatch for ${pythonResult.id}: Python=${JSON.stringify(pythonResult)} TS=${JSON.stringify(tsResult)}`);
 });


### PR DESCRIPTION
Closes #521

Расширяет существующий M10 differential harness без изменения production semantic core:

- scoped dictionary: root sentinel, local definition/reuse, parent visibility, shadowing, local conflict, forged occurrence;
- selected source evidence: single/multi segments, UTF-8 byte slicing, explicit dictionary choice, invalid partition, forged resolution;
- exact normalized Python v0.7 oracle ↔ TypeScript comparison;
- сохраняет read-only replay boundary и не сериализует runtime IDs/handles.

Scope ограничен тремя файлами из issue #521; `core/**`, `ts/src/**`, contracts/docs/workflows не изменялись.