### PR TITLE
governance: временно расширить contract budget для v0.9 candidate

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -118,8 +118,8 @@
       "scope": "directory",
       "metric": "files",
       "glob": "contracts/**",
-      "max": 4,
-      "max_growth": 0,
+      "max": 6,
+      "max_growth": 2,
       "count": "all_tracked",
       "level": "blocking"
     },


### PR DESCRIPTION
Подготовка MTS v0.9 по parent lifecycle #605; это отдельный governance-only PR A. Debt repayment owner: #610.

Этот PR **не добавляет** v0.9 contract/conformance и не меняет accepted v0.8. Он только разрешает временное сосуществование трёх contract/conformance пар в следующем отдельном PR:

```text
v0.7 previous evidence
v0.8 accepted current
v0.9 candidate
```

Изменяются ровно два значения одного blocking size rule:

```text
contracts-file-count-no-growth.max        4 -> 6
contracts-file-count-no-growth.max_growth 0 -> 2
```

GovernanceGrant для этого PR находится в #618. Долг погашается в #610 при acceptance v0.9: v0.7 pair удаляется из tracked contracts, лимит возвращается к `4 / 0`.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/src/**
  - ts/test/**
  - .github/**
expected_effects:
  - temporarily allow two additional contract files for v0.9 candidate coexistence
  - preserve accepted v0.8 pointers and all current evidence gates
  - defer creation of v0.9 candidate pair to a separate PR after this policy change is merged
```

Resolves #618