### PR TITLE
TypeScript: M10d relation and flat interpreter differential coverage

### DIFF
--- a/differential/fixtures-v0.7.json
+++ b/differential/fixtures-v0.7.json
@@ -45,6 +45,21 @@
     {"id":"selection-dictionary-choice","category":"selection","input":{"operation":"dictionary-choice","bytes":[120]}},
     {"id":"selection-gap","category":"selection","input":{"operation":"invalid-partition","bytes":[97,98],"segments":[[0,1,0]]}},
     {"id":"selection-overlap","category":"selection","input":{"operation":"invalid-partition","bytes":[97,98],"segments":[[0,2,0],[1,2,1]]}},
-    {"id":"selection-forged-resolution","category":"selection","input":{"operation":"forged-resolution","bytes":[97]}}
+    {"id":"selection-forged-resolution","category":"selection","input":{"operation":"forged-resolution","bytes":[97]}},
+
+    {"id":"relation-start-open","category":"relation","input":{"operation":"start-open"}},
+    {"id":"relation-end-open","category":"relation","input":{"operation":"end-open"}},
+    {"id":"relation-complete-form","category":"relation","input":{"operation":"complete-form"}},
+    {"id":"relation-forged-result","category":"relation","input":{"operation":"forged-result"}},
+    {"id":"relation-forged-binding","category":"relation","input":{"operation":"forged-binding"}},
+    {"id":"relation-forged-dgt","category":"relation","input":{"operation":"forged-dgt"}},
+    {"id":"relation-forged-act","category":"relation","input":{"operation":"forged-act"}},
+
+    {"id":"flat-single","category":"flat","input":{"operation":"single"}},
+    {"id":"flat-multi","category":"flat","input":{"operation":"multi"}},
+    {"id":"flat-distinct-readings","category":"flat","input":{"operation":"distinct-readings"}},
+    {"id":"flat-forged-result","category":"flat","input":{"operation":"forged-result"}},
+    {"id":"flat-forged-dgt","category":"flat","input":{"operation":"forged-dgt"}},
+    {"id":"flat-forged-act","category":"flat","input":{"operation":"forged-act"}}
   ]
 }

--- a/differential/python_oracle.py
+++ b/differential/python_oracle.py
@@ -394,7 +394,8 @@ def flat_distinct_fixture():
         after_context = define_context(builder, parent, result); act = define_act_header(builder, interpreter, role_dictionary, after_context)
         values = (source_evidence.source, source_evidence.selection_sequence, source_evidence.form_sequence, dictionary, source_evidence.grammar, source_evidence.theory, before_context, result, after_context); add_act_fields(builder, act, roles, values)
         return FlatSequenceReadingEvidence(source_evidence, interpreter, before_context, result, after_context, act, role_dictionary, roles)
-    return builder.freeze(root), byte_refs, reading(pair_source, pair_result), reading(carrier_source, carrier_ab), pair_result, carrier_ab
+    first = reading(pair_source, pair_result); second = reading(carrier_source, carrier_ab); network = builder.freeze(root)
+    return network, byte_refs, first, second, pair_result, carrier_ab
 
 
 def run_flat(case: dict) -> dict:

