### PR TITLE
MTS v0.9/M5: structural FORMAL and cross-context integration

### DIFF
--- a/ts/src/context-integration.ts
+++ b/ts/src/context-integration.ts
@@ -1,0 +1,393 @@
+import {
+  ExactSequenceError,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+  type WriteMemory,
+} from "./memory.js";
+import {
+  appendQuaternaryValue,
+  readQuaternaryState,
+  QuaternaryStateError,
+} from "./quaternary-state.js";
+import {
+  localRepresentativeResolution,
+  readContext,
+  StateError,
+} from "./state.js";
+import {
+  readStructuralInterpreter,
+  replayStructuralRule,
+  StructuralRuleError,
+  verifyStructuralInterpreter,
+  type StructuralInterpreter,
+  type StructuralRuleReplayEvidence,
+  type StructuralRuleReplayResult,
+} from "./structural-rule.js";
+
+export type ContextIntegrationErrorCode =
+  | "invalid-context-typing"
+  | "context-interpreter-mismatch"
+  | "lexical-parent-mismatch"
+  | "invalid-formal-sequence"
+  | "empty-formal-context"
+  | "formal-close-projection-mismatch"
+  | "invalid-quaternary-state"
+  | "quaternary-result-mismatch"
+  | "equality-evidence-mismatch"
+  | "equality-distinguished"
+  | "replay-wrote";
+
+export class ContextIntegrationError extends Error {
+  override readonly name = "ContextIntegrationError";
+
+  constructor(readonly code: ContextIntegrationErrorCode) {
+    super(code);
+  }
+}
+
+/**
+ * `I ⟼ K` is the explicit semantic typing/admission of one immutable context.
+ * The host object only bundles the three already materialized structural Links.
+ */
+export interface TypedContext {
+  readonly interpreter: LinkHandle;
+  readonly context: LinkHandle;
+  readonly typing: LinkHandle;
+}
+
+export interface FormalCloseEvidence {
+  readonly child: TypedContext;
+  readonly parentBefore: TypedContext;
+  readonly expectedChildInterpreter: StructuralInterpreter;
+  readonly expectedParentInterpreter: StructuralInterpreter;
+  readonly result: LinkHandle;
+  readonly ruleReplay: StructuralRuleReplayEvidence;
+}
+
+export interface FormalCloseResult {
+  readonly parentBefore: TypedContext;
+  readonly result: LinkHandle;
+  readonly replay: StructuralRuleReplayResult;
+}
+
+export interface FormalEqualityEvidence extends FormalCloseEvidence {
+  readonly resolutionContext: LinkHandle;
+  readonly contextRole: LinkHandle;
+  readonly leftRole: LinkHandle;
+  readonly rightRole: LinkHandle;
+  readonly leftRepresentativeRole: LinkHandle;
+  readonly rightRepresentativeRole: LinkHandle;
+}
+
+export function defineTypedContext(
+  memory: WriteMemory,
+  interpreter: LinkHandle,
+  parent: LinkHandle,
+  current: LinkHandle,
+): TypedContext {
+  readStructuralInterpreter(memory, interpreter);
+  const payload = memory.ensure(parent, current);
+  const context = memory.ensureStartSelfClosed(payload);
+  const typing = memory.ensure(interpreter, context);
+  return Object.freeze({ interpreter, context, typing });
+}
+
+/** Read-only verification of both K shape and its explicit `I ⟼ K` evidence. */
+export function verifyTypedContext(
+  memory: ReadMemory,
+  typed: TypedContext,
+  expectedInterpreter: StructuralInterpreter,
+): void {
+  try {
+    verifyStructuralInterpreter(memory, typed.interpreter, expectedInterpreter);
+    const typing = memory.poles(typed.typing);
+    if (typing.start !== typed.interpreter || typing.end !== typed.context) {
+      throw new ContextIntegrationError("invalid-context-typing");
+    }
+    readContext(memory, typed.context);
+  } catch (error) {
+    if (error instanceof ContextIntegrationError) throw error;
+    if (error instanceof StructuralRuleError) {
+      throw new ContextIntegrationError("context-interpreter-mismatch");
+    }
+    if (error instanceof StateError || error instanceof MemoryError) {
+      throw new ContextIntegrationError("invalid-context-typing");
+    }
+    throw error;
+  }
+}
+
+/**
+ * OPEN is an explicit context transition. No hidden parser stack is consulted:
+ * the lexical parent is the concrete K supplied here and the target I is data.
+ */
+export function openChildContext(
+  memory: WriteMemory,
+  parentBefore: TypedContext,
+  expectedParentInterpreter: StructuralInterpreter,
+  targetInterpreter: LinkHandle,
+  initialCurrent: LinkHandle,
+): TypedContext {
+  verifyTypedContext(memory, parentBefore, expectedParentInterpreter);
+  return defineTypedContext(memory, targetInterpreter, parentBefore.context, initialCurrent);
+}
+
+/** FORMAL starts at the exact empty sequence `Seq([])=R`. */
+export function openFormalContext(
+  memory: WriteMemory,
+  parentBefore: TypedContext,
+  expectedParentInterpreter: StructuralInterpreter,
+  formalInterpreter: LinkHandle,
+): TypedContext {
+  return openChildContext(
+    memory,
+    parentBefore,
+    expectedParentInterpreter,
+    formalInterpreter,
+    memory.root,
+  );
+}
+
+/** Q starts at structural QEmpty=R. */
+export function openQuaternaryContext(
+  memory: WriteMemory,
+  parentBefore: TypedContext,
+  expectedParentInterpreter: StructuralInterpreter,
+  quaternaryInterpreter: LinkHandle,
+): TypedContext {
+  return openChildContext(
+    memory,
+    parentBefore,
+    expectedParentInterpreter,
+    quaternaryInterpreter,
+    memory.root,
+  );
+}
+
+/**
+ * PARENT_CONTINUE for FORMAL. A returned `R` is appended as an explicit Cell,
+ * so one root-valued child result can never collapse to the empty sequence.
+ */
+export function continueFormalContext(
+  memory: WriteMemory,
+  before: TypedContext,
+  expectedInterpreter: StructuralInterpreter,
+  value: LinkHandle,
+): TypedContext {
+  verifyTypedContext(memory, before, expectedInterpreter);
+  let state;
+  try {
+    state = readContext(memory, before.context);
+    readExactSequence(memory, state.current);
+  } catch (error) {
+    if (error instanceof ExactSequenceError || error instanceof StateError || error instanceof MemoryError) {
+      throw new ContextIntegrationError("invalid-formal-sequence");
+    }
+    throw error;
+  }
+
+  const payload = memory.ensure(state.current, value);
+  const current = memory.ensureStartSelfClosed(payload);
+  return defineTypedContext(memory, before.interpreter, state.parent, current);
+}
+
+/** One immutable Q snapshot; lexical parent is preserved exactly. */
+export function continueQuaternaryContext(
+  memory: WriteMemory,
+  before: TypedContext,
+  expectedInterpreter: StructuralInterpreter,
+  value: LinkHandle,
+): TypedContext {
+  verifyTypedContext(memory, before, expectedInterpreter);
+  let state;
+  try {
+    state = readContext(memory, before.context);
+    readQuaternaryState(memory, state.current);
+  } catch (error) {
+    if (error instanceof QuaternaryStateError || error instanceof StateError || error instanceof MemoryError) {
+      throw new ContextIntegrationError("invalid-quaternary-state");
+    }
+    throw error;
+  }
+  const current = appendQuaternaryValue(memory, state.current, value);
+  return defineTypedContext(memory, before.interpreter, state.parent, current);
+}
+
+/**
+ * Read-only verification of `]`: CLOSE returns to the old lexical parent but
+ * does not append there. Parent continuation is a separate explicit operation.
+ */
+export function replayQuaternaryClose(
+  memory: ReadMemory,
+  child: TypedContext,
+  expectedChildInterpreter: StructuralInterpreter,
+  parentBefore: TypedContext,
+  expectedParentInterpreter: StructuralInterpreter,
+  expectedResult: LinkHandle,
+): LinkHandle {
+  const before = memory.linkCount;
+  try {
+    verifyTypedContext(memory, child, expectedChildInterpreter);
+    verifyTypedContext(memory, parentBefore, expectedParentInterpreter);
+    const childState = readContext(memory, child.context);
+    if (childState.parent !== parentBefore.context) {
+      throw new ContextIntegrationError("lexical-parent-mismatch");
+    }
+
+    const q = readQuaternaryState(memory, childState.current);
+    if (!q.started) {
+      if (expectedResult !== memory.root) {
+        throw new ContextIntegrationError("quaternary-result-mismatch");
+      }
+    } else {
+      const result = memory.poles(expectedResult);
+      if (result.start !== memory.root || result.end !== q.current) {
+        throw new ContextIntegrationError("quaternary-result-mismatch");
+      }
+    }
+    return expectedResult;
+  } catch (error) {
+    if (error instanceof ContextIntegrationError) throw error;
+    if (error instanceof QuaternaryStateError || error instanceof StateError || error instanceof MemoryError) {
+      throw new ContextIntegrationError("quaternary-result-mismatch");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new ContextIntegrationError("replay-wrote");
+    }
+  }
+}
+
+/**
+ * Generic FORMAL `)` replay. Rule selection remains structural: the supplied
+ * Act is checked against I/DR/Rule and explicit `T ⟼ Rule` admission by M4.
+ * M5 only adds the immutable lexical lifecycle and the exact close projection
+ * `[child-form-sequence, semantic-result]`.
+ */
+export function replayFormalClose(
+  memory: ReadMemory,
+  evidence: FormalCloseEvidence,
+): FormalCloseResult {
+  const before = memory.linkCount;
+  try {
+    verifyTypedContext(memory, evidence.child, evidence.expectedChildInterpreter);
+    verifyTypedContext(memory, evidence.parentBefore, evidence.expectedParentInterpreter);
+
+    const childState = readContext(memory, evidence.child.context);
+    if (childState.parent !== evidence.parentBefore.context) {
+      throw new ContextIntegrationError("lexical-parent-mismatch");
+    }
+
+    let form;
+    try {
+      form = readExactSequence(memory, childState.current);
+    } catch (error) {
+      if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+        throw new ContextIntegrationError("invalid-formal-sequence");
+      }
+      throw error;
+    }
+    if (form.values.length === 0) {
+      throw new ContextIntegrationError("empty-formal-context");
+    }
+
+    if (evidence.ruleReplay.expectedAfterContext !== evidence.parentBefore.context) {
+      throw new ContextIntegrationError("formal-close-projection-mismatch");
+    }
+    const replay = replayStructuralRule(memory, evidence.ruleReplay);
+    if (replay.interpreter !== evidence.child.interpreter) {
+      throw new ContextIntegrationError("context-interpreter-mismatch");
+    }
+
+    let projection;
+    try {
+      projection = readExactSequence(memory, evidence.ruleReplay.claimedBody);
+    } catch (error) {
+      if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+        throw new ContextIntegrationError("formal-close-projection-mismatch");
+      }
+      throw error;
+    }
+    if (
+      projection.values.length !== 2 ||
+      projection.values[0] !== childState.current ||
+      projection.values[1] !== evidence.result
+    ) {
+      throw new ContextIntegrationError("formal-close-projection-mismatch");
+    }
+
+    return Object.freeze({
+      parentBefore: evidence.parentBefore,
+      result: evidence.result,
+      replay,
+    });
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new ContextIntegrationError("replay-wrote");
+    }
+  }
+}
+
+function replayBinding(
+  replay: StructuralRuleReplayResult,
+  role: LinkHandle,
+): LinkHandle | undefined {
+  return replay.bindings.find((binding) => binding.role === role)?.value;
+}
+
+/**
+ * Specialized admitted FORMAL `=` judgment. The structural Rule is selected
+ * first; this checker merely verifies the context-local representative evidence
+ * that generic placeholder matching intentionally cannot derive.
+ */
+export function replayFormalEquality(
+  memory: ReadMemory,
+  evidence: FormalEqualityEvidence,
+): FormalCloseResult {
+  const before = memory.linkCount;
+  try {
+    const close = replayFormalClose(memory, evidence);
+    const context = replayBinding(close.replay, evidence.contextRole);
+    const left = replayBinding(close.replay, evidence.leftRole);
+    const right = replayBinding(close.replay, evidence.rightRole);
+    const leftRepresentative = replayBinding(close.replay, evidence.leftRepresentativeRole);
+    const rightRepresentative = replayBinding(close.replay, evidence.rightRepresentativeRole);
+
+    if (
+      context === undefined ||
+      left === undefined ||
+      right === undefined ||
+      leftRepresentative === undefined ||
+      rightRepresentative === undefined ||
+      context !== evidence.resolutionContext ||
+      close.result !== memory.root
+    ) {
+      throw new ContextIntegrationError("equality-evidence-mismatch");
+    }
+
+    const actualLeft = localRepresentativeResolution(memory, context, left).representative;
+    const actualRight = localRepresentativeResolution(memory, context, right).representative;
+    if (actualLeft !== leftRepresentative || actualRight !== rightRepresentative) {
+      throw new ContextIntegrationError("equality-evidence-mismatch");
+    }
+    if (actualLeft !== actualRight) {
+      throw new ContextIntegrationError("equality-distinguished");
+    }
+    return close;
+  } catch (error) {
+    if (error instanceof ContextIntegrationError || error instanceof StructuralRuleError) throw error;
+    if (error instanceof StateError || error instanceof MemoryError) {
+      throw new ContextIntegrationError("equality-evidence-mismatch");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new ContextIntegrationError("replay-wrote");
+    }
+  }
+}

--- a/ts/test/v09-context-integration.test.ts
+++ b/ts/test/v09-context-integration.test.ts
@@ -1,511 +1,220 @@
 import {
-  ContextIntegrationError,
-  continueFormalContext,
-  continueQuaternaryContext,
-  defineTypedContext,
-  openFormalContext,
-  openQuaternaryContext,
-  replayFormalClose,
-  replayFormalEquality,
-  replayQuaternaryClose,
-  type TypedContext,
+  ContextIntegrationError, continueFormalContext, continueQuaternaryContext,
+  defineTypedContext, openFormalContext, openQuaternaryContext,
+  replayFormalClose, replayFormalEquality, replayQuaternaryClose, type TypedContext,
 } from "../src/context-integration.js";
 import { materializeExactSequence, readExactSequence } from "../src/exact-sequence.js";
