### PR TITLE
TypeScript: M11b async IndexedDB checkpoint repository

### DIFF
--- a/ts/browser/indexeddb-dataset-repository.test.ts
+++ b/ts/browser/indexeddb-dataset-repository.test.ts
@@ -1,0 +1,107 @@
+import { IDBFactory } from "fake-indexeddb";
+import {
+  PersistentStore,
+  PersistentStoreError,
+  type PersistentTopologyBackend,
+  type StoredDataset,
+} from "../src/persistent-store.js";
+import {
+  IndexedDbDatasetRepository,
+  IndexedDbDatasetRepositoryError,
+} from "./indexeddb-dataset-repository.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`indexeddb-dataset-repository: ${message}`);
+}
+
+function clone(dataset: StoredDataset): StoredDataset {
+  return structuredClone(dataset);
+}
+
+class SnapshotBackend implements PersistentTopologyBackend {
+  constructor(private dataset: StoredDataset | undefined) {}
+
+  load(): StoredDataset | undefined {
+    return this.dataset === undefined ? undefined : clone(this.dataset);
+  }
+
+  commit(dataset: StoredDataset): void {
+    this.dataset = clone(dataset);
+  }
+}
+
+function makeDataset(): StoredDataset {
+  const backend = new SnapshotBackend(undefined);
+  const store = PersistentStore.create(backend, "browser-lineage");
+  const root = store.root;
+  const opening = store.materializeStartSelfClosed(root);
+  const closing = store.materializeEndSelfClosed(root);
+  store.materialize(opening, closing);
+  return store.snapshot();
+}
+
+async function main(): Promise<void> {
+  const factory = new IDBFactory();
+  const first = new IndexedDbDatasetRepository("mts-browser-test", factory);
+  assert(await first.load() === undefined, "fresh database must not invent a dataset");
+
+  const original = makeDataset();
+  await first.save(original);
+
+  // A new repository instance must observe only the transaction-completed checkpoint.
+  const reopenedRepository = new IndexedDbDatasetRepository("mts-browser-test", factory);
+  const loaded = await reopenedRepository.load();
+  assert(loaded !== undefined, "committed dataset must survive repository reopen");
+  assert(loaded !== original, "IndexedDB load must return detached structured data");
+  assert(JSON.stringify(loaded) === JSON.stringify(original), "checkpoint payload must round-trip exactly");
+
+  // Existing PersistentStore remains the semantic validator/runtime after async load.
+  const reopenedStore = PersistentStore.open(new SnapshotBackend(loaded));
+  assert(reopenedStore.count === original.topology.links.length, "reloaded topology count must validate");
+  const root = reopenedStore.root;
+  const opening = reopenedStore.allLinks()[1];
+  const closing = reopenedStore.allLinks()[2];
+  assert(opening !== undefined && closing !== undefined, "basis coordinates must survive checkpoint");
+  const loop = reopenedStore.materialize(opening, opening);
+  const updated = reopenedStore.snapshot();
+  assert(loop.local === original.topology.links.length, "new semantic link must append after loaded checkpoint");
+
+  await reopenedRepository.save(updated);
+  const secondLoad = await first.load();
+  assert(secondLoad !== undefined, "overwritten checkpoint must remain readable");
+  assert(secondLoad.topology.links.length === updated.topology.links.length, "save must replace current checkpoint atomically");
+
+  // The repository stores bytes/records; semantic fail-closed validation remains owned
+  // by PersistentStore. A corrupt checkpoint may be physically read but cannot open.
+  const malformed = {
+    schema: "mts-persistent-dataset/v0.1",
+    lineage: "bad",
+    topology: {
+      schema: "mts-storage-topology/v0.1",
+      root: 0,
+      links: [[0, 0], [1, 1]],
+    },
+  } as unknown as StoredDataset;
+  await reopenedRepository.save(malformed);
+  const corrupt = await first.load();
+  assert(corrupt !== undefined, "physically stored malformed checkpoint must be observable at storage boundary");
+  let rejected = false;
+  try {
+    PersistentStore.open(new SnapshotBackend(corrupt));
+  } catch (error) {
+    assert(error instanceof PersistentStoreError, "malformed checkpoint must fail through semantic persistence validator");
+    rejected = true;
+  }
+  assert(rejected, "malformed checkpoint must never become an opened PersistentStore");
+
+  let invalidNameRejected = false;
+  try {
+    new IndexedDbDatasetRepository("", factory);
+  } catch (error) {
+    assert(error instanceof IndexedDbDatasetRepositoryError, "invalid name must use repository error type");
+    invalidNameRejected = true;
+  }
+  assert(invalidNameRejected, "empty IndexedDB database name must reject");
+}
+
+await main();

