### PR TITLE
TypeScript: M10e colon and equality differential coverage

### DIFF
--- a/differential/fixtures-v0.7.json
+++ b/differential/fixtures-v0.7.json
@@ -60,6 +60,22 @@
     {"id":"flat-distinct-readings","category":"flat","input":{"operation":"distinct-readings"}},
     {"id":"flat-forged-result","category":"flat","input":{"operation":"forged-result"}},
     {"id":"flat-forged-dgt","category":"flat","input":{"operation":"forged-dgt"}},
-    {"id":"flat-forged-act","category":"flat","input":{"operation":"forged-act"}}
+    {"id":"flat-forged-act","category":"flat","input":{"operation":"forged-act"}},
+
+    {"id":"colon-valid","category":"colon","input":{"operation":"valid"}},
+    {"id":"colon-repeated-event","category":"colon","input":{"operation":"repeated-event"}},
+    {"id":"colon-conflict","category":"colon","input":{"operation":"conflict"}},
+    {"id":"colon-forged-occurrence","category":"colon","input":{"operation":"forged-occurrence"}},
+    {"id":"colon-forged-history","category":"colon","input":{"operation":"forged-history"}},
+    {"id":"colon-forged-act","category":"colon","input":{"operation":"forged-act"}},
+
+    {"id":"equality-identical","category":"equality","input":{"operation":"identical"}},
+    {"id":"equality-distinct","category":"equality","input":{"operation":"distinct"}},
+    {"id":"equality-shared-representative","category":"equality","input":{"operation":"shared-representative"}},
+    {"id":"equality-one-hop","category":"equality","input":{"operation":"one-hop"}},
+    {"id":"equality-non-transitive","category":"equality","input":{"operation":"non-transitive"}},
+    {"id":"equality-conflict","category":"equality","input":{"operation":"conflict"}},
+    {"id":"equality-forged-representative","category":"equality","input":{"operation":"forged-representative"}},
+    {"id":"equality-forged-act","category":"equality","input":{"operation":"forged-act"}}
   ]
 }

--- a/differential/python_oracle.py
+++ b/differential/python_oracle.py
@@ -14,11 +14,17 @@ if str(ROOT) not in sys.path:
 
 from core.anum_protocol import StreamError, deserialize_stream
 from core.foundation_v2_interpreter import (
+    ColonEffectEvidence,
+    ColonRoleRefs,
+    EqualityEvaluationEvidence,
+    EqualityRoleRefs,
     FlatSequenceReadingEvidence,
     FlatSequenceReadingRoleRefs,
     InterpreterReplayError,
     RelationStepEvidence,
     RelationStepRoleRefs,
+    replay_colon_effect,
+    replay_equality_evaluation,
     replay_flat_sequence_reading,
     replay_relation_step,
 )
@@ -412,10 +418,101 @@ def run_flat(case: dict) -> dict:
     return {"id": case["id"], "accepted": True, "observable": {"formCount": count, "resultMatchesExpected": result is expected, "readOnlyCountStable": before == after}}
 
 
