### PR TITLE
feat(v0.9): добавить canonical per-byte carrier

### DIFF
--- a/ts/src/byte-carrier.ts
+++ b/ts/src/byte-carrier.ts
@@ -1,0 +1,226 @@
+import {
+  ExactSequenceError,
+  materializeExactSequence,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+  type RootBasis,
+  type WriteMemory,
+} from "./memory.js";
+import {
+  appendQuaternaryValue,
+  closeQuaternaryState,
+} from "./quaternary-state.js";
+
+export type ByteCarrierErrorCode =
+  | "invalid-byte"
+  | "invalid-quaternary-byte-carrier"
+  | "not-byte-link"
+  | "invalid-byte-sequence"
+  | "invalid-unicode-text"
+  | "invalid-utf8";
+
+export interface CanonicalByteSequence {
+  readonly bytes: Uint8Array;
+  readonly byteLinks: readonly LinkHandle[];
+  readonly cells: readonly LinkHandle[];
+}
+
+export class ByteCarrierError extends Error {
+  override readonly name: string = "ByteCarrierError";
+
+  constructor(readonly code: ByteCarrierErrorCode) {
+    super(code);
+  }
+}
+
+const utf8Encoder = new TextEncoder();
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+export function byteToQuaternaryBits(value: number): string {
+  if (!Number.isInteger(value) || value < 0 || value > 255) {
+    throw new ByteCarrierError("invalid-byte");
+  }
+  return value.toString(2).padStart(8, "0");
+}
+
+/**
+ * Canonical STRING -> QUATERNARY representation selected for MTS v0.9:
+ * every exact physical byte is represented by its own `[8 bits]` group.
+ * No code-point or Unicode-normalization boundary participates here.
+ */
+export function encodeBytesToQuaternary(bytes: Uint8Array): string {
+  return Array.from(bytes, (value) => `[${byteToQuaternaryBits(value)}]`).join("");
+}
+
+/** Reads only the canonical per-byte spelling, not arbitrary Q syntax. */
+export function decodeBytesFromQuaternary(carrier: string): Uint8Array {
+  if (carrier.length % 10 !== 0) {
+    throw new ByteCarrierError("invalid-quaternary-byte-carrier");
+  }
+
+  const bytes = new Uint8Array(carrier.length / 10);
+  for (let offset = 0, index = 0; offset < carrier.length; offset += 10, index += 1) {
+    const group = carrier.slice(offset, offset + 10);
+    if (group[0] !== "[" || group[9] !== "]") {
+      throw new ByteCarrierError("invalid-quaternary-byte-carrier");
+    }
+    const bits = group.slice(1, 9);
+    if (!/^[01]{8}$/.test(bits)) {
+      throw new ByteCarrierError("invalid-quaternary-byte-carrier");
+    }
+    bytes[index] = Number.parseInt(bits, 2);
+  }
+  return bytes;
+}
+
+/**
+ * Structural definition Byte(p) := Denote_Q([p]). The returned handle is only
+ * the runtime reference to the already-defined Link form; byte identity comes
+ * from the eight Q values and canonical Link construction, never from `p` or
+ * from a 256-entry table index.
+ */
+export function materializeByteLink(
+  memory: WriteMemory,
+  basis: RootBasis,
+  value: number,
+): LinkHandle {
+  const bits = byteToQuaternaryBits(value);
+  let state = memory.root;
+  for (const bit of bits) {
+    state = appendQuaternaryValue(
+      memory,
+      state,
+      bit === "1" ? basis.L : basis.U,
+    );
+  }
+  return closeQuaternaryState(memory, state);
+}
+
+/**
+ * Convenience materialization of the complete byte vocabulary. Repeated calls
+ * reuse the same structurally derived Links through canonical `memory.ensure`;
+ * this array is not semantic authority.
+ */
+export function materializeByteVocabulary(
+  memory: WriteMemory,
+  basis: RootBasis,
+): readonly LinkHandle[] {
+  return Object.freeze(
+    Array.from({ length: 256 }, (_, value) => materializeByteLink(memory, basis, value)),
+  );
+}
+
+function semanticBitValue(
+  basis: RootBasis,
+  link: LinkHandle,
+): 0 | 1 {
+  if (link === basis.U) return 0;
+  if (link === basis.L) return 1;
+  throw new ByteCarrierError("not-byte-link");
+}
+
+/**
+ * Pure structural inverse for Byte(p). It does not call `find` or materialize
+ * missing Links, and therefore can be used by read/replay paths.
+ */
+export function readByteLink(
+  memory: ReadMemory,
+  basis: RootBasis,
+  link: LinkHandle,
+): number {
+  try {
+    const outer = memory.poles(link);
+    if (outer.start !== memory.root) {
+      throw new ByteCarrierError("not-byte-link");
+    }
+
+    const bits = new Array<0 | 1>(8);
+    let current = outer.end;
+    for (let index = 7; index >= 1; index -= 1) {
+      const pair = memory.poles(current);
+      bits[index] = semanticBitValue(basis, pair.end);
+      current = pair.start;
+    }
+    bits[0] = semanticBitValue(basis, current);
+
+    let value = 0;
+    for (const bit of bits) value = (value << 1) | bit;
+    return value;
+  } catch (error) {
+    if (error instanceof ByteCarrierError) throw error;
+    if (error instanceof MemoryError) {
+      throw new ByteCarrierError("not-byte-link");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Exact source-byte content is an ExactSequence of canonical Byte(p) Links.
+ * Occurrence/position therefore lives in sequence structure, not in copies of
+ * byte values, source offsets, UUIDs or runtime handles.
+ */
+export function materializeCanonicalByteSequence(
+  memory: WriteMemory,
+  basis: RootBasis,
+  bytes: Uint8Array,
+): LinkHandle {
+  const values = Array.from(bytes, (value) => materializeByteLink(memory, basis, value));
+  return materializeExactSequence(memory, values);
+}
+
+export function readCanonicalByteSequence(
+  memory: ReadMemory,
+  basis: RootBasis,
+  carrier: LinkHandle,
+): CanonicalByteSequence {
+  try {
+    const sequence = readExactSequence(memory, carrier);
+    const bytes = new Uint8Array(sequence.values.length);
+    for (let index = 0; index < sequence.values.length; index += 1) {
+      const value = sequence.values[index];
+      if (value === undefined) {
+        throw new ByteCarrierError("invalid-byte-sequence");
+      }
+      bytes[index] = readByteLink(memory, basis, value);
+    }
+    return Object.freeze({
+      bytes,
+      byteLinks: Object.freeze([...sequence.values]),
+      cells: Object.freeze([...sequence.cells]),
+    });
+  } catch (error) {
+    if (error instanceof ByteCarrierError) throw error;
+    if (error instanceof ExactSequenceError) {
+      throw new ByteCarrierError("invalid-byte-sequence");
+    }
+    throw error;
+  }
+}
+
+/** Strict Unicode-text layer above exact bytes. No normalization is applied. */
+export function textToUtf8Bytes(text: string): Uint8Array {
+  const bytes = utf8Encoder.encode(text);
+  try {
+    if (utf8Decoder.decode(bytes) !== text) {
+      throw new ByteCarrierError("invalid-unicode-text");
+    }
+  } catch (error) {
+    if (error instanceof ByteCarrierError) throw error;
+    throw new ByteCarrierError("invalid-unicode-text");
+  }
+  return bytes;
+}
+
+/** Strict UTF-8 interpretation; malformed exact bytes remain valid below it. */
+export function utf8BytesToText(bytes: Uint8Array): string {
+  try {
+    return utf8Decoder.decode(bytes);
+  } catch {
+    throw new ByteCarrierError("invalid-utf8");
+  }
+}

--- a/ts/test/v09-byte-carrier.test.ts
+++ b/ts/test/v09-byte-carrier.test.ts
@@ -1,0 +1,204 @@
+import {
+  type Abit,
+  executeAbits,
+  type StackAlgebra,
+} from "../src/anum.js";
+import {
+  ByteCarrierError,
+  byteToQuaternaryBits,
+  decodeBytesFromQuaternary,
+  encodeBytesToQuaternary,
+  materializeByteLink,
+  materializeByteVocabulary,
+  materializeCanonicalByteSequence,
+  readByteLink,
+  readCanonicalByteSequence,
+  textToUtf8Bytes,
+  utf8BytesToText,
+} from "../src/byte-carrier.js";
+import {
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  Memory,
+  type ReadMemory,
+} from "../src/memory.js";
+import { charToAnum } from "../src/tooling/payload.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function sameBytes(actual: Uint8Array, expected: Uint8Array, message: string): void {
+  same(actual.length, expected.length, `${message} length`);
+  for (let index = 0; index < actual.length; index += 1) {
+    same(actual[index], expected[index], `${message}[${index}]`);
+  }
+}
+
+function expectByteCarrierError(
+  code: ByteCarrierError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof ByteCarrierError, `expected ByteCarrierError, got ${String(error)}`);
+    same(error.code, code, "byte carrier error code");
+    return;
+  }
+  throw new Error(`expected ByteCarrierError(${code})`);
+}
+
+class PolesOnlyProbe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("byte read must not use find"); }
+  outgoing(): readonly LinkHandle[] { throw new Error("byte read must not use outgoing"); }
+  incoming(): readonly LinkHandle[] { throw new Error("byte read must not use incoming"); }
+}
+
+// Physical bytes have one exact canonical Q group each, below Unicode.
+{
+  same(byteToQuaternaryBits(0x00), "00000000", "zero byte bits");
+  same(byteToQuaternaryBits(0xff), "11111111", "max byte bits");
+  expectByteCarrierError("invalid-byte", () => byteToQuaternaryBits(-1));
+  expectByteCarrierError("invalid-byte", () => byteToQuaternaryBits(256));
+
+  const allBytes = Uint8Array.from({ length: 256 }, (_, value) => value);
+  const carrier = encodeBytesToQuaternary(allBytes);
+  same(carrier.length, 2560, "all-byte canonical carrier length");
+  sameBytes(decodeBytesFromQuaternary(carrier), allBytes, "all-byte canonical inverse");
+  same(encodeBytesToQuaternary(new Uint8Array()), "", "empty byte carrier");
+  sameBytes(decodeBytesFromQuaternary(""), new Uint8Array(), "empty byte inverse");
+
+  same(encodeBytesToQuaternary(Uint8Array.of(0x5b)), "[01011011]", "STRING glyph [ carrier");
+  expectByteCarrierError("invalid-quaternary-byte-carrier", () => decodeBytesFromQuaternary("[]"));
+  expectByteCarrierError("invalid-quaternary-byte-carrier", () => decodeBytesFromQuaternary("[0101101]"));
+  expectByteCarrierError("invalid-quaternary-byte-carrier", () => decodeBytesFromQuaternary("[01011012]"));
+  expectByteCarrierError("invalid-quaternary-byte-carrier", () => decodeBytesFromQuaternary(" [01011011]"));
+}
+
+// Byte(p) is reproduced from accepted Q denotation, not from an opaque ID table.
+{
+  const memory = new Memory();
+  const basis = ensureRootBasis(memory);
+  const algebra: StackAlgebra<LinkHandle> = Object.freeze({
+    root: basis.R,
+    linked: basis.L,
+    unlinked: basis.U,
+    link: (start: LinkHandle, end: LinkHandle) => memory.ensure(start, end),
+  });
+
+  const vocabulary = materializeByteVocabulary(memory, basis);
+  same(vocabulary.length, 256, "byte vocabulary size");
+  same(new Set(vocabulary).size, 256, "byte vocabulary semantic uniqueness");
+
+  for (let value = 0; value < 256; value += 1) {
+    const bits = byteToQuaternaryBits(value);
+    const accepted = executeAbits(
+      [...`[${bits}]`] as Abit[],
+      algebra,
+    ).denotation;
+    const derived = vocabulary[value];
+    assert(derived !== undefined, `missing byte ${value}`);
+    same(derived, accepted, `Byte(${value}) == Denote_Q([p])`);
+    same(materializeByteLink(memory, basis, value), derived, `Byte(${value}) canonical reuse`);
+    same(readByteLink(memory, basis, derived), value, `Byte(${value}) structural inverse`);
+  }
+
+  const before = memory.linkCount;
+  const again = materializeByteVocabulary(memory, basis);
+  same(memory.linkCount, before, "byte vocabulary rematerialization is canonical reuse");
+  for (let value = 0; value < 256; value += 1) {
+    same(again[value], vocabulary[value], `byte vocabulary reuse ${value}`);
+  }
+
+  const readOnly = new PolesOnlyProbe(memory);
+  for (let value = 0; value < 256; value += 1) {
+    const link = vocabulary[value];
+    assert(link !== undefined, `missing read-only byte ${value}`);
+    same(readByteLink(readOnly, basis, link), value, `read-only byte ${value}`);
+  }
+  same(memory.linkCount, before, "byte structural inverse does not materialize");
+  expectByteCarrierError("not-byte-link", () => readByteLink(memory, basis, basis.L));
+}
+
+// Source occurrence belongs to ExactSequence structure; repeated bytes reuse values.
+{
+  const memory = new Memory();
+  const basis = ensureRootBasis(memory);
+  const bytes = Uint8Array.of(0x5b, 0x5b, 0x00, 0xff, 0x5b);
+  const carrier = materializeCanonicalByteSequence(memory, basis, bytes);
+  assert(carrier !== basis.R, "nonempty byte sequence must not collapse to root");
+
+  const before = memory.linkCount;
+  const decoded = readCanonicalByteSequence(new PolesOnlyProbe(memory), basis, carrier);
+  sameBytes(decoded.bytes, bytes, "exact byte sequence inverse");
+  same(decoded.byteLinks[0], decoded.byteLinks[1], "repeated byte reuses one semantic Byte(p)");
+  same(decoded.byteLinks[0], decoded.byteLinks[4], "later repeated byte reuses one semantic Byte(p)");
+  same(memory.linkCount, before, "exact byte sequence read is non-materializing");
+  same(materializeCanonicalByteSequence(memory, basis, bytes), carrier, "exact byte sequence canonical reuse");
+
+  same(materializeCanonicalByteSequence(memory, basis, new Uint8Array()), basis.R, "empty byte sequence is root");
+}
+
+// Strict UTF-8 is a layer above exact bytes; no normalization is performed.
+{
+  const texts = [
+    "A",
+    "0",
+    "1",
+    "[",
+    "]",
+    "(",
+    ")",
+    ":",
+    "=",
+    "М",
+    "∞",
+    "⟼",
+    "🙂",
+  ] as const;
+
+  for (const text of texts) {
+    const bytes = textToUtf8Bytes(text);
+    same(utf8BytesToText(bytes), text, `UTF-8 roundtrip ${JSON.stringify(text)}`);
+    sameBytes(
+      decodeBytesFromQuaternary(encodeBytesToQuaternary(bytes)),
+      bytes,
+      `Q byte carrier roundtrip ${JSON.stringify(text)}`,
+    );
+  }
+
+  const combining = "e\u0301";
+  const precomposed = "é";
+  const combiningCarrier = encodeBytesToQuaternary(textToUtf8Bytes(combining));
+  const precomposedCarrier = encodeBytesToQuaternary(textToUtf8Bytes(precomposed));
+  assert(combiningCarrier !== precomposedCarrier, "canonical bytes must not Unicode-normalize text");
+  same(utf8BytesToText(decodeBytesFromQuaternary(combiningCarrier)), combining, "combining text preserved");
+  same(utf8BytesToText(decodeBytesFromQuaternary(precomposedCarrier)), precomposed, "precomposed text preserved");
+
+  const invalid = Uint8Array.of(0xff);
+  const truncated = Uint8Array.of(0xe2, 0x82);
+  sameBytes(decodeBytesFromQuaternary(encodeBytesToQuaternary(invalid)), invalid, "invalid FF remains exact bytes");
+  sameBytes(decodeBytesFromQuaternary(encodeBytesToQuaternary(truncated)), truncated, "truncated UTF-8 remains exact bytes");
+  expectByteCarrierError("invalid-utf8", () => utf8BytesToText(invalid));
+  expectByteCarrierError("invalid-utf8", () => utf8BytesToText(truncated));
+  expectByteCarrierError("invalid-unicode-text", () => textToUtf8Bytes("\ud800"));
+}
+
+// v0.8 public tooling remains untouched: its code-point envelope is explicitly legacy.
+{
+  const legacy = charToAnum("∞");
+  const canonical = encodeBytesToQuaternary(textToUtf8Bytes("∞"));
+  same(legacy, "[111000101000100010011110]", "accepted v0.8 code-point envelope spelling");
+  same(canonical, "[11100010][10001000][10011110]", "v0.9 per-byte spelling");
+  assert(legacy !== canonical, "candidate carrier delta must stay explicit before acceptance");
+}

