### PR TITLE
governance(v0.9): привязать M5 context integration evidence

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -12,7 +12,8 @@
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
-    "ts/test/v09-structural-rules.test.ts"
+    "ts/test/v09-structural-rules.test.ts",
+    "ts/test/v09-context-integration.test.ts"
   ],
   "implementedEvidence": {
     "606": {
@@ -54,6 +55,27 @@
       "wrongRuleBodyRejected": true,
       "missingRoleRejected": true,
       "multipleRoleBindingRejected": true
+    },
+    "609": {
+      "test": "ts/test/v09-context-integration.test.ts",
+      "typedContextAdmission": "I ⟼ K",
+      "immutableContextLifecycle": true,
+      "formalCurrentUsesExactSequence": true,
+      "returnedRootPositionPreserved": true,
+      "qFormalNestedReentry": true,
+      "formalCloseUsesStructuralRuleAdmission": true,
+      "relationWithoutPrecedence": true,
+      "nestedRelationGroupingDistinct": true,
+      "oneFormGroupingExplicitlyAdmitted": true,
+      "emptyFormalRejected": true,
+      "colonRuleIntegrated": true,
+      "signUseIdentityPreservedAcrossMeaningCollisions": true,
+      "localRepresentativeEquality": true,
+      "globalEqualityClosureUsed": false,
+      "wrongLexicalParentRejected": true,
+      "wrongInterpreterRejected": true,
+      "replayReadOnly": true,
+      "runTemporalOrderIndependentOfLexicalParent": true
     }
   },
   "requiredNegativeVectors": [
@@ -159,7 +181,7 @@
     "606": {"status": "candidate-green", "requiredForAcceptance": true},
     "607": {"status": "candidate-green", "requiredForAcceptance": true},
     "608": {"status": "candidate-green", "requiredForAcceptance": true},
-    "609": {"status": "planned", "requiredForAcceptance": true},
+    "609": {"status": "candidate-green", "requiredForAcceptance": true},
     "610": {"status": "blocked", "requiredForAcceptance": true}
   },
   "acceptance": {

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -38,7 +38,9 @@
     "byteCarrier": "ts/src/byte-carrier.ts",
     "byteCarrierEvidence": "ts/test/v09-byte-carrier.test.ts",
     "structuralRule": "ts/src/structural-rule.ts",
-    "structuralRuleEvidence": "ts/test/v09-structural-rules.test.ts"
+    "structuralRuleEvidence": "ts/test/v09-structural-rules.test.ts",
+    "contextIntegration": "ts/src/context-integration.ts",
+    "contextIntegrationEvidence": "ts/test/v09-context-integration.test.ts"
   },
   "semanticIdentity": {
     "acceptedV08TargetPreserved": true,
@@ -152,6 +154,9 @@
     "implementationIssue": 608,
     "implementationOwner": "ts/src/structural-rule.ts",
     "evidence": "ts/test/v09-structural-rules.test.ts",
+    "contextIntegrationIssue": 609,
+    "contextIntegrationOwner": "ts/src/context-integration.ts",
+    "contextIntegrationEvidence": "ts/test/v09-context-integration.test.ts",
     "interpreter": "I = D ⟼ (G ⟼ T)",
     "context": "K = K ⟼ (parent ⟼ current)",
     "contextUse": "I ⟼ K",
@@ -168,20 +173,29 @@
     "contextParentCarriesLexicalNesting": true,
     "hostModeEnumIsSemanticAuthority": false,
     "hostCallbackIdentityIsSemanticAuthority": false,
-    "candidateStructuralRuleKernelImplemented": true
+    "formalCurrentUsesExactSequence": true,
+    "closeMutatesLexicalParent": false,
+    "parentContinuationIsSeparateTransition": true,
+    "returnedRootPreservedAsExactPosition": true,
+    "qFormalReentryUsesExplicitContext": true,
+    "formalCloseUsesStructuralRuleAdmission": true,
+    "formalEqualityUsesContextLocalRepresentative": true,
+    "formalEqualityUsesGlobalTransitiveClosure": false,
+    "candidateStructuralRuleKernelImplemented": true,
+    "candidateCrossContextIntegrationImplemented": true
   },
   "semanticRules": {
-    "Q_OPEN": {"implementationStatus": "planned", "issue": 609},
+    "Q_OPEN": {"implementationStatus": "candidate-implemented", "issue": 609},
     "Q_VALUE": {"implementationStatus": "candidate-implemented", "issue": 606},
-    "Q_CLOSE": {"implementationStatus": "planned", "issue": 609},
+    "Q_CLOSE": {"implementationStatus": "candidate-implemented", "issue": 609},
     "Q_FINALIZE": {"implementationStatus": "candidate-implemented", "issue": 606},
-    "FORMAL_OPEN": {"implementationStatus": "planned", "issue": 609},
-    "FORMAL_GROUP": {"implementationStatus": "planned", "issue": 609},
+    "FORMAL_OPEN": {"implementationStatus": "candidate-implemented", "issue": 609},
+    "FORMAL_GROUP": {"implementationStatus": "candidate-implemented", "issue": 609},
     "FORMAL_LINK": {"implementationStatus": "candidate-implemented", "issue": 608},
     "FORMAL_COLON": {"implementationStatus": "candidate-implemented", "issue": 608},
-    "FORMAL_EQUAL": {"implementationStatus": "planned", "issue": 609},
-    "FORMAL_CLOSE": {"implementationStatus": "planned", "issue": 609},
-    "PARENT_CONTINUE": {"implementationStatus": "planned", "issue": 609}
+    "FORMAL_EQUAL": {"implementationStatus": "candidate-implemented", "issue": 609},
+    "FORMAL_CLOSE": {"implementationStatus": "candidate-implemented", "issue": 609},
+    "PARENT_CONTINUE": {"implementationStatus": "candidate-implemented", "issue": 609}
   },
   "effects": {
     "findEqualsMaterialize": false,
@@ -194,7 +208,7 @@
     {"issue": 606, "name": "root-safe exact sequence and structural QState", "status": "candidate-green"},
     {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary", "status": "candidate-green"},
     {"issue": 608, "name": "structural interpreter/rule and generic replay", "status": "candidate-green"},
-    {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "planned"},
+    {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "candidate-green"},
     {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
   ]
 }


### PR DESCRIPTION
Governance PR B для #609 после merge implementation PR #629 (`30de0b63…`).

Этот PR меняет только v0.9 candidate contract/conformance:

- добавляет `contextIntegration` / `contextIntegrationEvidence` owner paths;
- связывает immutable typed context lifecycle `I ⟼ K` и explicit OPEN/CLOSE/PARENT_CONTINUE с #609 implementation/evidence;
- добавляет `ts/test/v09-context-integration.test.ts` в `requiredExecutableGates`;
- фиксирует root-safe FORMAL current, Q↔FORMAL re-entry, returned `R` position preservation и structural Rule close;
- фиксирует FORMAL `=` как local representative judgment после Rule admission, без global transitive equality closure;
- переводит #609 и его реализованные semantic Rules в candidate-green/candidate-implemented;
- сохраняет `coverageState=partial`, `accepted=false`, `acceptanceReady=false` и accepted current v0.8.

Trusted GovernanceGrant находится в issue #609. `repo-policy.json` не меняется: существующие generic owner-path, cochange и executable-gate constraints должны быть достаточны.

```repo-guard-yaml
change_type: governance
scope:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - repo-policy.json
  - cutover/**
  - ts/src/**
  - ts/test/**
  - .github/**
expected_effects:
  - bind already-green M5 context integration implementation and executable evidence to v0.9 candidate
  - expose context integration owner/test gate to existing generic path and workflow coverage validation
  - mark slice 609 candidate-green and implemented context semantic rules candidate-implemented
  - keep coverage partial and acceptanceReady false for subsequent 597/594 readiness work
  - preserve accepted v0.8 runtime and cutover pointers
```

Resolves #609