### PR TITLE
TypeScript: verify exact sequence materialization effects

### DIFF
--- a/ts/src/memory.ts
+++ b/ts/src/memory.ts
@@ -24,6 +24,15 @@ export interface ReadMemory {
 }
 
 /**
+ * Narrow opt-in capability for replay that must prove an exact append-only
+ * before→after effect. The returned position is checker bookkeeping only: it
+ * never participates in semantic Link identity or ordered-pair canonicality.
+ */
+export interface AppendOnlyReadMemory extends ReadMemory {
+  issuanceIndex(link: LinkHandle): number;
+}
+
+/**
  * Narrow opt-in capability for operations whose accepted result is the whole
  * selected memory (for example an explicit all-links wildcard). Ordinary
  * replay/checkers should continue to depend on ReadMemory only.
@@ -51,7 +60,7 @@ export class MemoryError extends Error {
   override readonly name = "MemoryError";
 }
 
-export class Memory implements WriteMemory, EnumerableReadMemory {
+export class Memory implements WriteMemory, AppendOnlyReadMemory, EnumerableReadMemory {
   private readonly owner = Symbol("mts.memory.owner");
   private readonly handles: InternalHandle[] = [];
   private readonly links: LinkPoles[] = [];
@@ -151,6 +160,10 @@ export class Memory implements WriteMemory, EnumerableReadMemory {
   incoming(end: LinkHandle): readonly LinkHandle[] {
     const canonicalEnd = this.requireHandle(end);
     return [...(this.incomingIndex.get(canonicalEnd) ?? [])];
+  }
+
+  issuanceIndex(link: LinkHandle): number {
+    return this.requireHandle(link).slot;
   }
 
   allLinks(): readonly LinkHandle[] {

--- a/ts/src/sequence.ts
+++ b/ts/src/sequence.ts
@@ -1,4 +1,4 @@
-import type { LinkHandle, ReadMemory, WriteMemory } from "./memory.js";
+import type { AppendOnlyReadMemory, LinkHandle, ReadMemory, WriteMemory } from "./memory.js";
 
 export type SequenceItem =
   | { readonly kind: "atom"; readonly value: LinkHandle }
@@ -58,6 +58,12 @@ function validateDescription(memory: ReadMemory, description: SequenceDescriptio
     }
   };
   visit(description.items);
+}
+
+function appendOnlyReplayMemory(memory: ReadMemory): AppendOnlyReadMemory {
+  const candidate = memory as Partial<AppendOnlyReadMemory>;
+  if (typeof candidate.issuanceIndex !== "function") invalid();
+  return memory as AppendOnlyReadMemory;
 }
 
 export function replayRootOpeningRestoration(
@@ -178,9 +184,22 @@ export function replaySequenceMaterialization(
   memory: ReadMemory,
   effect: SequenceMaterializationEffect,
 ): LinkHandle {
+  const replayMemory = appendOnlyReplayMemory(memory);
   const before = memory.linkCount;
   validateDescription(memory, effect.description);
-  const required = new Set<LinkHandle>();
+  if (
+    !Number.isInteger(effect.linkCountBefore)
+    || !Number.isInteger(effect.linkCountAfter)
+    || effect.linkCountBefore < 0
+    || effect.linkCountAfter < effect.linkCountBefore
+    || effect.linkCountAfter !== memory.linkCount
+    || effect.linkCountAfter !== effect.linkCountBefore + effect.created.length
+  ) invalid();
+
+  // The mutable host already contains the after-state. Append-order is used only
+  // to reconstruct the exact write interval; it never changes semantic identity.
+  const firstCreatedUses: LinkHandle[] = [];
+  const seenCreatedUses = new Set<LinkHandle>();
   const collect = (items: readonly SequenceItem[]): LinkHandle => {
     const values = items.map((item) => item.kind === "atom" ? item.value : collect(item.items));
     if (values.length === 0) return memory.root;
@@ -188,24 +207,31 @@ export function replaySequenceMaterialization(
     for (let index = 1; index < values.length; index += 1) {
       const ref = memory.find(result, values[index]!);
       if (ref === undefined) invalid();
-      required.add(ref);
+      const issued = replayMemory.issuanceIndex(ref);
+      if (issued >= effect.linkCountAfter) invalid();
+      if (issued >= effect.linkCountBefore && !seenCreatedUses.has(ref)) {
+        seenCreatedUses.add(ref);
+        firstCreatedUses.push(ref);
+      }
       result = ref;
     }
     return result;
   };
   const result = collect(effect.description.items);
   if (result !== effect.result) invalid();
+  if (firstCreatedUses.length !== effect.created.length) invalid();
 
   const seen = new Set<LinkHandle>();
-  for (const edge of effect.created) {
+  for (let index = 0; index < effect.created.length; index += 1) {
+    const edge = effect.created[index]!;
     validateHandle(memory, edge.ref);
-    if (seen.has(edge.ref) || !required.has(edge.ref)) invalid();
+    if (seen.has(edge.ref) || edge.ref !== firstCreatedUses[index]) invalid();
     seen.add(edge.ref);
+    if (replayMemory.issuanceIndex(edge.ref) !== effect.linkCountBefore + index) invalid();
     const poles = memory.poles(edge.ref);
     if (poles.start !== edge.start || poles.end !== edge.end) invalid();
     if (memory.find(edge.start, edge.end) !== edge.ref) invalid();
   }
-  if (effect.linkCountAfter !== effect.linkCountBefore + effect.created.length) invalid();
   if (memory.linkCount !== before) invalid();
   return result;
 }

--- a/ts/test/sequence-materialization.test.ts
+++ b/ts/test/sequence-materialization.test.ts
@@ -146,6 +146,27 @@ const description = (memory: Memory, ...items: SequenceItem[]): SequenceDescript
 
 {
   const m = new Memory();
+  const [a, b, c] = anchors(m, 3);
+  assert(a && b && c, "exact effect refs");
+  const effect = materializeSequence(m, description(m, atom(a), atom(b), atom(c)));
+  same(effect.created.length, 2, "exact effect creates two folds");
+
+  const omitted = Object.freeze({
+    ...effect,
+    created: Object.freeze([]),
+    linkCountAfter: effect.linkCountBefore,
+  });
+  reject(() => replaySequenceMaterialization(m, omitted));
+
+  const reordered = Object.freeze({
+    ...effect,
+    created: Object.freeze([...effect.created].reverse()),
+  });
+  reject(() => replaySequenceMaterialization(m, reordered));
+}
+
+{
+  const m = new Memory();
   const [a, b] = anchors(m, 2);
   assert(a && b, "missing pair refs");
   const fake: SequenceMaterializationEffect = Object.freeze({

--- a/ts/test/sequence-materialization.test.ts
+++ b/ts/test/sequence-materialization.test.ts
@@ -1,4 +1,4 @@
-import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
+import { Memory, type AppendOnlyReadMemory, type LinkHandle, type LinkPoles } from "../src/memory.js";
 import {
   SequenceReplayError,
   materializeSequence,
@@ -181,12 +181,13 @@ const description = (memory: Memory, ...items: SequenceItem[]): SequenceDescript
   same(m.linkCount, before, "missing replay pair not materialized");
 }
 
-class Probe implements ReadMemory {
-  constructor(private readonly source: ReadMemory) {}
+class Probe implements AppendOnlyReadMemory {
+  constructor(private readonly source: AppendOnlyReadMemory) {}
   get root(): LinkHandle { return this.source.root; }
   get linkCount(): number { return this.source.linkCount; }
   poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
   find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined { return this.source.find(start, end); }
+  issuanceIndex(link: LinkHandle): number { return this.source.issuanceIndex(link); }
   outgoing(): readonly LinkHandle[] { throw new Error("materialization replay must not scan outgoing"); }
   incoming(): readonly LinkHandle[] { throw new Error("materialization replay must not scan incoming"); }
 }


### PR DESCRIPTION
Closes #535

Исправляет найденный после M10h parity defect в trusted sequence materialization replay.

- regression-first: omitted `created` evidence теперь reject;
- regression-first: reordered `created` evidence теперь reject;
- replay привязан к exact `linkCountAfter` текущей after-memory;
- ordered first-created fold uses должны точно совпадать с `created`;
- каждый created ref обязан находиться в записанном append interval;
- private LinkHandle slot не раскрывается: введена узкая `AppendOnlyReadMemory.issuanceIndex()` capability только для checker bookkeeping;
- replay остаётся read-only и не сканирует outgoing/incoming;
- empty/singleton/reuse/nested materialization semantics не меняются.

Python oracle, contracts, differential harness, docs и workflows не меняются.