### PR TITLE
TypeScript: M12b compressed replay/proof/checker API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -56,3 +56,100 @@ export type {
   PersistentSequenceItem,
   PersistentSequenceMaterialization,
 } from "./persistent-sequence.js";
+
+// M12b exports only operations that are meaningful at the consumer boundary.
+// The role schemas they verify remain implementation vocabulary rather than
+// standalone package entrypoints; callers use the top-level evidence shapes.
+export {
+  InterpreterReplayError,
+  replayColonEffect,
+  replayEqualityEvaluation,
+  replayFlatReading,
+  replayFlatSubselectionContinuation,
+  replayFlatSubselectionReading,
+  replayRelationStep,
+  replayRelationSubselectionStep,
+} from "./interpreter.js";
+export type {
+  ColonReplayEvidence,
+  EqualityReplayEvidence,
+  FlatReadingEvidence,
+  RelationReplayEvidence,
+} from "./interpreter.js";
+
+export {
+  SequenceReplayError,
+  materializeSequence,
+  replayResolvedSequenceGrouping,
+  replayRootOpeningRestoration,
+  replaySequenceMaterialization,
+} from "./sequence.js";
+export type {
+  MaterializedEdge,
+  SequenceDescription,
+  SequenceItem,
+  SequenceMaterializationEffect,
+} from "./sequence.js";
+
+export {
+  DirectDeixisReplayError,
+  analyzeDirectDeixisCarrier,
+} from "./direct-deixis.js";
+export type {
+  DeicticOccurrence,
+  DeicticPole,
+  DirectDeixisVocabulary,
+} from "./direct-deixis.js";
+
+export {
+  BUNDLE_KIND_ORDER,
+  BundleElaborationError,
+  ValueBundleReplayError,
+  bundleRoleAt,
+  elaborateBundleRoles,
+  resolveFlatBundle,
+  valuesEqual,
+} from "./value-bundle.js";
+export type {
+  BundleElaboration,
+  BundleNodeKind,
+  BundleRole,
+  BundleRoleAt,
+  BundleValue,
+  ExpectedRole,
+  LinkValue,
+  MtsValue,
+  OccurrencePath,
+  ResolvedOccurrence,
+  ValueBundleVocabulary,
+} from "./value-bundle.js";
+
+export {
+  RunReplayError,
+  replayRun,
+} from "./run.js";
+export type {
+  RunEvidence,
+  RunReplayErrorCode,
+  RunStepSelection,
+} from "./run.js";
+
+export {
+  ProofRuleReplayError,
+  replayDecomposeEqualRelations,
+} from "./proof.js";
+export type {
+  DecomposeEqualityEvidence,
+  ProofRuleReplayErrorCode,
+} from "./proof.js";
+
+export {
+  IntegratedCheckerError,
+  replayIntegratedProof,
+} from "./checker.js";
+export type {
+  IntegratedCheckerErrorCode,
+  IntegratedProofEvidence,
+  ProofGoalSelection,
+  ProofJudgmentSelection,
+} from "./checker.js";

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -1,36 +1,81 @@
 import * as publicApi from "../src/public.js";
 import type {
   AnumForm,
+  DecomposeEqualityEvidence,
+  DirectDeixisVocabulary,
+  IntegratedProofEvidence,
   LinkHandle,
+  MtsValue,
   PersistentSequenceDescription,
   PersistentTopologyBackend,
   ReadMemory,
+  RelationReplayEvidence,
+  RunEvidence,
+  SequenceDescription,
   StackAlgebra,
   StoredDataset,
   WriteMemory,
 } from "../src/public.js";
