### PR TITLE
governance(v0.9): привязать M3 byte-carrier evidence

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -10,7 +10,8 @@
   "acceptanceReady": false,
   "coverageState": "partial",
   "requiredExecutableGates": [
-    "ts/test/v09-structural-carriers.test.ts"
+    "ts/test/v09-structural-carriers.test.ts",
+    "ts/test/v09-byte-carrier.test.ts"
   ],
   "implementedEvidence": {
     "606": {
@@ -19,6 +20,18 @@
       "quaternaryDifferentialCount": 21845,
       "acceptedQuaternaryDenotationPreserved": true,
       "readOnlyStructuralReads": true
+    },
+    "607": {
+      "test": "ts/test/v09-byte-carrier.test.ts",
+      "canonicalPhysicalByteCount": 256,
+      "canonicalByteSemanticLinkCount": 256,
+      "acceptedQuaternaryByteDifferentialCount": 256,
+      "readOnlyStructuralByteInverse": true,
+      "exactByteSequenceUsesExactSequence": true,
+      "repeatedByteReusesSemanticLink": true,
+      "invalidUtf8CarrierAllowedBelowTextLayer": true,
+      "unicodeNormalizationApplied": false,
+      "acceptedV08PublicToolingPreserved": true
     }
   },
   "requiredNegativeVectors": [
@@ -121,7 +134,7 @@
   },
   "implementationSlices": {
     "606": {"status": "candidate-green", "requiredForAcceptance": true},
-    "607": {"status": "planned", "requiredForAcceptance": true},
+    "607": {"status": "candidate-green", "requiredForAcceptance": true},
     "608": {"status": "planned", "requiredForAcceptance": true},
     "609": {"status": "planned", "requiredForAcceptance": true},
     "610": {"status": "blocked", "requiredForAcceptance": true}

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -34,7 +34,9 @@
   "candidateOwners": {
     "exactSequence": "ts/src/exact-sequence.ts",
     "quaternaryState": "ts/src/quaternary-state.ts",
-    "structuralCarrierEvidence": "ts/test/v09-structural-carriers.test.ts"
+    "structuralCarrierEvidence": "ts/test/v09-structural-carriers.test.ts",
+    "byteCarrier": "ts/src/byte-carrier.ts",
+    "byteCarrierEvidence": "ts/test/v09-byte-carrier.test.ts"
   },
   "semanticIdentity": {
     "acceptedV08TargetPreserved": true,
@@ -67,6 +69,9 @@
   },
   "canonicalStringQuaternaryCarrier": {
     "ownerIssue": 602,
+    "implementationIssue": 607,
+    "implementationOwner": "ts/src/byte-carrier.ts",
+    "evidence": "ts/test/v09-byte-carrier.test.ts",
     "stringValue": "exact finite byte content",
     "canonicalUnit": "byte",
     "byteEnvelope": "[bbbbbbbb]",
@@ -77,7 +82,12 @@
     "unicodeSegmentationIsFoundation": false,
     "invalidUtf8CarrierAllowed": true,
     "byteSemanticBridge": "Byte(p) := Denote_Q([p]) for exactly eight bits p",
-    "representationEqualsInterpretation": false
+    "byteVocabularySize": 256,
+    "sourceContentCarrier": "ExactSequence<Byte(p)>",
+    "runtimeByteIdIsSemanticIdentity": false,
+    "acceptedV08PublicToolingPreservedUntilCutover": true,
+    "representationEqualsInterpretation": false,
+    "candidateImplemented": true
   },
   "signMeaningEquations": {
     "∞": "m∞ = m∞ ⟼ m∞",
@@ -171,7 +181,7 @@
   },
   "migrationSlices": [
     {"issue": 606, "name": "root-safe exact sequence and structural QState", "status": "candidate-green"},
-    {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary", "status": "planned"},
+    {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary", "status": "candidate-green"},
     {"issue": 608, "name": "structural interpreter/rule and generic replay", "status": "planned"},
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "planned"},
     {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}


### PR DESCRIPTION
Финальный governance PR B для #607 после merge implementation PR #623 (`8cd98b12…`).

Этот PR **не меняет TypeScript/runtime и repo-policy**. Он только проецирует уже существующий green evidence в MTS v0.9 candidate:

- добавляет `byteCarrier` и `byteCarrierEvidence` в candidate owners;
- связывает canonical STRING→Q carrier с implementation issue/owner/evidence;
- фиксирует структурный `Byte(p) := Denote_Q([p])`, vocabulary size 256 и `ExactSequence<Byte(p)>` для exact source bytes;
- добавляет `ts/test/v09-byte-carrier.test.ts` в candidate `requiredExecutableGates`;
- фиксирует только фактически прошедшие M3 evidence counts/invariants;
- помечает #607 как `candidate-green`;
- сохраняет `accepted=false`, `acceptanceReady=false`, accepted current v0.8;
- не заявляет #608/#609 реализованными.

Trusted GovernanceGrant находится в owner issue #607. Нового repo-guard primitive не требуется: существующие generic candidate owner path-existence и workflow-path coverage constraints уже автоматически покрывают новые owner/gate paths.

```repo-guard-yaml
change_type: governance
scope:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - repo-policy.json
  - cutover/**
  - ts/src/**
  - ts/test/**
  - .github/**
expected_effects:
  - bind already-green M3 canonical byte carrier evidence to the v0.9 candidate
  - expose byte carrier implementation and test owner paths to existing generic path validation
  - require the M3 executable gate through existing blocking project CI coverage binding
  - mark only slice 607 candidate-green while keeping v0.9 non-accepted and not acceptance-ready
```

Resolves #607