### PR TITLE
governance(v0.9): привязать M2 executable evidence

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -8,8 +8,19 @@
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
   "acceptanceReady": false,
-  "coverageState": "scaffold-unimplemented",
-  "requiredExecutableGates": [],
+  "coverageState": "partial",
+  "requiredExecutableGates": [
+    "ts/test/v09-structural-carriers.test.ts"
+  ],
+  "implementedEvidence": {
+    "606": {
+      "test": "ts/test/v09-structural-carriers.test.ts",
+      "exactSequenceExhaustiveCount": 781,
+      "quaternaryDifferentialCount": 21845,
+      "acceptedQuaternaryDenotationPreserved": true,
+      "readOnlyStructuralReads": true
+    }
+  },
   "requiredNegativeVectors": [
     "exact-sequence-empty-vs-single-root",
     "exact-sequence-leading-root-loss",
@@ -109,7 +120,7 @@
     "compatibilityRuntimeSelectable": false
   },
   "implementationSlices": {
-    "606": {"status": "planned", "requiredForAcceptance": true},
+    "606": {"status": "candidate-green", "requiredForAcceptance": true},
     "607": {"status": "planned", "requiredForAcceptance": true},
     "608": {"status": "planned", "requiredForAcceptance": true},
     "609": {"status": "planned", "requiredForAcceptance": true},

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -31,6 +31,11 @@
     "proof": "ts/src/proof.ts",
     "checker": "ts/src/checker.ts"
   },
+  "candidateOwners": {
+    "exactSequence": "ts/src/exact-sequence.ts",
+    "quaternaryState": "ts/src/quaternary-state.ts",
+    "structuralCarrierEvidence": "ts/test/v09-structural-carriers.test.ts"
+  },
   "semanticIdentity": {
     "acceptedV08TargetPreserved": true,
     "runtimeHandleIsSemanticIdentity": false,
@@ -103,10 +108,14 @@
     "classes": ["EXACT_SEQUENCE", "FOLD_RESULT", "RESTRICTED_ROOTED_SEQUENCE"],
     "exactSequence": {
       "ownerIssue": 604,
+      "implementationIssue": 606,
+      "implementationOwner": "ts/src/exact-sequence.ts",
+      "evidence": "ts/test/v09-structural-carriers.test.ts",
       "empty": "R",
       "append": "Cell(prev,value)=startSelfClosed(prev ⟼ value)",
       "positionsContainingRootPreserved": true,
-      "runtimePositionIdAllowed": false
+      "runtimePositionIdAllowed": false,
+      "candidateImplemented": true
     },
     "foldResult": {
       "injectiveSequenceIdentityRequired": false
@@ -117,10 +126,14 @@
   },
   "quaternaryState": {
     "ownerIssue": 604,
+    "implementationIssue": 606,
+    "implementationOwner": "ts/src/quaternary-state.ts",
+    "evidence": "ts/test/v09-structural-carriers.test.ts",
     "empty": "R",
     "nonEmpty": "QNonEmpty(x)=startSelfClosed(x)",
     "hostStartedBooleanIsSemanticAuthority": false,
-    "acceptedV08DenotationPreserved": true
+    "acceptedV08DenotationPreserved": true,
+    "candidateImplemented": true
   },
   "contextSemantics": {
     "ownerIssue": 601,
@@ -138,9 +151,9 @@
   },
   "semanticRules": {
     "Q_OPEN": {"implementationStatus": "planned", "issue": 609},
-    "Q_VALUE": {"implementationStatus": "planned", "issue": 606},
+    "Q_VALUE": {"implementationStatus": "candidate-implemented", "issue": 606},
     "Q_CLOSE": {"implementationStatus": "planned", "issue": 609},
-    "Q_FINALIZE": {"implementationStatus": "planned", "issue": 606},
+    "Q_FINALIZE": {"implementationStatus": "candidate-implemented", "issue": 606},
     "FORMAL_OPEN": {"implementationStatus": "planned", "issue": 609},
     "FORMAL_GROUP": {"implementationStatus": "planned", "issue": 609},
     "FORMAL_LINK": {"implementationStatus": "planned", "issue": 608},
@@ -157,10 +170,10 @@
     "explicitMaterializationMustReuseSameGroundedForm": true
   },
   "migrationSlices": [
-    {"issue": 606, "name": "root-safe exact sequence and structural QState"},
-    {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary"},
-    {"issue": 608, "name": "structural interpreter/rule and generic replay"},
-    {"issue": 609, "name": "FORMAL contexts and cross-context integration"},
-    {"issue": 610, "name": "acceptance cutover and governance debt repayment"}
+    {"issue": 606, "name": "root-safe exact sequence and structural QState", "status": "candidate-green"},
+    {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary", "status": "planned"},
+    {"issue": 608, "name": "structural interpreter/rule and generic replay", "status": "planned"},
+    {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "planned"},
+    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
   ]
 }

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -158,6 +158,16 @@
           "projection": "object_values",
           "type": "repository_path_set"
         }
+      },
+      {
+        "id": "v09-candidate-gate-paths-exist",
+        "kind": "referenced_paths_exist",
+        "source": {
+          "document": "candidate-v09-conformance",
+          "pointer": "/requiredExecutableGates",
+          "projection": "array_items",
+          "type": "repository_path_set"
+        }
       }
     ]
   },

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -148,6 +148,16 @@
           "projection": "object_values",
           "type": "repository_path_set"
         }
+      },
+      {
+        "id": "v09-candidate-owner-paths-exist",
+        "kind": "referenced_paths_exist",
+        "source": {
+          "document": "candidate-v09-contract",
+          "pointer": "/candidateOwners",
+          "projection": "object_values",
+          "type": "repository_path_set"
+        }
       }
     ]
   },
@@ -174,6 +184,18 @@
         "type": "string_set"
       },
       "target_anchor_type": "negative_vector_test"
+    },
+    {
+      "id": "v09-candidate-gates-covered-by-project-ci",
+      "kind": "workflow_path_coverage",
+      "source": {
+        "document": "candidate-v09-conformance",
+        "pointer": "/requiredExecutableGates",
+        "projection": "array_items",
+        "type": "repository_path_set"
+      },
+      "workflow": "project-ci",
+      "covers": ["ts/test/**"]
     }
   ],
   "anchors": {


### PR DESCRIPTION
Финальный governance PR B для #606 после merge implementation PR #621 (`d64055a5…`).

Этот PR **не меняет TypeScript/runtime**. Он только связывает уже существующий green evidence с MTS v0.9 candidate:

- добавляет `exactSequence`, `quaternaryState` и test owner paths в candidate contract;
- помечает #606 slice как `candidate-green`;
- добавляет `ts/test/v09-structural-carriers.test.ts` в candidate `requiredExecutableGates`;
- переводит `coverageState` из scaffold в `partial`;
- добавляет generic repo-guard path-existence и project-CI coverage bindings;
- сохраняет `accepted=false`, `acceptanceReady=false`, accepted current v0.8;
- не заявляет #608/#609 Rules реализованными.

Trusted GovernanceGrant находится прямо в owner issue #606. Нового policy relaxation нет: добавляемые constraints являются tightening.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 300
must_touch:
  - repo-policy.json
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - cutover/**
  - ts/src/**
  - ts/test/**
  - .github/**
expected_effects:
  - bind already-green M2 structural carrier evidence to the v0.9 candidate
  - require every declared v0.9 executable gate to be covered by blocking project CI
  - keep v0.9 non-accepted and preserve v0.8 current pointers
  - expose exact candidate implementation owner paths to repo-guard path validation
```

Resolves #606