+
+// These capabilities and implementation vocabularies are deliberately not part
+// of the package root. If one leaks into public.ts, the now-unused directive
+// makes typecheck fail instead of silently widening the API.
+// @ts-expect-error M12 keeps append-order replay capability internal.
+import type { AppendOnlyReadMemory } from "../src/public.js";
+// @ts-expect-error M12 keeps topology enumeration capability internal.
+import type { EnumerableReadMemory } from "../src/public.js";
+// @ts-expect-error Consumers use RelationReplayEvidence, not standalone role plumbing.
+import type { RelationRoles } from "../src/public.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`public-api: ${message}`);
 }
 
 const expectedRuntimeExports = [
+  "BUNDLE_KIND_ORDER",
+  "BundleElaborationError",
+  "DirectDeixisReplayError",
   "IncrementalQuaternaryDecoder",
+  "IntegratedCheckerError",
+  "InterpreterReplayError",
   "Memory",
   "MemoryError",
   "PersistentStore",
   "PersistentStoreError",
+  "ProofRuleReplayError",
   "QuaternaryDecodeError",
+  "RunReplayError",
+  "SequenceReplayError",
   "StreamError",
+  "ValueBundleReplayError",
+  "analyzeDirectDeixisCarrier",
+  "bundleRoleAt",
   "deserializeAnum",
   "deserializeStream",
+  "elaborateBundleRoles",
   "ensureRootBasis",
   "executeAbits",
   "materializePersistentSequence",
+  "materializeSequence",
   "normalizeRawForm",
   "parseRawQuaternary",
+  "replayColonEffect",
+  "replayDecomposeEqualRelations",
+  "replayEqualityEvaluation",
+  "replayFlatReading",
+  "replayFlatSubselectionContinuation",
+  "replayFlatSubselectionReading",
+  "replayIntegratedProof",
   "replayPersistentSequenceMaterialization",
+  "replayRelationStep",
+  "replayRelationSubselectionStep",
+  "replayResolvedSequenceGrouping",
+  "replayRootOpeningRestoration",
+  "replayRun",
+  "replaySequenceMaterialization",
+  "resolveFlatBundle",
   "symbolicStackAlgebra",
+  "valuesEqual",
 ].sort();
 
 assert(
@@ -38,8 +83,9 @@ assert(
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
 );
 
-// Compile-time smoke for the intended consumer types. White-box capabilities and
-// role/evidence plumbing intentionally remain available only from internal modules.
+// Compile-time smoke for the intended consumer concepts. The top-level evidence
+// shapes are public because callers must provide them, while their nested role
+// schemas are intentionally not separate package-root vocabulary.
 const read: ReadMemory | undefined = undefined;
 const write: WriteMemory | undefined = undefined;
 const link: LinkHandle | undefined = undefined;
@@ -47,5 +93,28 @@ const form: AnumForm | undefined = undefined;
 const algebra: StackAlgebra<string> | undefined = undefined;
 const backend: PersistentTopologyBackend | undefined = undefined;
 const dataset: StoredDataset | undefined = undefined;
-const sequence: PersistentSequenceDescription | undefined = undefined;
-void [read, write, link, form, algebra, backend, dataset, sequence];
+const persistentSequence: PersistentSequenceDescription | undefined = undefined;
+const sequence: SequenceDescription | undefined = undefined;
+const relation: RelationReplayEvidence | undefined = undefined;
+const deixis: DirectDeixisVocabulary | undefined = undefined;
+const value: MtsValue | undefined = undefined;
+const run: RunEvidence | undefined = undefined;
+const proof: DecomposeEqualityEvidence | undefined = undefined;
+const integrated: IntegratedProofEvidence | undefined = undefined;
+void [
+  read,
+  write,
+  link,
+  form,
+  algebra,
+  backend,
+  dataset,
+  persistentSequence,
+  sequence,
+  relation,
+  deixis,
+  value,
+  run,
+  proof,
+  integrated,
+];


### PR DESCRIPTION
Closes #559

Завершает второй auditable slice M12 public API compression без изменения semantic implementations.

- расширяет единый `ts/src/public.ts` selected replay/materialization/Direct Deixis/ValueBundle/Run/proof/checker entrypoints;
- экспортирует только top-level consumer evidence/result/error types, но не отдельные `*Roles` vocabularies;
- `AppendOnlyReadMemory` и `EnumerableReadMemory` остаются internal capabilities;
- `expandResolvedBundleQuery` намеренно не входит в package root, потому что его текущая сигнатура требует internal `EnumerableReadMemory`;
- `BUNDLE_KIND_ORDER` экспортируется вместе с `ValueBundleVocabulary`, поскольку порядок `kindTags` является частью необходимого consumer construction contract;
- exact runtime allowlist расширен и по-прежнему veto'ит accidental API growth;
- compile-time negative guards фиксируют, что internal memory capabilities и `RelationRoles` не утекли в package root.

Production semantic modules, Python oracle, contracts и workflows не меняются. M13/cutover в этот PR не входит.