### PR TITLE
TypeScript: M11a browser-target core bundle gate

### DIFF
--- a/ts/browser/core-smoke.ts
+++ b/ts/browser/core-smoke.ts
@@ -1,0 +1,59 @@
+import { Memory, ensureRootBasis } from "../src/memory.js";
+import {
+  deserializeAnum,
+  normalizeRawForm,
+  parseRawQuaternary,
+  symbolicStackAlgebra,
+} from "../src/anum.js";
+import {
+  PersistentStore,
+  type PersistentTopologyBackend,
+  type StoredDataset,
+} from "../src/persistent-store.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`browser-core-smoke: ${message}`);
+}
+
+// Этот entry намеренно browser-neutral: только global ECMAScript и production TS core.
+// Если import graph случайно потянет NodeJsonFileBackend/node:fs, esbuild platform=browser
+// должен упасть ещё до выполнения этих проверок.
+const memory = new Memory();
+const { R, O, C, L, U } = ensureRootBasis(memory);
+assert(memory.root === R, "root basis must reuse Memory.root");
+assert(memory.find(O, C) === L, "O⟼C must resolve canonical L");
+assert(memory.find(C, O) === U, "C⟼O must resolve canonical U");
+const beforeReuse = memory.linkCount;
+assert(memory.ensure(O, C) === L, "same ordered pair must reuse L");
+assert(memory.linkCount === beforeReuse, "canonical pair reuse must not grow Memory");
+
+const form = parseRawQuaternary("[10]");
+assert(normalizeRawForm(form) === "[10]", "raw ANUM parsing must be shared with Node tests");
+const denotation = deserializeAnum(form, symbolicStackAlgebra);
+assert(denotation.operations.join(",") === "OPEN,VALUE,VALUE,CLOSE", "ANUM stack operations must match accepted traversal");
+
+class BrowserMemoryBackend implements PersistentTopologyBackend {
+  private dataset: StoredDataset | undefined;
+
+  load(): StoredDataset | undefined {
+    return this.dataset === undefined
+      ? undefined
+      : JSON.parse(JSON.stringify(this.dataset)) as StoredDataset;
+  }
+
+  commit(dataset: StoredDataset): void {
+    this.dataset = JSON.parse(JSON.stringify(dataset)) as StoredDataset;
+  }
+}
+
+const store = PersistentStore.create(new BrowserMemoryBackend(), "browser-smoke");
+const persistentRoot = store.root;
+const persistentOpening = store.materializeStartSelfClosed(persistentRoot);
+const persistentClosing = store.materializeEndSelfClosed(persistentRoot);
+const persistentLinked = store.materialize(persistentOpening, persistentClosing);
+assert(store.find(persistentOpening, persistentClosing)?.local === persistentLinked.local, "storage-neutral persistent pair lookup must work in browser target");
+const runtime = store.runtimeMemory();
+assert(runtime.linkCount === store.count, "storage-neutral persistence must reconstruct the same core Memory topology");
+
+// Node executes the browser-target bundle as a deterministic CI smoke after esbuild has
+// already proved that the import graph is browser-resolvable. No DOM semantics are added.

--- a/ts/package.json
+++ b/ts/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
+    "browser:check": "esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && node dist/browser/core-smoke.js",
     "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js && node dist/test/differential.test.js && node dist/test/sequence-differential.test.js && node dist/test/materialization-differential.test.js && node dist/test/direct-deixis-differential.test.js && node dist/test/value-bundle-differential.test.js && node dist/test/run-differential.test.js && node dist/test/proof-differential.test.js && node dist/test/checker-differential.test.js && node dist/test/persistence-differential.test.js && node dist/test/persistent-sequence-differential.test.js",
-    "check": "npm run typecheck && npm test"
+    "check": "npm run typecheck && npm test && npm run browser:check"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "esbuild": "0.25.0",
     "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
Closes #553

Добавляет первый M11 browser-integration gate без UI и без IndexedDB.

- `ts/browser/core-smoke.ts` импортирует production Memory, ANUM и storage-neutral PersistentStore;
- `esbuild --platform=browser --format=esm` обязан собрать import graph без Node builtins;
- bundle затем выполняет deterministic R/O/C/L/U, canonical-pair, ANUM и persistent-topology smoke;
- Node-only `node-json-backend.ts` не импортируется;
- существующие Node/unit/differential suites остаются mandatory и выполняются до browser gate;
- production `ts/src/**`, Python oracle, contracts/docs/workflows не меняются.

Репозиторий ранее не имел package-lock, поэтому M11a сохраняет существующую npm-модель и pin'ит esbuild непосредственно в package.json.