### PR TITLE
Post-cutover: prove typed @mts/core package boundary

### DIFF
--- a/ts/consumer/package-consumer.ts
+++ b/ts/consumer/package-consumer.ts
@@ -1,0 +1,21 @@
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+  type ReadMemory,
+} from "@mts/core";
+import { textToAnum } from "@mts/core/tooling/payload";
+
+// Package-boundary smoke: this file must resolve through package exports and
+// generated declarations, not through source-relative imports.
+const memory = new Memory();
+const basis = ensureRootBasis(memory);
+const read: ReadMemory = memory;
+const link: LinkHandle = basis.L;
+const encoded: string = textToAnum("A");
+void [read, link, encoded];
+
+// Internal source modules are intentionally not package subpaths.
+// @ts-expect-error @mts/core/memory is not exported by package.json.
+import type { AppendOnlyReadMemory } from "@mts/core/memory";
+void (undefined as unknown as AppendOnlyReadMemory);

--- a/ts/package.json
+++ b/ts/package.json
@@ -2,10 +2,20 @@
   "name": "@mts/core",
   "private": true,
   "type": "module",
+  "types": "./dist/src/public.d.ts",
   "exports": {
-    ".": "./dist/src/public.js",
-    "./tooling/payload": "./dist/src/tooling/payload.js",
-    "./tooling/notation": "./dist/src/tooling/notation.js"
+    ".": {
+      "types": "./dist/src/public.d.ts",
+      "default": "./dist/src/public.js"
+    },
+    "./tooling/payload": {
+      "types": "./dist/src/tooling/payload.d.ts",
+      "default": "./dist/src/tooling/payload.js"
+    },
+    "./tooling/notation": {
+      "types": "./dist/src/tooling/notation.d.ts",
+      "default": "./dist/src/tooling/notation.js"
+    }
   },
   "bin": {
     "mts": "./dist/src/tooling/cli.js"
@@ -13,9 +23,10 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
+    "package:check": "tsc -p tsconfig.consumer.json --noEmit",
     "browser:typecheck": "tsc -p tsconfig.browser.json",
     "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
-    "test": "npm run build && node dist/test/release-cutover.test.js && node dist/test/public-api.test.js && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js && node dist/test/tooling.test.js",
+    "test": "npm run build && npm run package:check && node dist/test/release-cutover.test.js && node dist/test/public-api.test.js && node dist/test/memory.test.js && node dist/test/anum.test.js && node dist/test/anum-carrier.test.js && node dist/test/structural-readers.test.js && node dist/test/state.test.js && node dist/test/dictionary.test.js && node dist/test/source.test.js && node dist/test/source-subselection.test.js && node dist/test/interpreter-relation.test.js && node dist/test/interpreter-flat.test.js && node dist/test/interpreter-colon.test.js && node dist/test/interpreter-equality.test.js && node dist/test/sequence-grouping.test.js && node dist/test/sequence-materialization.test.js && node dist/test/direct-deixis.test.js && node dist/test/value-bundle-elaboration.test.js && node dist/test/value-bundle-resolved.test.js && node dist/test/run.test.js && node dist/test/proof.test.js && node dist/test/checker.test.js && node dist/test/persistence-topology.test.js && node dist/test/persistent-store.test.js && node dist/test/persistent-sequence.test.js && node dist/test/node-json-backend.test.js && node dist/test/tooling.test.js",
     "check": "npm run typecheck && npm test && npm run browser:check"
   },
   "devDependencies": {

--- a/ts/test/release-cutover.test.ts
+++ b/ts/test/release-cutover.test.ts
@@ -40,12 +40,26 @@ function pythonFiles(directory: string): string[] {
   return result;
 }
 
+interface PackageExportTarget {
+  readonly types?: string;
+  readonly default?: string;
+}
+
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "ts/package.json"), "utf8")) as {
   readonly name?: string;
-  readonly exports?: Record<string, unknown>;
+  readonly types?: string;
+  readonly exports?: Record<string, string | PackageExportTarget>;
 };
 assert(packageJson.name === "@mts/core", "canonical package must be @mts/core");
-assert(packageJson.exports?.["."] === "./dist/src/public.js", "package root must be public.ts build output");
+assert(packageJson.types === "./dist/src/public.d.ts", "package root declarations must be public.ts build output");
+const rootExport = packageJson.exports?.["."];
+assert(
+  typeof rootExport === "object"
+    && rootExport !== null
+    && rootExport.types === "./dist/src/public.d.ts"
+    && rootExport.default === "./dist/src/public.js",
+  "package root must expose matching declaration and runtime outputs",
+);
 
 const contract = JSON.parse(readFileSync(join(repoRoot, "contracts/mts-contract-v0.8.json"), "utf8")) as {
   readonly schema?: string;

--- a/ts/tsconfig.consumer.json
+++ b/ts/tsconfig.consumer.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": ["consumer/package-consumer.ts"]
+}

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitOverride": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "declaration": true,
     "rootDir": ".",
     "outDir": "dist"
   },


### PR DESCRIPTION
Closes #574

Post-cutover package-boundary hardening only; no MTS semantic/runtime implementation changes.

- emits TypeScript declarations from the current build;
- exposes matching `types` + runtime targets for package root and tooling subpaths;
- adds a separate consumer compile config that imports `@mts/core` by package name after build;
- verifies an internal source subpath remains unavailable;
- updates the release-cutover package assertion to bind both `.d.ts` and `.js` outputs.

Do not merge until full CI, blocking repo-guard, behind_by=0 and final exact-head race gates are green.