### PR TITLE
governance(v0.9): привязать M4 structural Rule evidence

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -11,7 +11,8 @@
   "coverageState": "partial",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
-    "ts/test/v09-byte-carrier.test.ts"
+    "ts/test/v09-byte-carrier.test.ts",
+    "ts/test/v09-structural-rules.test.ts"
   ],
   "implementedEvidence": {
     "606": {
@@ -32,6 +33,27 @@
       "invalidUtf8CarrierAllowedBelowTextLayer": true,
       "unicodeNormalizationApplied": false,
       "acceptedV08PublicToolingPreserved": true
+    },
+    "608": {
+      "test": "ts/test/v09-structural-rules.test.ts",
+      "structuralInterpreter": "I = D ⟼ (G ⟼ T)",
+      "structuralRoleDictionary": "DR = DR ⟼ ExactSequence(roles)",
+      "structuralRule": "Rule = DR ⟼ Body",
+      "explicitTheoryAdmission": "T ⟼ Rule",
+      "genericRuleReplayReadOnly": true,
+      "exactOneBindingPerDeclaredRole": true,
+      "undeclaredRoleBindingRejected": true,
+      "hostCallbackIdentityUsedForRuleSelection": false,
+      "typeScriptRolePropertyUsedForRoleIdentity": false,
+      "relationPilot": true,
+      "colonEffectCorePilot": true,
+      "stableParentContextTransitionPilot": true,
+      "forgedInterpreterRejected": true,
+      "forgedRoleDictionaryRejected": true,
+      "unadmittedRuleRejected": true,
+      "wrongRuleBodyRejected": true,
+      "missingRoleRejected": true,
+      "multipleRoleBindingRejected": true
     }
   },
   "requiredNegativeVectors": [
@@ -49,6 +71,7 @@
     "rule-not-admitted-by-theory",
     "rule-missing-required-role",
     "rule-conflicting-role-binding",
+    "rule-undeclared-role-binding",
     "rule-wrong-result",
     "rule-wrong-before-context",
     "rule-wrong-after-context",
@@ -135,7 +158,7 @@
   "implementationSlices": {
     "606": {"status": "candidate-green", "requiredForAcceptance": true},
     "607": {"status": "candidate-green", "requiredForAcceptance": true},
-    "608": {"status": "planned", "requiredForAcceptance": true},
+    "608": {"status": "candidate-green", "requiredForAcceptance": true},
     "609": {"status": "planned", "requiredForAcceptance": true},
     "610": {"status": "blocked", "requiredForAcceptance": true}
   },

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -36,7 +36,9 @@
     "quaternaryState": "ts/src/quaternary-state.ts",
     "structuralCarrierEvidence": "ts/test/v09-structural-carriers.test.ts",
     "byteCarrier": "ts/src/byte-carrier.ts",
-    "byteCarrierEvidence": "ts/test/v09-byte-carrier.test.ts"
+    "byteCarrierEvidence": "ts/test/v09-byte-carrier.test.ts",
+    "structuralRule": "ts/src/structural-rule.ts",
+    "structuralRuleEvidence": "ts/test/v09-structural-rules.test.ts"
   },
   "semanticIdentity": {
     "acceptedV08TargetPreserved": true,
@@ -147,6 +149,9 @@
   },
   "contextSemantics": {
     "ownerIssue": 601,
+    "implementationIssue": 608,
+    "implementationOwner": "ts/src/structural-rule.ts",
+    "evidence": "ts/test/v09-structural-rules.test.ts",
     "interpreter": "I = D ⟼ (G ⟼ T)",
     "context": "K = K ⟼ (parent ⟼ current)",
     "contextUse": "I ⟼ K",
@@ -154,10 +159,16 @@
     "rule": "Rule = DR ⟼ Body",
     "ruleAdmission": "T ⟼ Rule",
     "actField": "Act ⟼ (role ⟼ value)",
+    "declaredRoleLinksArePlaceholders": true,
+    "exactOneBindingPerDeclaredRole": true,
+    "undeclaredRoleBindingAllowed": false,
+    "genericRuleReplayReadOnly": true,
+    "typeScriptRolePropertyIsSemanticAuthority": false,
     "runCarriesTemporalOrder": true,
     "contextParentCarriesLexicalNesting": true,
     "hostModeEnumIsSemanticAuthority": false,
-    "hostCallbackIdentityIsSemanticAuthority": false
+    "hostCallbackIdentityIsSemanticAuthority": false,
+    "candidateStructuralRuleKernelImplemented": true
   },
   "semanticRules": {
     "Q_OPEN": {"implementationStatus": "planned", "issue": 609},
@@ -166,9 +177,9 @@
     "Q_FINALIZE": {"implementationStatus": "candidate-implemented", "issue": 606},
     "FORMAL_OPEN": {"implementationStatus": "planned", "issue": 609},
     "FORMAL_GROUP": {"implementationStatus": "planned", "issue": 609},
-    "FORMAL_LINK": {"implementationStatus": "planned", "issue": 608},
-    "FORMAL_COLON": {"implementationStatus": "planned", "issue": 608},
-    "FORMAL_EQUAL": {"implementationStatus": "planned", "issue": 608},
+    "FORMAL_LINK": {"implementationStatus": "candidate-implemented", "issue": 608},
+    "FORMAL_COLON": {"implementationStatus": "candidate-implemented", "issue": 608},
+    "FORMAL_EQUAL": {"implementationStatus": "planned", "issue": 609},
     "FORMAL_CLOSE": {"implementationStatus": "planned", "issue": 609},
     "PARENT_CONTINUE": {"implementationStatus": "planned", "issue": 609}
   },
