### PR TITLE
feat(v0.9): добавить structural Rule replay kernel

### DIFF
--- a/ts/src/structural-rule.ts
+++ b/ts/src/structural-rule.ts
@@ -1,0 +1,420 @@
+import {
+  ExactSequenceError,
+  materializeExactSequence,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+  type WriteMemory,
+} from "./memory.js";
+import {
+  readActHeader,
+  StructuralReadError,
+} from "./structural-readers.js";
+
+export type StructuralRuleErrorCode =
+  | "invalid-interpreter"
+  | "interpreter-mismatch"
+  | "invalid-role-dictionary"
+  | "duplicate-role"
+  | "invalid-rule"
+  | "rule-role-dictionary-mismatch"
+  | "rule-not-admitted"
+  | "invalid-act"
+  | "missing-role-binding"
+  | "multiple-role-bindings"
+  | "undeclared-role-binding"
+  | "template-mismatch"
+  | "after-context-mismatch"
+  | "replay-wrote";
+
+export class StructuralRuleError extends Error {
+  override readonly name = "StructuralRuleError";
+
+  constructor(readonly code: StructuralRuleErrorCode) {
+    super(code);
+  }
+}
+
+export interface StructuralInterpreter {
+  readonly dictionary: LinkHandle;
+  readonly grammar: LinkHandle;
+  readonly theory: LinkHandle;
+}
+
+export interface StructuralRoleDictionary {
+  readonly roleSequence: LinkHandle;
+  readonly roles: readonly LinkHandle[];
+}
+
+export interface StructuralRule {
+  readonly roleDictionary: LinkHandle;
+  readonly body: LinkHandle;
+}
+
+export interface StructuralRoleBinding {
+  readonly role: LinkHandle;
+  readonly value: LinkHandle;
+}
+
+export interface StructuralRuleReplayEvidence {
+  readonly act: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly ruleAdmission: LinkHandle;
+  readonly claimedBody: LinkHandle;
+  /** Grounded D/G/T evidence selected by the surrounding source/context path. */
+  readonly expectedInterpreter: StructuralInterpreter;
+  /** Grounded K_after expected by the surrounding transition. */
+  readonly expectedAfterContext: LinkHandle;
+}
+
+export interface StructuralRuleReplayResult {
+  readonly interpreter: LinkHandle;
+  readonly interpreterStructure: StructuralInterpreter;
+  readonly roleDictionary: LinkHandle;
+  readonly roles: readonly LinkHandle[];
+  readonly bindings: readonly StructuralRoleBinding[];
+  readonly rule: LinkHandle;
+  readonly body: LinkHandle;
+  readonly claimedBody: LinkHandle;
+  readonly afterContext: LinkHandle;
+}
+
+export function defineStructuralInterpreter(
+  memory: WriteMemory,
+  dictionary: LinkHandle,
+  grammar: LinkHandle,
+  theory: LinkHandle,
+): LinkHandle {
+  return memory.ensure(dictionary, memory.ensure(grammar, theory));
+}
+
+export function readStructuralInterpreter(
+  memory: ReadMemory,
+  interpreter: LinkHandle,
+): StructuralInterpreter {
+  try {
+    const outer = memory.poles(interpreter);
+    const grammarAndTheory = memory.poles(outer.end);
+    return Object.freeze({
+      dictionary: outer.start,
+      grammar: grammarAndTheory.start,
+      theory: grammarAndTheory.end,
+    });
+  } catch (error) {
+    if (error instanceof MemoryError) {
+      throw new StructuralRuleError("invalid-interpreter");
+    }
+    throw error;
+  }
+}
+
+export function verifyStructuralInterpreter(
+  memory: ReadMemory,
+  interpreter: LinkHandle,
+  expected: StructuralInterpreter,
+): void {
+  const actual = readStructuralInterpreter(memory, interpreter);
+  if (
+    actual.dictionary !== expected.dictionary ||
+    actual.grammar !== expected.grammar ||
+    actual.theory !== expected.theory
+  ) {
+    throw new StructuralRuleError("interpreter-mismatch");
+  }
+}
+
+export function defineStructuralRoleDictionary(
+  memory: WriteMemory,
+  roles: readonly LinkHandle[],
+): LinkHandle {
+  if (new Set(roles).size !== roles.length) {
+    throw new StructuralRuleError("duplicate-role");
+  }
+  const roleSequence = materializeExactSequence(memory, roles);
+  return memory.ensureStartSelfClosed(roleSequence);
+}
+
+export function readStructuralRoleDictionary(
+  memory: ReadMemory,
+  roleDictionary: LinkHandle,
+): StructuralRoleDictionary {
+  try {
+    const dictionary = memory.poles(roleDictionary);
+    if (dictionary.start !== roleDictionary) {
+      throw new StructuralRuleError("invalid-role-dictionary");
+    }
+    const sequence = readExactSequence(memory, dictionary.end);
+    if (new Set(sequence.values).size !== sequence.values.length) {
+      throw new StructuralRuleError("duplicate-role");
+    }
+    return Object.freeze({
+      roleSequence: dictionary.end,
+      roles: Object.freeze([...sequence.values]),
+    });
+  } catch (error) {
+    if (error instanceof StructuralRuleError) throw error;
+    if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+      throw new StructuralRuleError("invalid-role-dictionary");
+    }
+    throw error;
+  }
+}
+
+export function defineStructuralRule(
+  memory: WriteMemory,
+  roleDictionary: LinkHandle,
+  body: LinkHandle,
+): LinkHandle {
+  return memory.ensure(roleDictionary, body);
+}
+
+export function readStructuralRule(
+  memory: ReadMemory,
+  rule: LinkHandle,
+): StructuralRule {
+  try {
+    const poles = memory.poles(rule);
+    return Object.freeze({
+      roleDictionary: poles.start,
+      body: poles.end,
+    });
+  } catch (error) {
+    if (error instanceof MemoryError) {
+      throw new StructuralRuleError("invalid-rule");
+    }
+    throw error;
+  }
+}
+
+export function admitStructuralRule(
+  memory: WriteMemory,
+  theory: LinkHandle,
+  rule: LinkHandle,
+): LinkHandle {
+  return memory.ensure(theory, rule);
+}
+
+export function verifyStructuralRuleAdmission(
+  memory: ReadMemory,
+  theory: LinkHandle,
+  rule: LinkHandle,
+  admission: LinkHandle,
+): void {
+  try {
+    const poles = memory.poles(admission);
+    if (poles.start !== theory || poles.end !== rule) {
+      throw new StructuralRuleError("rule-not-admitted");
+    }
+  } catch (error) {
+    if (error instanceof StructuralRuleError) throw error;
+    if (error instanceof MemoryError) {
+      throw new StructuralRuleError("rule-not-admitted");
+    }
+    throw error;
+  }
+}
+
+function readExactActBindings(
+  memory: ReadMemory,
+  act: LinkHandle,
+  roles: readonly LinkHandle[],
+): readonly StructuralRoleBinding[] {
+  const roleSet = new Set(roles);
+  const values = new Map<LinkHandle, LinkHandle[]>();
+  for (const role of roles) values.set(role, []);
+
+  try {
+    for (const attachment of memory.outgoing(act)) {
+      // The start-selfclosed Act itself carries ActHeader and is not a field.
+      if (attachment === act) continue;
+      const attachmentPoles = memory.poles(attachment);
+      if (attachmentPoles.start !== act) {
+        throw new StructuralRuleError("invalid-act");
+      }
+      const field = memory.poles(attachmentPoles.end);
+      if (!roleSet.has(field.start)) {
+        throw new StructuralRuleError("undeclared-role-binding");
+      }
+      values.get(field.start)?.push(field.end);
+    }
+  } catch (error) {
+    if (error instanceof StructuralRuleError) throw error;
+    if (error instanceof MemoryError) {
+      throw new StructuralRuleError("invalid-act");
+    }
+    throw error;
+  }
+
+  const bindings: StructuralRoleBinding[] = [];
+  for (const role of roles) {
+    const matches = values.get(role) ?? [];
+    if (matches.length === 0) {
+      throw new StructuralRuleError("missing-role-binding");
+    }
+    if (matches.length !== 1) {
+      throw new StructuralRuleError("multiple-role-bindings");
+    }
+    const value = matches[0];
+    if (value === undefined) {
+      throw new Error("internal structural role cardinality invariant violated");
+    }
+    bindings.push(Object.freeze({ role, value }));
+  }
+  return Object.freeze(bindings);
+}
+
+function bindingMap(
+  bindings: readonly StructuralRoleBinding[],
+): ReadonlyMap<LinkHandle, LinkHandle> {
+  const result = new Map<LinkHandle, LinkHandle>();
+  for (const binding of bindings) {
+    if (result.has(binding.role)) {
+      throw new StructuralRuleError("duplicate-role");
+    }
+    result.set(binding.role, binding.value);
+  }
+  return result;
+}
+
+/**
+ * Generic Rule matcher. Only Links declared by DR are placeholders. Any
+ * template subtree with no declared role is a grounded constant and therefore
+ * uses the current canonical Memory identity rather than importing a new
+ * recursive equality theory ahead of #582/#583.
+ */
+export function matchStructuralTemplate(
+  memory: ReadMemory,
+  template: LinkHandle,
+  claimed: LinkHandle,
+  bindings: readonly StructuralRoleBinding[],
+): void {
+  const rho = bindingMap(bindings);
+  const containsMemo = new Map<LinkHandle, boolean>();
+  const containsActive = new Set<LinkHandle>();
+
+  const containsRole = (node: LinkHandle): boolean => {
+    if (rho.has(node)) return true;
+    const cached = containsMemo.get(node);
+    if (cached !== undefined) return cached;
+    if (containsActive.has(node)) return false;
+    containsActive.add(node);
+    try {
+      const poles = memory.poles(node);
+      const result = containsRole(poles.start) || containsRole(poles.end);
+      containsMemo.set(node, result);
+      return result;
+    } finally {
+      containsActive.delete(node);
+    }
+  };
+
+  const visited = new Map<LinkHandle, Set<LinkHandle>>();
+  const markVisited = (left: LinkHandle, right: LinkHandle): boolean => {
+    let rights = visited.get(left);
+    if (rights === undefined) {
+      rights = new Set<LinkHandle>();
+      visited.set(left, rights);
+    }
+    if (rights.has(right)) return true;
+    rights.add(right);
+    return false;
+  };
+
+  const match = (left: LinkHandle, right: LinkHandle): void => {
+    const replacement = rho.get(left);
+    if (replacement !== undefined) {
+      if (replacement !== right) {
+        throw new StructuralRuleError("template-mismatch");
+      }
+      return;
+    }
+
+    if (!containsRole(left)) {
+      if (left !== right) {
+        throw new StructuralRuleError("template-mismatch");
+      }
+      return;
+    }
+
+    if (markVisited(left, right)) return;
+    try {
+      const leftPoles = memory.poles(left);
+      const rightPoles = memory.poles(right);
+      match(leftPoles.start, rightPoles.start);
+      match(leftPoles.end, rightPoles.end);
+    } catch (error) {
+      if (error instanceof StructuralRuleError) throw error;
+      if (error instanceof MemoryError) {
+        throw new StructuralRuleError("template-mismatch");
+      }
+      throw error;
+    }
+  };
+
+  match(template, claimed);
+}
+
+/**
+ * Read-only generic replay: semantic selection comes from structural I/DR/Rule
+ * and explicit T ⟼ Rule admission. No callback name, RuleKind/opcode or TS role
+ * property participates in rule identity.
+ */
+export function replayStructuralRule(
+  memory: ReadMemory,
+  evidence: StructuralRuleReplayEvidence,
+): StructuralRuleReplayResult {
+  const before = memory.linkCount;
+  try {
+    const header = readActHeader(memory, evidence.act);
+    verifyStructuralInterpreter(memory, header.interpreter, evidence.expectedInterpreter);
+    if (header.afterContext !== evidence.expectedAfterContext) {
+      throw new StructuralRuleError("after-context-mismatch");
+    }
+
+    const interpreter = readStructuralInterpreter(memory, header.interpreter);
+    const rule = readStructuralRule(memory, evidence.rule);
+    if (rule.roleDictionary !== header.roleDictionary) {
+      throw new StructuralRuleError("rule-role-dictionary-mismatch");
+    }
+
+    verifyStructuralRuleAdmission(
+      memory,
+      interpreter.theory,
+      evidence.rule,
+      evidence.ruleAdmission,
+    );
+
+    const roleDictionary = readStructuralRoleDictionary(memory, header.roleDictionary);
+    const bindings = readExactActBindings(memory, evidence.act, roleDictionary.roles);
+    matchStructuralTemplate(memory, rule.body, evidence.claimedBody, bindings);
+
+    if (memory.linkCount !== before) {
+      throw new StructuralRuleError("replay-wrote");
+    }
+
+    return Object.freeze({
+      interpreter: header.interpreter,
+      interpreterStructure: interpreter,
+      roleDictionary: header.roleDictionary,
+      roles: roleDictionary.roles,
+      bindings,
+      rule: evidence.rule,
+      body: rule.body,
+      claimedBody: evidence.claimedBody,
+      afterContext: header.afterContext,
+    });
+  } catch (error) {
+    if (error instanceof StructuralRuleError) throw error;
+    if (error instanceof StructuralReadError || error instanceof MemoryError) {
+      throw new StructuralRuleError("invalid-act");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new StructuralRuleError("replay-wrote");
+    }
+  }
+}

