### PR TITLE
governance(v0.9): завершить machine reconciliation #597

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -8,12 +8,14 @@
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
   "acceptanceReady": false,
-  "coverageState": "partial",
+  "coverageState": "complete",
+  "coverageStateMeaning": "all currently required v0.9 executable vectors are mapped to green evidence; semantic closure and acceptance remain separate gates",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
     "ts/test/v09-structural-rules.test.ts",
-    "ts/test/v09-context-integration.test.ts"
+    "ts/test/v09-context-integration.test.ts",
+    "ts/test/v09-readiness.test.ts"
   ],
   "implementedEvidence": {
     "606": {
@@ -76,6 +78,17 @@
       "wrongInterpreterRejected": true,
       "replayReadOnly": true,
       "runTemporalOrderIndependentOfLexicalParent": true
+    },
+    "597": {
+      "test": "ts/test/v09-readiness.test.ts",
+      "restrictedRootedFoldCounterexample": true,
+      "exactSequencePredecessorCycleRejected": true,
+      "repeatedSemanticValueUsesDistinctStructuralPositions": true,
+      "hostStartedShadowIsNotSemanticAuthority": true,
+      "nonemptyQuaternaryCloseIntegrated": true,
+      "identicalUnboundEqualityUsesMemberRepresentative": true,
+      "wrongBeforeContextRejected": true,
+      "readOnlyReconciliationReplay": true
     }
   },
   "requiredNegativeVectors": [
@@ -166,6 +179,131 @@
     "run-carries-time-not-context-parent",
     "same-semantic-value-repeated-with-distinct-occurrence-evidence"
   ],
