### PR TITLE
TypeScript: preserve converter/CLI tooling before Python removal

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -3,14 +3,19 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./dist/src/public.js"
+    ".": "./dist/src/public.js",
+    "./tooling/payload": "./dist/src/tooling/payload.js",
+    "./tooling/notation": "./dist/src/tooling/notation.js"
+  },
+  "bin": {
+    "mts": "./dist/src/tooling/cli.js"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
     "browser:typecheck": "tsc -p tsconfig.browser.json",
     "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
-    "test": "npm run build && node dist/test/public-api.test.js && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js && node dist/test/differential.test.js && node dist/test/sequence-differential.test.js && node dist/test/materialization-differential.test.js && node dist/test/direct-deixis-differential.test.js && node dist/test/value-bundle-differential.test.js && node dist/test/run-differential.test.js && node dist/test/proof-differential.test.js && node dist/test/checker-differential.test.js && node dist/test/persistence-differential.test.js && node dist/test/persistent-sequence-differential.test.js",
+    "test": "npm run build && node dist/test/public-api.test.js && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js && node dist/test/tooling.test.js && node dist/test/differential.test.js && node dist/test/sequence-differential.test.js && node dist/test/materialization-differential.test.js && node dist/test/direct-deixis-differential.test.js && node dist/test/value-bundle-differential.test.js && node dist/test/run-differential.test.js && node dist/test/proof-differential.test.js && node dist/test/checker-differential.test.js && node dist/test/persistence-differential.test.js && node dist/test/persistent-sequence-differential.test.js",
     "check": "npm run typecheck && npm test && npm run browser:check"
   },
   "devDependencies": {

--- a/ts/src/tooling/cli.ts
+++ b/ts/src/tooling/cli.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import {
+  StreamError,
+  deserializeAnum,
+  normalizeRawForm,
+  parseRawQuaternary,
+  symbolicStackAlgebra,
+} from "../anum.js";
+import { anumToText, textToAnum } from "./payload.js";
+import { asciiToUnicode, unicodeToAscii } from "./notation.js";
+
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function usage(): never {
+  return fail("usage: mts <parse|validate|deserialize|normalize|text-to-anum|anum-to-text|to-ascii|to-unicode> <value-or-file>");
+}
+
+function readAnumFile(path: string): { readonly mode: "quaternary" | "string"; readonly text: string } {
+  const text = readFileSync(path, "utf8");
+  const mode = /^\s*#\s*anum-format:\s*string\b/m.test(text) ? "string" : "quaternary";
+  return { mode, text };
+}
+
+function requireQuaternary(command: string, path: string): string {
+  const source = readAnumFile(path);
+  if (source.mode !== "quaternary") fail(`${command} поддерживает только quaternary *.anum`);
+  return source.text;
+}
+
+function main(argv: readonly string[]): void {
+  const command = argv[0];
+  const value = argv[1];
+  if (!command || value === undefined || argv.length !== 2) usage();
+
+  if (command === "parse") {
+    const source = readAnumFile(value);
+    if (source.mode === "string") {
+      process.stdout.write(`format: string\ntext:\n${source.text.replace(/^\s*#\s*anum-format:\s*string\s*\r?\n/m, "")}\n`);
+      return;
+    }
+    const form = parseRawQuaternary(source.text);
+    process.stdout.write("format: quaternary\ntokens:\n");
+    form.tokens.forEach((token, index) => process.stdout.write(`  ${index}: ${token.abit}\n`));
+    return;
+  }
+
+  if (command === "validate") {
+    const source = requireQuaternary(command, value);
+    try {
+      const form = parseRawQuaternary(source);
+      deserializeAnum(form, symbolicStackAlgebra);
+      process.stdout.write("valid: true\n");
+    } catch (error) {
+      if (error instanceof StreamError) {
+        process.stdout.write(`valid: false\nerror: ${error.code}\n`);
+        return;
+      }
+      throw error;
+    }
+    return;
+  }
+
+  if (command === "deserialize") {
+    const form = parseRawQuaternary(requireQuaternary(command, value));
+    const result = deserializeAnum(form, symbolicStackAlgebra);
+    process.stdout.write(`input: ${normalizeRawForm(form)}\n`);
+    process.stdout.write(`denotation: ${result.denotation}\n`);
+    process.stdout.write(`resolved_values: ${result.resolvedValues.join(" ")}\n`);
+    process.stdout.write(`operations: ${result.operations.join(" ")}\n`);
+    return;
+  }
+
+  if (command === "normalize") {
+    const form = parseRawQuaternary(requireQuaternary(command, value));
+    process.stdout.write(`${normalizeRawForm(form)}\n`);
+    return;
+  }
+
+  if (command === "text-to-anum") {
+    process.stdout.write(`${textToAnum(value)}\n`);
+    return;
+  }
+  if (command === "anum-to-text") {
+    process.stdout.write(`${anumToText(value)}\n`);
+    return;
+  }
+  if (command === "to-ascii") {
+    process.stdout.write(`${unicodeToAscii(value)}\n`);
+    return;
+  }
+  if (command === "to-unicode") {
+    process.stdout.write(`${asciiToUnicode(value)}\n`);
+    return;
+  }
+
+  fail(`invalid choice: ${command}`);
+}
+
+try {
+  main(process.argv.slice(2));
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/ts/src/tooling/notation.ts
+++ b/ts/src/tooling/notation.ts
@@ -1,0 +1,92 @@
+const UNICODE_TO_ASCII = [
+  ["¬⟼", "!->"],
+  ["⟼", "->"],
+  ["≠", "!="],
+  ["¬", "!"],
+  ["♂", "M"],
+  ["♀", "F"],
+  ["∞", "INF"],
+] as const;
+
+const ASCII_SYMBOL_TOKENS = [
+  ["!->", "¬⟼"],
+  ["->", "⟼"],
+  ["!=", "≠"],
+  ["!", "¬"],
+] as const;
+
+const ASCII_WORD_TOKENS = new Map<string, string>([
+  ["INF", "∞"],
+  ["M", "♂"],
+  ["F", "♀"],
+]);
+
+function isWordChar(symbol: string): boolean {
+  return /^[\p{L}\p{N}_]$/u.test(symbol);
+}
+
+function isPlainAlnum(symbol: string): boolean {
+  return /^[\p{L}\p{N}]$/u.test(symbol) && !"♂♀∞⟼¬≠".includes(symbol);
+}
+
+export function unicodeToAscii(formula: string): string {
+  const replacements = new Map<string, string>(UNICODE_TO_ASCII);
+  const patterns = [...replacements.keys()].sort((left, right) => right.length - left.length);
+  const parts: string[] = [];
+
+  for (let index = 0; index < formula.length;) {
+    let token: string | undefined;
+    for (const pattern of patterns) {
+      if (formula.startsWith(pattern, index)) {
+        token = pattern;
+        break;
+      }
+    }
+    const source = token ?? formula[index]!;
+    const replacement = replacements.get(source) ?? source;
+    const previous = parts.at(-1);
+    if (previous && replacement && isPlainAlnum(previous.at(-1)!) && isPlainAlnum(replacement[0]!)) {
+      parts.push(" ");
+    }
+    parts.push(replacement);
+    index += source.length;
+  }
+  return parts.join("");
+}
+
+export function asciiToUnicode(formula: string): string {
+  const result: string[] = [];
+  for (let index = 0; index < formula.length;) {
+    let matched = false;
+    for (const [source, replacement] of ASCII_SYMBOL_TOKENS) {
+      if (formula.startsWith(source, index)) {
+        result.push(replacement);
+        index += source.length;
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+
+    const symbol = formula[index]!;
+    if (isWordChar(symbol)) {
+      let end = index + 1;
+      while (end < formula.length && isWordChar(formula[end]!)) end += 1;
+      const word = formula.slice(index, end);
+      result.push(ASCII_WORD_TOKENS.get(word) ?? word);
+      index = end;
+      continue;
+    }
+    result.push(symbol);
+    index += 1;
+  }
+  return result.join("");
+}
+
+export function abitsToAprover(anum: string): string {
+  return anum;
+}
+
+export function aproverToAbits(anum: string): string {
+  return anum;
+}

--- a/ts/src/tooling/payload.ts
+++ b/ts/src/tooling/payload.ts
@@ -1,0 +1,144 @@
+export interface TextToAnumDetail {
+  readonly char: string;
+  readonly codepoint: string;
+  readonly utf8Bytes: readonly string[];
+  readonly utf8Binary: readonly string[];
+  readonly anum: string;
+}
+
+export interface AnumToTextDetail {
+  readonly anum: string;
+  readonly abits: string;
+  readonly utf8Bytes: readonly string[];
+  readonly codepoint: string;
+  readonly char: string;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+function hexByte(value: number): string {
+  return `0x${value.toString(16).toUpperCase().padStart(2, "0")}`;
+}
+
+function codepoint(value: string): string {
+  const point = value.codePointAt(0);
+  if (point === undefined) throw new Error("empty character");
+  return `U+${point.toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
+export function byteToAbits(value: number): string {
+  if (!Number.isInteger(value) || value < 0 || value > 255) {
+    throw new RangeError(`Ожидается значение байта 0–255, получено: ${String(value)}`);
+  }
+  return value.toString(2).padStart(8, "0");
+}
+
+export function abitsToByte(abits: string): number {
+  if (abits.length !== 8) {
+    throw new RangeError(`Ожидается 8 абитов, получено ${abits.length}: ${JSON.stringify(abits)}`);
+  }
+  if (!/^[01]{8}$/.test(abits)) {
+    throw new RangeError(`Недопустимая абитовая восьмёрка: ${JSON.stringify(abits)}`);
+  }
+  return Number.parseInt(abits, 2);
+}
+
+export function charToAnum(char: string): string {
+  if ([...char].length !== 1) throw new RangeError("Ожидается ровно один Unicode-символ");
+  const bytes = encoder.encode(char);
+  return `[${Array.from(bytes, byteToAbits).join("")}]`;
+}
+
+export function textToAnum(text: string): string {
+  return [...text].map(charToAnum).join("");
+}
+
+export function textToAnumVerbose(text: string): readonly TextToAnumDetail[] {
+  return Object.freeze([...text].map((char) => {
+    const bytes = [...encoder.encode(char)];
+    return Object.freeze({
+      char,
+      codepoint: codepoint(char),
+      utf8Bytes: Object.freeze(bytes.map(hexByte)),
+      utf8Binary: Object.freeze(bytes.map(byteToAbits)),
+      anum: charToAnum(char),
+    });
+  }));
+}
+
+export function extractCharAnums(anum: string): readonly string[] {
+  const groups: string[] = [];
+  let depth = 0;
+  let current = "";
+
+  for (const symbol of anum) {
+    if (symbol === "[") {
+      depth += 1;
+      if (depth > 1) current += symbol;
+      continue;
+    }
+    if (symbol === "]") {
+      depth -= 1;
+      if (depth < 0) throw new RangeError("Лишняя закрывающая скобка ]");
+      if (depth === 0) {
+        groups.push(current);
+        current = "";
+      } else {
+        current += symbol;
+      }
+      continue;
+    }
+    if (symbol === "0" || symbol === "1") {
+      if (depth === 0) throw new RangeError(`Абит ${JSON.stringify(symbol)} вне контекста`);
+      current += symbol;
+      continue;
+    }
+    if (/\s/u.test(symbol)) continue;
+    throw new RangeError(`Недопустимый символ: ${JSON.stringify(symbol)}`);
+  }
+
+  if (depth !== 0) throw new RangeError(`Незакрытые скобки []: глубина = ${depth}`);
+  return Object.freeze(groups);
+}
+
+export function anumToChar(abits: string): string {
+  if (abits.length === 0 || abits.length % 8 !== 0) {
+    throw new RangeError(`Длина абитов (${abits.length}) должна быть ненулевой и кратной 8`);
+  }
+  const bytes: number[] = [];
+  for (let index = 0; index < abits.length; index += 8) {
+    bytes.push(abitsToByte(abits.slice(index, index + 8)));
+  }
+  let value: string;
+  try {
+    value = decoder.decode(Uint8Array.from(bytes));
+  } catch {
+    throw new RangeError("Ачисло символа содержит некорректную UTF-8 последовательность");
+  }
+  if ([...value].length !== 1) {
+    throw new RangeError(`Ожидается ровно один UTF-8 символ, декодировано: ${[...value].length}`);
+  }
+  return value;
+}
+
+export function anumToText(anum: string): string {
+  return extractCharAnums(anum).map(anumToChar).join("");
+}
+
+export function anumToTextVerbose(anum: string): readonly AnumToTextDetail[] {
+  return Object.freeze(extractCharAnums(anum).map((abits) => {
+    const bytes: number[] = [];
+    for (let index = 0; index < abits.length; index += 8) {
+      bytes.push(abitsToByte(abits.slice(index, index + 8)));
+    }
+    const char = anumToChar(abits);
+    return Object.freeze({
+      anum: `[${abits}]`,
+      abits,
+      utf8Bytes: Object.freeze(bytes.map(hexByte)),
+      codepoint: codepoint(char),
+      char,
+    });
+  }));
+}

--- a/ts/test/tooling.test.ts
+++ b/ts/test/tooling.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  abitsToByte,
+  anumToChar,
+  anumToText,
+  anumToTextVerbose,
+  byteToAbits,
+  charToAnum,
+  extractCharAnums,
+  textToAnum,
+  textToAnumVerbose,
+} from "../src/tooling/payload.js";
+import {
+  abitsToAprover,
+  aproverToAbits,
+  asciiToUnicode,
+  unicodeToAscii,
+} from "../src/tooling/notation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function equal<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: expected ${String(expected)}, got ${String(actual)}`);
+}
+function throws(action: () => unknown, message: string): void {
+  let thrown = false;
+  try { action(); } catch { thrown = true; }
+  assert(thrown, message);
+}
+
+for (let value = 0; value <= 255; value += 1) equal(abitsToByte(byteToAbits(value)), value, `byte round-trip ${value}`);
+throws(() => byteToAbits(-1), "negative byte must reject");
+throws(() => byteToAbits(256), "large byte must reject");
+throws(() => byteToAbits(1.5), "non-integer byte must reject");
+throws(() => abitsToByte("101"), "short abit byte must reject");
+throws(() => abitsToByte("101x0101"), "foreign abit must reject");
+
+equal(charToAnum("A").length, 10, "ASCII character width");
+equal(charToAnum("М").length, 18, "Cyrillic character width");
+equal(charToAnum("∞").length, 26, "three-byte character width");
+for (const text of ["", "hello", "МТС", "hello МТС", "♂♀∞→", "0123456789", "hello, world!"]) {
+  equal(anumToText(textToAnum(text)), text, `payload round-trip ${JSON.stringify(text)}`);
+}
+throws(() => anumToChar(""), "empty character payload must reject");
+throws(() => anumToChar(byteToAbits(0x41) + byteToAbits(0x42)), "two characters in one group must reject");
+throws(() => anumToChar("11111111"), "invalid UTF-8 must reject");
+equal(JSON.stringify(extractCharAnums("[10101010]")), JSON.stringify(["10101010"]), "single group extraction");
+equal(extractCharAnums("[11111111][00000000]").length, 2, "multiple group extraction");
+throws(() => extractCharAnums("[11"), "unclosed group must reject");
+throws(() => extractCharAnums("11]]"), "extra close must reject");
+throws(() => extractCharAnums("1[11]"), "abit outside group must reject");
+equal(extractCharAnums("[11] [00]").length, 2, "whitespace between groups is ignored");
+const encodedDetail = textToAnumVerbose("A")[0];
+assert(encodedDetail !== undefined, "missing encode detail");
+equal(encodedDetail.codepoint, "U+0041", "codepoint formatting");
+assert(encodedDetail.utf8Bytes.includes("0x41"), "UTF-8 byte detail");
+throws(() => anumToTextVerbose(`[${byteToAbits(0x41)}${byteToAbits(0x42)}]`), "verbose multi-char boundary must reject");
+
+equal(unicodeToAscii("a ⟼ b"), "a -> b", "arrow conversion");
+equal(unicodeToAscii("a ¬⟼ b"), "a !-> b", "negated arrow conversion");
+equal(unicodeToAscii("∞ : ∞ ⟼ ∞"), "INF : INF -> INF", "complex Unicode conversion");
+equal(unicodeToAscii("♂v : ♂v ⟼ v"), "M v : M v -> v", "self-closure spacing");
+equal(unicodeToAscii("♂♀"), "M F", "adjacent word token spacing");
+equal(asciiToUnicode("a -> b"), "a ⟼ b", "ASCII arrow conversion");
+equal(asciiToUnicode("a !-> b"), "a ¬⟼ b", "ASCII negated arrow conversion");
+equal(asciiToUnicode("INF : INF -> INF"), "∞ : ∞ ⟼ ∞", "complex ASCII conversion");
+for (const word of ["FORM", "MTC", "INFO", "FROM", "MODEM", "FF", "MM"]) {
+  equal(asciiToUnicode(word), word, `word-boundary regression ${word}`);
+}
+equal(asciiToUnicode("the FORM of M"), "the FORM of ♂", "standalone token in sentence");
+equal(asciiToUnicode(unicodeToAscii("♂∞♀")), "♂ ∞ ♀", "notation round-trip separators");
+equal(abitsToAprover("[[][10][00]"), "[[][10][00]", "abit aprover identity");
+equal(aproverToAbits("[[]][10][00]"), "[[]][10][00]", "aprover abit identity");
+
+const directory = mkdtempSync(join(tmpdir(), "mts-tooling-"));
+try {
+  const cli = resolve(process.cwd(), "dist/src/tooling/cli.js");
+  const run = (...args: string[]) => spawnSync(process.execPath, [cli, ...args], { encoding: "utf8" });
+  const sample = join(directory, "sample.anum");
+  writeFileSync(sample, "# anum-format: quaternary\n[]\n", "utf8");
+  const parsed = run("parse", sample);
+  equal(parsed.status, 0, "parse exit");
+  assert(parsed.stdout.includes("format: quaternary") && parsed.stdout.includes("0: [") && parsed.stdout.includes("1: ]"), "parse output");
+
+  const invalid = join(directory, "invalid.anum");
+  writeFileSync(invalid, "]", "utf8");
+  const validation = run("validate", invalid);
+  equal(validation.status, 0, "invalid semantic validation is a reported result");
+  assert(validation.stdout.includes("valid: false") && validation.stdout.includes("error: unexpected-close"), "validation output");
+
+  const sequence = join(directory, "sequence.anum");
+  writeFileSync(sequence, "1110", "utf8");
+  const deserialized = run("deserialize", sequence);
+  equal(deserialized.status, 0, "deserialize exit");
+  assert(deserialized.stdout.includes("denotation: (((L⟼L)⟼L)⟼U)") && deserialized.stdout.includes("resolved_values: L L L U"), "deserialize output");
+
+  const spaced = join(directory, "spaced.anum");
+  writeFileSync(spaced, "# anum-format: quaternary\n[ 0 1 ] # comment\n", "utf8");
+  equal(run("normalize", spaced).stdout.trim(), "[01]", "normalize output");
+
+  const stringMode = join(directory, "string.anum");
+  writeFileSync(stringMode, "# anum-format: string\na b\n", "utf8");
+  for (const command of ["validate", "deserialize", "normalize"]) {
+    const result = run(command, stringMode);
+    assert(result.status !== 0 && result.stderr.includes(command) && result.stderr.includes("quaternary"), `${command} string mode rejection`);
+  }
+  for (const command of ["project", "quote", "unquote", "realize"]) {
+    const result = run(command, "missing.anum");
+    assert(result.status !== 0 && result.stderr.includes("invalid choice"), `${command} must remain unavailable`);
+  }
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #565

Pre-cutover tooling migration only; accepted MTS semantics and current Python owners are unchanged.

- ports UTF-8 text↔abit payload helpers to TypeScript;
- ports Unicode↔ASCII notation conversion including issue #46 word-boundary regression;
- adds TS `mts` CLI for current ANUM parse/validate/deserialize/normalize plus converter commands;
- keeps semantic `ts/src/public.ts` unchanged and exposes tooling only via separate subpaths/CLI;
- ports converter and CLI regression coverage to TypeScript.

This PR does **not** delete Python yet and does not change contracts/current ownership. It makes the final M13d Python removal lossless for supported converter behavior.