--- a/ts/test/v09-structural-rules.test.ts
+++ b/ts/test/v09-structural-rules.test.ts
@@ -1,0 +1,263 @@
+import { defineDictionaryEffect, defineDictionaryScope } from "../src/dictionary.js";
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule, defineStructuralInterpreter, defineStructuralRoleDictionary,
+  defineStructuralRule, replayStructuralRule, StructuralRuleError,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function expectRuleError(code: StructuralRuleError["code"], effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof StructuralRuleError, `expected StructuralRuleError, got ${String(error)}`);
+    same(error.code, code, "structural rule error code");
+    return;
+  }
+  throw new Error(`expected StructuralRuleError(${code})`);
+}
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  const seed = memory.ensureEndSelfClosed(memory.root);
+  let tag = memory.ensureStartSelfClosed(memory.root);
+  for (let index = 0; index < count; index += 1) {
+    tag = memory.ensureStartSelfClosed(tag);
+    result.push(memory.ensure(seed, tag));
+  }
+  return result;
+}
+
+class ReplayProbe implements ReadMemory {
+  outgoingCalls = 0;
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("generic rule replay must not use find"); }
+  incoming(): readonly LinkHandle[] { throw new Error("generic rule replay must not use incoming"); }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.outgoingCalls += 1;
+    return this.source.outgoing(start);
+  }
+}
+
+function structuralContext(memory: Memory, parent: LinkHandle, current: LinkHandle): LinkHandle {
+  return memory.ensureStartSelfClosed(memory.ensure(parent, current));
+}
+function defineAct(
+  memory: Memory, interpreter: LinkHandle, roleDictionary: LinkHandle,
+  afterContext: LinkHandle, fields: readonly (readonly [LinkHandle, LinkHandle])[],
+): LinkHandle {
+  const act = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+  for (const [role, value] of fields) defineActField(memory, act, role, value);
+  return act;
+}
+interface RuleFixture {
+  readonly interpreter: LinkHandle;
+  readonly expectedInterpreter: StructuralInterpreter;
+  readonly roleDictionary: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly admission: LinkHandle;
+}
+function defineRuleFixture(
+  memory: Memory, expectedInterpreter: StructuralInterpreter,
+  roles: readonly LinkHandle[], body: LinkHandle,
+): RuleFixture {
+  const interpreter = defineStructuralInterpreter(
+    memory, expectedInterpreter.dictionary, expectedInterpreter.grammar, expectedInterpreter.theory,
+  );
+  const roleDictionary = defineStructuralRoleDictionary(memory, roles);
+  const rule = defineStructuralRule(memory, roleDictionary, body);
+  const admission = admitStructuralRule(memory, expectedInterpreter.theory, rule);
+  return Object.freeze({ interpreter, expectedInterpreter, roleDictionary, rule, admission });
+}
+
+// FORMAL relation pilot: one admitted structural Rule derives form/result/K shapes.
+{
+  const memory = new Memory();
+  const refs = anchors(memory, 12);
+  const [dictionary, grammar, theory, fixed, binding, parent, fixedRole, bindingRole, parentRole, other] = refs;
+  assert(dictionary && grammar && theory && fixed && binding && parent && fixedRole && bindingRole && parentRole && other, "relation refs");
+  const expectedInterpreter = Object.freeze({ dictionary, grammar, theory });
+  const templateForm = memory.ensureStartSelfClosed(fixedRole);
+  const templateResult = memory.ensure(bindingRole, fixedRole);
+  const templateBefore = structuralContext(memory, parentRole, bindingRole);
+  const templateAfter = structuralContext(memory, parentRole, templateResult);
+  const body = materializeExactSequence(memory, [templateForm, templateResult, templateBefore, templateAfter]);
+  const fixture = defineRuleFixture(memory, expectedInterpreter, [fixedRole, bindingRole, parentRole], body);
+  const form = memory.ensureStartSelfClosed(fixed);
+  const result = memory.ensure(binding, fixed);
+  assert(result !== binding && result !== fixed, "relation result fixture must be non-degenerate");
+  const beforeContext = defineContext(memory, parent, binding);
+  const afterContext = defineContext(memory, parent, result);
+  const claimedBody = materializeExactSequence(memory, [form, result, beforeContext, afterContext]);
+  const act = defineAct(memory, fixture.interpreter, fixture.roleDictionary, afterContext, [
+    [fixedRole, fixed], [bindingRole, binding], [parentRole, parent],
+  ]);
+
+  const before = memory.linkCount;
+  const probe = new ReplayProbe(memory);
+  const replayed = replayStructuralRule(probe, {
+    act, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  });
+  same(replayed.body, body, "relation structural body");
+  same(replayed.afterContext, afterContext, "relation K_after");
+  same(replayed.bindings.length, 3, "relation exact role binding count");
+  same(memory.linkCount, before, "relation generic replay is read-only");
+  assert(probe.outgoingCalls > 0, "generic replay reads Act fields structurally");
+
+  const wrongResult = memory.ensure(other, fixed);
+  const wrongClaim = materializeExactSequence(memory, [form, wrongResult, beforeContext, afterContext]);
+  expectRuleError("template-mismatch", () => replayStructuralRule(memory, {
+    act, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody: wrongClaim,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+
+  const wrongAfter = defineContext(memory, other, result);
+  const wrongHeaderAct = defineAct(memory, fixture.interpreter, fixture.roleDictionary, wrongAfter, [
+    [fixedRole, fixed], [bindingRole, binding], [parentRole, parent],
+  ]);
+  expectRuleError("after-context-mismatch", () => replayStructuralRule(memory, {
+    act: wrongHeaderAct, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+
+  const forgedInterpreter = defineStructuralInterpreter(memory, other, grammar, theory);
+  const forgedInterpreterAct = defineAct(memory, forgedInterpreter, fixture.roleDictionary, afterContext, [
+    [fixedRole, fixed], [bindingRole, binding], [parentRole, parent],
+  ]);
+  expectRuleError("interpreter-mismatch", () => replayStructuralRule(memory, {
+    act: forgedInterpreterAct, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+
+  // Same (I,DR,K_after) denotes the same semantic Act. Malformed variants therefore
+  // use structurally distinct K_after values rather than pretending to be instances.
+  const missingAfter = defineContext(memory, other, binding);
+  const missingRoleAct = defineAct(memory, fixture.interpreter, fixture.roleDictionary, missingAfter, [
+    [fixedRole, fixed], [bindingRole, binding],
+  ]);
+  expectRuleError("missing-role-binding", () => replayStructuralRule(memory, {
+    act: missingRoleAct, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: missingAfter,
+  }));
+
+  const multipleAfter = defineContext(memory, parent, other);
+  const multipleRoleAct = defineAct(memory, fixture.interpreter, fixture.roleDictionary, multipleAfter, [
+    [fixedRole, fixed], [fixedRole, other], [bindingRole, binding], [parentRole, parent],
+  ]);
+  expectRuleError("multiple-role-bindings", () => replayStructuralRule(memory, {
+    act: multipleRoleAct, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: multipleAfter,
+  }));
+
+  const [undeclaredRole, extraCurrent] = anchors(memory, 2);
+  assert(undeclaredRole && extraCurrent, "undeclared role refs");
+  const extraAfter = defineContext(memory, extraCurrent, other);
+  const extraRoleAct = defineAct(memory, fixture.interpreter, fixture.roleDictionary, extraAfter, [
+    [fixedRole, fixed], [bindingRole, binding], [parentRole, parent], [undeclaredRole, other],
+  ]);
+  expectRuleError("undeclared-role-binding", () => replayStructuralRule(memory, {
+    act: extraRoleAct, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: extraAfter,
+  }));
+
+  const forgedRoleDictionary = defineStructuralRoleDictionary(memory, [fixedRole, bindingRole, undeclaredRole]);
+  const forgedRoleAct = defineAct(memory, fixture.interpreter, forgedRoleDictionary, afterContext, [
+    [fixedRole, fixed], [bindingRole, binding], [undeclaredRole, parent],
+  ]);
+  expectRuleError("rule-role-dictionary-mismatch", () => replayStructuralRule(memory, {
+    act: forgedRoleAct, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+
+  const forgedAdmission = memory.ensure(other, fixture.rule);
+  expectRuleError("rule-not-admitted", () => replayStructuralRule(memory, {
+    act, rule: fixture.rule, ruleAdmission: forgedAdmission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+
+  const wrongBody = materializeExactSequence(memory, [templateForm, templateBefore]);
+  const wrongRule = defineStructuralRule(memory, fixture.roleDictionary, wrongBody);
+  const wrongRuleAdmission = admitStructuralRule(memory, theory, wrongRule);
+  expectRuleError("template-mismatch", () => replayStructuralRule(memory, {
+    act, rule: wrongRule, ruleAdmission: wrongRuleAdmission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+  expectRuleError("duplicate-role", () => defineStructuralRoleDictionary(memory, [fixedRole, fixedRole]));
+}
+
+// Colon Entry/effect core pilot: body is structural data, not replayColonEffect callback identity.
+{
+  const memory = new Memory();
+  const refs = anchors(memory, 14);
+  const [grammar, theory, parentScope, historyBefore, sourceContent, form, sourceRole, formRole, beforeRole, parentRole, historyRole, contextCurrent] = refs;
+  assert(grammar && theory && parentScope && historyBefore && sourceContent && form && sourceRole && formRole && beforeRole && parentRole && historyRole && contextCurrent, "colon refs");
+  const beforeScope = defineDictionaryScope(memory, parentScope, historyBefore);
+  const templateEntry = memory.ensure(sourceRole, formRole);
+  const templateOccurrence = memory.ensure(beforeRole, templateEntry);
+  const templateHistoryAfter = memory.ensure(historyRole, templateOccurrence);
+  const templateAfterScope = memory.ensureStartSelfClosed(memory.ensure(parentRole, templateHistoryAfter));
+  const body = materializeExactSequence(memory, [templateEntry, templateOccurrence, templateHistoryAfter, templateAfterScope]);
+  const expectedInterpreter = Object.freeze({ dictionary: beforeScope, grammar, theory });
+  const fixture = defineRuleFixture(memory, expectedInterpreter, [sourceRole, formRole, beforeRole, parentRole, historyRole], body);
+  const effect = defineDictionaryEffect(memory, beforeScope, parentScope, historyBefore, sourceContent, form);
+  const claimedBody = materializeExactSequence(memory, [effect.entry, effect.occurrence, effect.historyAfter, effect.afterScope]);
+  const afterContext = defineContext(memory, contextCurrent, effect.afterScope);
+  const act = defineAct(memory, fixture.interpreter, fixture.roleDictionary, afterContext, [
+    [sourceRole, sourceContent], [formRole, form], [beforeRole, beforeScope],
+    [parentRole, parentScope], [historyRole, historyBefore],
+  ]);
+  const before = memory.linkCount;
+  replayStructuralRule(new ReplayProbe(memory), {
+    act, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  });
+  same(memory.linkCount, before, "colon structural replay is read-only");
+
+  const forgedOccurrence = memory.ensure(parentScope, effect.entry);
+  const forgedBody = materializeExactSequence(memory, [effect.entry, forgedOccurrence, effect.historyAfter, effect.afterScope]);
+  expectRuleError("template-mismatch", () => replayStructuralRule(memory, {
+    act, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody: forgedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+}
+
+// Context-transition pilot: stable lexical parent is an ordinary Rule template obligation.
+{
+  const memory = new Memory();
+  const refs = anchors(memory, 10);
+  const [dictionary, grammar, theory, parent, beforeValue, result, parentRole, beforeRole, resultRole, otherParent] = refs;
+  assert(dictionary && grammar && theory && parent && beforeValue && result && parentRole && beforeRole && resultRole && otherParent, "context refs");
+  const templateBefore = structuralContext(memory, parentRole, beforeRole);
+  const templateAfter = structuralContext(memory, parentRole, resultRole);
+  const body = materializeExactSequence(memory, [templateBefore, templateAfter]);
+  const expectedInterpreter = Object.freeze({ dictionary, grammar, theory });
+  const fixture = defineRuleFixture(memory, expectedInterpreter, [parentRole, beforeRole, resultRole], body);
+  const beforeContext = defineContext(memory, parent, beforeValue);
+  const afterContext = defineContext(memory, parent, result);
+  const claimedBody = materializeExactSequence(memory, [beforeContext, afterContext]);
+  const act = defineAct(memory, fixture.interpreter, fixture.roleDictionary, afterContext, [
+    [parentRole, parent], [beforeRole, beforeValue], [resultRole, result],
+  ]);
+  replayStructuralRule(new ReplayProbe(memory), {
+    act, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  });
+
+  const changedParentAfter = defineContext(memory, otherParent, result);
+  const changedParentClaim = materializeExactSequence(memory, [beforeContext, changedParentAfter]);
+  expectRuleError("template-mismatch", () => replayStructuralRule(memory, {
+    act, rule: fixture.rule, ruleAdmission: fixture.admission, claimedBody: changedParentClaim,
+    expectedInterpreter, expectedAfterContext: afterContext,
+  }));
+}


### PR DESCRIPTION
Implementation PR A для #608, пересозданный от свежего `main` после concurrent docs merge #625. Supersedes unmerged #626 только из-за `behind_by` race; кодовая версия уже прошла TypeScript/full CI и repo-guard на PR merge ref, но этот PR обязан пройти собственные checks заново.

Candidate-only: accepted v0.8 runtime/public replay exports не меняются; contracts/repo-policy будут отдельным governance PR только после green merge.

## Что реализовано

- structural interpreter `I = D ⟼ (G ⟼ T)`;
- structural role dictionary `DR = DR ⟼ ExactSequence(roles)`;
- `Rule = DR ⟼ Body`;
- explicit admission `T ⟼ Rule`;
- exact Act schema: ровно одна binding на каждую declared role, undeclared/missing/multiple bindings reject;
- один generic read-only matcher `match(template, claimed, rho_Act)`:
  - только Links, объявленные в DR, являются placeholders;
  - grounded template subtrees остаются grounded canonical Links;
  - role-containing structure сравнивается рекурсивно по poles;
  - callback name / RuleKind / opcode / TS property name не участвуют в semantic identity;
- `replayStructuralRule` выбирает Rule только через structural I/DR/Rule + explicit `T ⟼ Rule` evidence и проверяет `K_after` без materialization.

## Executable pilots

`ts/test/v09-structural-rules.test.ts` покрывает relation core, colon Entry/effect core, stable-parent context transition, forged I/DR/admission/body/result/K, missing/multiple/extra roles и duplicate DR roles. Malformed Act fixtures намеренно различаются структурным header: одинаковый `(I,DR,K_after)` не используется как источник instance identity.

Общую recursive equality/bisimulation здесь намеренно не вводим: grounded subtree equality остаётся current canonical Link identity до #582/#583.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/structural-rule.ts
  - ts/test/v09-structural-rules.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 800
must_touch:
  - ts/src/structural-rule.ts
  - ts/test/v09-structural-rules.test.ts
must_not_touch:
  - repo-policy.json
  - contracts/**
  - cutover/**
  - .github/**
expected_effects:
  - add structural I/DR/Rule/T-admission candidate forms
  - enforce exact structural Act role bindings without TypeScript role-property authority
  - replay admitted Rule body through one read-only placeholder matcher
  - pilot relation, colon-effect core, and stable-parent context transition without callback/opcode selection
  - preserve accepted v0.8 replay exports/runtime
```

Related: #608, #601, #595, #596, #597