@@ -182,7 +193,7 @@
   "migrationSlices": [
     {"issue": 606, "name": "root-safe exact sequence and structural QState", "status": "candidate-green"},
     {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary", "status": "candidate-green"},
-    {"issue": 608, "name": "structural interpreter/rule and generic replay", "status": "planned"},
+    {"issue": 608, "name": "structural interpreter/rule and generic replay", "status": "candidate-green"},
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "planned"},
     {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
   ]


### PR DESCRIPTION
Governance PR B для #608 после merge implementation PR #627 (`33608494…`).

Этот PR меняет только v0.9 candidate contract/conformance:

- добавляет `structuralRule` / `structuralRuleEvidence` owner paths;
- связывает structural `I/DR/Rule/T⟼Rule` kernel с #608 implementation/evidence;
- фиксирует exact declared-role binding и read-only generic replay invariants;
- добавляет `ts/test/v09-structural-rules.test.ts` в `requiredExecutableGates`;
- фиксирует только реально прошедшие relation/colon/context-transition и negative evidence;
- помечает #608 `candidate-green`;
- `FORMAL_LINK` и `FORMAL_COLON` отмечены candidate-implemented как доказанные pilots;
- `FORMAL_EQUAL` **не** заявляется реализованным: его final integrated owner перенесён на #609, чей scope явно включает `: / = rules`;
- `accepted=false`, `acceptanceReady=false`, accepted current v0.8 остаются неизменными.

Trusted GovernanceGrant находится в issue #608. `repo-policy.json` не меняется: существующие generic owner path / executable gate coverage constraints должны быть достаточны; если они пройдут, repo-guard расширять не требуется.

```repo-guard-yaml
change_type: governance
scope:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - repo-policy.json
  - cutover/**
  - ts/src/**
  - ts/test/**
  - .github/**
expected_effects:
  - bind already-green M4 structural Rule implementation and executable evidence to the v0.9 candidate
  - expose structural Rule owner and test gate to existing generic path and workflow coverage validation
  - mark slice 608 candidate-green without changing v0.9 acceptance state
  - record FORMAL_LINK and FORMAL_COLON candidate pilots while keeping FORMAL_EQUAL planned for integrated slice 609
  - preserve accepted v0.8 runtime and compatibility replay exports
```

Resolves #608