-import {
-  Memory,
-  ensureRootBasis,
-  type LinkHandle,
-  type LinkPoles,
-  type ReadMemory,
-} from "../src/memory.js";
+import { Memory, ensureRootBasis, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
 import { replayRun } from "../src/run.js";
 import { defineContext, defineLocalRepresentativeBinding, readContext } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
 import {
-  admitStructuralRule,
-  defineStructuralInterpreter,
-  defineStructuralRoleDictionary,
-  defineStructuralRule,
-  StructuralRuleError,
-  type StructuralInterpreter,
+  admitStructuralRule, defineStructuralInterpreter, defineStructuralRoleDictionary,
+  defineStructuralRule, StructuralRuleError, type StructuralInterpreter,
 } from "../src/structural-rule.js";
 
-function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
-}
+function assert(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(message); }
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
 }
 function expectContextError(code: ContextIntegrationError["code"], effect: () => unknown): void {
-  try { effect(); }
-  catch (error) {
+  try { effect(); } catch (error) {
     assert(error instanceof ContextIntegrationError, `expected ContextIntegrationError, got ${String(error)}`);
-    same(error.code, code, "context integration error code");
-    return;
+    same(error.code, code, "context integration error code"); return;
   }
   throw new Error(`expected ContextIntegrationError(${code})`);
 }
 function expectRuleError(code: StructuralRuleError["code"], effect: () => unknown): void {
-  try { effect(); }
-  catch (error) {
+  try { effect(); } catch (error) {
     assert(error instanceof StructuralRuleError, `expected StructuralRuleError, got ${String(error)}`);
-    same(error.code, code, "structural rule error code");
-    return;
+    same(error.code, code, "structural rule error code"); return;
   }
   throw new Error(`expected StructuralRuleError(${code})`);
 }
-
-/** Structurally distinct ordinary Links; fixture order never participates in semantic identity. */
 function anchors(memory: Memory, count: number): readonly LinkHandle[] {
-  const result: LinkHandle[] = [];
-  const seed = memory.ensureEndSelfClosed(memory.root);
+  const result: LinkHandle[] = []; const seed = memory.ensureEndSelfClosed(memory.root);
   let tag = memory.ensureStartSelfClosed(memory.root);
   for (let index = 0; index < count; index += 1) {
-    tag = memory.ensureStartSelfClosed(tag);
-    result.push(memory.ensure(seed, tag));
+    tag = memory.ensureStartSelfClosed(tag); result.push(memory.ensure(seed, tag));
   }
   return Object.freeze(result);
 }
-
 class ReplayProbe implements ReadMemory {
-  outgoingCalls = 0;
-  constructor(private readonly source: ReadMemory) {}
-  get root(): LinkHandle { return this.source.root; }
-  get linkCount(): number { return this.source.linkCount; }
+  outgoingCalls = 0; constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; } get linkCount(): number { return this.source.linkCount; }
   poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
   find(): LinkHandle | undefined { throw new Error("M5 replay must not use find"); }
   incoming(): readonly LinkHandle[] { throw new Error("M5 replay must not use incoming"); }
-  outgoing(start: LinkHandle): readonly LinkHandle[] {
-    this.outgoingCalls += 1;
-    return this.source.outgoing(start);
-  }
+  outgoing(start: LinkHandle): readonly LinkHandle[] { this.outgoingCalls += 1; return this.source.outgoing(start); }
 }
-
-interface InterpreterFixture {
-  readonly handle: LinkHandle;
-  readonly structure: StructuralInterpreter;
-}
-interface RuleFixture {
-  readonly roleDictionary: LinkHandle;
-  readonly rule: LinkHandle;
-  readonly admission: LinkHandle;
-}
-function interpreter(
-  memory: Memory,
-  dictionary: LinkHandle,
-  grammar: LinkHandle,
-  theory: LinkHandle,
-): InterpreterFixture {
+interface IFix { readonly handle: LinkHandle; readonly structure: StructuralInterpreter; }
+interface RFix { readonly roleDictionary: LinkHandle; readonly rule: LinkHandle; readonly admission: LinkHandle; }
+function interpreter(memory: Memory, dictionary: LinkHandle, grammar: LinkHandle, theory: LinkHandle): IFix {
   const structure = Object.freeze({ dictionary, grammar, theory });
-  return Object.freeze({
-    handle: defineStructuralInterpreter(memory, dictionary, grammar, theory),
-    structure,
-  });
+  return Object.freeze({ handle: defineStructuralInterpreter(memory, dictionary, grammar, theory), structure });
 }
-function rule(
-  memory: Memory,
-  owner: InterpreterFixture,
-  roles: readonly LinkHandle[],
-  body: LinkHandle,
-): RuleFixture {
-  const roleDictionary = defineStructuralRoleDictionary(memory, roles);
-  const ruleRef = defineStructuralRule(memory, roleDictionary, body);
-  return Object.freeze({
-    roleDictionary,
-    rule: ruleRef,
-    admission: admitStructuralRule(memory, owner.structure.theory, ruleRef),
-  });
+function rule(memory: Memory, owner: IFix, roles: readonly LinkHandle[], body: LinkHandle): RFix {
+  const roleDictionary = defineStructuralRoleDictionary(memory, roles); const ruleRef = defineStructuralRule(memory, roleDictionary, body);
+  return Object.freeze({ roleDictionary, rule: ruleRef, admission: admitStructuralRule(memory, owner.structure.theory, ruleRef) });
 }
-function act(
-  memory: Memory,
-  owner: InterpreterFixture,
-  selected: RuleFixture,
-  after: LinkHandle,
-  fields: readonly (readonly [LinkHandle, LinkHandle])[],
-): LinkHandle {
+function act(memory: Memory, owner: IFix, selected: RFix, after: LinkHandle,
+  fields: readonly (readonly [LinkHandle, LinkHandle])[]): LinkHandle {
   const result = defineActHeader(memory, owner.handle, selected.roleDictionary, after);
-  for (const [roleRef, value] of fields) defineActField(memory, result, roleRef, value);
-  return result;
+  for (const [roleRef, value] of fields) defineActField(memory, result, roleRef, value); return result;
 }
-function parentContext(memory: Memory, owner: InterpreterFixture, marker: LinkHandle): TypedContext {
+function parentContext(memory: Memory, owner: IFix, marker: LinkHandle): TypedContext {
   return defineTypedContext(memory, owner.handle, memory.root, materializeExactSequence(memory, [marker]));
 }
-function closeEvidence(
-  child: TypedContext,
-  parentBefore: TypedContext,
-  formal: InterpreterFixture,
-  parentOwner: InterpreterFixture,
-  result: LinkHandle,
-  selected: RuleFixture,
-  selectedAct: LinkHandle,
-  claimedBody: LinkHandle,
-) {
-  return Object.freeze({
-    child,
-    parentBefore,
-    expectedChildInterpreter: formal.structure,
-    expectedParentInterpreter: parentOwner.structure,
-    result,
-    ruleReplay: Object.freeze({
-      act: selectedAct,
-      rule: selected.rule,
-      ruleAdmission: selected.admission,
-      claimedBody,
-      expectedInterpreter: formal.structure,
-      expectedAfterContext: parentBefore.context,
-    }),
-  });
+function evidence(child: TypedContext, parent: TypedContext, parentOwner: IFix, result: LinkHandle,
+  selected: RFix, selectedAct: LinkHandle) {
+  return Object.freeze({ child, parentBefore: parent, expectedChildInterpreter: formalI.structure,
+    expectedParentInterpreter: parentOwner.structure, result,
+    ruleReplay: Object.freeze({ act: selectedAct, rule: selected.rule, ruleAdmission: selected.admission,
+      claimedBody: materializeExactSequence(memory, [readContext(memory, child.context).current, result]),
+      expectedInterpreter: formalI.structure, expectedAfterContext: parent.context }) });
+}
+function formalChild(parent: TypedContext, parentOwner: IFix, values: readonly LinkHandle[]): TypedContext {
+  let child = openFormalContext(memory, parent, parentOwner.structure, formalI.handle);
+  for (const value of values) child = continueFormalContext(memory, child, formalI.structure, value); return child;
 }
 
-const memory = new Memory();
-const basis = ensureRootBasis(memory);
-const pool = anchors(memory, 64);
-let cursor = 0;
-function next(name: string): LinkHandle {
-  const value = pool[cursor];
-  cursor += 1;
-  assert(value !== undefined, `missing structural fixture ${name}`);
-  return value;
-}
-
-// One structural pool is partitioned once. Re-running the same anchor recipe would
-// canonically return the same Links and therefore must not be used as an instance factory.
+const memory = new Memory(); const basis = ensureRootBasis(memory); const pool = anchors(memory, 64); let cursor = 0;
+function next(name: string): LinkHandle { const value = pool[cursor++]; assert(value !== undefined, `missing ${name}`); return value; }
+// One recursively distinct pool is partitioned once; repeated recipes are not instance factories.
 const rootI = interpreter(memory, next("root-D"), next("root-G"), next("root-T"));
 const formalI = interpreter(memory, next("formal-D"), next("formal-G"), next("formal-T"));
 const qI = interpreter(memory, next("q-D"), next("q-G"), next("q-T"));
-assert(rootI.handle !== formalI.handle && formalI.handle !== qI.handle, "interpreters differ structurally");
-
-const marker0 = next("marker0");
-const marker1 = next("marker1");
-const marker2 = next("marker2");
-const marker3 = next("marker3");
-const marker4 = next("marker4");
-const marker5 = next("marker5");
-const marker6 = next("marker6");
-const marker7 = next("marker7");
-const marker8 = next("marker8");
-const marker9 = next("marker9");
-const marker10 = next("marker10");
-const A = next("A");
-const B = next("B");
-const C = next("C");
-const arrowCarrier = next("arrow-carrier");
-const oneCarrier = next("one-carrier");
-const equalCarrier = next("equal-carrier");
-const infinityCarrier = next("infinity-carrier");
-const colonCarrier = next("colon-carrier");
-const leftRole = next("left-role");
-const rightRole = next("right-role");
-const valueRole = next("value-role");
-const contextRole = next("context-role");
-const leftRepresentativeRole = next("left-representative-role");
-const rightRepresentativeRole = next("right-representative-role");
-const sourceRole = next("source-role");
-const formRole = next("form-role");
-const beforeRole = next("before-role");
-const afterRole = next("after-role");
-const representative = next("representative");
-const otherRepresentative = next("other-representative");
-const runValue0 = next("run-value-0");
-const runValue1 = next("run-value-1");
-const runValue2 = next("run-value-2");
-const lexicalParentCurrent = next("lexical-parent-current");
-
-// Same root meaning does not erase carrier/sign/use identity.
-const arrowUse = memory.ensure(arrowCarrier, basis.L);
-const abitOneUse = memory.ensure(oneCarrier, basis.L);
-const equalUse = memory.ensure(equalCarrier, basis.R);
-const infinityUse = memory.ensure(infinityCarrier, basis.R);
+assert(rootI.handle !== formalI.handle && formalI.handle !== qI.handle, "I fixtures differ structurally");
+const marker0 = next("m0"), marker1 = next("m1"), marker2 = next("m2"), marker3 = next("m3");
+const marker4 = next("m4"), marker5 = next("m5"), marker6 = next("m6"), marker7 = next("m7");
+const marker8 = next("m8"), marker9 = next("m9"), marker10 = next("m10");
+const A = next("A"), B = next("B"), C = next("C");
+const arrowCarrier = next("arrow"), oneCarrier = next("one"), equalCarrier = next("equal");
+const infinityCarrier = next("infinity"), colonCarrier = next("colon");
+const leftRole = next("left"), rightRole = next("right"), valueRole = next("value"), contextRole = next("context");
+const leftRepRole = next("leftRep"), rightRepRole = next("rightRep"), sourceRole = next("source"), formRole = next("form");
+const beforeRole = next("before"), afterRole = next("after"), representative = next("rep"), otherRep = next("otherRep");
+const run0 = next("run0"), run1 = next("run1"), run2 = next("run2"), lexicalCurrent = next("lexical");
+const arrowUse = memory.ensure(arrowCarrier, basis.L), oneUse = memory.ensure(oneCarrier, basis.L);
+const equalUse = memory.ensure(equalCarrier, basis.R), infinityUse = memory.ensure(infinityCarrier, basis.R);
 const colonUse = memory.ensure(colonCarrier, memory.ensure(basis.R, basis.L));
-assert(arrowUse !== abitOneUse, "FORMAL arrow stays distinct from quaternary 1 use");
-assert(equalUse !== infinityUse, "FORMAL = stays distinct from infinity use");
+assert(arrowUse !== oneUse, "arrow use != quaternary 1 use"); assert(equalUse !== infinityUse, "= use != infinity use");
 
-// Admitted relation rule: exactly `(left ⟼ right)`, without precedence/associativity.
-const relationTemplateForm = materializeExactSequence(memory, [leftRole, arrowUse, rightRole]);
-const relationTemplateResult = memory.ensure(leftRole, rightRole);
-const relationRule = rule(
-  memory,
-  formalI,
-  [leftRole, rightRole],
-  materializeExactSequence(memory, [relationTemplateForm, relationTemplateResult]),
-);
-function evaluateRelation(
-  parent: TypedContext,
-  parentOwner: InterpreterFixture,
-  left: LinkHandle,
-  right: LinkHandle,
-): LinkHandle {
-  let child = openFormalContext(memory, parent, parentOwner.structure, formalI.handle);
-  child = continueFormalContext(memory, child, formalI.structure, left);
-  child = continueFormalContext(memory, child, formalI.structure, arrowUse);
-  child = continueFormalContext(memory, child, formalI.structure, right);
-  const result = memory.ensure(left, right);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, result]);
+const relationForm = materializeExactSequence(memory, [leftRole, arrowUse, rightRole]);
+const relationResult = memory.ensure(leftRole, rightRole);
+const relationRule = rule(memory, formalI, [leftRole, rightRole], materializeExactSequence(memory, [relationForm, relationResult]));
+function relation(parent: TypedContext, parentOwner: IFix, left: LinkHandle, right: LinkHandle): LinkHandle {
+  const child = formalChild(parent, parentOwner, [left, arrowUse, right]); const result = memory.ensure(left, right);
   const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, left], [rightRole, right]]);
-  const probe = new ReplayProbe(memory);
-  const before = memory.linkCount;
-  same(
-    replayFormalClose(probe, closeEvidence(child, parent, formalI, parentOwner, result, relationRule, selectedAct, claimed)).result,
-    result,
-    "relation close result",
-  );
-  same(memory.linkCount, before, "relation replay is read-only");
-  assert(probe.outgoingCalls > 0, "relation replay reads structural Act fields");
-  return result;
+  const before = memory.linkCount; const probe = new ReplayProbe(memory);
+  same(replayFormalClose(probe, evidence(child, parent, parentOwner, result, relationRule, selectedAct)).result, result, "relation result");
+  same(memory.linkCount, before, "relation replay read-only"); assert(probe.outgoingCalls > 0, "Act fields read structurally"); return result;
 }
+const p0 = parentContext(memory, rootI, marker0); const ab0 = relation(p0, rootI, A, B);
+same(ab0, memory.ensure(A, B), "(A ⟼ B)"); const p0before = readContext(memory, p0.context);
+const p0after = continueFormalContext(memory, p0, rootI.structure, ab0);
+same(readContext(memory, p0.context).current, p0before.current, "CLOSE leaves parent immutable");
+same(readContext(memory, p0after.context).parent, p0before.parent, "PARENT_CONTINUE keeps lexical parent");
+const p0values = readExactSequence(memory, readContext(memory, p0after.context).current).values;
+same(p0values[p0values.length - 1], ab0, "PARENT_CONTINUE appends result");
 
-const relationParent = parentContext(memory, rootI, marker0);
-const relation = evaluateRelation(relationParent, rootI, A, B);
-same(relation, memory.ensure(A, B), "(A ⟼ B)");
-const parentBeforeState = readContext(memory, relationParent.context);
-const parentAfter = continueFormalContext(memory, relationParent, rootI.structure, relation);
-same(readContext(memory, relationParent.context).current, parentBeforeState.current, "CLOSE does not mutate parent-before");
-same(readContext(memory, parentAfter.context).parent, parentBeforeState.parent, "PARENT_CONTINUE keeps lexical parent");
-const parentValues = readExactSequence(memory, readContext(memory, parentAfter.context).current).values;
-same(parentValues[parentValues.length - 1], relation, "PARENT_CONTINUE appends result");
-
-// Nested left/right forms remain different exact relation trees.
 const rightParent = parentContext(memory, rootI, marker1);
-let rightOuter = openFormalContext(memory, rightParent, rootI.structure, formalI.handle);
-rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, A);
-rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, arrowUse);
-const bc = evaluateRelation(rightOuter, formalI, B, C);
-rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, bc);
-const rightNested = memory.ensure(A, bc);
-replayFormalClose(memory, closeEvidence(
-  rightOuter,
-  rightParent,
-  formalI,
-  rootI,
-  rightNested,
-  relationRule,
-  act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]]),
-  materializeExactSequence(memory, [readContext(memory, rightOuter.context).current, rightNested]),
-));
-
-const leftParent = parentContext(memory, rootI, marker2);
-let leftOuter = openFormalContext(memory, leftParent, rootI.structure, formalI.handle);
-const ab = evaluateRelation(leftOuter, formalI, A, B);
-leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, ab);
+let rightOuter = formalChild(rightParent, rootI, [A, arrowUse]); const bc = relation(rightOuter, formalI, B, C);
+rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, bc); const rightNested = memory.ensure(A, bc);
+replayFormalClose(memory, evidence(rightOuter, rightParent, rootI, rightNested, relationRule,
+  act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]])));
+const leftParent = parentContext(memory, rootI, marker2); let leftOuter = openFormalContext(memory, leftParent, rootI.structure, formalI.handle);
+const ab = relation(leftOuter, formalI, A, B); leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, ab);
 leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, arrowUse);
-leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, C);
-const leftNested = memory.ensure(ab, C);
-replayFormalClose(memory, closeEvidence(
-  leftOuter,
-  leftParent,
-  formalI,
-  rootI,
-  leftNested,
-  relationRule,
-  act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]]),
-  materializeExactSequence(memory, [readContext(memory, leftOuter.context).current, leftNested]),
-));
-assert(rightNested !== leftNested, "right/left nested relations differ");
+leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, C); const leftNested = memory.ensure(ab, C);
+replayFormalClose(memory, evidence(leftOuter, leftParent, rootI, leftNested, relationRule,
+  act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]])));
+assert(rightNested !== leftNested, "right/left nested relation forms differ");
 
-// Bare `A ⟼ B ⟼ C` has no admitted minimal-F1 relation shape.
 {
-  const parent = parentContext(memory, rootI, marker3);
-  let bare = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  for (const value of [A, arrowUse, B, arrowUse, C]) {
-    bare = continueFormalContext(memory, bare, formalI.structure, value);
-  }
-  const result = memory.ensure(ab, C);
-  expectRuleError("template-mismatch", () => replayFormalClose(memory, closeEvidence(
-    bare,
-    parent,
-    formalI,
-    rootI,
-    result,
-    relationRule,
-    act(memory, formalI, relationRule, parent.context, [[leftRole, A], [rightRole, B]]),
-    materializeExactSequence(memory, [readContext(memory, bare.context).current, result]),
-  )));
+  const parent = parentContext(memory, rootI, marker3); const bare = formalChild(parent, rootI, [A, arrowUse, B, arrowUse, C]);
+  const result = memory.ensure(ab, C); const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, A], [rightRole, B]]);
+  expectRuleError("template-mismatch", () => replayFormalClose(memory, evidence(bare, parent, rootI, result, relationRule, selectedAct)));
 }
 
-// One-value grouping is explicitly admitted; empty FORMAL remains unadmitted.
-const oneTemplate = materializeExactSequence(memory, [valueRole]);
-const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memory, [oneTemplate, valueRole]));
+const oneForm = materializeExactSequence(memory, [valueRole]);
+const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memory, [oneForm, valueRole]));
 {
-  const parent = parentContext(memory, rootI, marker4);
-  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  child = continueFormalContext(memory, child, formalI.structure, A);
+  const parent = parentContext(memory, rootI, marker4); const child = formalChild(parent, rootI, [A]);
   const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, A]]);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
-  replayFormalClose(memory, closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claimed));
-
+  replayFormalClose(memory, evidence(child, parent, rootI, A, oneRule, selectedAct));
   const empty = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  expectContextError("empty-formal-context", () => replayFormalClose(
-    memory,
-    closeEvidence(empty, parent, formalI, rootI, A, oneRule, selectedAct, claimed),
-  ));
+  expectContextError("empty-formal-context", () => replayFormalClose(memory, evidence(empty, parent, rootI, A, oneRule, selectedAct)));
 }
 
-// `[]`, `[[]]`, `([[]])`: returned R is preserved as an exact FORMAL position.
 {
-  const parent = parentContext(memory, rootI, marker5);
-  let formal = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  const emptyQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
-  const before = memory.linkCount;
+  const parent = parentContext(memory, rootI, marker5); let formal = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  const emptyQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle); const before = memory.linkCount;
   same(replayQuaternaryClose(memory, emptyQ, qI.structure, formal, formalI.structure, memory.root), memory.root, "[] -> R");
-  same(memory.linkCount, before, "Q close replay is read-only");
-  formal = continueFormalContext(memory, formal, formalI.structure, memory.root);
-  const firstValues = readExactSequence(memory, readContext(memory, formal.context).current).values;
-  same(firstValues.length, 1, "returned R occupies one FORMAL position");
-  same(firstValues[0], memory.root, "returned position is R");
-
+  same(memory.linkCount, before, "Q close read-only"); formal = continueFormalContext(memory, formal, formalI.structure, memory.root);
+  const values = readExactSequence(memory, readContext(memory, formal.context).current).values;
+  same(values.length, 1, "returned R is one FORMAL position"); same(values[0], memory.root, "returned position value R");
   let outerQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
   const innerQ = openQuaternaryContext(memory, outerQ, qI.structure, qI.handle);
-  const innerResult = replayQuaternaryClose(memory, innerQ, qI.structure, outerQ, qI.structure, memory.root);
-  outerQ = continueQuaternaryContext(memory, outerQ, qI.structure, innerResult);
-  const outerResult = replayQuaternaryClose(memory, outerQ, qI.structure, formal, formalI.structure, memory.root);
-  same(outerResult, memory.root, "[[]] -> R");
-
-  let wrapper = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  wrapper = continueFormalContext(memory, wrapper, formalI.structure, outerResult);
-  const wrapperClaim = materializeExactSequence(memory, [readContext(memory, wrapper.context).current, memory.root]);
-  replayFormalClose(memory, closeEvidence(
-    wrapper,
-    parent,
-    formalI,
-    rootI,
-    memory.root,
-    oneRule,
-    act(memory, formalI, oneRule, parent.context, [[valueRole, memory.root]]),
-    wrapperClaim,
-  ));
-  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) has one R-valued form");
+  const inner = replayQuaternaryClose(memory, innerQ, qI.structure, outerQ, qI.structure, memory.root);
+  outerQ = continueQuaternaryContext(memory, outerQ, qI.structure, inner);
+  const outer = replayQuaternaryClose(memory, outerQ, qI.structure, formal, formalI.structure, memory.root); same(outer, memory.root, "[[]] -> R");
+  const wrapper = formalChild(parent, rootI, [outer]); const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, memory.root]]);
+  replayFormalClose(memory, evidence(wrapper, parent, rootI, memory.root, oneRule, selectedAct));
+  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) keeps one R-valued form");
 }
 
-// Colon is a distinct admitted FORMAL use yielding carrier -> form Entry.
 {
-  const parent = parentContext(memory, rootI, marker6);
-  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  for (const value of [A, colonUse, B]) child = continueFormalContext(memory, child, formalI.structure, value);
-  const template = materializeExactSequence(memory, [sourceRole, colonUse, formRole]);
-  const entryTemplate = memory.ensure(sourceRole, formRole);
-  const colonRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [template, entryTemplate]));
-  const entry = memory.ensure(A, B);
-  replayFormalClose(memory, closeEvidence(
-    child,
-    parent,
-    formalI,
-    rootI,
-    entry,
-    colonRule,
-    act(memory, formalI, colonRule, parent.context, [[sourceRole, A], [formRole, B]]),
-    materializeExactSequence(memory, [readContext(memory, child.context).current, entry]),
-  ));
+  const parent = parentContext(memory, rootI, marker6); const child = formalChild(parent, rootI, [A, colonUse, B]);
+  const form = materializeExactSequence(memory, [sourceRole, colonUse, formRole]); const entryTemplate = memory.ensure(sourceRole, formRole);
+  const colonRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [form, entryTemplate]));
+  const entry = memory.ensure(A, B); const selectedAct = act(memory, formalI, colonRule, parent.context, [[sourceRole, A], [formRole, B]]);
+  replayFormalClose(memory, evidence(child, parent, rootI, entry, colonRule, selectedAct));
 }
 
-// `=` is a structural Rule plus a specialized one-hop local representative judgment.
-const equalityTemplate = materializeExactSequence(memory, [leftRole, equalUse, rightRole]);
-const equalityRule = rule(
-  memory,
-  formalI,
-  [contextRole, leftRole, rightRole, leftRepresentativeRole, rightRepresentativeRole],
-  materializeExactSequence(memory, [equalityTemplate, memory.root]),
-);
-function equalityChild(parent: TypedContext): TypedContext {
-  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  child = continueFormalContext(memory, child, formalI.structure, A);
-  child = continueFormalContext(memory, child, formalI.structure, equalUse);
-  return continueFormalContext(memory, child, formalI.structure, B);
+const equalityForm = materializeExactSequence(memory, [leftRole, equalUse, rightRole]);
+const equalityRule = rule(memory, formalI, [contextRole, leftRole, rightRole, leftRepRole, rightRepRole],
+  materializeExactSequence(memory, [equalityForm, memory.root]));
+function equalityEvidence(parent: TypedContext, context: LinkHandle, leftRep: LinkHandle, rightRep: LinkHandle) {
+  const child = formalChild(parent, rootI, [A, equalUse, B]);
+  const selectedAct = act(memory, formalI, equalityRule, parent.context, [[contextRole, context], [leftRole, A], [rightRole, B],
+    [leftRepRole, leftRep], [rightRepRole, rightRep]]);
+  return { ...evidence(child, parent, rootI, memory.root, equalityRule, selectedAct), resolutionContext: context,
+    contextRole, leftRole, rightRole, leftRepresentativeRole: leftRepRole, rightRepresentativeRole: rightRepRole };
 }
 {
-  const resolutionContext = defineContext(memory, memory.root, marker7);
-  defineLocalRepresentativeBinding(memory, resolutionContext, A, representative);
-  defineLocalRepresentativeBinding(memory, resolutionContext, B, representative);
-  const parent = parentContext(memory, rootI, marker7);
-  const child = equalityChild(parent);
-  const selectedAct = act(memory, formalI, equalityRule, parent.context, [
-    [contextRole, resolutionContext], [leftRole, A], [rightRole, B],
-    [leftRepresentativeRole, representative], [rightRepresentativeRole, representative],
-  ]);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, memory.root]);
-  const before = memory.linkCount;
-  replayFormalEquality(new ReplayProbe(memory), {
-    ...closeEvidence(child, parent, formalI, rootI, memory.root, equalityRule, selectedAct, claimed),
-    resolutionContext,
-    contextRole,
-    leftRole,
-    rightRole,
-    leftRepresentativeRole,
-    rightRepresentativeRole,
-  });
-  same(memory.linkCount, before, "equality replay is read-only");
-
-  const distinctContext = defineContext(memory, memory.root, marker8);
-  defineLocalRepresentativeBinding(memory, distinctContext, A, representative);
-  defineLocalRepresentativeBinding(memory, distinctContext, B, otherRepresentative);
-  // This extra binding would collapse a transitive equality closure, which M5 intentionally does not compute.
-  defineLocalRepresentativeBinding(memory, distinctContext, representative, otherRepresentative);
-  const distinctParent = parentContext(memory, rootI, marker8);
-  const distinctChild = equalityChild(distinctParent);
-  const distinctAct = act(memory, formalI, equalityRule, distinctParent.context, [
-    [contextRole, distinctContext], [leftRole, A], [rightRole, B],
-    [leftRepresentativeRole, representative], [rightRepresentativeRole, otherRepresentative],
-  ]);
-  expectContextError("equality-distinguished", () => replayFormalEquality(memory, {
-    ...closeEvidence(
-      distinctChild,
-      distinctParent,
-      formalI,
-      rootI,
-      memory.root,
-      equalityRule,
-      distinctAct,
-      materializeExactSequence(memory, [readContext(memory, distinctChild.context).current, memory.root]),
-    ),
-    resolutionContext: distinctContext,
-    contextRole,
-    leftRole,
-    rightRole,
-    leftRepresentativeRole,
-    rightRepresentativeRole,
-  }));
+  const context = defineContext(memory, memory.root, marker7);
+  defineLocalRepresentativeBinding(memory, context, A, representative); defineLocalRepresentativeBinding(memory, context, B, representative);
+  const parent = parentContext(memory, rootI, marker7); const before = memory.linkCount;
+  replayFormalEquality(new ReplayProbe(memory), equalityEvidence(parent, context, representative, representative));
+  same(memory.linkCount, before, "equality replay read-only");
+  const distinct = defineContext(memory, memory.root, marker8);
+  defineLocalRepresentativeBinding(memory, distinct, A, representative); defineLocalRepresentativeBinding(memory, distinct, B, otherRep);
+  defineLocalRepresentativeBinding(memory, distinct, representative, otherRep); // no transitive closure in M5
+  expectContextError("equality-distinguished", () => replayFormalEquality(memory,
+    equalityEvidence(parentContext(memory, rootI, marker8), distinct, representative, otherRep)));
 }
 