+  "vectorEvidence": {
+    "negative": {
+      "ts/test/v09-structural-carriers.test.ts": [
+        "exact-sequence-empty-vs-single-root",
+        "exact-sequence-leading-root-loss",
+        "exact-sequence-malformed-cell"
+      ],
+      "ts/test/v09-byte-carrier.test.ts": [
+        "canonical-string-carrier-codepoint-envelope",
+        "canonical-byte-opaque-runtime-id"
+      ],
+      "ts/test/v09-structural-rules.test.ts": [
+        "forged-interpreter-configuration",
+        "interpreter-components-disagree-with-evidence",
+        "forged-role-dictionary",
+        "rule-not-admitted-by-theory",
+        "rule-missing-required-role",
+        "rule-conflicting-role-binding",
+        "rule-undeclared-role-binding",
+        "rule-wrong-result",
+        "rule-wrong-after-context"
+      ],
+      "ts/test/v09-context-integration.test.ts": [
+        "context-close-wrong-parent",
+        "parent-continuation-wrong-interpreter",
+        "returned-root-disappears-from-exact-parent-sequence",
+        "noncanonical-unparenthesized-formal-relation",
+        "empty-formal-context-admitted",
+        "read-or-replay-materializes"
+      ],
+      "ts/test/v09-readiness.test.ts": [
+        "restricted-rooted-sequence-admits-root",
+        "exact-sequence-predecessor-cycle",
+        "q-state-hidden-started-disagrees",
+        "rule-wrong-before-context"
+      ]
+    },
+    "carrier": {
+      "ts/test/v09-byte-carrier.test.ts": [
+        "empty-bytes",
+        "ascii-A",
+        "ascii-0",
+        "ascii-1",
+        "ascii-open-square",
+        "ascii-close-square",
+        "ascii-open-round",
+        "ascii-close-round",
+        "ascii-colon",
+        "ascii-equals",
+        "utf8-cyrillic-M",
+        "utf8-infinity",
+        "utf8-formal-arrow",
+        "utf8-four-byte-codepoint",
+        "combining-sequence-distinct-from-precomposed",
+        "invalid-utf8-ff-carrier",
+        "invalid-utf8-truncated-carrier",
+        "repeated-byte-carrier",
+        "string-open-square-distinct-from-raw-q-open-use"
+      ]
+    },
+    "sequence": {
+      "ts/test/v09-structural-carriers.test.ts": [
+        "exact-empty",
+        "exact-single-root",
+        "exact-single-linked",
+        "exact-root-linked",
+        "exact-linked-root",
+        "exact-root-root",
+        "exact-linked-linked",
+        "exact-root-linked-root",
+        "q-empty-stream",
+        "q-one",
+        "q-zero",
+        "q-one-zero",
+        "q-empty-group",
+        "q-one-group",
+        "q-zero-group",
+        "q-nested-empty-group",
+        "q-one-then-empty-group",
+        "q-empty-group-then-one"
+      ]
+    },
+    "semanticRule": {
+      "ts/test/v09-structural-carriers.test.ts": [
+        "q-first-value",
+        "q-next-value",
+        "q-first-returned-root",
+        "q-finalize-empty",
+        "q-finalize-nonempty"
+      ],
+      "ts/test/v09-context-integration.test.ts": [
+        "q-open-child-has-explicit-parent-and-empty-state",
+        "q-close-empty",
+        "q-close-nested-empty",
+        "formal-open-explicit-child-context",
+        "formal-one-form-group-if-admitted",
+        "formal-link-binary",
+        "formal-left-right-grouping-distinct",
+        "colon-source-content-to-form",
+        "colon-replay-read-only",
+        "equality-shared-local-representative",
+        "equality-distinct-representative",
+        "formal-close-to-exact-parent",
+        "formal-close-returned-root",
+        "parent-consumes-child-result",
+        "parent-preserves-returned-root-position"
+      ],
+      "ts/test/v09-readiness.test.ts": [
+        "q-close-nonempty",
+        "equality-identical-unbound"
+      ]
+    },
+    "context": {
+      "ts/test/v09-context-integration.test.ts": [
+        "formal-nested-right",
+        "formal-nested-left",
+        "formal-q-nested-empty",
+        "close-recovers-explicit-lexical-parent",
+        "run-carries-time-not-context-parent"
+      ],
+      "ts/test/v09-readiness.test.ts": [
+        "same-semantic-value-repeated-with-distinct-occurrence-evidence"
+      ]
+    }
+  },
   "baselineV08Invariants": {
     "linkIdentityByOrderedPoles": true,
     "rootIsOnlyFullySelfClosedLink": true,
@@ -182,6 +320,7 @@
     "607": {"status": "candidate-green", "requiredForAcceptance": true},
     "608": {"status": "candidate-green", "requiredForAcceptance": true},
     "609": {"status": "candidate-green", "requiredForAcceptance": true},
+    "597": {"status": "candidate-green", "requiredForAcceptance": true},
     "610": {"status": "blocked", "requiredForAcceptance": true}
   },
   "acceptance": {

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -40,7 +40,8 @@
     "structuralRule": "ts/src/structural-rule.ts",
     "structuralRuleEvidence": "ts/test/v09-structural-rules.test.ts",
     "contextIntegration": "ts/src/context-integration.ts",
-    "contextIntegrationEvidence": "ts/test/v09-context-integration.test.ts"
+    "contextIntegrationEvidence": "ts/test/v09-context-integration.test.ts",
+    "machineReadinessEvidence": "ts/test/v09-readiness.test.ts"
   },
   "semanticIdentity": {
     "acceptedV08TargetPreserved": true,
@@ -196,6 +197,15 @@
     "FORMAL_EQUAL": {"implementationStatus": "candidate-implemented", "issue": 609},
     "FORMAL_CLOSE": {"implementationStatus": "candidate-implemented", "issue": 609},
     "PARENT_CONTINUE": {"implementationStatus": "candidate-implemented", "issue": 609}
+  },
+  "machineReconciliation": {
+    "ownerIssue": 597,
+    "evidence": "ts/test/v09-readiness.test.ts",
+    "executableCoverageComplete": true,
+    "semanticClosureComplete": false,
+    "semanticClosureOwner": 594,
+    "acceptedV08Preserved": true,
+    "candidateAcceptanceAuthorized": false
   },
   "effects": {
     "findEqualsMaterialize": false,


### PR DESCRIPTION
Финальный governance PR для #597 после green test-only PR #631.

## Что фиксируется

- `ts/test/v09-readiness.test.ts` становится обязательным v0.9 executable gate;
- `coverageState` переводится `partial -> complete` **только в смысле текущего executable corpus**;
- добавлен полный `vectorEvidence`: каждый required negative/carrier/sequence/semantic/context vector привязан к конкретному green test;
- добавлен `implementedEvidence.597` и candidate owner machine-readiness evidence;
- machine reconciliation отмечает `executableCoverageComplete=true`, но одновременно `semanticClosureComplete=false`, owner semantic closure = #594;
- #597 становится `candidate-green`;
- `accepted=false`, `acceptanceReady=false`, accepted current v0.8 и #610 blocked сохраняются.

GovernanceGrant находится в issue #597 и разрешает только `contracts/**`, без policy relaxation.

```repo-guard-yaml
change_type: governance
scope:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 200
must_touch:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - repo-policy.json
  - cutover/**
  - ts/src/**
  - ts/test/**
  - .github/**
expected_effects:
  - bind already-green 597 readiness evidence into v0.9 candidate governance
  - map every currently required executable vector to concrete test evidence
  - mark executable machine coverage complete without claiming semantic closure
  - keep acceptanceReady false until 594 and keep 610 blocked
  - preserve accepted v0.8 runtime public facade and cutover pointers
```

Resolves #597