--- a/differential/python_oracle.py
+++ b/differential/python_oracle.py
@@ -13,6 +13,15 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from core.anum_protocol import StreamError, deserialize_stream
+from core.foundation_v2_interpreter import (
+    FlatSequenceReadingEvidence,
+    FlatSequenceReadingRoleRefs,
+    InterpreterReplayError,
+    RelationStepEvidence,
+    RelationStepRoleRefs,
+    replay_flat_sequence_reading,
+    replay_relation_step,
+)
 from core.foundation_v2_persistent import JsonLinkStore, PERSISTENT_SCHEMA, PersistentStoreError
 from core.foundation_v2_source import (
     SegmentSpec,
@@ -25,6 +34,8 @@ from core.foundation_v2_state import (
     DictionaryLookupError,
     RepresentativeConflictError,
     current_of_context,
+    define_act_field,
+    define_act_header,
     define_context,
     define_dictionary_effect,
     define_dictionary_scope,
@@ -54,6 +65,7 @@ FROZEN_BLOBS = {
     "core/foundation_v2_materialization.py": "ff894030ec06f15acb8530cda8fe2143ecabbed3",
     "core/foundation_v2_source.py": "12c764f2ab0d7b2b98078cccb6325d0663be5996",
     "core/foundation_v2_state.py": "70e7ae5eece7f347d0879ba73edc3477cf91f8b7",
+    "core/foundation_v2_interpreter.py": "851fc6bb8050ebfe55d9c89b26df42aa90b2ec37",
 }
 
 
@@ -171,6 +183,13 @@ def next_anchor(builder: LinkNetworkBuilder, current):
     return builder.ensure_start_self_closed(current)
 
 
+def anchors(builder: LinkNetworkBuilder, current, count: int):
+    refs = []
+    for _ in range(count):
+        current = next_anchor(builder, current); refs.append(current)
+    return refs, current
+
+
 def run_source(case: dict) -> dict:
     operation = case["input"]["operation"]
     builder = LinkNetworkBuilder(); root = builder.ensure_root()
@@ -228,26 +247,19 @@ def run_dictionary(case: dict) -> dict:
         try: read_dictionary_scope(network, root)
         except DictionaryLookupError: return {"id": case["id"], "accepted": False, "error": "invalid-dictionary"}
         raise RuntimeError("root dictionary sentinel was unexpectedly accepted")
-
     scope = define_dictionary_scope(builder, root, root)
-    first = define_dictionary_effect(builder, scope, root, root, content, form_one)
-    repeated = define_dictionary_effect(builder, scope, root, root, content, form_one)
+    first = define_dictionary_effect(builder, scope, root, root, content, form_one); repeated = define_dictionary_effect(builder, scope, root, root, content, form_one)
     selected = first.after_scope; expected_form = form_one; expected_occurrence = first.occurrence
-    if operation == "parent-visible":
-        selected = define_dictionary_scope(builder, first.after_scope, root)
+    if operation == "parent-visible": selected = define_dictionary_scope(builder, first.after_scope, root)
     elif operation == "shadow":
-        child = define_dictionary_scope(builder, first.after_scope, root)
-        second = define_dictionary_effect(builder, child, first.after_scope, root, content, form_two)
+        child = define_dictionary_scope(builder, first.after_scope, root); second = define_dictionary_effect(builder, child, first.after_scope, root, content, form_two)
         selected = second.after_scope; expected_form = form_two; expected_occurrence = second.occurrence
     elif operation == "conflict":
-        second = define_dictionary_effect(builder, first.after_scope, root, first.history_after, content, form_two)
-        network = builder.freeze(root)
+        second = define_dictionary_effect(builder, first.after_scope, root, first.history_after, content, form_two); network = builder.freeze(root)
         try: lookup_scoped_dictionary(network, second.after_scope, content)
         except DictionaryConflictError: return {"id": case["id"], "accepted": False, "error": "local-form-conflict"}
         raise RuntimeError("dictionary local conflict was unexpectedly accepted")
-    elif operation not in ("single", "forged-occurrence"):
-        raise RuntimeError(f"unknown dictionary operation: {operation}")
-
+    elif operation not in ("single", "forged-occurrence"): raise RuntimeError(f"unknown dictionary operation: {operation}")
     network = builder.freeze(root); before = network.snapshot(); resolution = lookup_scoped_dictionary(network, selected, content)
     if resolution is None: raise RuntimeError("dictionary fixture did not resolve")
     if operation == "forged-occurrence":
@@ -261,15 +273,13 @@ def run_dictionary(case: dict) -> dict:
 def selection_fixture(builder, root, data, segments):
     refs = byte_vocabulary(builder, root); front_end = SourceFrontEndBuilder(builder, root, refs); source = front_end.source_occurrence(data)
     cursor = refs[255]; forms = []
-    for _ in segments:
-        cursor = next_anchor(builder, cursor); forms.append(cursor)
+    for _ in segments: cursor = next_anchor(builder, cursor); forms.append(cursor)
     grammar = next_anchor(builder, cursor); theory = next_anchor(builder, grammar)
     dictionary = define_dictionary_scope(builder, root, root); history = root; specs = []
     for start, end, form_index in segments:
         slice_content = front_end.content_ref(data[start:end]); form = forms[form_index]
         effect = define_dictionary_effect(builder, dictionary, root, history, slice_content, form)
-        dictionary = effect.after_scope; history = effect.history_after
-        specs.append(SegmentSpec(start, end, form, effect.occurrence))
+        dictionary = effect.after_scope; history = effect.history_after; specs.append(SegmentSpec(start, end, form, effect.occurrence))
     return refs, front_end, source, forms, dictionary, grammar, theory, specs
 
 
@@ -284,7 +294,6 @@ def run_selection(case: dict) -> dict:
         ev2 = front_end.build_selected_evidence(source, (SegmentSpec(0, len(data), form_two, e2.occurrence),), dictionary=e2.after_scope, grammar=grammar, theory=theory)
         network = builder.freeze(root); before = network.snapshot(); r1 = replay_source_front_end(network, ev1, refs); r2 = replay_source_front_end(network, ev2, refs); after = network.snapshot()
         return {"id": case["id"], "accepted": True, "observable": {"firstMatches": r1 == (form_one,), "secondMatches": r2 == (form_two,), "formsDistinct": form_one is not form_two, "sourceShared": ev1.source is ev2.source, "contentShared": ev1.content is ev2.content, "readOnlyCountStable": len(before.links) == len(after.links)}}
-
     segments = [tuple(item) for item in case["input"].get("segments", [[0, len(data), 0]])]
     refs, front_end, source, forms, dictionary, grammar, theory, specs = selection_fixture(builder, root, data, segments)
     if operation == "invalid-partition":
@@ -292,8 +301,7 @@ def run_selection(case: dict) -> dict:
         except SourceReplayError: return {"id": case["id"], "accepted": False, "error": "invalid-selected-partition"}
         raise RuntimeError("invalid selected partition was unexpectedly accepted")
     evidence = front_end.build_selected_evidence(source, tuple(specs), dictionary=dictionary, grammar=grammar, theory=theory)
-    if operation == "forged-resolution":
-        evidence = replace(evidence, segments=(replace(evidence.segments[0], resolution=root),))
+    if operation == "forged-resolution": evidence = replace(evidence, segments=(replace(evidence.segments[0], resolution=root),))
     network = builder.freeze(root); before = network.snapshot()
     try: resolved = replay_source_front_end(network, evidence, refs)
     except SourceReplayError:
@@ -303,10 +311,110 @@ def run_selection(case: dict) -> dict:
     return {"id": case["id"], "accepted": True, "observable": {"formCount": len(resolved), "formsMatchExpected": resolved == expected, "readOnlyCountStable": len(before.links) == len(after.links)}}
 
 
+def relation_roles(builder, cursor):
+    refs, cursor = anchors(builder, cursor, 11)
+    return RelationStepRoleRefs(*refs), cursor
+
+
+def flat_roles(builder, cursor):
+    refs, cursor = anchors(builder, cursor, 9)
+    return FlatSequenceReadingRoleRefs(*refs), cursor
+
+
+def add_act_fields(builder, act, roles, values):
+    for role, value in zip(roles.__dict__.values(), values, strict=True): define_act_field(builder, act, role, value)
+
+
+def relation_fixture(operation: str):
+    builder = LinkNetworkBuilder(); root = builder.ensure_root(); byte_refs = byte_vocabulary(builder, root); front = SourceFrontEndBuilder(builder, root, byte_refs); cursor = byte_refs[255]
+    base, cursor = anchors(builder, cursor, 6); fixed, parent, binding, interpreter, role_dictionary, forged = base
+    if operation in ("start-open", "forged-result", "forged-binding", "forged-dgt", "forged-act"): form = builder.ensure_start_self_closed(fixed); expected_poles = (binding, fixed)
+    elif operation == "end-open": form = builder.ensure_end_self_closed(fixed); expected_poles = (fixed, binding)
+    elif operation == "complete-form":
+        other = next_anchor(builder, cursor); cursor = other; form = builder.ensure(fixed, other); expected_poles = (binding, other)
+    else: raise RuntimeError(f"unknown relation operation: {operation}")
+    grammar = next_anchor(builder, form); theory = next_anchor(builder, grammar); cursor = theory
+    source = front.source_occurrence(b"x"); dictionary = define_dictionary_scope(builder, root, root)
+    effect = define_dictionary_effect(builder, dictionary, root, root, front.content_ref(b"x"), form); dictionary = effect.after_scope
+    source_evidence = front.build_selected_evidence(source, (SegmentSpec(0, 1, form, effect.occurrence),), dictionary=dictionary, grammar=grammar, theory=theory)
+    before_context = define_context(builder, parent, binding); result = builder.ensure(*expected_poles); after_context = define_context(builder, parent, result)
+    roles, cursor = relation_roles(builder, cursor); act = define_act_header(builder, interpreter, role_dictionary, after_context)
+    values = (source_evidence.source, source_evidence.selection_sequence, source_evidence.form_sequence, dictionary, grammar, theory, form, before_context, binding, result, after_context)
+    add_act_fields(builder, act, roles, values)
+    wrong_end = next_anchor(builder, cursor); wrong_result = builder.ensure(binding, wrong_end)
+    evidence = RelationStepEvidence(source_evidence, interpreter, form, before_context, binding, result, after_context, act, role_dictionary, roles)
+    if operation == "forged-result": evidence = replace(evidence, result=wrong_result)
+    elif operation == "forged-binding": evidence = replace(evidence, binding=fixed)
+    elif operation == "forged-dgt": evidence = replace(evidence, source_evidence=replace(source_evidence, grammar=forged))
+    elif operation == "forged-act": evidence = replace(evidence, role_dictionary=forged)
+    return builder.freeze(root), byte_refs, evidence, result
+
+
+def run_relation(case: dict) -> dict:
+    operation = case["input"]["operation"]; network, byte_refs, evidence, expected = relation_fixture(operation); before = network.snapshot()
+    try: result = replay_relation_step(network, evidence, byte_refs)
+    except InterpreterReplayError:
+        return {"id": case["id"], "accepted": False, "error": "invalid-relation-evidence"}
+    after = network.snapshot()
+    return {"id": case["id"], "accepted": True, "observable": {"resultMatchesExpected": result is expected, "readOnlyCountStable": before == after}}
+
+
+def flat_standard_fixture(operation: str):
+    count = 1 if operation == "single" else 2
+    builder = LinkNetworkBuilder(); root = builder.ensure_root(); byte_refs = byte_vocabulary(builder, root); front = SourceFrontEndBuilder(builder, root, byte_refs); cursor = byte_refs[255]
+    forms, cursor = anchors(builder, cursor, count); grammar = next_anchor(builder, cursor); theory = next_anchor(builder, grammar); cursor = theory
+    dictionary = define_dictionary_scope(builder, root, root); history = root; specs = []; data = bytes(97 + index for index in range(count))
+    for index, form in enumerate(forms):
+        effect = define_dictionary_effect(builder, dictionary, root, history, front.content_ref(bytes([97 + index])), form)
+        dictionary = effect.after_scope; history = effect.history_after; specs.append(SegmentSpec(index, index + 1, form, effect.occurrence))
+    source = front.source_occurrence(data); source_evidence = front.build_selected_evidence(source, tuple(specs), dictionary=dictionary, grammar=grammar, theory=theory)
+    base, cursor = anchors(builder, cursor, 5); interpreter, role_dictionary, parent, current, forged = base
+    result = forms[0] if count == 1 else builder.ensure(forms[0], forms[1]); before_context = define_context(builder, parent, current); after_context = define_context(builder, parent, result)
+    roles, cursor = flat_roles(builder, cursor); act = define_act_header(builder, interpreter, role_dictionary, after_context)
+    values = (source_evidence.source, source_evidence.selection_sequence, source_evidence.form_sequence, dictionary, grammar, theory, before_context, result, after_context)
+    add_act_fields(builder, act, roles, values)
+    wrong = builder.ensure(forms[0], next_anchor(builder, cursor)); evidence = FlatSequenceReadingEvidence(source_evidence, interpreter, before_context, result, after_context, act, role_dictionary, roles)
+    if operation == "forged-result": evidence = replace(evidence, result=wrong)
+    elif operation == "forged-dgt": evidence = replace(evidence, source_evidence=replace(source_evidence, theory=forged))
+    elif operation == "forged-act": evidence = replace(evidence, role_dictionary=forged)
+    return builder.freeze(root), byte_refs, evidence, result, count
+
+
+def flat_distinct_fixture():
+    builder = LinkNetworkBuilder(); root = builder.ensure_root(); byte_refs = byte_vocabulary(builder, root); front = SourceFrontEndBuilder(builder, root, byte_refs); cursor = byte_refs[255]
+    refs, cursor = anchors(builder, cursor, 2); a, b = refs; carrier_a = builder.ensure(root, a); carrier_ab = builder.ensure(carrier_a, b); pair_result = builder.ensure(a, b)
+    dictionary = define_dictionary_scope(builder, root, root); history = root; occurrences = {}
+    for raw, form in ((b"a", a), (b"b", b), (b"ab", carrier_ab)):
+        effect = define_dictionary_effect(builder, dictionary, root, history, front.content_ref(raw), form); dictionary = effect.after_scope; history = effect.history_after; occurrences[raw] = effect.occurrence
+    source = front.source_occurrence(b"ab"); dgt, cursor = anchors(builder, cursor, 4); pair_g, pair_t, carrier_g, carrier_t = dgt
+    pair_source = front.build_selected_evidence(source, (SegmentSpec(0, 1, a, occurrences[b"a"]), SegmentSpec(1, 2, b, occurrences[b"b"])), dictionary=dictionary, grammar=pair_g, theory=pair_t)
+    carrier_source = front.build_selected_evidence(source, (SegmentSpec(0, 2, carrier_ab, occurrences[b"ab"]),), dictionary=dictionary, grammar=carrier_g, theory=carrier_t)
+    base, cursor = anchors(builder, cursor, 4); interpreter, role_dictionary, parent, current = base; before_context = define_context(builder, parent, current); roles, cursor = flat_roles(builder, cursor)
+    def reading(source_evidence, result):
+        after_context = define_context(builder, parent, result); act = define_act_header(builder, interpreter, role_dictionary, after_context)
+        values = (source_evidence.source, source_evidence.selection_sequence, source_evidence.form_sequence, dictionary, source_evidence.grammar, source_evidence.theory, before_context, result, after_context); add_act_fields(builder, act, roles, values)
+        return FlatSequenceReadingEvidence(source_evidence, interpreter, before_context, result, after_context, act, role_dictionary, roles)
+    return builder.freeze(root), byte_refs, reading(pair_source, pair_result), reading(carrier_source, carrier_ab), pair_result, carrier_ab
+
+
+def run_flat(case: dict) -> dict:
+    operation = case["input"]["operation"]
+    if operation == "distinct-readings":
+        network, byte_refs, first, second, first_expected, second_expected = flat_distinct_fixture(); before = network.snapshot()
+        first_result = replay_flat_sequence_reading(network, first, byte_refs); second_result = replay_flat_sequence_reading(network, second, byte_refs); after = network.snapshot()
+        return {"id": case["id"], "accepted": True, "observable": {"sameSource": first.source_evidence.source is second.source_evidence.source, "readingsDistinct": first_result is not second_result, "resultsMatchExpected": first_result is first_expected and second_result is second_expected, "readOnlyCountStable": before == after}}
+    network, byte_refs, evidence, expected, count = flat_standard_fixture(operation); before = network.snapshot()
+    try: result = replay_flat_sequence_reading(network, evidence, byte_refs)
+    except InterpreterReplayError:
+        return {"id": case["id"], "accepted": False, "error": "invalid-flat-evidence"}
+    after = network.snapshot()
+    return {"id": case["id"], "accepted": True, "observable": {"formCount": count, "resultMatchesExpected": result is expected, "readOnlyCountStable": before == after}}
+
+
 def main() -> int:
     if len(sys.argv) != 2: raise SystemExit("usage: python_oracle.py FIXTURES.json")
     corpus = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")); verify_freeze(corpus); results = []
-    runners = {"topology": run_topology, "anum": run_anum, "persistence": run_persistence, "source": run_source, "state": run_state, "dictionary": run_dictionary, "selection": run_selection}
+    runners = {"topology": run_topology, "anum": run_anum, "persistence": run_persistence, "source": run_source, "state": run_state, "dictionary": run_dictionary, "selection": run_selection, "relation": run_relation, "flat": run_flat}
     for case in corpus["cases"]:
         runner = runners.get(case["category"])
         if runner is None: raise RuntimeError(f"unknown differential category: {case['category']}")

--- a/ts/test/differential.test.ts
+++ b/ts/test/differential.test.ts
@@ -42,6 +42,16 @@ import {
   readDictionaryScope,
   verifyVisibleDictionaryOccurrence,
 } from "../src/dictionary.js";
+import {
+  InterpreterReplayError,
+  replayFlatReading,
+  replayRelationStep,
+  type FlatReadingEvidence,
+  type FlatReadingRoles,
+  type RelationReplayEvidence,
+  type RelationRoles,
+} from "../src/interpreter.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -50,7 +60,7 @@ function assert(condition: unknown, message: string): asserts condition {
 type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 interface DifferentialCase {
   readonly id: string;
-  readonly category: "topology" | "anum" | "persistence" | "source" | "state" | "dictionary" | "selection";
+  readonly category: "topology" | "anum" | "persistence" | "source" | "state" | "dictionary" | "selection" | "relation" | "flat";
   readonly input: Record<string, Json>;
 }
 interface Corpus {
@@ -73,7 +83,6 @@ function canonical(value: Json): Json {
   }
   return value;
 }
-
 function sameJson(left: Json, right: Json): boolean {
   return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
 }
@@ -82,10 +91,8 @@ function topologyObservable(memory: Memory): Json {
   const topology = exportTopology(memory);
   return { root: topology.root, links: topology.links.map(([start, end]) => [start, end]) };
 }
-
 function storageImage(input: Record<string, Json>): StorageTopologyImage {
-  const root = input.root;
-  const links = input.links;
+  const root = input.root; const links = input.links;
   assert(typeof root === "number" && Array.isArray(links), "invalid topology fixture");
   return {
     schema: STORAGE_TOPOLOGY_SCHEMA,
@@ -98,10 +105,8 @@ function storageImage(input: Record<string, Json>): StorageTopologyImage {
     }),
   };
 }
-
 function runTopology(test: DifferentialCase): Result {
-  const operation = test.input.operation;
-  assert(typeof operation === "string", "topology fixture needs operation");
+  const operation = test.input.operation; assert(typeof operation === "string", "topology fixture needs operation");
   try {
     if (operation === "basis-loop") {
       const memory = new Memory(); const { L } = ensureRootBasis(memory); memory.ensure(L, L);
@@ -111,16 +116,13 @@ function runTopology(test: DifferentialCase): Result {
       const memory = new Memory(); const { O, C, L } = ensureRootBasis(memory); const before = memory.linkCount; const reused = memory.ensure(O, C);
       return { id: test.id, accepted: true, observable: { ...(topologyObservable(memory) as Record<string, Json>), countBefore: before, countAfter: memory.linkCount, reused: reused === L } };
     }
-    if (operation === "restore") {
-      return { id: test.id, accepted: true, observable: topologyObservable(restoreTopology(storageImage(test.input))) };
-    }
+    if (operation === "restore") return { id: test.id, accepted: true, observable: topologyObservable(restoreTopology(storageImage(test.input))) };
     throw new Error(`unknown topology fixture operation: ${operation}`);
   } catch (error) {
     if (error instanceof PersistenceTopologyError) return { id: test.id, accepted: false, error: "invalid-topology" };
     throw error;
   }
 }
-
 function runAnum(test: DifferentialCase): Result {
   const source = test.input.source; assert(typeof source === "string", "ANUM fixture needs source");
   try {
@@ -132,9 +134,7 @@ function runAnum(test: DifferentialCase): Result {
   }
 }
 
-function cloneDataset(dataset: StoredDataset): StoredDataset {
-  return JSON.parse(JSON.stringify(dataset)) as StoredDataset;
-}
+function cloneDataset(dataset: StoredDataset): StoredDataset { return JSON.parse(JSON.stringify(dataset)) as StoredDataset; }
 class MemoryBackend implements PersistentTopologyBackend {
   constructor(public dataset?: StoredDataset) {}
   load(): StoredDataset | undefined { return this.dataset === undefined ? undefined : cloneDataset(this.dataset); }
@@ -176,6 +176,11 @@ function byteVocabulary(memory: Memory): readonly LinkHandle[] {
   const refs: LinkHandle[] = []; let current = memory.root;
   for (let value = 0; value < 256; value += 1) { current = memory.ensureStartSelfClosed(current); refs.push(current); }
   return Object.freeze(refs);
+}
+function anchorChain(memory: Memory, start: LinkHandle, count: number): { readonly refs: readonly LinkHandle[]; readonly last: LinkHandle } {
+  const refs: LinkHandle[] = []; let current = start;
+  for (let index = 0; index < count; index += 1) { current = memory.ensureStartSelfClosed(current); refs.push(current); }
+  return { refs: Object.freeze(refs), last: current };
 }
 function sourceBytes(input: Record<string, Json>): Uint8Array {
   const raw = input.bytes; assert(Array.isArray(raw), "source fixture needs byte array");
@@ -254,8 +259,7 @@ function runDictionary(test: DifferentialCase): Result {
 
 type SegmentTuple = readonly [number, number, number];
 function segmentTuples(input: Record<string, Json>, byteLength: number): readonly SegmentTuple[] {
-  const raw = input.segments ?? [[0, byteLength, 0]];
-  assert(Array.isArray(raw), "selection fixture needs segments");
+  const raw = input.segments ?? [[0, byteLength, 0]]; assert(Array.isArray(raw), "selection fixture needs segments");
   return raw.map((item) => {
     assert(Array.isArray(item) && item.length === 3, "invalid selection segment fixture");
     const [start, end, form] = item; assert(typeof start === "number" && typeof end === "number" && typeof form === "number", "invalid selection segment values");
@@ -300,13 +304,98 @@ function runSelection(test: DifferentialCase): Result {
   } else if (operation !== "selected") throw new Error(`unknown selection operation: ${operation}`);
   const before = memory.linkCount;
   try {
-    const resolved = replaySelectedSourceEvidence(memory, fixture.refs, evidence); const after = memory.linkCount;
-    const expected = segments.map(([, , index]) => fixture.forms[index]);
+    const resolved = replaySelectedSourceEvidence(memory, fixture.refs, evidence); const after = memory.linkCount; const expected = segments.map(([, , index]) => fixture.forms[index]);
     return { id: test.id, accepted: true, observable: { formCount: resolved.length, formsMatchExpected: resolved.every((form, index) => form === expected[index]), readOnlyCountStable: before === after } };
   } catch (error) {
     if (operation === "forged-resolution" && error instanceof SourceError) return { id: test.id, accepted: false, error: "invalid-source-evidence" };
     throw error;
   }
+}
+
+function relationRoles(memory: Memory, cursor: LinkHandle): { readonly roles: RelationRoles; readonly last: LinkHandle } {
+  const chain = anchorChain(memory, cursor, 11); const r = chain.refs;
+  return { roles: Object.freeze({ source: r[0]!, sourceSelection: r[1]!, formSequence: r[2]!, dictionary: r[3]!, grammar: r[4]!, theory: r[5]!, form: r[6]!, beforeContext: r[7]!, binding: r[8]!, result: r[9]!, afterContext: r[10]! }), last: chain.last };
+}
+function flatRoles(memory: Memory, cursor: LinkHandle): { readonly roles: FlatReadingRoles; readonly last: LinkHandle } {
+  const chain = anchorChain(memory, cursor, 9); const r = chain.refs;
+  return { roles: Object.freeze({ source: r[0]!, sourceSelection: r[1]!, formSequence: r[2]!, dictionary: r[3]!, grammar: r[4]!, theory: r[5]!, beforeContext: r[6]!, result: r[7]!, afterContext: r[8]! }), last: chain.last };
+}
+function relationAct(memory: Memory, sourceEvidence: SourceFrontEndEvidence, roles: RelationRoles, interpreter: LinkHandle, roleDictionary: LinkHandle, form: LinkHandle, beforeContext: LinkHandle, binding: LinkHandle, result: LinkHandle, afterContext: LinkHandle): RelationReplayEvidence {
+  const act = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+  const fields: readonly [LinkHandle, LinkHandle][] = [[roles.source, sourceEvidence.source], [roles.sourceSelection, sourceEvidence.selectionSequence], [roles.formSequence, sourceEvidence.formSequence], [roles.dictionary, sourceEvidence.dictionary], [roles.grammar, sourceEvidence.grammar], [roles.theory, sourceEvidence.theory], [roles.form, form], [roles.beforeContext, beforeContext], [roles.binding, binding], [roles.result, result], [roles.afterContext, afterContext]];
+  for (const [role, value] of fields) defineActField(memory, act, role, value);
+  return Object.freeze({ sourceEvidence, act, roles, interpreter, roleDictionary });
+}
+function runRelation(test: DifferentialCase): Result {
+  const operation = test.input.operation; assert(typeof operation === "string", "relation fixture needs operation");
+  const memory = new Memory(); const byteRefs = byteVocabulary(memory); let cursor = byteRefs[255]!; const base = anchorChain(memory, cursor, 6); cursor = base.last;
+  const [fixed, parent, binding, interpreter, roleDictionary, forged] = base.refs; assert(fixed && parent && binding && interpreter && roleDictionary && forged, "relation refs");
+  let form: LinkHandle; let resultStart: LinkHandle; let resultEnd: LinkHandle;
+  if (["start-open", "forged-result", "forged-binding", "forged-dgt", "forged-act"].includes(operation)) { form = memory.ensureStartSelfClosed(fixed); resultStart = binding; resultEnd = fixed; }
+  else if (operation === "end-open") { form = memory.ensureEndSelfClosed(fixed); resultStart = fixed; resultEnd = binding; }
+  else if (operation === "complete-form") { const next = memory.ensureStartSelfClosed(cursor); cursor = next; form = memory.ensure(fixed, next); resultStart = binding; resultEnd = next; }
+  else throw new Error(`unknown relation operation: ${operation}`);
+  const grammar = memory.ensureStartSelfClosed(form); const theory = memory.ensureStartSelfClosed(grammar); cursor = theory;
+  const content = materializeSourceContent(memory, byteRefs, new Uint8Array([120])); const source = defineSourceForm(memory, content); let dictionary = defineDictionaryScope(memory, memory.root, memory.root);
+  const effect = defineDictionaryEffect(memory, dictionary, memory.root, memory.root, content, form); dictionary = effect.afterScope;
+  const sourceEvidence = buildSelectedSourceEvidence(memory, byteRefs, source, [{ start: 0, end: 1, form, dictionaryOccurrence: effect.occurrence }], { dictionary, grammar, theory });
+  const beforeContext = defineContext(memory, parent, binding); const expected = memory.ensure(resultStart, resultEnd); const afterContext = defineContext(memory, parent, expected);
+  const roleFixture = relationRoles(memory, cursor); cursor = roleFixture.last; let actBinding = binding; let actResult = expected; let evidenceSource = sourceEvidence; let evidenceRoleDictionary = roleDictionary;
+  if (operation === "forged-binding") actBinding = fixed;
+  if (operation === "forged-result") { const wrongEnd = memory.ensureStartSelfClosed(cursor); actResult = memory.ensure(binding, wrongEnd); }
+  let evidence = relationAct(memory, sourceEvidence, roleFixture.roles, interpreter, roleDictionary, form, beforeContext, actBinding, actResult, afterContext);
+  if (operation === "forged-dgt") { evidenceSource = Object.freeze({ ...sourceEvidence, grammar: forged }); evidence = Object.freeze({ ...evidence, sourceEvidence: evidenceSource }); }
+  if (operation === "forged-act") { evidenceRoleDictionary = forged; evidence = Object.freeze({ ...evidence, roleDictionary: evidenceRoleDictionary }); }
+  const before = memory.linkCount;
+  try {
+    const result = replayRelationStep(memory, byteRefs, evidence); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { resultMatchesExpected: result === expected, readOnlyCountStable: before === after } };
+  } catch (error) {
+    if (error instanceof InterpreterReplayError) return { id: test.id, accepted: false, error: "invalid-relation-evidence" };
+    throw error;
+  }
+}
+
+function flatAct(memory: Memory, sourceEvidence: SourceFrontEndEvidence, roles: FlatReadingRoles, interpreter: LinkHandle, roleDictionary: LinkHandle, beforeContext: LinkHandle, result: LinkHandle, afterContext: LinkHandle): FlatReadingEvidence {
+  const act = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+  const fields: readonly [LinkHandle, LinkHandle][] = [[roles.source, sourceEvidence.source], [roles.sourceSelection, sourceEvidence.selectionSequence], [roles.formSequence, sourceEvidence.formSequence], [roles.dictionary, sourceEvidence.dictionary], [roles.grammar, sourceEvidence.grammar], [roles.theory, sourceEvidence.theory], [roles.beforeContext, beforeContext], [roles.result, result], [roles.afterContext, afterContext]];
+  for (const [role, value] of fields) defineActField(memory, act, role, value);
+  return Object.freeze({ sourceEvidence, act, roles, interpreter, roleDictionary });
+}
+function runFlat(test: DifferentialCase): Result {
+  const operation = test.input.operation; assert(typeof operation === "string", "flat fixture needs operation");
+  if (operation === "distinct-readings") return runFlatDistinct(test);
+  const count = operation === "single" ? 1 : 2; const memory = new Memory(); const byteRefs = byteVocabulary(memory); let cursor = byteRefs[255]!; const formChain = anchorChain(memory, cursor, count); cursor = formChain.last; const forms = formChain.refs;
+  const grammar = memory.ensureStartSelfClosed(cursor); const theory = memory.ensureStartSelfClosed(grammar); cursor = theory; let dictionary = defineDictionaryScope(memory, memory.root, memory.root); let history = memory.root; const specs: SelectedSegmentSpec[] = []; const bytes = new Uint8Array(count);
+  for (let index = 0; index < count; index += 1) { const form = forms[index]!; const value = 97 + index; bytes[index] = value; const content = materializeSourceContent(memory, byteRefs, new Uint8Array([value])); const effect = defineDictionaryEffect(memory, dictionary, memory.root, history, content, form); dictionary = effect.afterScope; history = effect.historyAfter; specs.push(Object.freeze({ start: index, end: index + 1, form, dictionaryOccurrence: effect.occurrence })); }
+  const source = defineSourceForm(memory, materializeSourceContent(memory, byteRefs, bytes)); const sourceEvidence = buildSelectedSourceEvidence(memory, byteRefs, source, specs, { dictionary, grammar, theory });
+  const base = anchorChain(memory, cursor, 5); cursor = base.last; const [interpreter, roleDictionary, parent, current, forged] = base.refs; assert(interpreter && roleDictionary && parent && current && forged, "flat refs");
+  const expected = count === 1 ? forms[0]! : memory.ensure(forms[0]!, forms[1]!); const beforeContext = defineContext(memory, parent, current); const afterContext = defineContext(memory, parent, expected); const roleFixture = flatRoles(memory, cursor); cursor = roleFixture.last;
+  let actResult = expected; if (operation === "forged-result") { const wrong = memory.ensure(forms[0]!, memory.ensureStartSelfClosed(cursor)); actResult = wrong; }
+  let evidence = flatAct(memory, sourceEvidence, roleFixture.roles, interpreter, roleDictionary, beforeContext, actResult, afterContext);
+  if (operation === "forged-dgt") evidence = Object.freeze({ ...evidence, sourceEvidence: Object.freeze({ ...sourceEvidence, theory: forged }) });
+  else if (operation === "forged-act") evidence = Object.freeze({ ...evidence, roleDictionary: forged });
+  else if (!["single", "multi", "forged-result"].includes(operation)) throw new Error(`unknown flat operation: ${operation}`);
+  const before = memory.linkCount;
+  try {
+    const result = replayFlatReading(memory, byteRefs, evidence); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { formCount: count, resultMatchesExpected: result === expected, readOnlyCountStable: before === after } };
+  } catch (error) {
+    if (error instanceof InterpreterReplayError) return { id: test.id, accepted: false, error: "invalid-flat-evidence" };
+    throw error;
+  }
+}
+function runFlatDistinct(test: DifferentialCase): Result {
+  const memory = new Memory(); const byteRefs = byteVocabulary(memory); let cursor = byteRefs[255]!; const formChain = anchorChain(memory, cursor, 2); cursor = formChain.last; const [a, b] = formChain.refs; assert(a && b, "distinct form refs");
+  const carrierA = memory.ensure(memory.root, a); const carrierAB = memory.ensure(carrierA, b); const pairResult = memory.ensure(a, b); let dictionary = defineDictionaryScope(memory, memory.root, memory.root); let history = memory.root; const occurrences = new Map<string, LinkHandle>();
+  for (const [key, raw, form] of [["a", new Uint8Array([97]), a], ["b", new Uint8Array([98]), b], ["ab", new Uint8Array([97, 98]), carrierAB]] as const) { const effect = defineDictionaryEffect(memory, dictionary, memory.root, history, materializeSourceContent(memory, byteRefs, raw), form); dictionary = effect.afterScope; history = effect.historyAfter; occurrences.set(key, effect.occurrence); }
+  const source = defineSourceForm(memory, materializeSourceContent(memory, byteRefs, new Uint8Array([97, 98]))); const dgt = anchorChain(memory, cursor, 4); cursor = dgt.last; const [pairG, pairT, carrierG, carrierT] = dgt.refs; assert(pairG && pairT && carrierG && carrierT, "distinct DGT refs");
+  const pairSource = buildSelectedSourceEvidence(memory, byteRefs, source, [{ start: 0, end: 1, form: a, dictionaryOccurrence: occurrences.get("a")! }, { start: 1, end: 2, form: b, dictionaryOccurrence: occurrences.get("b")! }], { dictionary, grammar: pairG, theory: pairT });
+  const carrierSource = buildSelectedSourceEvidence(memory, byteRefs, source, [{ start: 0, end: 2, form: carrierAB, dictionaryOccurrence: occurrences.get("ab")! }], { dictionary, grammar: carrierG, theory: carrierT });
+  const base = anchorChain(memory, cursor, 4); cursor = base.last; const [interpreter, roleDictionary, parent, current] = base.refs; assert(interpreter && roleDictionary && parent && current, "distinct act refs"); const beforeContext = defineContext(memory, parent, current); const roleFixture = flatRoles(memory, cursor);
+  const pairAfter = defineContext(memory, parent, pairResult); const carrierAfter = defineContext(memory, parent, carrierAB); const first = flatAct(memory, pairSource, roleFixture.roles, interpreter, roleDictionary, beforeContext, pairResult, pairAfter); const second = flatAct(memory, carrierSource, roleFixture.roles, interpreter, roleDictionary, beforeContext, carrierAB, carrierAfter);
+  const before = memory.linkCount; const firstResult = replayFlatReading(memory, byteRefs, first); const secondResult = replayFlatReading(memory, byteRefs, second); const after = memory.linkCount;
+  return { id: test.id, accepted: true, observable: { sameSource: pairSource.source === carrierSource.source, readingsDistinct: firstResult !== secondResult, resultsMatchExpected: firstResult === pairResult && secondResult === carrierAB, readOnlyCountStable: before === after } };
 }
 
 const repoRoot = resolve(process.cwd(), "..");
@@ -317,15 +406,7 @@ assert(corpus.contract === "mts-contract/v0.7", "differential fixtures must sele
 const python = spawnSync("python3", ["differential/python_oracle.py", "differential/fixtures-v0.7.json"], { cwd: repoRoot, encoding: "utf8" });
 assert(python.status === 0, `frozen Python oracle adapter failed: ${python.stderr || python.stdout}`);
 const expected = JSON.parse(python.stdout) as Result[];
-const runners: Record<DifferentialCase["category"], (test: DifferentialCase) => Result> = {
-  topology: runTopology,
-  anum: runAnum,
-  persistence: runPersistence,
-  source: runSource,
-  state: runState,
-  dictionary: runDictionary,
-  selection: runSelection,
-};
+const runners: Record<DifferentialCase["category"], (test: DifferentialCase) => Result> = { topology: runTopology, anum: runAnum, persistence: runPersistence, source: runSource, state: runState, dictionary: runDictionary, selection: runSelection, relation: runRelation, flat: runFlat };
 const actual = corpus.cases.map((test) => runners[test.category](test));
 assert(expected.length === actual.length, "differential result cardinality mismatch");
 expected.forEach((pythonResult, index) => {


### PR DESCRIPTION
Closes #523

Расширяет существующий M10 differential harness на первый read-only interpreter slice поверх принятого M10c:

- one-pole relation replay для start/end self-closed forms;
- flat singleton/multi reading и две явные segmentation одного source;
- negative forged result/binding/D-G-T/Act evidence;
- pin frozen Python `core/foundation_v2_interpreter.py` owner blob;
- exact normalized Python v0.7 ↔ TypeScript comparison без runtime IDs/handles.

Production semantic code не меняется. `:` / `=` и subselection остаются за пределами этого slice.