+def colon_roles(builder, cursor):
+    refs, cursor = anchors(builder, cursor, 10)
+    return ColonRoleRefs(*refs), cursor
+
+
+def make_colon_evidence(builder, root, *, before_dictionary=None, parent=None, history_before=None, source_content=None, form=None):
+    cursor = root
+    seed, cursor = anchors(builder, cursor, 5)
+    default_content, default_form, interpreter, role_dictionary, context_current = seed
+    if parent is None: parent = root
+    if history_before is None: history_before = root
+    if source_content is None: source_content = default_content
+    if form is None: form = default_form
+    if before_dictionary is None: before_dictionary = define_dictionary_scope(builder, parent, history_before)
+    source = builder.ensure_start_self_closed(source_content)
+    effect = define_dictionary_effect(builder, before_dictionary, parent, history_before, source_content, form)
+    context = define_context(builder, root, context_current)
+    roles, cursor = colon_roles(builder, cursor)
+    act = define_act_header(builder, interpreter, role_dictionary, context)
+    values = (source, source_content, form, before_dictionary, effect.entry, effect.occurrence, history_before, effect.history_after, effect.after_scope, context)
+    add_act_fields(builder, act, roles, values)
+    evidence = ColonEffectEvidence(interpreter, source, source_content, form, before_dictionary, effect.entry, effect.occurrence, effect.history_after, effect.after_scope, context, act, role_dictionary, roles)
+    return evidence, effect, cursor
+
+
+def run_colon(case: dict) -> dict:
+    operation = case["input"]["operation"]; builder = LinkNetworkBuilder(); root = builder.ensure_root()
+    if operation == "repeated-event":
+        content = next_anchor(builder, root); form = next_anchor(builder, content); base = define_dictionary_scope(builder, root, root)
+        first = define_dictionary_effect(builder, base, root, root, content, form)
+        evidence, second, _ = make_colon_evidence(builder, root, before_dictionary=first.after_scope, parent=root, history_before=first.history_after, source_content=content, form=form)
+        expected_distinct = second.occurrence is not first.occurrence
+    elif operation == "conflict":
+        content = next_anchor(builder, root); form_one = next_anchor(builder, content); form_two = next_anchor(builder, form_one); base = define_dictionary_scope(builder, root, root)
+        first = define_dictionary_effect(builder, base, root, root, content, form_one)
+        evidence, _effect, _ = make_colon_evidence(builder, root, before_dictionary=first.after_scope, parent=root, history_before=first.history_after, source_content=content, form=form_two)
+        network = builder.freeze(root)
+        try: replay_colon_effect(network, evidence)
+        except InterpreterReplayError: return {"id": case["id"], "accepted": False, "error": "invalid-colon-evidence"}
+        raise RuntimeError("colon conflict was unexpectedly accepted")
+    else:
+        evidence, effect, cursor = make_colon_evidence(builder, root)
+        expected_distinct = False
+        if operation == "forged-occurrence": evidence = replace(evidence, definition_occurrence=next_anchor(builder, cursor))
+        elif operation == "forged-history": evidence = replace(evidence, history_after=builder.ensure(next_anchor(builder, cursor), evidence.definition_occurrence))
+        elif operation == "forged-act": evidence = replace(evidence, role_dictionary=next_anchor(builder, cursor))
+        elif operation != "valid": raise RuntimeError(f"unknown colon operation: {operation}")
+    network = builder.freeze(root); before = network.snapshot()
+    try: result = replay_colon_effect(network, evidence)
+    except InterpreterReplayError:
+        return {"id": case["id"], "accepted": False, "error": "invalid-colon-evidence"}
+    after = network.snapshot(); before_parent, history_before = read_dictionary_scope(network, evidence.before_dictionary); after_parent, _ = read_dictionary_scope(network, evidence.after_dictionary)
+    resolution = lookup_scoped_dictionary(network, evidence.after_dictionary, evidence.source_content); before_resolution = lookup_scoped_dictionary(network, evidence.before_dictionary, evidence.source_content)
+    history_link = network.link(evidence.history_after)
+    observable = {"resultMatchesExpected": result is evidence.after_dictionary, "occurrenceVisibleAfter": resolution is not None and evidence.definition_occurrence in resolution.occurrences, "occurrenceInvisibleBefore": before_resolution is None or evidence.definition_occurrence not in before_resolution.occurrences, "parentPreserved": before_parent is after_parent, "historyAppended": history_link.start is history_before and history_link.end is evidence.definition_occurrence, "structuralEventDistinct": expected_distinct, "readOnlyCountStable": before == after}
+    return {"id": case["id"], "accepted": True, "observable": observable}
+
+
+def equality_roles(builder, cursor):
+    refs, cursor = anchors(builder, cursor, 5)
+    return EqualityRoleRefs(*refs), cursor
+
+
+def run_equality(case: dict) -> dict:
+    operation = case["input"]["operation"]; builder = LinkNetworkBuilder(); root = builder.ensure_root(); refs, cursor = anchors(builder, root, 7)
+    parent, current, left, right, representative, interpreter, role_dictionary = refs; context = define_context(builder, parent, current)
+    left_rep = left; right_rep = right; expected = False
+    if operation == "identical": right = left; right_rep = left; expected = True
+    elif operation == "distinct": pass
+    elif operation == "shared-representative":
+        define_local_representative_binding(builder, context, left, representative); define_local_representative_binding(builder, context, right, representative); left_rep = representative; right_rep = representative; expected = True
+    elif operation == "one-hop":
+        define_local_representative_binding(builder, context, left, right); left_rep = right; right_rep = right; expected = True
+    elif operation == "non-transitive":
+        define_local_representative_binding(builder, context, left, right); define_local_representative_binding(builder, context, right, representative); left_rep = right; right_rep = representative; expected = False
+    elif operation == "conflict":
+        define_local_representative_binding(builder, context, left, right); define_local_representative_binding(builder, context, left, representative); left_rep = right
+    elif operation == "forged-representative": left_rep = representative
+    elif operation == "forged-act": pass
+    else: raise RuntimeError(f"unknown equality operation: {operation}")
+    roles, cursor = equality_roles(builder, cursor); act = define_act_header(builder, interpreter, role_dictionary, context); values = (context, left, right, left_rep, right_rep); add_act_fields(builder, act, roles, values)
+    evidence = EqualityEvaluationEvidence(interpreter, context, left, right, left_rep, right_rep, act, role_dictionary, roles)
+    if operation == "forged-act": evidence = replace(evidence, role_dictionary=next_anchor(builder, cursor))
+    network = builder.freeze(root); before = network.snapshot()
+    try: result = replay_equality_evaluation(network, evidence)
+    except (InterpreterReplayError, RepresentativeConflictError):
+        return {"id": case["id"], "accepted": False, "error": "invalid-equality-evidence"}
+    after = network.snapshot()
+    return {"id": case["id"], "accepted": True, "observable": {"equal": result, "resultMatchesExpected": result is expected, "readOnlyCountStable": before == after}}
+
+
 def main() -> int:
     if len(sys.argv) != 2: raise SystemExit("usage: python_oracle.py FIXTURES.json")
     corpus = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")); verify_freeze(corpus); results = []