-// Wrong lexical parent, wrong child I and wrong parent-continuation I are all rejected.
 {
-  const parent = parentContext(memory, rootI, marker9);
-  const otherParent = parentContext(memory, rootI, marker10);
-  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  child = continueFormalContext(memory, child, formalI.structure, A);
-  const claim = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
-  const selectedAct = act(memory, formalI, oneRule, otherParent.context, [[valueRole, A]]);
-  expectContextError("lexical-parent-mismatch", () => replayFormalClose(
-    memory,
-    closeEvidence(child, otherParent, formalI, rootI, A, oneRule, selectedAct, claim),
-  ));
-  expectContextError("context-interpreter-mismatch", () => replayFormalClose(memory, {
-    ...closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claim),
-    expectedChildInterpreter: qI.structure,
-  }));
+  const parent = parentContext(memory, rootI, marker9), otherParent = parentContext(memory, rootI, marker10);
+  const child = formalChild(parent, rootI, [A]);
+  const wrongParentAct = act(memory, formalI, oneRule, otherParent.context, [[valueRole, A]]);
+  expectContextError("lexical-parent-mismatch", () => replayFormalClose(memory, evidence(child, otherParent, rootI, A, oneRule, wrongParentAct)));
+  const correctAct = act(memory, formalI, oneRule, parent.context, [[valueRole, A]]);
+  expectContextError("context-interpreter-mismatch", () => replayFormalClose(memory,
+    { ...evidence(child, parent, rootI, A, oneRule, correctAct), expectedChildInterpreter: qI.structure }));
   expectContextError("context-interpreter-mismatch", () => continueFormalContext(memory, parent, qI.structure, A));
 }
 
-// Run owns temporal order independently of the common lexical K.parent.
 {
-  const lexicalParent = defineContext(memory, memory.root, lexicalParentCurrent);
-  const k0 = defineContext(memory, lexicalParent, runValue0);
-  const k1 = defineContext(memory, lexicalParent, runValue1);
-  const k2 = defineContext(memory, lexicalParent, runValue2);
-  const runRoles = defineStructuralRoleDictionary(memory, [beforeRole, afterRole]);
-  const firstAct = defineActHeader(memory, formalI.handle, runRoles, k1);
-  defineActField(memory, firstAct, beforeRole, k0);
-  defineActField(memory, firstAct, afterRole, k1);
-  const secondAct = defineActHeader(memory, formalI.handle, runRoles, k2);
-  defineActField(memory, secondAct, beforeRole, k1);
-  defineActField(memory, secondAct, afterRole, k2);
-  const run1 = memory.ensure(memory.root, firstAct);
-  const run2 = memory.ensure(run1, secondAct);
-  same(replayRun(memory, {
-    runRoot: run2,
-    initialContext: k0,
-    terminalContext: k2,
-    steps: [{ act: firstAct, beforeRole, afterRole }, { act: secondAct, beforeRole, afterRole }],
-  }).length, 2, "Run preserves temporal order");
-  same(readContext(memory, k0).parent, lexicalParent, "k0 lexical parent");
-  same(readContext(memory, k1).parent, lexicalParent, "k1 lexical parent");
+  const lexicalParent = defineContext(memory, memory.root, lexicalCurrent);
+  const k0 = defineContext(memory, lexicalParent, run0), k1 = defineContext(memory, lexicalParent, run1), k2 = defineContext(memory, lexicalParent, run2);
+  const roles = defineStructuralRoleDictionary(memory, [beforeRole, afterRole]);
+  const a0 = defineActHeader(memory, formalI.handle, roles, k1); defineActField(memory, a0, beforeRole, k0); defineActField(memory, a0, afterRole, k1);
+  const a1 = defineActHeader(memory, formalI.handle, roles, k2); defineActField(memory, a1, beforeRole, k1); defineActField(memory, a1, afterRole, k2);
+  const r0 = memory.ensure(memory.root, a0), r1 = memory.ensure(r0, a1);
+  same(replayRun(memory, { runRoot: r1, initialContext: k0, terminalContext: k2,
+    steps: [{ act: a0, beforeRole, afterRole }, { act: a1, beforeRole, afterRole }] }).length, 2, "Run temporal order");
+  same(readContext(memory, k0).parent, lexicalParent, "k0 lexical parent"); same(readContext(memory, k1).parent, lexicalParent, "k1 lexical parent");
   same(readContext(memory, k2).parent, lexicalParent, "k2 lexical parent");
 }

--- a/ts/test/v09-context-integration.test.ts
+++ b/ts/test/v09-context-integration.test.ts
@@ -106,8 +106,9 @@ const relationRule = rule(memory, formalI, [leftRole, rightRole], materializeExa
 function relation(parent: TypedContext, parentOwner: IFix, left: LinkHandle, right: LinkHandle): LinkHandle {
   const child = formalChild(parent, parentOwner, [left, arrowUse, right]); const result = memory.ensure(left, right);
   const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, left], [rightRole, right]]);
+  const replayEvidence = evidence(child, parent, parentOwner, result, relationRule, selectedAct);
   const before = memory.linkCount; const probe = new ReplayProbe(memory);
-  same(replayFormalClose(probe, evidence(child, parent, parentOwner, result, relationRule, selectedAct)).result, result, "relation result");
+  same(replayFormalClose(probe, replayEvidence).result, result, "relation result");
   same(memory.linkCount, before, "relation replay read-only"); assert(probe.outgoingCalls > 0, "Act fields read structurally"); return result;
 }
 const p0 = parentContext(memory, rootI, marker0); const ab0 = relation(p0, rootI, A, B);
@@ -185,8 +186,8 @@ function equalityEvidence(parent: TypedContext, context: LinkHandle, leftRep: Li
 {
   const context = defineContext(memory, memory.root, marker7);
   defineLocalRepresentativeBinding(memory, context, A, representative); defineLocalRepresentativeBinding(memory, context, B, representative);
-  const parent = parentContext(memory, rootI, marker7); const before = memory.linkCount;
-  replayFormalEquality(new ReplayProbe(memory), equalityEvidence(parent, context, representative, representative));
+  const parent = parentContext(memory, rootI, marker7); const replayEvidence = equalityEvidence(parent, context, representative, representative);
+  const before = memory.linkCount; replayFormalEquality(new ReplayProbe(memory), replayEvidence);
   same(memory.linkCount, before, "equality replay read-only");
   const distinct = defineContext(memory, memory.root, marker8);
   defineLocalRepresentativeBinding(memory, distinct, A, representative); defineLocalRepresentativeBinding(memory, distinct, B, otherRep);

--- a/ts/test/v09-context-integration.test.ts
+++ b/ts/test/v09-context-integration.test.ts
@@ -54,7 +54,9 @@ function expectRuleError(code: StructuralRuleError["code"], effect: () => unknow
   }
   throw new Error(`expected StructuralRuleError(${code})`);
 }
-function anchors(memory: Memory, count: number): LinkHandle[] {
+
+/** Structurally distinct ordinary Links; fixture order never participates in semantic identity. */
+function anchors(memory: Memory, count: number): readonly LinkHandle[] {
   const result: LinkHandle[] = [];
   const seed = memory.ensureEndSelfClosed(memory.root);
   let tag = memory.ensureStartSelfClosed(memory.root);
@@ -62,12 +64,7 @@ function anchors(memory: Memory, count: number): LinkHandle[] {
     tag = memory.ensureStartSelfClosed(tag);
     result.push(memory.ensure(seed, tag));
   }
-  return result;
-}
-function required(values: readonly LinkHandle[], index: number, name: string): LinkHandle {
-  const value = values[index];
-  assert(value !== undefined, `missing fixture ${name}`);
-  return value;
+  return Object.freeze(result);
 }
 
 class ReplayProbe implements ReadMemory {
@@ -88,21 +85,22 @@ interface InterpreterFixture {
   readonly handle: LinkHandle;
   readonly structure: StructuralInterpreter;
 }
-function interpreter(memory: Memory): InterpreterFixture {
-  const refs = anchors(memory, 3);
-  const dictionary = required(refs, 0, "dictionary");
-  const grammar = required(refs, 1, "grammar");
-  const theory = required(refs, 2, "theory");
+interface RuleFixture {
+  readonly roleDictionary: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly admission: LinkHandle;
+}
+function interpreter(
+  memory: Memory,
+  dictionary: LinkHandle,
+  grammar: LinkHandle,
+  theory: LinkHandle,
+): InterpreterFixture {
   const structure = Object.freeze({ dictionary, grammar, theory });
   return Object.freeze({
     handle: defineStructuralInterpreter(memory, dictionary, grammar, theory),
     structure,
   });
-}
-interface RuleFixture {
-  readonly roleDictionary: LinkHandle;
-  readonly rule: LinkHandle;
-  readonly admission: LinkHandle;
 }
 function rule(
   memory: Memory,
@@ -130,12 +128,7 @@ function act(
   return result;
 }
 function parentContext(memory: Memory, owner: InterpreterFixture, marker: LinkHandle): TypedContext {
-  return defineTypedContext(
-    memory,
-    owner.handle,
-    memory.root,
-    materializeExactSequence(memory, [marker]),
-  );
+  return defineTypedContext(memory, owner.handle, memory.root, materializeExactSequence(memory, [marker]));
 }
 function closeEvidence(
   child: TypedContext,
@@ -166,55 +159,68 @@ function closeEvidence(
 
 const memory = new Memory();
 const basis = ensureRootBasis(memory);
-const rootI = interpreter(memory);
-const formalI = interpreter(memory);
-const qI = interpreter(memory);
-const refs = anchors(memory, 40);
-const marker0 = required(refs, 0, "marker0");
-const marker1 = required(refs, 1, "marker1");
-const marker2 = required(refs, 2, "marker2");
-const marker3 = required(refs, 3, "marker3");
-const marker4 = required(refs, 4, "marker4");
-const marker5 = required(refs, 5, "marker5");
-const marker6 = required(refs, 6, "marker6");
-const marker7 = required(refs, 7, "marker7");
-const marker8 = required(refs, 8, "marker8");
-const marker9 = required(refs, 9, "marker9");
-const marker10 = required(refs, 10, "marker10");
-const A = required(refs, 11, "A");
-const B = required(refs, 12, "B");
-const C = required(refs, 13, "C");
-const arrowCarrier = required(refs, 14, "arrowCarrier");
-const oneCarrier = required(refs, 15, "oneCarrier");
-const equalCarrier = required(refs, 16, "equalCarrier");
-const infinityCarrier = required(refs, 17, "infinityCarrier");
-const colonCarrier = required(refs, 18, "colonCarrier");
-const leftRole = required(refs, 19, "leftRole");
-const rightRole = required(refs, 20, "rightRole");
-const valueRole = required(refs, 21, "valueRole");
-const contextRole = required(refs, 22, "contextRole");
-const leftRepresentativeRole = required(refs, 23, "leftRepresentativeRole");
-const rightRepresentativeRole = required(refs, 24, "rightRepresentativeRole");
-const sourceRole = required(refs, 25, "sourceRole");
-const formRole = required(refs, 26, "formRole");
-const beforeRole = required(refs, 27, "beforeRole");
-const afterRole = required(refs, 28, "afterRole");
-const representative = required(refs, 29, "representative");
-const otherRepresentative = required(refs, 30, "otherRepresentative");
-const runValue0 = required(refs, 31, "runValue0");
-const runValue1 = required(refs, 32, "runValue1");
-const runValue2 = required(refs, 33, "runValue2");
+const pool = anchors(memory, 64);
+let cursor = 0;
+function next(name: string): LinkHandle {
+  const value = pool[cursor];
+  cursor += 1;
+  assert(value !== undefined, `missing structural fixture ${name}`);
+  return value;
+}
 
-// Same root meaning does not erase sign/carrier/use identity.
+// One structural pool is partitioned once. Re-running the same anchor recipe would
+// canonically return the same Links and therefore must not be used as an instance factory.
+const rootI = interpreter(memory, next("root-D"), next("root-G"), next("root-T"));
+const formalI = interpreter(memory, next("formal-D"), next("formal-G"), next("formal-T"));
+const qI = interpreter(memory, next("q-D"), next("q-G"), next("q-T"));
+assert(rootI.handle !== formalI.handle && formalI.handle !== qI.handle, "interpreters differ structurally");
+
+const marker0 = next("marker0");
+const marker1 = next("marker1");
+const marker2 = next("marker2");
+const marker3 = next("marker3");
+const marker4 = next("marker4");
+const marker5 = next("marker5");
+const marker6 = next("marker6");
+const marker7 = next("marker7");
+const marker8 = next("marker8");
+const marker9 = next("marker9");
+const marker10 = next("marker10");
+const A = next("A");
+const B = next("B");
+const C = next("C");
+const arrowCarrier = next("arrow-carrier");
+const oneCarrier = next("one-carrier");
+const equalCarrier = next("equal-carrier");
+const infinityCarrier = next("infinity-carrier");
+const colonCarrier = next("colon-carrier");
+const leftRole = next("left-role");
+const rightRole = next("right-role");
+const valueRole = next("value-role");
+const contextRole = next("context-role");
+const leftRepresentativeRole = next("left-representative-role");
+const rightRepresentativeRole = next("right-representative-role");
+const sourceRole = next("source-role");
+const formRole = next("form-role");
+const beforeRole = next("before-role");
+const afterRole = next("after-role");
+const representative = next("representative");
+const otherRepresentative = next("other-representative");
+const runValue0 = next("run-value-0");
+const runValue1 = next("run-value-1");
+const runValue2 = next("run-value-2");
+const lexicalParentCurrent = next("lexical-parent-current");
+
+// Same root meaning does not erase carrier/sign/use identity.
 const arrowUse = memory.ensure(arrowCarrier, basis.L);
 const abitOneUse = memory.ensure(oneCarrier, basis.L);
 const equalUse = memory.ensure(equalCarrier, basis.R);
 const infinityUse = memory.ensure(infinityCarrier, basis.R);
 const colonUse = memory.ensure(colonCarrier, memory.ensure(basis.R, basis.L));
-assert(arrowUse !== abitOneUse, "FORMAL arrow must stay distinct from quaternary 1 use");
-assert(equalUse !== infinityUse, "FORMAL = must stay distinct from infinity use");
+assert(arrowUse !== abitOneUse, "FORMAL arrow stays distinct from quaternary 1 use");
+assert(equalUse !== infinityUse, "FORMAL = stays distinct from infinity use");
 
-// Relation Rule admits exactly `(left ⟼ right)` and returns `left ⟼ right`.
+// Admitted relation rule: exactly `(left ⟼ right)`, without precedence/associativity.
 const relationTemplateForm = materializeExactSequence(memory, [leftRole, arrowUse, rightRole]);
 const relationTemplateResult = memory.ensure(leftRole, rightRole);
 const relationRule = rule(
@@ -243,22 +249,22 @@ function evaluateRelation(
     result,
     "relation close result",
   );
-  same(memory.linkCount, before, "relation close replay is read-only");
-  assert(probe.outgoingCalls > 0, "relation close reads structural Act fields");
+  same(memory.linkCount, before, "relation replay is read-only");
+  assert(probe.outgoingCalls > 0, "relation replay reads structural Act fields");
   return result;
 }
 
 const relationParent = parentContext(memory, rootI, marker0);
 const relation = evaluateRelation(relationParent, rootI, A, B);
 same(relation, memory.ensure(A, B), "(A ⟼ B)");
-const beforeParentState = readContext(memory, relationParent.context);
-const afterParent = continueFormalContext(memory, relationParent, rootI.structure, relation);
-same(readContext(memory, relationParent.context).current, beforeParentState.current, "CLOSE leaves parent-before immutable");
-same(readContext(memory, afterParent.context).parent, beforeParentState.parent, "PARENT_CONTINUE preserves lexical parent");
-const continued = readExactSequence(memory, readContext(memory, afterParent.context).current).values;
-same(continued[continued.length - 1], relation, "PARENT_CONTINUE appends semantic result");
+const parentBeforeState = readContext(memory, relationParent.context);
+const parentAfter = continueFormalContext(memory, relationParent, rootI.structure, relation);
+same(readContext(memory, relationParent.context).current, parentBeforeState.current, "CLOSE does not mutate parent-before");
+same(readContext(memory, parentAfter.context).parent, parentBeforeState.parent, "PARENT_CONTINUE keeps lexical parent");
+const parentValues = readExactSequence(memory, readContext(memory, parentAfter.context).current).values;
+same(parentValues[parentValues.length - 1], relation, "PARENT_CONTINUE appends result");
 
-// `(A ⟼ (B ⟼ C))` and `((A ⟼ B) ⟼ C)` remain different exact trees.
+// Nested left/right forms remain different exact relation trees.
 const rightParent = parentContext(memory, rootI, marker1);
 let rightOuter = openFormalContext(memory, rightParent, rootI.structure, formalI.handle);
 rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, A);
@@ -266,19 +272,16 @@ rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, arrowU
 const bc = evaluateRelation(rightOuter, formalI, B, C);
 rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, bc);
 const rightNested = memory.ensure(A, bc);
-replayFormalClose(
-  memory,
-  closeEvidence(
-    rightOuter,
-    rightParent,
-    formalI,
-    rootI,
-    rightNested,
-    relationRule,
-    act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]]),
-    materializeExactSequence(memory, [readContext(memory, rightOuter.context).current, rightNested]),
-  ),
-);
+replayFormalClose(memory, closeEvidence(
+  rightOuter,
+  rightParent,
+  formalI,
+  rootI,
+  rightNested,
+  relationRule,
+  act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]]),
+  materializeExactSequence(memory, [readContext(memory, rightOuter.context).current, rightNested]),
+));
 
 const leftParent = parentContext(memory, rootI, marker2);
 let leftOuter = openFormalContext(memory, leftParent, rootI.structure, formalI.handle);