--- a/ts/browser/indexeddb-dataset-repository.ts
+++ b/ts/browser/indexeddb-dataset-repository.ts
@@ -1,0 +1,120 @@
+import type { StoredDataset } from "../src/persistent-store.js";
+
+const DATABASE_VERSION = 1;
+const DATASET_STORE = "datasets";
+const CURRENT_DATASET_KEY = "current";
+
+export class IndexedDbDatasetRepositoryError extends Error {
+  override readonly name = "IndexedDbDatasetRepositoryError";
+}
+
+function failure(message: string, cause?: unknown): IndexedDbDatasetRepositoryError {
+  return new IndexedDbDatasetRepositoryError(
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function requestResult<T>(request: IDBRequest<T>, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(failure(message, request.error));
+  });
+}
+
+function transactionCompletion(transaction: IDBTransaction, message: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(failure(message, transaction.error));
+    transaction.onerror = () => {
+      // `abort` is the authoritative terminal event; assigning this handler also
+      // prevents an IndexedDB implementation from surfacing an unhandled error.
+    };
+  });
+}
+
+/**
+ * Browser-only durable repository for one complete persistent dataset checkpoint.
+ *
+ * It intentionally does not implement `PersistentTopologyBackend`: that interface
+ * is synchronous, while IndexedDB durability is only known after a transaction's
+ * asynchronous `complete` event. Browser orchestration must explicitly await
+ * `load()` / `save()` and may then use the unchanged synchronous PersistentStore
+ * against an in-memory backend for semantic operations.
+ */
+export class IndexedDbDatasetRepository {
+  constructor(
+    readonly databaseName: string,
+    private readonly factory: IDBFactory = indexedDB,
+  ) {
+    if (typeof databaseName !== "string" || databaseName.length === 0) {
+      throw failure("invalid IndexedDB database name");
+    }
+  }
+
+  async load(): Promise<StoredDataset | undefined> {
+    const database = await this.open();
+    try {
+      const transaction = database.transaction(DATASET_STORE, "readonly");
+      const completed = transactionCompletion(
+        transaction,
+        "cannot complete IndexedDB dataset read",
+      );
+      const value = await requestResult<unknown>(
+        transaction.objectStore(DATASET_STORE).get(CURRENT_DATASET_KEY),
+        "cannot read IndexedDB dataset",
+      );
+      await completed;
+      return value === undefined ? undefined : value as StoredDataset;
+    } finally {
+      database.close();
+    }
+  }
+
+  async save(dataset: StoredDataset): Promise<void> {
+    const database = await this.open();
+    try {
+      const transaction = database.transaction(DATASET_STORE, "readwrite");
+      const completed = transactionCompletion(
+        transaction,
+        "cannot commit IndexedDB dataset",
+      );
+      const request = transaction.objectStore(DATASET_STORE).put(
+        dataset,
+        CURRENT_DATASET_KEY,
+      );
+      await requestResult(request, "cannot write IndexedDB dataset");
+      // Request success is not durability. Only transaction completion publishes
+      // a successful save to callers.
+      await completed;
+    } finally {
+      database.close();
+    }
+  }
+
+  private open(): Promise<IDBDatabase> {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+      let request: IDBOpenDBRequest;
+      try {
+        request = this.factory.open(this.databaseName, DATABASE_VERSION);
+      } catch (error) {
+        reject(failure("cannot open IndexedDB dataset database", error));
+        return;
+      }
+
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(DATASET_STORE)) {
+          database.createObjectStore(DATASET_STORE);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(
+        failure("cannot open IndexedDB dataset database", request.error),
+      );
+      request.onblocked = () => reject(
+        failure("IndexedDB dataset database upgrade is blocked"),
+      );
+    });
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -5,13 +5,15 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "browser:check": "esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && node dist/browser/core-smoke.js",
+    "browser:typecheck": "tsc -p tsconfig.browser.json",
+    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
     "test": "npm run build && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js && node dist/test/differential.test.js && node dist/test/sequence-differential.test.js && node dist/test/materialization-differential.test.js && node dist/test/direct-deixis-differential.test.js && node dist/test/value-bundle-differential.test.js && node dist/test/run-differential.test.js && node dist/test/proof-differential.test.js && node dist/test/checker-differential.test.js && node dist/test/persistence-differential.test.js && node dist/test/persistent-sequence-differential.test.js",
     "check": "npm run typecheck && npm test && npm run browser:check"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
     "esbuild": "0.25.0",
+    "fake-indexeddb": "6.2.5",
     "typescript": "5.9.3"
   }
 }

--- a/ts/tsconfig.browser.json
+++ b/ts/tsconfig.browser.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "browser/core-smoke.ts",
+    "browser/indexeddb-dataset-repository.ts",
+    "browser/indexeddb-dataset-repository.test.ts"
+  ]
+}


### PR DESCRIPTION
Closes #555

Добавляет browser-only async persistence boundary без изменения synchronous PersistentStore semantics.

- `IndexedDbDatasetRepository` использует только стандартный `IDBFactory` и `await load()/save()` для whole-dataset checkpoints;
- класс намеренно НЕ implements `PersistentTopologyBackend`: IndexedDB transaction completion асинхронен, поэтому подделывать synchronous commit было бы ослаблением уже принятой atomicity;
- `save()` резолвится только после transaction `complete`;
- новый `tsconfig.browser.json` typecheck'ит browser graph с DOM libs и без Node ambient types;
- functional test через injected fake IndexedDB проверяет fresh/load/save/reopen/overwrite и validation через существующий `PersistentStore.open`;
- malformed physically stored checkpoint остаётся fail-closed на semantic persistence boundary;
- browser bundle отдельно собирает IndexedDB adapter с `--platform=browser`;
- production `ts/src/**`, Python oracle, contracts/docs/workflows не меняются.

`fake-indexeddb` используется только в тесте как implementation стандартного IndexedDB API; production adapter не зависит от wrapper-library.