--- a/ts/test/v09-byte-carrier.test.ts
+++ b/ts/test/v09-byte-carrier.test.ts
@@ -194,7 +194,7 @@ class PolesOnlyProbe implements ReadMemory {
   expectByteCarrierError("invalid-unicode-text", () => textToUtf8Bytes("\ud800"));
 }
 
-// v0.8 public tooling remains untouched: its code-point envelope is explicitly legacy.
+// Accepted v0.8 public tooling stays unchanged; the candidate delta remains explicit until cutover.
 {
   const legacy = charToAnum("∞");
   const canonical = encodeBytesToQuaternary(textToUtf8Bytes("∞"));


### PR DESCRIPTION
Closes implementation part of #607 (governance/evidence projection remains a separate PR after this code is merged).

## Что изменено

- добавлен internal candidate owner `ts/src/byte-carrier.ts`;
- exact bytes кодируются канонически как одна Q-группа `[8 bits]` на каждый байт;
- `Byte(p)` материализуется структурно как `Denote_Q([p])`, без injected `byteRefs[256]` как semantic authority;
- добавлен read-only structural inverse `Byte(p) -> p` без `find`/write;
- source-byte content выражается `ExactSequence` из canonical `Byte(p)` Links, поэтому повтор/позиция не создают semantic copies;
- strict UTF-8 interpretation отделён от exact byte layer; malformed bytes остаются допустимым byte carrier;
- accepted v0.8 `tooling/payload` не изменён, а его code-point envelope явно сравнивается с v0.9 per-byte spelling в тесте.

## Evidence в PR

`ts/test/v09-byte-carrier.test.ts` проверяет полный corpus 0..255, 256 structural `Byte(p)`, equality with accepted `executeAbits([p])`, canonical reuse, read-only inverse, repeated-byte exact sequence, UTF-8/no-normalization vectors и malformed-byte boundary.

## Не меняется

- accepted MTS v0.8;
- package public exports;
- `ts/src/source.ts` compatibility surface;
- contracts/conformance/repo-policy — отдельный governance PR после green merge.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/byte-carrier.ts
  - ts/test/v09-byte-carrier.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 500
must_touch:
  - ts/src/byte-carrier.ts
  - ts/test/v09-byte-carrier.test.ts
must_not_touch:
  - repo-policy.json
  - contracts/**
  - cutover/**
  - .github/**
expected_effects:
  - add canonical one-Q-group-per-byte STRING to QUATERNARY candidate carrier
  - derive Byte(p) structurally as Denote_Q([p]) without opaque injected byte identity
  - represent exact source bytes as ExactSequence of canonical Byte(p) Links
  - keep strict UTF-8 interpretation above exact malformed-byte-capable carrier
  - preserve accepted v0.8 runtime and public tooling surface
```

Related: #607, #602, #604, #597