-    runners = {"topology": run_topology, "anum": run_anum, "persistence": run_persistence, "source": run_source, "state": run_state, "dictionary": run_dictionary, "selection": run_selection, "relation": run_relation, "flat": run_flat}
+    runners = {"topology": run_topology, "anum": run_anum, "persistence": run_persistence, "source": run_source, "state": run_state, "dictionary": run_dictionary, "selection": run_selection, "relation": run_relation, "flat": run_flat, "colon": run_colon, "equality": run_equality}
     for case in corpus["cases"]:
         runner = runners.get(case["category"])
         if runner is None: raise RuntimeError(f"unknown differential category: {case['category']}")

--- a/ts/test/differential.test.ts
+++ b/ts/test/differential.test.ts
@@ -44,8 +44,14 @@ import {
 } from "../src/dictionary.js";
 import {
   InterpreterReplayError,
+  replayColonEffect,
+  replayEqualityEvaluation,
   replayFlatReading,
   replayRelationStep,
+  type ColonReplayEvidence,
+  type ColonRoles,
+  type EqualityReplayEvidence,
+  type EqualityRoles,
   type FlatReadingEvidence,
   type FlatReadingRoles,
   type RelationReplayEvidence,
@@ -60,7 +66,7 @@ function assert(condition: unknown, message: string): asserts condition {
 type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 interface DifferentialCase {
   readonly id: string;
-  readonly category: "topology" | "anum" | "persistence" | "source" | "state" | "dictionary" | "selection" | "relation" | "flat";
+  readonly category: "topology" | "anum" | "persistence" | "source" | "state" | "dictionary" | "selection" | "relation" | "flat" | "colon" | "equality";
   readonly input: Record<string, Json>;
 }
 interface Corpus {
@@ -398,6 +404,93 @@ function runFlatDistinct(test: DifferentialCase): Result {
   return { id: test.id, accepted: true, observable: { sameSource: pairSource.source === carrierSource.source, readingsDistinct: firstResult !== secondResult, resultsMatchExpected: firstResult === pairResult && secondResult === carrierAB, readOnlyCountStable: before === after } };
 }
 
+interface ColonFields {
+  readonly source: LinkHandle;
+  readonly sourceContent: LinkHandle;
+  readonly form: LinkHandle;
+  readonly beforeDictionary: LinkHandle;
+  readonly entry: LinkHandle;
+  readonly definitionOccurrence: LinkHandle;
+  readonly historyBefore: LinkHandle;
+  readonly historyAfter: LinkHandle;
+  readonly afterDictionary: LinkHandle;
+  readonly context: LinkHandle;
+}
+function colonRoles(memory: Memory, cursor: LinkHandle): { readonly roles: ColonRoles; readonly last: LinkHandle } {
+  const chain = anchorChain(memory, cursor, 10); const r = chain.refs;
+  return { roles: Object.freeze({ source: r[0]!, sourceContent: r[1]!, form: r[2]!, beforeDictionary: r[3]!, entry: r[4]!, definitionOccurrence: r[5]!, historyBefore: r[6]!, historyAfter: r[7]!, afterDictionary: r[8]!, context: r[9]! }), last: chain.last };
+}
+function colonEvidence(memory: Memory, fields: ColonFields, roles: ColonRoles, interpreter: LinkHandle, roleDictionary: LinkHandle): ColonReplayEvidence {
+  const act = defineActHeader(memory, interpreter, roleDictionary, fields.context);
+  const values: readonly [LinkHandle, LinkHandle][] = [[roles.source, fields.source], [roles.sourceContent, fields.sourceContent], [roles.form, fields.form], [roles.beforeDictionary, fields.beforeDictionary], [roles.entry, fields.entry], [roles.definitionOccurrence, fields.definitionOccurrence], [roles.historyBefore, fields.historyBefore], [roles.historyAfter, fields.historyAfter], [roles.afterDictionary, fields.afterDictionary], [roles.context, fields.context]];
+  for (const [role, value] of values) defineActField(memory, act, role, value);
+  return Object.freeze({ act, roles, interpreter, roleDictionary });
+}
+function makeColonFixture(memory: Memory, options: { readonly beforeDictionary?: LinkHandle; readonly parent?: LinkHandle; readonly historyBefore?: LinkHandle; readonly sourceContent?: LinkHandle; readonly form?: LinkHandle } = {}) {
+  let cursor = memory.root; const seed = anchorChain(memory, cursor, 5); cursor = seed.last; const [defaultContent, defaultForm, interpreter, roleDictionary, contextCurrent] = seed.refs; assert(defaultContent && defaultForm && interpreter && roleDictionary && contextCurrent, "colon seed");
+  const parent = options.parent ?? memory.root; const historyBefore = options.historyBefore ?? memory.root; const sourceContent = options.sourceContent ?? defaultContent; const form = options.form ?? defaultForm; const beforeDictionary = options.beforeDictionary ?? defineDictionaryScope(memory, parent, historyBefore);
+  const source = defineSourceForm(memory, sourceContent); const effect = defineDictionaryEffect(memory, beforeDictionary, parent, historyBefore, sourceContent, form); const context = defineContext(memory, memory.root, contextCurrent); const roleFixture = colonRoles(memory, cursor);
+  const fields: ColonFields = Object.freeze({ source, sourceContent, form, beforeDictionary, entry: effect.entry, definitionOccurrence: effect.occurrence, historyBefore, historyAfter: effect.historyAfter, afterDictionary: effect.afterScope, context });
+  return { fields, effect, roles: roleFixture.roles, interpreter, roleDictionary, last: roleFixture.last };
+}
+function runColon(test: DifferentialCase): Result {
+  const operation = test.input.operation; assert(typeof operation === "string", "colon fixture needs operation"); const memory = new Memory(); let fields: ColonFields; let roles: ColonRoles; let interpreter: LinkHandle; let roleDictionary: LinkHandle; let structuralEventDistinct = false;
+  if (operation === "repeated-event") {
+    const content = memory.ensureStartSelfClosed(memory.root); const form = memory.ensureStartSelfClosed(content); const base = defineDictionaryScope(memory, memory.root, memory.root); const first = defineDictionaryEffect(memory, base, memory.root, memory.root, content, form); const fixture = makeColonFixture(memory, { beforeDictionary: first.afterScope, parent: memory.root, historyBefore: first.historyAfter, sourceContent: content, form });
+    ({ fields, roles, interpreter, roleDictionary } = fixture); structuralEventDistinct = fixture.effect.occurrence !== first.occurrence;
+  } else if (operation === "conflict") {
+    const content = memory.ensureStartSelfClosed(memory.root); const formOne = memory.ensureStartSelfClosed(content); const formTwo = memory.ensureStartSelfClosed(formOne); const base = defineDictionaryScope(memory, memory.root, memory.root); const first = defineDictionaryEffect(memory, base, memory.root, memory.root, content, formOne); const fixture = makeColonFixture(memory, { beforeDictionary: first.afterScope, parent: memory.root, historyBefore: first.historyAfter, sourceContent: content, form: formTwo });
+    const evidence = colonEvidence(memory, fixture.fields, fixture.roles, fixture.interpreter, fixture.roleDictionary);
+    try { replayColonEffect(memory, evidence); }
+    catch (error) { if (error instanceof InterpreterReplayError) return { id: test.id, accepted: false, error: "invalid-colon-evidence" }; throw error; }
+    throw new Error("colon conflict was unexpectedly accepted");
+  } else {
+    const fixture = makeColonFixture(memory); ({ fields, roles, interpreter, roleDictionary } = fixture);
+    if (operation === "forged-occurrence") fields = Object.freeze({ ...fields, definitionOccurrence: memory.ensureStartSelfClosed(fixture.last) });
+    else if (operation === "forged-history") fields = Object.freeze({ ...fields, historyAfter: memory.ensure(memory.ensureStartSelfClosed(fixture.last), fields.definitionOccurrence) });
+    else if (operation === "forged-act") roleDictionary = memory.ensureStartSelfClosed(fixture.last);
+    else if (operation !== "valid") throw new Error(`unknown colon operation: ${operation}`);
+  }
+  const evidence = colonEvidence(memory, fields, roles, interpreter, roleDictionary); const before = memory.linkCount;
+  try {
+    const result = replayColonEffect(memory, evidence); const after = memory.linkCount; const beforeScope = readDictionaryScope(memory, fields.beforeDictionary); const afterScope = readDictionaryScope(memory, fields.afterDictionary); const resolution = lookupScopedDictionary(memory, fields.afterDictionary, fields.sourceContent); const beforeResolution = lookupScopedDictionary(memory, fields.beforeDictionary, fields.sourceContent); const history = memory.poles(fields.historyAfter);
+    return { id: test.id, accepted: true, observable: { resultMatchesExpected: result === fields.afterDictionary, occurrenceVisibleAfter: resolution !== undefined && resolution.occurrences.includes(fields.definitionOccurrence), occurrenceInvisibleBefore: beforeResolution === undefined || !beforeResolution.occurrences.includes(fields.definitionOccurrence), parentPreserved: beforeScope.parentScope === afterScope.parentScope, historyAppended: history.start === fields.historyBefore && history.end === fields.definitionOccurrence, structuralEventDistinct, readOnlyCountStable: before === after } };
+  } catch (error) {
+    if (error instanceof InterpreterReplayError) return { id: test.id, accepted: false, error: "invalid-colon-evidence" };
+    throw error;
+  }
+}
+
+function equalityRoles(memory: Memory, cursor: LinkHandle): { readonly roles: EqualityRoles; readonly last: LinkHandle } {
+  const chain = anchorChain(memory, cursor, 5); const r = chain.refs;
+  return { roles: Object.freeze({ context: r[0]!, left: r[1]!, right: r[2]!, leftRepresentative: r[3]!, rightRepresentative: r[4]! }), last: chain.last };
+}
+function equalityEvidence(memory: Memory, roles: EqualityRoles, interpreter: LinkHandle, roleDictionary: LinkHandle, context: LinkHandle, left: LinkHandle, right: LinkHandle, leftRepresentative: LinkHandle, rightRepresentative: LinkHandle): EqualityReplayEvidence {
+  const act = defineActHeader(memory, interpreter, roleDictionary, context); const values: readonly [LinkHandle, LinkHandle][] = [[roles.context, context], [roles.left, left], [roles.right, right], [roles.leftRepresentative, leftRepresentative], [roles.rightRepresentative, rightRepresentative]];
+  for (const [role, value] of values) defineActField(memory, act, role, value);
+  return Object.freeze({ act, roles, interpreter, roleDictionary });
+}
+function runEquality(test: DifferentialCase): Result {
+  const operation = test.input.operation; assert(typeof operation === "string", "equality fixture needs operation"); const memory = new Memory(); const base = anchorChain(memory, memory.root, 7); let cursor = base.last; const [parent, current, originalLeft, originalRight, representative, interpreter, originalRoleDictionary] = base.refs; assert(parent && current && originalLeft && originalRight && representative && interpreter && originalRoleDictionary, "equality refs");
+  const context = defineContext(memory, parent, current); let left = originalLeft; let right = originalRight; let leftRepresentative = left; let rightRepresentative = right; let roleDictionary = originalRoleDictionary; let expected = false;
+  if (operation === "identical") { right = left; rightRepresentative = left; expected = true; }
+  else if (operation === "distinct") {}
+  else if (operation === "shared-representative") { defineLocalRepresentativeBinding(memory, context, left, representative); defineLocalRepresentativeBinding(memory, context, right, representative); leftRepresentative = representative; rightRepresentative = representative; expected = true; }
+  else if (operation === "one-hop") { defineLocalRepresentativeBinding(memory, context, left, right); leftRepresentative = right; rightRepresentative = right; expected = true; }
+  else if (operation === "non-transitive") { defineLocalRepresentativeBinding(memory, context, left, right); defineLocalRepresentativeBinding(memory, context, right, representative); leftRepresentative = right; rightRepresentative = representative; expected = false; }
+  else if (operation === "conflict") { defineLocalRepresentativeBinding(memory, context, left, right); defineLocalRepresentativeBinding(memory, context, left, representative); leftRepresentative = right; }
+  else if (operation === "forged-representative") { leftRepresentative = representative; }
+  else if (operation !== "forged-act") throw new Error(`unknown equality operation: ${operation}`);
+  const roleFixture = equalityRoles(memory, cursor); cursor = roleFixture.last; if (operation === "forged-act") roleDictionary = memory.ensureStartSelfClosed(cursor); const evidence = equalityEvidence(memory, roleFixture.roles, interpreter, roleDictionary, context, left, right, leftRepresentative, rightRepresentative); const before = memory.linkCount;
+  try {
+    const equal = replayEqualityEvaluation(memory, evidence); const after = memory.linkCount;
+    return { id: test.id, accepted: true, observable: { equal, resultMatchesExpected: equal === expected, readOnlyCountStable: before === after } };
+  } catch (error) {
+    if (error instanceof InterpreterReplayError || (error instanceof StateError && error.code === "representative-conflict")) return { id: test.id, accepted: false, error: "invalid-equality-evidence" };
+    throw error;
+  }
+}
+
 const repoRoot = resolve(process.cwd(), "..");
 const fixturePath = resolve(repoRoot, "differential/fixtures-v0.7.json");
 const corpus = JSON.parse(readFileSync(fixturePath, "utf8")) as Corpus;
@@ -406,7 +499,7 @@ assert(corpus.contract === "mts-contract/v0.7", "differential fixtures must sele
 const python = spawnSync("python3", ["differential/python_oracle.py", "differential/fixtures-v0.7.json"], { cwd: repoRoot, encoding: "utf8" });
 assert(python.status === 0, `frozen Python oracle adapter failed: ${python.stderr || python.stdout}`);
 const expected = JSON.parse(python.stdout) as Result[];
-const runners: Record<DifferentialCase["category"], (test: DifferentialCase) => Result> = { topology: runTopology, anum: runAnum, persistence: runPersistence, source: runSource, state: runState, dictionary: runDictionary, selection: runSelection, relation: runRelation, flat: runFlat };
+const runners: Record<DifferentialCase["category"], (test: DifferentialCase) => Result> = { topology: runTopology, anum: runAnum, persistence: runPersistence, source: runSource, state: runState, dictionary: runDictionary, selection: runSelection, relation: runRelation, flat: runFlat, colon: runColon, equality: runEquality };
 const actual = corpus.cases.map((test) => runners[test.category](test));
 assert(expected.length === actual.length, "differential result cardinality mismatch");
 expected.forEach((pythonResult, index) => {

--- a/ts/test/differential.test.ts
+++ b/ts/test/differential.test.ts
@@ -434,7 +434,7 @@ function makeColonFixture(memory: Memory, options: { readonly beforeDictionary?:
   return { fields, effect, roles: roleFixture.roles, interpreter, roleDictionary, last: roleFixture.last };
 }
 function runColon(test: DifferentialCase): Result {
-  const operation = test.input.operation; assert(typeof operation === "string", "colon fixture needs operation"); const memory = new Memory(); let fields: ColonFields; let roles: ColonRoles; let interpreter: LinkHandle; let roleDictionary: LinkHandle; let structuralEventDistinct = false;
+  const operation = test.input.operation; assert(typeof operation === "string", "colon fixture needs operation"); const memory = new Memory(); let fields: ColonFields; let roles: ColonRoles; let interpreter: LinkHandle; let roleDictionary: LinkHandle; let forgedRoleDictionary: LinkHandle | undefined; let structuralEventDistinct = false;
   if (operation === "repeated-event") {
     const content = memory.ensureStartSelfClosed(memory.root); const form = memory.ensureStartSelfClosed(content); const base = defineDictionaryScope(memory, memory.root, memory.root); const first = defineDictionaryEffect(memory, base, memory.root, memory.root, content, form); const fixture = makeColonFixture(memory, { beforeDictionary: first.afterScope, parent: memory.root, historyBefore: first.historyAfter, sourceContent: content, form });
     ({ fields, roles, interpreter, roleDictionary } = fixture); structuralEventDistinct = fixture.effect.occurrence !== first.occurrence;
@@ -448,10 +448,12 @@ function runColon(test: DifferentialCase): Result {
     const fixture = makeColonFixture(memory); ({ fields, roles, interpreter, roleDictionary } = fixture);
     if (operation === "forged-occurrence") fields = Object.freeze({ ...fields, definitionOccurrence: memory.ensureStartSelfClosed(fixture.last) });
     else if (operation === "forged-history") fields = Object.freeze({ ...fields, historyAfter: memory.ensure(memory.ensureStartSelfClosed(fixture.last), fields.definitionOccurrence) });
-    else if (operation === "forged-act") roleDictionary = memory.ensureStartSelfClosed(fixture.last);
+    else if (operation === "forged-act") forgedRoleDictionary = memory.ensureStartSelfClosed(fixture.last);
     else if (operation !== "valid") throw new Error(`unknown colon operation: ${operation}`);
   }
-  const evidence = colonEvidence(memory, fields, roles, interpreter, roleDictionary); const before = memory.linkCount;
+  let evidence = colonEvidence(memory, fields, roles, interpreter, roleDictionary);
+  if (forgedRoleDictionary !== undefined) evidence = Object.freeze({ ...evidence, roleDictionary: forgedRoleDictionary });
+  const before = memory.linkCount;
   try {
     const result = replayColonEffect(memory, evidence); const after = memory.linkCount; const beforeScope = readDictionaryScope(memory, fields.beforeDictionary); const afterScope = readDictionaryScope(memory, fields.afterDictionary); const resolution = lookupScopedDictionary(memory, fields.afterDictionary, fields.sourceContent); const beforeResolution = lookupScopedDictionary(memory, fields.beforeDictionary, fields.sourceContent); const history = memory.poles(fields.historyAfter);
     return { id: test.id, accepted: true, observable: { resultMatchesExpected: result === fields.afterDictionary, occurrenceVisibleAfter: resolution !== undefined && resolution.occurrences.includes(fields.definitionOccurrence), occurrenceInvisibleBefore: beforeResolution === undefined || !beforeResolution.occurrences.includes(fields.definitionOccurrence), parentPreserved: beforeScope.parentScope === afterScope.parentScope, historyAppended: history.start === fields.historyBefore && history.end === fields.definitionOccurrence, structuralEventDistinct, readOnlyCountStable: before === after } };
@@ -471,8 +473,8 @@ function equalityEvidence(memory: Memory, roles: EqualityRoles, interpreter: Lin
   return Object.freeze({ act, roles, interpreter, roleDictionary });
 }
 function runEquality(test: DifferentialCase): Result {
-  const operation = test.input.operation; assert(typeof operation === "string", "equality fixture needs operation"); const memory = new Memory(); const base = anchorChain(memory, memory.root, 7); let cursor = base.last; const [parent, current, originalLeft, originalRight, representative, interpreter, originalRoleDictionary] = base.refs; assert(parent && current && originalLeft && originalRight && representative && interpreter && originalRoleDictionary, "equality refs");
-  const context = defineContext(memory, parent, current); let left = originalLeft; let right = originalRight; let leftRepresentative = left; let rightRepresentative = right; let roleDictionary = originalRoleDictionary; let expected = false;
+  const operation = test.input.operation; assert(typeof operation === "string", "equality fixture needs operation"); const memory = new Memory(); const base = anchorChain(memory, memory.root, 7); let cursor = base.last; const [parent, current, originalLeft, originalRight, representative, interpreter, roleDictionary] = base.refs; assert(parent && current && originalLeft && originalRight && representative && interpreter && roleDictionary, "equality refs");
+  const context = defineContext(memory, parent, current); let left = originalLeft; let right = originalRight; let leftRepresentative = left; let rightRepresentative = right; let forgedRoleDictionary: LinkHandle | undefined; let expected = false;
   if (operation === "identical") { right = left; rightRepresentative = left; expected = true; }
   else if (operation === "distinct") {}
   else if (operation === "shared-representative") { defineLocalRepresentativeBinding(memory, context, left, representative); defineLocalRepresentativeBinding(memory, context, right, representative); leftRepresentative = representative; rightRepresentative = representative; expected = true; }
@@ -480,8 +482,11 @@ function runEquality(test: DifferentialCase): Result {
   else if (operation === "non-transitive") { defineLocalRepresentativeBinding(memory, context, left, right); defineLocalRepresentativeBinding(memory, context, right, representative); leftRepresentative = right; rightRepresentative = representative; expected = false; }
   else if (operation === "conflict") { defineLocalRepresentativeBinding(memory, context, left, right); defineLocalRepresentativeBinding(memory, context, left, representative); leftRepresentative = right; }
   else if (operation === "forged-representative") { leftRepresentative = representative; }
-  else if (operation !== "forged-act") throw new Error(`unknown equality operation: ${operation}`);
-  const roleFixture = equalityRoles(memory, cursor); cursor = roleFixture.last; if (operation === "forged-act") roleDictionary = memory.ensureStartSelfClosed(cursor); const evidence = equalityEvidence(memory, roleFixture.roles, interpreter, roleDictionary, context, left, right, leftRepresentative, rightRepresentative); const before = memory.linkCount;
+  else if (operation === "forged-act") forgedRoleDictionary = memory.ensureStartSelfClosed(cursor);
+  else throw new Error(`unknown equality operation: ${operation}`);
+  const roleFixture = equalityRoles(memory, cursor); cursor = roleFixture.last; let evidence = equalityEvidence(memory, roleFixture.roles, interpreter, roleDictionary, context, left, right, leftRepresentative, rightRepresentative);
+  if (forgedRoleDictionary !== undefined) evidence = Object.freeze({ ...evidence, roleDictionary: forgedRoleDictionary });
+  const before = memory.linkCount;
   try {
     const equal = replayEqualityEvaluation(memory, evidence); const after = memory.linkCount;
     return { id: test.id, accepted: true, observable: { equal, resultMatchesExpected: equal === expected, readOnlyCountStable: before === after } };


### PR DESCRIPTION
Closes #525

Расширяет существующий M10 differential harness на следующий interpreter slice без изменения production semantic core:

- persistent colon (`:`) dictionary-effect replay;
- repeated definition как отдельный structural history event;
- colon conflict и forged occurrence/history/Act evidence;
- local equality (`=`) для identical/distinct/shared representative;
- exact one-hop и deliberate non-transitive representative semantics;
- representative conflict и forged representative/Act evidence;
- exact normalized frozen Python v0.7 ↔ TypeScript comparison;
- read-only link-count stability.

Source subselection/continuation остаётся за пределами этого slice.