### PR TITLE
TypeScript: align root-opening restoration with frozen Python

### DIFF
--- a/ts/src/sequence.ts
+++ b/ts/src/sequence.ts
@@ -70,15 +70,15 @@ export function replayRootOpeningRestoration(
   validateInputs(memory, forms, openForm, closeForm);
   if (forms.length === 0 || forms[0] !== openForm) return forms;
 
+  // Frozen v0.7 restores only an overall delimiter deficit. A temporary prefix
+  // deficit compensated by later opens stays malformed for grouping to reject.
   let balance = 0;
-  let minimum = 0;
   for (const form of forms) {
     if (form === openForm) balance += 1;
     else if (form === closeForm) balance -= 1;
-    minimum = Math.min(minimum, balance);
   }
-  const result = minimum < 0
-    ? Object.freeze([...Array<LinkHandle>(-minimum).fill(openForm), ...forms])
+  const result = balance < 0
+    ? Object.freeze([...Array<LinkHandle>(-balance).fill(openForm), ...forms])
     : forms;
   if (memory.linkCount !== before) invalid();
   return result;

--- a/ts/test/sequence-grouping.test.ts
+++ b/ts/test/sequence-grouping.test.ts
@@ -94,6 +94,16 @@ function group(item: SequenceItem | undefined, length: number, message: string):
   same(deficit[0], open, "restored repeated opening");
   same(deficit[1], open, "original opening retained");
 
+  // Frozen Python restores only a final close/open deficit. A temporary prefix
+  // deficit that is compensated later must remain malformed for grouping to reject.
+  const recoveredPrefixDeficit = [open, close, close, open] as const;
+  same(
+    replayRootOpeningRestoration(m, recoveredPrefixDeficit, open, close),
+    recoveredPrefixDeficit,
+    "recovered prefix deficit must remain unchanged",
+  );
+  reject(() => replayResolvedSequenceGrouping(m, recoveredPrefixDeficit, open, close));
+
   const ineligible = [a, close] as const;
   same(replayRootOpeningRestoration(m, ineligible, open, close), ineligible, "non-leading open unchanged");
   same(m.linkCount, before, "restoration must be read-only");


### PR DESCRIPTION
Closes #531

Исправляет обнаруженный при M10-аудите semantic parity gap в TypeScript root-opening restoration.

- regression-first фиксирует recovered prefix deficit `[open, close, close, open]`;
- restoration теперь использует final exact open/close balance, как frozen Python v0.7;
- temporary prefix deficit, компенсированный поздним `open`, не превращается в валидную grouping sequence;
- malformed unchanged sequence остаётся fail-closed на grouping;
- read-only invariant сохраняется.

Python oracle, contracts, docs и differential harness не меняются. Следующий M10 slice добавит sequence grouping differential уже поверх исправленного production TS.