@@ -287,22 +290,19 @@ leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, ab);
 leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, arrowUse);
 leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, C);
 const leftNested = memory.ensure(ab, C);
-replayFormalClose(
-  memory,
-  closeEvidence(
-    leftOuter,
-    leftParent,
-    formalI,
-    rootI,
-    leftNested,
-    relationRule,
-    act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]]),
-    materializeExactSequence(memory, [readContext(memory, leftOuter.context).current, leftNested]),
-  ),
-);
-assert(rightNested !== leftNested, "right and left nested relation trees must differ");
+replayFormalClose(memory, closeEvidence(
+  leftOuter,
+  leftParent,
+  formalI,
+  rootI,
+  leftNested,
+  relationRule,
+  act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]]),
+  materializeExactSequence(memory, [readContext(memory, leftOuter.context).current, leftNested]),
+));
+assert(rightNested !== leftNested, "right/left nested relations differ");
 
-// No precedence/associativity shortcut admits bare `A ⟼ B ⟼ C`.
+// Bare `A ⟼ B ⟼ C` has no admitted minimal-F1 relation shape.
 {
   const parent = parentContext(memory, rootI, marker3);
   let bare = openFormalContext(memory, parent, rootI.structure, formalI.handle);
@@ -310,15 +310,19 @@ assert(rightNested !== leftNested, "right and left nested relation trees must di
     bare = continueFormalContext(memory, bare, formalI.structure, value);
   }
   const result = memory.ensure(ab, C);
-  const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, A], [rightRole, B]]);
-  const claimed = materializeExactSequence(memory, [readContext(memory, bare.context).current, result]);
-  expectRuleError("template-mismatch", () => replayFormalClose(
-    memory,
-    closeEvidence(bare, parent, formalI, rootI, result, relationRule, selectedAct, claimed),
-  ));
+  expectRuleError("template-mismatch", () => replayFormalClose(memory, closeEvidence(
+    bare,
+    parent,
+    formalI,
+    rootI,
+    result,
+    relationRule,
+    act(memory, formalI, relationRule, parent.context, [[leftRole, A], [rightRole, B]]),
+    materializeExactSequence(memory, [readContext(memory, bare.context).current, result]),
+  )));
 }
 
-// A one-value group is admitted explicitly; `()` itself is not.
+// One-value grouping is explicitly admitted; empty FORMAL remains unadmitted.
 const oneTemplate = materializeExactSequence(memory, [valueRole]);
 const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memory, [oneTemplate, valueRole]));
 {
@@ -336,7 +340,7 @@ const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memo
   ));
 }
 
-// `[]`, `[[]]`, `([[]])`: Q result R survives as an explicit FORMAL position.
+// `[]`, `[[]]`, `([[]])`: returned R is preserved as an exact FORMAL position.
 {
   const parent = parentContext(memory, rootI, marker5);
   let formal = openFormalContext(memory, parent, rootI.structure, formalI.handle);
@@ -345,9 +349,9 @@ const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memo
   same(replayQuaternaryClose(memory, emptyQ, qI.structure, formal, formalI.structure, memory.root), memory.root, "[] -> R");
   same(memory.linkCount, before, "Q close replay is read-only");
   formal = continueFormalContext(memory, formal, formalI.structure, memory.root);
-  const returnedRoot = readExactSequence(memory, readContext(memory, formal.context).current).values;
-  same(returnedRoot.length, 1, "returned R is one exact FORMAL position");
-  same(returnedRoot[0], memory.root, "returned R position value");
+  const firstValues = readExactSequence(memory, readContext(memory, formal.context).current).values;
+  same(firstValues.length, 1, "returned R occupies one FORMAL position");
+  same(firstValues[0], memory.root, "returned position is R");
 
   let outerQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
   const innerQ = openQuaternaryContext(memory, outerQ, qI.structure, qI.handle);
@@ -358,27 +362,42 @@ const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memo
 
   let wrapper = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   wrapper = continueFormalContext(memory, wrapper, formalI.structure, outerResult);
-  const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, memory.root]]);
-  const claimed = materializeExactSequence(memory, [readContext(memory, wrapper.context).current, memory.root]);
-  replayFormalClose(memory, closeEvidence(wrapper, parent, formalI, rootI, memory.root, oneRule, selectedAct, claimed));
-  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) has one root-valued form");
+  const wrapperClaim = materializeExactSequence(memory, [readContext(memory, wrapper.context).current, memory.root]);
+  replayFormalClose(memory, closeEvidence(
+    wrapper,
+    parent,
+    formalI,
+    rootI,
+    memory.root,
+    oneRule,
+    act(memory, formalI, oneRule, parent.context, [[valueRole, memory.root]]),
+    wrapperClaim,
+  ));
+  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) has one R-valued form");
 }
 
-// `:` is admitted as its own sign/use and yields carrier -> form Entry structurally.
+// Colon is a distinct admitted FORMAL use yielding carrier -> form Entry.
 {
   const parent = parentContext(memory, rootI, marker6);
   let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   for (const value of [A, colonUse, B]) child = continueFormalContext(memory, child, formalI.structure, value);
   const template = materializeExactSequence(memory, [sourceRole, colonUse, formRole]);
   const entryTemplate = memory.ensure(sourceRole, formRole);
-  const selectedRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [template, entryTemplate]));
+  const colonRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [template, entryTemplate]));
   const entry = memory.ensure(A, B);
-  const selectedAct = act(memory, formalI, selectedRule, parent.context, [[sourceRole, A], [formRole, B]]);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, entry]);
-  replayFormalClose(memory, closeEvidence(child, parent, formalI, rootI, entry, selectedRule, selectedAct, claimed));
+  replayFormalClose(memory, closeEvidence(
+    child,
+    parent,
+    formalI,
+    rootI,
+    entry,
+    colonRule,
+    act(memory, formalI, colonRule, parent.context, [[sourceRole, A], [formRole, B]]),
+    materializeExactSequence(memory, [readContext(memory, child.context).current, entry]),
+  ));
 }
 
-// `=`: admitted structural Rule + one-hop context-local representative evidence.
+// `=` is a structural Rule plus a specialized one-hop local representative judgment.
 const equalityTemplate = materializeExactSequence(memory, [leftRole, equalUse, rightRole]);
 const equalityRule = rule(
   memory,
@@ -418,6 +437,7 @@ function equalityChild(parent: TypedContext): TypedContext {
   const distinctContext = defineContext(memory, memory.root, marker8);
   defineLocalRepresentativeBinding(memory, distinctContext, A, representative);
   defineLocalRepresentativeBinding(memory, distinctContext, B, otherRepresentative);
+  // This extra binding would collapse a transitive equality closure, which M5 intentionally does not compute.
   defineLocalRepresentativeBinding(memory, distinctContext, representative, otherRepresentative);
   const distinctParent = parentContext(memory, rootI, marker8);
   const distinctChild = equalityChild(distinctParent);
@@ -425,9 +445,17 @@ function equalityChild(parent: TypedContext): TypedContext {
     [contextRole, distinctContext], [leftRole, A], [rightRole, B],
     [leftRepresentativeRole, representative], [rightRepresentativeRole, otherRepresentative],
   ]);
-  const distinctClaim = materializeExactSequence(memory, [readContext(memory, distinctChild.context).current, memory.root]);
   expectContextError("equality-distinguished", () => replayFormalEquality(memory, {
-    ...closeEvidence(distinctChild, distinctParent, formalI, rootI, memory.root, equalityRule, distinctAct, distinctClaim),
+    ...closeEvidence(
+      distinctChild,
+      distinctParent,
+      formalI,
+      rootI,
+      memory.root,
+      equalityRule,
+      distinctAct,
+      materializeExactSequence(memory, [readContext(memory, distinctChild.context).current, memory.root]),
+    ),
     resolutionContext: distinctContext,
     contextRole,
     leftRole,
@@ -437,28 +465,28 @@ function equalityChild(parent: TypedContext): TypedContext {
   }));
 }
 
-// Wrong lexical parent / wrong I / wrong continuation I reject.
+// Wrong lexical parent, wrong child I and wrong parent-continuation I are all rejected.
 {
   const parent = parentContext(memory, rootI, marker9);
   const otherParent = parentContext(memory, rootI, marker10);
   let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   child = continueFormalContext(memory, child, formalI.structure, A);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
+  const claim = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
   const selectedAct = act(memory, formalI, oneRule, otherParent.context, [[valueRole, A]]);
   expectContextError("lexical-parent-mismatch", () => replayFormalClose(
     memory,
-    closeEvidence(child, otherParent, formalI, rootI, A, oneRule, selectedAct, claimed),
+    closeEvidence(child, otherParent, formalI, rootI, A, oneRule, selectedAct, claim),
   ));
   expectContextError("context-interpreter-mismatch", () => replayFormalClose(memory, {
-    ...closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claimed),
+    ...closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claim),
     expectedChildInterpreter: qI.structure,
   }));
   expectContextError("context-interpreter-mismatch", () => continueFormalContext(memory, parent, qI.structure, A));
 }
 
-// Run owns temporal order; K.parent independently remains lexical nesting.
+// Run owns temporal order independently of the common lexical K.parent.
 {
-  const lexicalParent = defineContext(memory, memory.root, required(refs, 34, "lexicalParentCurrent"));
+  const lexicalParent = defineContext(memory, memory.root, lexicalParentCurrent);
   const k0 = defineContext(memory, lexicalParent, runValue0);
   const k1 = defineContext(memory, lexicalParent, runValue1);
   const k2 = defineContext(memory, lexicalParent, runValue2);
@@ -476,7 +504,7 @@ function equalityChild(parent: TypedContext): TypedContext {
     initialContext: k0,
     terminalContext: k2,
     steps: [{ act: firstAct, beforeRole, afterRole }, { act: secondAct, beforeRole, afterRole }],
-  }).length, 2, "Run preserves two temporal steps");
+  }).length, 2, "Run preserves temporal order");
   same(readContext(memory, k0).parent, lexicalParent, "k0 lexical parent");
   same(readContext(memory, k1).parent, lexicalParent, "k1 lexical parent");
   same(readContext(memory, k2).parent, lexicalParent, "k2 lexical parent");

