### PR TITLE
Governance: one-hop envelope for atomic TypeScript cutover

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@85a2e3c61223497c3fc601c670aa15b99ecc870f
+        uses: netkeep80/repo-guard@fea585e849677f58805724fc74dd208e0b0cfab9
         with:
           mode: check-pr
           enforcement: blocking

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -47,6 +47,7 @@
       "status": "accepted",
       "accepted": true
     },
+    "required_paths": [],
     "cochange": [
       "current.contract",
       "current.conformance"

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -34,16 +34,6 @@
         "format": "json"
       }
     },
-    "previous": {
-      "contract": {
-        "path": "contracts/mts-contract-v0.6.json",
-        "format": "json"
-      },
-      "conformance": {
-        "path": "contracts/mts-conformance-v0.6.json",
-        "format": "json"
-      }
-    },
     "pair_fields": {
       "contract_id": "/schema",
       "conformance_contract_id": "/contract",
@@ -57,69 +47,15 @@
       "status": "accepted",
       "accepted": true
     },
-    "acceptance": {
-      "document": {
-        "path": "cutover/foundation-v2-c9-acceptance-v0.1.json",
-        "format": "json"
-      },
-      "current_contract_path": "/current/contract",
-      "current_conformance_path": "/current/conformance"
-    },
-    "required_paths": [
-      {
-        "document": "current.contract",
-        "pointer": "/owners",
-        "projection": "object_values"
-      },
-      {
-        "document": "current.conformance",
-        "pointer": "/requiredExecutableGates",
-        "projection": "array_items"
-      },
-      {
-        "document": "acceptance",
-        "pointer": "/current",
-        "projection": "object_values"
-      }
-    ],
     "cochange": [
       "current.contract",
-      "current.conformance",
-      "acceptance"
+      "current.conformance"
     ],
     "control_paths": [
-      "contracts/mts-contract-v*.json",
-      "contracts/mts-conformance-v*.json",
-      "cutover/foundation-v2-c9-acceptance-v*.json"
+      "contracts/mts-contract-v0.7.json",
+      "contracts/mts-conformance-v0.7.json"
     ]
   },
-  "evidence_bindings": [
-    {
-      "id": "required-gates-covered-by-project-ci",
-      "kind": "workflow_path_coverage",
-      "source": {
-        "document": "contract-conformance.current.conformance",
-        "pointer": "/requiredExecutableGates",
-        "projection": "array_items",
-        "type": "repository_path_set"
-      },
-      "workflow": "project-ci",
-      "covers": [
-        "tests/**"
-      ]
-    },
-    {
-      "id": "negative-vectors-have-test-evidence",
-      "kind": "anchor_value_coverage",
-      "source": {
-        "document": "contract-conformance.current.conformance",
-        "pointer": "/requiredNegativeVectors",
-        "projection": "array_items",
-        "type": "string_set"
-      },
-      "target_anchor_type": "negative_vector_test"
-    }
-  ],
   "anchors": {
     "types": {
       "negative_vector_test": {

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -23,53 +23,6 @@
       }
     ]
   },
-  "contract_conformance": {
-    "current": {
-      "contract": {
-        "path": "contracts/mts-contract-v0.7.json",
-        "format": "json"
-      },
-      "conformance": {
-        "path": "contracts/mts-conformance-v0.7.json",
-        "format": "json"
-      }
-    },
-    "pair_fields": {
-      "contract_id": "/schema",
-      "conformance_contract_id": "/contract",
-      "contract_conformance_path": "/conformanceCorpus",
-      "contract_status": "/status",
-      "conformance_status": "/status",
-      "contract_accepted": "/accepted",
-      "conformance_accepted": "/accepted"
-    },
-    "accepted_state": {
-      "status": "accepted",
-      "accepted": true
-    },
-    "required_paths": [],
-    "cochange": [
-      "current.contract",
-      "current.conformance"
-    ],
-    "control_paths": [
-      "contracts/mts-contract-v0.7.json",
-      "contracts/mts-conformance-v0.7.json"
-    ]
-  },
-  "anchors": {
-    "types": {
-      "negative_vector_test": {
-        "sources": [
-          {
-            "kind": "regex",
-            "glob": "tests/**",
-            "pattern": "executed\\.add\\(\"([^\"]+)\"\\)"
-          }
-        ]
-      }
-    }
-  },
   "paths": {
     "forbidden": [
       "legacy/**",


### PR DESCRIPTION
Closes #569

Governance-only prerequisite for #568. It does **not** accept v0.8 and does not touch runtime, contracts, cutover evidence or project CI.

- current machine boundary remains accepted v0.7;
- project CI remains unchanged and keeps running the existing Python + TypeScript coverage until cutover;
- repo-guard is repinned to `fea585e8…`, whose exact post-merge CI is green;
- transitional policy bindings to v0.6/C9/Python physical paths are removed so the next atomic head can replace them rather than being forced to preserve them;
- #568 is responsible for immediately restoring strict v0.8/previous-v0.7 TS path/evidence bindings.