--- a/ts/test/v09-context-integration.test.ts
+++ b/ts/test/v09-context-integration.test.ts
@@ -1,0 +1,466 @@
+import {
+  ContextIntegrationError,
+  continueFormalContext,
+  continueQuaternaryContext,
+  defineTypedContext,
+  openFormalContext,
+  openQuaternaryContext,
+  replayFormalClose,
+  replayFormalEquality,
+  replayQuaternaryClose,
+  type TypedContext,
+} from "../src/context-integration.js";
+import { materializeExactSequence, readExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import { replayRun } from "../src/run.js";
+import {
+  defineContext,
+  defineLocalRepresentativeBinding,
+  readContext,
+} from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  StructuralRuleError,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+function expectContextError(code: ContextIntegrationError["code"], effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof ContextIntegrationError, `expected ContextIntegrationError, got ${String(error)}`);
+    same(error.code, code, "context integration error code");
+    return;
+  }
+  throw new Error(`expected ContextIntegrationError(${code})`);
+}
+function expectRuleError(code: StructuralRuleError["code"], effect: () => unknown): void {
+  try { effect(); }
+  catch (error) {
+    assert(error instanceof StructuralRuleError, `expected StructuralRuleError, got ${String(error)}`);
+    same(error.code, code, "structural rule error code");
+    return;
+  }
+  throw new Error(`expected StructuralRuleError(${code})`);
+}
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  const seed = memory.ensureEndSelfClosed(memory.root);
+  let tag = memory.ensureStartSelfClosed(memory.root);
+  for (let index = 0; index < count; index += 1) {
+    tag = memory.ensureStartSelfClosed(tag);
+    result.push(memory.ensure(seed, tag));
+  }
+  return result;
+}
+
+class ReplayProbe implements ReadMemory {
+  outgoingCalls = 0;
+  constructor(private readonly source: ReadMemory) {}
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("M5 replay must not use find"); }
+  incoming(): readonly LinkHandle[] { throw new Error("M5 replay must not use incoming"); }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.outgoingCalls += 1;
+    return this.source.outgoing(start);
+  }
+}
+
+interface InterpreterFixture {
+  readonly handle: LinkHandle;
+  readonly structure: StructuralInterpreter;
+}
+function interpreter(memory: Memory): InterpreterFixture {
+  const refs = anchors(memory, 3);
+  const [dictionary, grammar, theory] = refs;
+  assert(dictionary && grammar && theory, "interpreter refs");
+  const structure = Object.freeze({ dictionary, grammar, theory });
+  return Object.freeze({
+    handle: defineStructuralInterpreter(memory, dictionary, grammar, theory),
+    structure,
+  });
+}
+interface RuleFixture {
+  readonly roleDictionary: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly admission: LinkHandle;
+}
+function rule(
+  memory: Memory,
+  owner: InterpreterFixture,
+  roles: readonly LinkHandle[],
+  body: LinkHandle,
+): RuleFixture {
+  const roleDictionary = defineStructuralRoleDictionary(memory, roles);
+  const ruleRef = defineStructuralRule(memory, roleDictionary, body);
+  return Object.freeze({
+    roleDictionary,
+    rule: ruleRef,
+    admission: admitStructuralRule(memory, owner.structure.theory, ruleRef),
+  });
+}
+function act(
+  memory: Memory,
+  owner: InterpreterFixture,
+  ruleFixture: RuleFixture,
+  after: LinkHandle,
+  fields: readonly (readonly [LinkHandle, LinkHandle])[],
+): LinkHandle {
+  const result = defineActHeader(memory, owner.handle, ruleFixture.roleDictionary, after);
+  for (const [role, value] of fields) defineActField(memory, result, role, value);
+  return result;
+}
+function parentContext(
+  memory: Memory,
+  owner: InterpreterFixture,
+  marker: LinkHandle,
+): TypedContext {
+  return defineTypedContext(
+    memory,
+    owner.handle,
+    memory.root,
+    materializeExactSequence(memory, [marker]),
+  );
+}
+function closeEvidence(
+  child: TypedContext,
+  parentBefore: TypedContext,
+  formal: InterpreterFixture,
+  parentOwner: InterpreterFixture,
+  result: LinkHandle,
+  selected: RuleFixture,
+  selectedAct: LinkHandle,
+  claimedBody: LinkHandle,
+) {
+  return Object.freeze({
+    child,
+    parentBefore,
+    expectedChildInterpreter: formal.structure,
+    expectedParentInterpreter: parentOwner.structure,
+    result,
+    ruleReplay: Object.freeze({
+      act: selectedAct,
+      rule: selected.rule,
+      ruleAdmission: selected.admission,
+      claimedBody,
+      expectedInterpreter: formal.structure,
+      expectedAfterContext: parentBefore.context,
+    }),
+  });
+}
+
+const memory = new Memory();
+const basis = ensureRootBasis(memory);
+const rootI = interpreter(memory);
+const formalI = interpreter(memory);
+const qI = interpreter(memory);
+const refs = anchors(memory, 30);
+const [
+  marker0, marker1, marker2, marker3, A, B, C,
+  arrowCarrier, oneCarrier, equalCarrier, infinityCarrier, colonCarrier,
+  leftRole, rightRole, valueRole, contextRole, leftRepresentativeRole,
+  rightRepresentativeRole, sourceRole, formRole, beforeRole, afterRole,
+  representative, otherRepresentative, runValue0, runValue1, runValue2,
+] = refs;
+assert(
+  marker0 && marker1 && marker2 && marker3 && A && B && C && arrowCarrier && oneCarrier &&
+  equalCarrier && infinityCarrier && colonCarrier && leftRole && rightRole && valueRole &&
+  contextRole && leftRepresentativeRole && rightRepresentativeRole && sourceRole && formRole &&
+  beforeRole && afterRole && representative && otherRepresentative && runValue0 && runValue1 && runValue2,
+  "M5 refs",
+);
+
+// Carrier/use identity is retained even when root meanings intentionally collide.
+const arrowUse = memory.ensure(arrowCarrier, basis.L);
+const abitOneUse = memory.ensure(oneCarrier, basis.L);
+const equalUse = memory.ensure(equalCarrier, basis.R);
+const infinityUse = memory.ensure(infinityCarrier, basis.R);
+const colonMeaning = memory.ensure(basis.R, basis.L);
+const colonUse = memory.ensure(colonCarrier, colonMeaning);
+assert(arrowUse !== abitOneUse, "FORMAL arrow use must not flatten into quaternary 1 use");
+assert(equalUse !== infinityUse, "FORMAL = use must not flatten into infinity use");
+
+// Admitted relation Rule: exact FORMAL sequence, no precedence or associativity primitive.
+const relationTemplateForm = materializeExactSequence(memory, [leftRole, arrowUse, rightRole]);
+const relationTemplateResult = memory.ensure(leftRole, rightRole);
+const relationBody = materializeExactSequence(memory, [relationTemplateForm, relationTemplateResult]);
+const relationRule = rule(memory, formalI, [leftRole, rightRole], relationBody);
+
+function evaluateRelation(
+  parent: TypedContext,
+  parentOwner: InterpreterFixture,
+  left: LinkHandle,
+  right: LinkHandle,
+): LinkHandle {
+  let child = openFormalContext(memory, parent, parentOwner.structure, formalI.handle);
+  child = continueFormalContext(memory, child, formalI.structure, left);
+  child = continueFormalContext(memory, child, formalI.structure, arrowUse);
+  child = continueFormalContext(memory, child, formalI.structure, right);
+  const result = memory.ensure(left, right);
+  const claimedBody = materializeExactSequence(memory, [readContext(memory, child.context).current, result]);
+  const selectedAct = act(memory, formalI, relationRule, parent.context, [
+    [leftRole, left], [rightRole, right],
+  ]);
+  const probe = new ReplayProbe(memory);
+  const before = memory.linkCount;
+  const replayed = replayFormalClose(
+    probe,
+    closeEvidence(child, parent, formalI, parentOwner, result, relationRule, selectedAct, claimedBody),
+  );
+  same(replayed.result, result, "relation close result");
+  same(memory.linkCount, before, "relation close replay is read-only");
+  assert(probe.outgoingCalls > 0, "relation close uses structural Act fields");
+  return result;
+}
+
+const relationParent = parentContext(memory, rootI, marker0);
+const relation = evaluateRelation(relationParent, rootI, A, B);
+same(relation, memory.ensure(A, B), "(A ⟼ B)");
+const relationParentStateBefore = readContext(memory, relationParent.context);
+const relationParentAfter = continueFormalContext(memory, relationParent, rootI.structure, relation);
+same(readContext(memory, relationParent.context).current, relationParentStateBefore.current, "CLOSE does not mutate parent");
+same(readContext(memory, relationParentAfter.context).parent, relationParentStateBefore.parent, "PARENT_CONTINUE preserves lexical parent");
+const continuedValues = readExactSequence(memory, readContext(memory, relationParentAfter.context).current).values;
+same(continuedValues.at(-1), relation, "PARENT_CONTINUE appends result");
+
+// Right and left nested FORMAL groups stay structurally distinct.
+const rightParent = parentContext(memory, rootI, marker1);
+let rightOuter = openFormalContext(memory, rightParent, rootI.structure, formalI.handle);
+rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, A);
+rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, arrowUse);
+const bc = evaluateRelation(rightOuter, formalI, B, C);
+rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, bc);
+const rightNested = (() => {
+  const result = memory.ensure(A, bc);
+  const claimed = materializeExactSequence(memory, [readContext(memory, rightOuter.context).current, result]);
+  const selectedAct = act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]]);
+  replayFormalClose(memory, closeEvidence(rightOuter, rightParent, formalI, rootI, result, relationRule, selectedAct, claimed));
+  return result;
+})();
+
+const leftParent = parentContext(memory, rootI, marker2);
+let leftOuter = openFormalContext(memory, leftParent, rootI.structure, formalI.handle);
+const ab = evaluateRelation(leftOuter, formalI, A, B);
+leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, ab);
+leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, arrowUse);
+leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, C);
+const leftNested = (() => {
+  const result = memory.ensure(ab, C);
+  const claimed = materializeExactSequence(memory, [readContext(memory, leftOuter.context).current, result]);
+  const selectedAct = act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]]);
+  replayFormalClose(memory, closeEvidence(leftOuter, leftParent, formalI, rootI, result, relationRule, selectedAct, claimed));
+  return result;
+})();
+assert(rightNested !== leftNested, "(A ⟼ (B ⟼ C)) must differ from ((A ⟼ B) ⟼ C)");
+
+// Bare A ⟼ B ⟼ C has no admitted foundation relation shape.
+{
+  const parent = parentContext(memory, rootI, marker3);
+  let bare = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  for (const value of [A, arrowUse, B, arrowUse, C]) {
+    bare = continueFormalContext(memory, bare, formalI.structure, value);
+  }
+  const result = memory.ensure(memory.ensure(A, B), C);
+  const claimed = materializeExactSequence(memory, [readContext(memory, bare.context).current, result]);
+  const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, A], [rightRole, B]]);
+  expectRuleError("template-mismatch", () => replayFormalClose(
+    memory,
+    closeEvidence(bare, parent, formalI, rootI, result, relationRule, selectedAct, claimed),
+  ));
+}
+
+// Explicit one-value grouping Rule is admitted; empty FORMAL remains unadmitted.
+const oneTemplateForm = materializeExactSequence(memory, [valueRole]);
+const oneBody = materializeExactSequence(memory, [oneTemplateForm, valueRole]);
+const oneRule = rule(memory, formalI, [valueRole], oneBody);
+{
+  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  child = continueFormalContext(memory, child, formalI.structure, A);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
+  const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, A]]);
+  replayFormalClose(memory, closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claimed));
+
+  const empty = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  expectContextError("empty-formal-context", () => replayFormalClose(
+    memory,
+    closeEvidence(empty, parent, formalI, rootI, A, oneRule, selectedAct, claimed),
+  ));
+}
+
+// Q OPEN/CLOSE re-entry: [] -> R; [ [] ] also returns R, but parent FORMAL keeps the explicit position.
+{
+  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  let formal = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  const emptyQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
+  const before = memory.linkCount;
+  same(replayQuaternaryClose(memory, emptyQ, qI.structure, formal, formalI.structure, memory.root), memory.root, "[] closes to R");
+  same(memory.linkCount, before, "Q close replay is read-only");
+  formal = continueFormalContext(memory, formal, formalI.structure, memory.root);
+  const values = readExactSequence(memory, readContext(memory, formal.context).current).values;
+  same(values.length, 1, "returned R is one FORMAL position");
+  same(values[0], memory.root, "returned R position value");
+
+  let outerQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
+  const innerQ = openQuaternaryContext(memory, outerQ, qI.structure, qI.handle);
+  const innerResult = replayQuaternaryClose(memory, innerQ, qI.structure, outerQ, qI.structure, memory.root);
+  outerQ = continueQuaternaryContext(memory, outerQ, qI.structure, innerResult);
+  const outerResult = replayQuaternaryClose(memory, outerQ, qI.structure, formal, formalI.structure, memory.root);
+  same(outerResult, memory.root, "[[]] closes canonically to R");
+
+  let wrapper = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  wrapper = continueFormalContext(memory, wrapper, formalI.structure, outerResult);
+  const claimed = materializeExactSequence(memory, [readContext(memory, wrapper.context).current, memory.root]);
+  const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, memory.root]]);
+  replayFormalClose(memory, closeEvidence(wrapper, parent, formalI, rootI, memory.root, oneRule, selectedAct, claimed));
+  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) contains one R before close");
+}
+
+// Colon is a distinct admitted FORMAL use even though its meaning is itself structural.
+{
+  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  child = continueFormalContext(memory, child, formalI.structure, A);
+  child = continueFormalContext(memory, child, formalI.structure, colonUse);
+  child = continueFormalContext(memory, child, formalI.structure, B);
+  const templateForm = materializeExactSequence(memory, [sourceRole, colonUse, formRole]);
+  const templateEntry = memory.ensure(sourceRole, formRole);
+  const selectedRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [templateForm, templateEntry]));
+  const entry = memory.ensure(A, B);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, entry]);
+  const selectedAct = act(memory, formalI, selectedRule, parent.context, [[sourceRole, A], [formRole, B]]);
+  replayFormalClose(memory, closeEvidence(child, parent, formalI, rootI, entry, selectedRule, selectedAct, claimed));
+}
+
+// FORMAL `=`: structural Rule first, then one-hop context-local representative judgment.
+const equalityTemplateForm = materializeExactSequence(memory, [leftRole, equalUse, rightRole]);
+const equalityBody = materializeExactSequence(memory, [equalityTemplateForm, memory.root]);
+const equalityRule = rule(
+  memory,
+  formalI,
+  [contextRole, leftRole, rightRole, leftRepresentativeRole, rightRepresentativeRole],
+  equalityBody,
+);
+{
+  const resolutionContext = defineContext(memory, memory.root, anchors(memory, 1)[0] ?? memory.root);
+  defineLocalRepresentativeBinding(memory, resolutionContext, A, representative);
+  defineLocalRepresentativeBinding(memory, resolutionContext, B, representative);
+  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  child = continueFormalContext(memory, child, formalI.structure, A);
+  child = continueFormalContext(memory, child, formalI.structure, equalUse);
+  child = continueFormalContext(memory, child, formalI.structure, B);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, memory.root]);
+  const selectedAct = act(memory, formalI, equalityRule, parent.context, [
+    [contextRole, resolutionContext], [leftRole, A], [rightRole, B],
+    [leftRepresentativeRole, representative], [rightRepresentativeRole, representative],
+  ]);
+  const before = memory.linkCount;
+  replayFormalEquality(new ReplayProbe(memory), {
+    ...closeEvidence(child, parent, formalI, rootI, memory.root, equalityRule, selectedAct, claimed),
+    resolutionContext,
+    contextRole,
+    leftRole,
+    rightRole,
+    leftRepresentativeRole,
+    rightRepresentativeRole,
+  });
+  same(memory.linkCount, before, "equality replay is read-only");
+
+  const distinctContext = defineContext(memory, memory.root, anchors(memory, 1)[0] ?? memory.root);
+  defineLocalRepresentativeBinding(memory, distinctContext, A, representative);
+  defineLocalRepresentativeBinding(memory, distinctContext, B, otherRepresentative);
+  // Even if representative itself has a local binding, equality does not compute transitive closure.
+  defineLocalRepresentativeBinding(memory, distinctContext, representative, otherRepresentative);
+  const distinctParent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  let distinctChild = openFormalContext(memory, distinctParent, rootI.structure, formalI.handle);
+  distinctChild = continueFormalContext(memory, distinctChild, formalI.structure, A);
+  distinctChild = continueFormalContext(memory, distinctChild, formalI.structure, equalUse);
+  distinctChild = continueFormalContext(memory, distinctChild, formalI.structure, B);
+  const distinctClaim = materializeExactSequence(memory, [readContext(memory, distinctChild.context).current, memory.root]);
+  const distinctAct = act(memory, formalI, equalityRule, distinctParent.context, [
+    [contextRole, distinctContext], [leftRole, A], [rightRole, B],
+    [leftRepresentativeRole, representative], [rightRepresentativeRole, otherRepresentative],
+  ]);
+  expectContextError("equality-distinguished", () => replayFormalEquality(memory, {
+    ...closeEvidence(distinctChild, distinctParent, formalI, rootI, memory.root, equalityRule, distinctAct, distinctClaim),
+    resolutionContext: distinctContext,
+    contextRole,
+    leftRole,
+    rightRole,
+    leftRepresentativeRole,
+    rightRepresentativeRole,
+  }));
+}
+
+// Negative lifecycle evidence: wrong parent, wrong I and wrong continuation I all reject.
+{
+  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  const otherParent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
+  child = continueFormalContext(memory, child, formalI.structure, A);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
+  const selectedAct = act(memory, formalI, oneRule, otherParent.context, [[valueRole, A]]);
+  expectContextError("lexical-parent-mismatch", () => replayFormalClose(
+    memory,
+    closeEvidence(child, otherParent, formalI, rootI, A, oneRule, selectedAct, claimed),
+  ));
+
+  expectContextError("context-interpreter-mismatch", () => replayFormalClose(memory, {
+    ...closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claimed),
+    expectedChildInterpreter: qI.structure,
+  }));
+  expectContextError("context-interpreter-mismatch", () => continueFormalContext(
+    memory,
+    parent,
+    qI.structure,
+    A,
+  ));
+}
+
+// Run is temporal order; K.parent remains lexical structure and does not encode the step sequence.
+{
+  const lexicalParent = defineContext(memory, memory.root, anchors(memory, 1)[0] ?? memory.root);
+  const k0 = defineContext(memory, lexicalParent, runValue0);
+  const k1 = defineContext(memory, lexicalParent, runValue1);
+  const k2 = defineContext(memory, lexicalParent, runValue2);
+  const runRoles = defineStructuralRoleDictionary(memory, [beforeRole, afterRole]);
+  const firstAct = defineActHeader(memory, formalI.handle, runRoles, k1);
+  defineActField(memory, firstAct, beforeRole, k0);
+  defineActField(memory, firstAct, afterRole, k1);
+  const secondAct = defineActHeader(memory, formalI.handle, runRoles, k2);
+  defineActField(memory, secondAct, beforeRole, k1);
+  defineActField(memory, secondAct, afterRole, k2);
+  const run1 = memory.ensure(memory.root, firstAct);
+  const run2 = memory.ensure(run1, secondAct);
+  const acts = replayRun(memory, {
+    runRoot: run2,
+    initialContext: k0,
+    terminalContext: k2,
+    steps: [
+      { act: firstAct, beforeRole, afterRole },
+      { act: secondAct, beforeRole, afterRole },
+    ],
+  });
+  same(acts.length, 2, "Run preserves two temporal steps");
+  same(readContext(memory, k0).parent, lexicalParent, "k0 lexical parent");
+  same(readContext(memory, k1).parent, lexicalParent, "k1 lexical parent");
+  same(readContext(memory, k2).parent, lexicalParent, "k2 lexical parent");
+}

--- a/ts/test/v09-context-integration.test.ts
+++ b/ts/test/v09-context-integration.test.ts
@@ -19,11 +19,7 @@ import {
   type ReadMemory,
 } from "../src/memory.js";
 import { replayRun } from "../src/run.js";
-import {
-  defineContext,
-  defineLocalRepresentativeBinding,
-  readContext,
-} from "../src/state.js";
+import { defineContext, defineLocalRepresentativeBinding, readContext } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
 import {
   admitStructuralRule,
@@ -68,6 +64,11 @@ function anchors(memory: Memory, count: number): LinkHandle[] {
   }
   return result;
 }
+function required(values: readonly LinkHandle[], index: number, name: string): LinkHandle {
+  const value = values[index];
+  assert(value !== undefined, `missing fixture ${name}`);
+  return value;
+}
 
 class ReplayProbe implements ReadMemory {
   outgoingCalls = 0;
@@ -89,8 +90,9 @@ interface InterpreterFixture {
 }
 function interpreter(memory: Memory): InterpreterFixture {
   const refs = anchors(memory, 3);
-  const [dictionary, grammar, theory] = refs;
-  assert(dictionary && grammar && theory, "interpreter refs");
+  const dictionary = required(refs, 0, "dictionary");
+  const grammar = required(refs, 1, "grammar");
+  const theory = required(refs, 2, "theory");
   const structure = Object.freeze({ dictionary, grammar, theory });
   return Object.freeze({
     handle: defineStructuralInterpreter(memory, dictionary, grammar, theory),
@@ -119,19 +121,15 @@ function rule(
 function act(
   memory: Memory,
   owner: InterpreterFixture,
-  ruleFixture: RuleFixture,
+  selected: RuleFixture,
   after: LinkHandle,
   fields: readonly (readonly [LinkHandle, LinkHandle])[],
 ): LinkHandle {
-  const result = defineActHeader(memory, owner.handle, ruleFixture.roleDictionary, after);
-  for (const [role, value] of fields) defineActField(memory, result, role, value);
+  const result = defineActHeader(memory, owner.handle, selected.roleDictionary, after);
+  for (const [roleRef, value] of fields) defineActField(memory, result, roleRef, value);
   return result;
 }
-function parentContext(
-  memory: Memory,
-  owner: InterpreterFixture,
-  marker: LinkHandle,
-): TypedContext {
+function parentContext(memory: Memory, owner: InterpreterFixture, marker: LinkHandle): TypedContext {
   return defineTypedContext(
     memory,
     owner.handle,
@@ -171,38 +169,60 @@ const basis = ensureRootBasis(memory);
 const rootI = interpreter(memory);
 const formalI = interpreter(memory);
 const qI = interpreter(memory);
-const refs = anchors(memory, 30);
-const [
-  marker0, marker1, marker2, marker3, A, B, C,
-  arrowCarrier, oneCarrier, equalCarrier, infinityCarrier, colonCarrier,
-  leftRole, rightRole, valueRole, contextRole, leftRepresentativeRole,
-  rightRepresentativeRole, sourceRole, formRole, beforeRole, afterRole,
-  representative, otherRepresentative, runValue0, runValue1, runValue2,
-] = refs;
-assert(
-  marker0 && marker1 && marker2 && marker3 && A && B && C && arrowCarrier && oneCarrier &&
-  equalCarrier && infinityCarrier && colonCarrier && leftRole && rightRole && valueRole &&
-  contextRole && leftRepresentativeRole && rightRepresentativeRole && sourceRole && formRole &&
-  beforeRole && afterRole && representative && otherRepresentative && runValue0 && runValue1 && runValue2,
-  "M5 refs",
-);
+const refs = anchors(memory, 40);
+const marker0 = required(refs, 0, "marker0");
+const marker1 = required(refs, 1, "marker1");
+const marker2 = required(refs, 2, "marker2");
+const marker3 = required(refs, 3, "marker3");
+const marker4 = required(refs, 4, "marker4");
+const marker5 = required(refs, 5, "marker5");
+const marker6 = required(refs, 6, "marker6");
+const marker7 = required(refs, 7, "marker7");
+const marker8 = required(refs, 8, "marker8");
+const marker9 = required(refs, 9, "marker9");
+const marker10 = required(refs, 10, "marker10");
+const A = required(refs, 11, "A");
+const B = required(refs, 12, "B");
+const C = required(refs, 13, "C");
+const arrowCarrier = required(refs, 14, "arrowCarrier");
+const oneCarrier = required(refs, 15, "oneCarrier");
+const equalCarrier = required(refs, 16, "equalCarrier");
+const infinityCarrier = required(refs, 17, "infinityCarrier");
+const colonCarrier = required(refs, 18, "colonCarrier");
+const leftRole = required(refs, 19, "leftRole");
+const rightRole = required(refs, 20, "rightRole");
+const valueRole = required(refs, 21, "valueRole");
+const contextRole = required(refs, 22, "contextRole");
+const leftRepresentativeRole = required(refs, 23, "leftRepresentativeRole");
+const rightRepresentativeRole = required(refs, 24, "rightRepresentativeRole");
+const sourceRole = required(refs, 25, "sourceRole");
+const formRole = required(refs, 26, "formRole");
+const beforeRole = required(refs, 27, "beforeRole");
+const afterRole = required(refs, 28, "afterRole");
+const representative = required(refs, 29, "representative");
+const otherRepresentative = required(refs, 30, "otherRepresentative");
+const runValue0 = required(refs, 31, "runValue0");
+const runValue1 = required(refs, 32, "runValue1");
+const runValue2 = required(refs, 33, "runValue2");
 
-// Carrier/use identity is retained even when root meanings intentionally collide.
+// Same root meaning does not erase sign/carrier/use identity.
 const arrowUse = memory.ensure(arrowCarrier, basis.L);
 const abitOneUse = memory.ensure(oneCarrier, basis.L);
 const equalUse = memory.ensure(equalCarrier, basis.R);
 const infinityUse = memory.ensure(infinityCarrier, basis.R);
-const colonMeaning = memory.ensure(basis.R, basis.L);
-const colonUse = memory.ensure(colonCarrier, colonMeaning);
-assert(arrowUse !== abitOneUse, "FORMAL arrow use must not flatten into quaternary 1 use");
-assert(equalUse !== infinityUse, "FORMAL = use must not flatten into infinity use");
+const colonUse = memory.ensure(colonCarrier, memory.ensure(basis.R, basis.L));
+assert(arrowUse !== abitOneUse, "FORMAL arrow must stay distinct from quaternary 1 use");
+assert(equalUse !== infinityUse, "FORMAL = must stay distinct from infinity use");
 
-// Admitted relation Rule: exact FORMAL sequence, no precedence or associativity primitive.
+// Relation Rule admits exactly `(left ⟼ right)` and returns `left ⟼ right`.
 const relationTemplateForm = materializeExactSequence(memory, [leftRole, arrowUse, rightRole]);
 const relationTemplateResult = memory.ensure(leftRole, rightRole);
-const relationBody = materializeExactSequence(memory, [relationTemplateForm, relationTemplateResult]);
-const relationRule = rule(memory, formalI, [leftRole, rightRole], relationBody);
-
+const relationRule = rule(
+  memory,
+  formalI,
+  [leftRole, rightRole],
+  materializeExactSequence(memory, [relationTemplateForm, relationTemplateResult]),
+);
 function evaluateRelation(
   parent: TypedContext,
   parentOwner: InterpreterFixture,
@@ -214,46 +234,51 @@ function evaluateRelation(
   child = continueFormalContext(memory, child, formalI.structure, arrowUse);
   child = continueFormalContext(memory, child, formalI.structure, right);
   const result = memory.ensure(left, right);
-  const claimedBody = materializeExactSequence(memory, [readContext(memory, child.context).current, result]);
-  const selectedAct = act(memory, formalI, relationRule, parent.context, [
-    [leftRole, left], [rightRole, right],
-  ]);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, result]);
+  const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, left], [rightRole, right]]);
   const probe = new ReplayProbe(memory);
   const before = memory.linkCount;
-  const replayed = replayFormalClose(
-    probe,
-    closeEvidence(child, parent, formalI, parentOwner, result, relationRule, selectedAct, claimedBody),
+  same(
+    replayFormalClose(probe, closeEvidence(child, parent, formalI, parentOwner, result, relationRule, selectedAct, claimed)).result,
+    result,
+    "relation close result",
   );
-  same(replayed.result, result, "relation close result");
   same(memory.linkCount, before, "relation close replay is read-only");
-  assert(probe.outgoingCalls > 0, "relation close uses structural Act fields");
+  assert(probe.outgoingCalls > 0, "relation close reads structural Act fields");
   return result;
 }
 
 const relationParent = parentContext(memory, rootI, marker0);
 const relation = evaluateRelation(relationParent, rootI, A, B);
 same(relation, memory.ensure(A, B), "(A ⟼ B)");
-const relationParentStateBefore = readContext(memory, relationParent.context);
-const relationParentAfter = continueFormalContext(memory, relationParent, rootI.structure, relation);
-same(readContext(memory, relationParent.context).current, relationParentStateBefore.current, "CLOSE does not mutate parent");
-same(readContext(memory, relationParentAfter.context).parent, relationParentStateBefore.parent, "PARENT_CONTINUE preserves lexical parent");
-const continuedValues = readExactSequence(memory, readContext(memory, relationParentAfter.context).current).values;
-same(continuedValues.at(-1), relation, "PARENT_CONTINUE appends result");
+const beforeParentState = readContext(memory, relationParent.context);
+const afterParent = continueFormalContext(memory, relationParent, rootI.structure, relation);
+same(readContext(memory, relationParent.context).current, beforeParentState.current, "CLOSE leaves parent-before immutable");
+same(readContext(memory, afterParent.context).parent, beforeParentState.parent, "PARENT_CONTINUE preserves lexical parent");
+const continued = readExactSequence(memory, readContext(memory, afterParent.context).current).values;
+same(continued[continued.length - 1], relation, "PARENT_CONTINUE appends semantic result");
 
-// Right and left nested FORMAL groups stay structurally distinct.
+// `(A ⟼ (B ⟼ C))` and `((A ⟼ B) ⟼ C)` remain different exact trees.
 const rightParent = parentContext(memory, rootI, marker1);
 let rightOuter = openFormalContext(memory, rightParent, rootI.structure, formalI.handle);
 rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, A);
 rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, arrowUse);
 const bc = evaluateRelation(rightOuter, formalI, B, C);
 rightOuter = continueFormalContext(memory, rightOuter, formalI.structure, bc);
-const rightNested = (() => {
-  const result = memory.ensure(A, bc);
-  const claimed = materializeExactSequence(memory, [readContext(memory, rightOuter.context).current, result]);
-  const selectedAct = act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]]);
-  replayFormalClose(memory, closeEvidence(rightOuter, rightParent, formalI, rootI, result, relationRule, selectedAct, claimed));
-  return result;
-})();
+const rightNested = memory.ensure(A, bc);
+replayFormalClose(
+  memory,
+  closeEvidence(
+    rightOuter,
+    rightParent,
+    formalI,
+    rootI,
+    rightNested,
+    relationRule,
+    act(memory, formalI, relationRule, rightParent.context, [[leftRole, A], [rightRole, bc]]),
+    materializeExactSequence(memory, [readContext(memory, rightOuter.context).current, rightNested]),
+  ),
+);
 
 const leftParent = parentContext(memory, rootI, marker2);
 let leftOuter = openFormalContext(memory, leftParent, rootI.structure, formalI.handle);
@@ -261,41 +286,47 @@ const ab = evaluateRelation(leftOuter, formalI, A, B);
 leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, ab);
 leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, arrowUse);
 leftOuter = continueFormalContext(memory, leftOuter, formalI.structure, C);
-const leftNested = (() => {
-  const result = memory.ensure(ab, C);
-  const claimed = materializeExactSequence(memory, [readContext(memory, leftOuter.context).current, result]);
-  const selectedAct = act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]]);
-  replayFormalClose(memory, closeEvidence(leftOuter, leftParent, formalI, rootI, result, relationRule, selectedAct, claimed));
-  return result;
-})();
-assert(rightNested !== leftNested, "(A ⟼ (B ⟼ C)) must differ from ((A ⟼ B) ⟼ C)");
+const leftNested = memory.ensure(ab, C);
+replayFormalClose(
+  memory,
+  closeEvidence(
+    leftOuter,
+    leftParent,
+    formalI,
+    rootI,
+    leftNested,
+    relationRule,
+    act(memory, formalI, relationRule, leftParent.context, [[leftRole, ab], [rightRole, C]]),
+    materializeExactSequence(memory, [readContext(memory, leftOuter.context).current, leftNested]),
+  ),
+);
+assert(rightNested !== leftNested, "right and left nested relation trees must differ");
 
-// Bare A ⟼ B ⟼ C has no admitted foundation relation shape.
+// No precedence/associativity shortcut admits bare `A ⟼ B ⟼ C`.
 {
   const parent = parentContext(memory, rootI, marker3);
   let bare = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   for (const value of [A, arrowUse, B, arrowUse, C]) {
     bare = continueFormalContext(memory, bare, formalI.structure, value);
   }
-  const result = memory.ensure(memory.ensure(A, B), C);
-  const claimed = materializeExactSequence(memory, [readContext(memory, bare.context).current, result]);
+  const result = memory.ensure(ab, C);
   const selectedAct = act(memory, formalI, relationRule, parent.context, [[leftRole, A], [rightRole, B]]);
+  const claimed = materializeExactSequence(memory, [readContext(memory, bare.context).current, result]);
   expectRuleError("template-mismatch", () => replayFormalClose(
     memory,
     closeEvidence(bare, parent, formalI, rootI, result, relationRule, selectedAct, claimed),
   ));
 }
 
-// Explicit one-value grouping Rule is admitted; empty FORMAL remains unadmitted.
-const oneTemplateForm = materializeExactSequence(memory, [valueRole]);
-const oneBody = materializeExactSequence(memory, [oneTemplateForm, valueRole]);
-const oneRule = rule(memory, formalI, [valueRole], oneBody);
+// A one-value group is admitted explicitly; `()` itself is not.
+const oneTemplate = materializeExactSequence(memory, [valueRole]);
+const oneRule = rule(memory, formalI, [valueRole], materializeExactSequence(memory, [oneTemplate, valueRole]));
 {
-  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  const parent = parentContext(memory, rootI, marker4);
   let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   child = continueFormalContext(memory, child, formalI.structure, A);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
   const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, A]]);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
   replayFormalClose(memory, closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claimed));
 
   const empty = openFormalContext(memory, parent, rootI.structure, formalI.handle);
@@ -305,73 +336,73 @@ const oneRule = rule(memory, formalI, [valueRole], oneBody);
   ));
 }
 
-// Q OPEN/CLOSE re-entry: [] -> R; [ [] ] also returns R, but parent FORMAL keeps the explicit position.
+// `[]`, `[[]]`, `([[]])`: Q result R survives as an explicit FORMAL position.
 {
-  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  const parent = parentContext(memory, rootI, marker5);
   let formal = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   const emptyQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
   const before = memory.linkCount;
-  same(replayQuaternaryClose(memory, emptyQ, qI.structure, formal, formalI.structure, memory.root), memory.root, "[] closes to R");
+  same(replayQuaternaryClose(memory, emptyQ, qI.structure, formal, formalI.structure, memory.root), memory.root, "[] -> R");
   same(memory.linkCount, before, "Q close replay is read-only");
   formal = continueFormalContext(memory, formal, formalI.structure, memory.root);
-  const values = readExactSequence(memory, readContext(memory, formal.context).current).values;
-  same(values.length, 1, "returned R is one FORMAL position");
-  same(values[0], memory.root, "returned R position value");
+  const returnedRoot = readExactSequence(memory, readContext(memory, formal.context).current).values;
+  same(returnedRoot.length, 1, "returned R is one exact FORMAL position");
+  same(returnedRoot[0], memory.root, "returned R position value");
 
   let outerQ = openQuaternaryContext(memory, formal, formalI.structure, qI.handle);
   const innerQ = openQuaternaryContext(memory, outerQ, qI.structure, qI.handle);
   const innerResult = replayQuaternaryClose(memory, innerQ, qI.structure, outerQ, qI.structure, memory.root);
   outerQ = continueQuaternaryContext(memory, outerQ, qI.structure, innerResult);
   const outerResult = replayQuaternaryClose(memory, outerQ, qI.structure, formal, formalI.structure, memory.root);
-  same(outerResult, memory.root, "[[]] closes canonically to R");
+  same(outerResult, memory.root, "[[]] -> R");
 
   let wrapper = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   wrapper = continueFormalContext(memory, wrapper, formalI.structure, outerResult);
-  const claimed = materializeExactSequence(memory, [readContext(memory, wrapper.context).current, memory.root]);
   const selectedAct = act(memory, formalI, oneRule, parent.context, [[valueRole, memory.root]]);
+  const claimed = materializeExactSequence(memory, [readContext(memory, wrapper.context).current, memory.root]);
   replayFormalClose(memory, closeEvidence(wrapper, parent, formalI, rootI, memory.root, oneRule, selectedAct, claimed));
-  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) contains one R before close");
+  same(readExactSequence(memory, readContext(memory, wrapper.context).current).values.length, 1, "([[]]) has one root-valued form");
 }
 
-// Colon is a distinct admitted FORMAL use even though its meaning is itself structural.
+// `:` is admitted as its own sign/use and yields carrier -> form Entry structurally.
 {
-  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  const parent = parentContext(memory, rootI, marker6);
   let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
-  child = continueFormalContext(memory, child, formalI.structure, A);
-  child = continueFormalContext(memory, child, formalI.structure, colonUse);
-  child = continueFormalContext(memory, child, formalI.structure, B);
-  const templateForm = materializeExactSequence(memory, [sourceRole, colonUse, formRole]);
-  const templateEntry = memory.ensure(sourceRole, formRole);
-  const selectedRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [templateForm, templateEntry]));
+  for (const value of [A, colonUse, B]) child = continueFormalContext(memory, child, formalI.structure, value);
+  const template = materializeExactSequence(memory, [sourceRole, colonUse, formRole]);
+  const entryTemplate = memory.ensure(sourceRole, formRole);
+  const selectedRule = rule(memory, formalI, [sourceRole, formRole], materializeExactSequence(memory, [template, entryTemplate]));
   const entry = memory.ensure(A, B);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, entry]);
   const selectedAct = act(memory, formalI, selectedRule, parent.context, [[sourceRole, A], [formRole, B]]);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, entry]);
   replayFormalClose(memory, closeEvidence(child, parent, formalI, rootI, entry, selectedRule, selectedAct, claimed));
 }
 
-// FORMAL `=`: structural Rule first, then one-hop context-local representative judgment.
-const equalityTemplateForm = materializeExactSequence(memory, [leftRole, equalUse, rightRole]);
-const equalityBody = materializeExactSequence(memory, [equalityTemplateForm, memory.root]);
+// `=`: admitted structural Rule + one-hop context-local representative evidence.
+const equalityTemplate = materializeExactSequence(memory, [leftRole, equalUse, rightRole]);
 const equalityRule = rule(
   memory,
   formalI,
   [contextRole, leftRole, rightRole, leftRepresentativeRole, rightRepresentativeRole],
-  equalityBody,
+  materializeExactSequence(memory, [equalityTemplate, memory.root]),
 );
-{
-  const resolutionContext = defineContext(memory, memory.root, anchors(memory, 1)[0] ?? memory.root);
-  defineLocalRepresentativeBinding(memory, resolutionContext, A, representative);
-  defineLocalRepresentativeBinding(memory, resolutionContext, B, representative);
-  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+function equalityChild(parent: TypedContext): TypedContext {
   let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   child = continueFormalContext(memory, child, formalI.structure, A);
   child = continueFormalContext(memory, child, formalI.structure, equalUse);
-  child = continueFormalContext(memory, child, formalI.structure, B);
-  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, memory.root]);
+  return continueFormalContext(memory, child, formalI.structure, B);
+}
+{
+  const resolutionContext = defineContext(memory, memory.root, marker7);
+  defineLocalRepresentativeBinding(memory, resolutionContext, A, representative);
+  defineLocalRepresentativeBinding(memory, resolutionContext, B, representative);
+  const parent = parentContext(memory, rootI, marker7);
+  const child = equalityChild(parent);
   const selectedAct = act(memory, formalI, equalityRule, parent.context, [
     [contextRole, resolutionContext], [leftRole, A], [rightRole, B],
     [leftRepresentativeRole, representative], [rightRepresentativeRole, representative],
   ]);
+  const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, memory.root]);
   const before = memory.linkCount;
   replayFormalEquality(new ReplayProbe(memory), {
     ...closeEvidence(child, parent, formalI, rootI, memory.root, equalityRule, selectedAct, claimed),
@@ -384,21 +415,17 @@ const equalityRule = rule(
   });
   same(memory.linkCount, before, "equality replay is read-only");
 
-  const distinctContext = defineContext(memory, memory.root, anchors(memory, 1)[0] ?? memory.root);
+  const distinctContext = defineContext(memory, memory.root, marker8);
   defineLocalRepresentativeBinding(memory, distinctContext, A, representative);
   defineLocalRepresentativeBinding(memory, distinctContext, B, otherRepresentative);
-  // Even if representative itself has a local binding, equality does not compute transitive closure.
   defineLocalRepresentativeBinding(memory, distinctContext, representative, otherRepresentative);
-  const distinctParent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
-  let distinctChild = openFormalContext(memory, distinctParent, rootI.structure, formalI.handle);
-  distinctChild = continueFormalContext(memory, distinctChild, formalI.structure, A);
-  distinctChild = continueFormalContext(memory, distinctChild, formalI.structure, equalUse);
-  distinctChild = continueFormalContext(memory, distinctChild, formalI.structure, B);
-  const distinctClaim = materializeExactSequence(memory, [readContext(memory, distinctChild.context).current, memory.root]);
+  const distinctParent = parentContext(memory, rootI, marker8);
+  const distinctChild = equalityChild(distinctParent);
   const distinctAct = act(memory, formalI, equalityRule, distinctParent.context, [
     [contextRole, distinctContext], [leftRole, A], [rightRole, B],
     [leftRepresentativeRole, representative], [rightRepresentativeRole, otherRepresentative],
   ]);
+  const distinctClaim = materializeExactSequence(memory, [readContext(memory, distinctChild.context).current, memory.root]);
   expectContextError("equality-distinguished", () => replayFormalEquality(memory, {
     ...closeEvidence(distinctChild, distinctParent, formalI, rootI, memory.root, equalityRule, distinctAct, distinctClaim),
     resolutionContext: distinctContext,
@@ -410,10 +437,10 @@ const equalityRule = rule(
   }));
 }
 
-// Negative lifecycle evidence: wrong parent, wrong I and wrong continuation I all reject.
+// Wrong lexical parent / wrong I / wrong continuation I reject.
 {
-  const parent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
-  const otherParent = parentContext(memory, rootI, anchors(memory, 1)[0] ?? memory.root);
+  const parent = parentContext(memory, rootI, marker9);
+  const otherParent = parentContext(memory, rootI, marker10);
   let child = openFormalContext(memory, parent, rootI.structure, formalI.handle);
   child = continueFormalContext(memory, child, formalI.structure, A);
   const claimed = materializeExactSequence(memory, [readContext(memory, child.context).current, A]);
@@ -422,22 +449,16 @@ const equalityRule = rule(
     memory,
     closeEvidence(child, otherParent, formalI, rootI, A, oneRule, selectedAct, claimed),
   ));
-
   expectContextError("context-interpreter-mismatch", () => replayFormalClose(memory, {
     ...closeEvidence(child, parent, formalI, rootI, A, oneRule, selectedAct, claimed),
     expectedChildInterpreter: qI.structure,
   }));
-  expectContextError("context-interpreter-mismatch", () => continueFormalContext(
-    memory,
-    parent,
-    qI.structure,
-    A,
-  ));
+  expectContextError("context-interpreter-mismatch", () => continueFormalContext(memory, parent, qI.structure, A));
 }
 
-// Run is temporal order; K.parent remains lexical structure and does not encode the step sequence.
+// Run owns temporal order; K.parent independently remains lexical nesting.
 {
-  const lexicalParent = defineContext(memory, memory.root, anchors(memory, 1)[0] ?? memory.root);
+  const lexicalParent = defineContext(memory, memory.root, required(refs, 34, "lexicalParentCurrent"));
   const k0 = defineContext(memory, lexicalParent, runValue0);
   const k1 = defineContext(memory, lexicalParent, runValue1);
   const k2 = defineContext(memory, lexicalParent, runValue2);
@@ -450,16 +471,12 @@ const equalityRule = rule(
   defineActField(memory, secondAct, afterRole, k2);
   const run1 = memory.ensure(memory.root, firstAct);
   const run2 = memory.ensure(run1, secondAct);
-  const acts = replayRun(memory, {
+  same(replayRun(memory, {
     runRoot: run2,
     initialContext: k0,
     terminalContext: k2,
-    steps: [
-      { act: firstAct, beforeRole, afterRole },
-      { act: secondAct, beforeRole, afterRole },
-    ],
-  });
-  same(acts.length, 2, "Run preserves two temporal steps");
+    steps: [{ act: firstAct, beforeRole, afterRole }, { act: secondAct, beforeRole, afterRole }],
+  }).length, 2, "Run preserves two temporal steps");
   same(readContext(memory, k0).parent, lexicalParent, "k0 lexical parent");
   same(readContext(memory, k1).parent, lexicalParent, "k1 lexical parent");
   same(readContext(memory, k2).parent, lexicalParent, "k2 lexical parent");


### PR DESCRIPTION
Implementation PR A для #609. Candidate-only: accepted v0.8 runtime/public facade не меняются; contracts/conformance/repo-policy остаются для отдельного governance PR после green merge.

## Что реализовано

- explicit typed context `I ⟼ K`, где `K = K ⟼ (parent ⟼ current)`;
- immutable OPEN / CLOSE / PARENT_CONTINUE без hidden stack;
- FORMAL current поверх root-safe ExactSequence, включая explicit position со значением `R`;
- Q OPEN/CLOSE внутри FORMAL и возврат в старый lexical parent;
- FORMAL `)` через существующий structural Rule replay и `T ⟼ Rule` admission;
- specialised FORMAL `=` как read-only проверка explicit context-local representatives после Rule admission;
- sign/use carrier сохраняется отдельно от root meaning (`⟼`/`1`, `=`/`∞` не схлопываются как употребления).

## Executable challenges

`ts/test/v09-context-integration.test.ts` покрывает `(A ⟼ B)`, оба варианта вложенности, reject bare `A ⟼ B ⟼ C`, explicit one-form rule, reject `()`, `[]`, `[[]]`, `([[]])`, colon path, equality same/distinct representative, wrong lexical parent/I, read-only replay и независимость temporal Run от `K.parent`.

Отдельно тест фиксирует no-instance lesson: повтор одного и того же structural fixture recipe не используется как instance factory; разные test interpreters различены рекурсивной Link-структурой.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/context-integration.ts
  - ts/test/v09-context-integration.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 800
must_touch:
  - ts/src/context-integration.ts
  - ts/test/v09-context-integration.test.ts
must_not_touch:
  - repo-policy.json
  - contracts/**
  - cutover/**
  - .github/**
expected_effects:
  - add immutable typed context OPEN/CLOSE/PARENT_CONTINUE candidate lifecycle
  - integrate nested Q and FORMAL contexts without hidden stack or host mode authority
  - replay FORMAL close through admitted structural Rules
  - verify FORMAL equality through explicit one-hop local representative evidence
  - preserve sign/use carrier identity when root meanings coincide
  - preserve accepted v0.8 runtime and public facade
```

Related: #609, #608, #597, #594.