### PR TITLE
governance(v0.9): завершить F1 semantic closure #594

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -7,15 +7,16 @@
   "contract": "mts-contract/v0.9",
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
-  "acceptanceReady": false,
+  "acceptanceReady": true,
   "coverageState": "complete",
-  "coverageStateMeaning": "all currently required v0.9 executable vectors are mapped to green evidence; semantic closure and acceptance remain separate gates",
+  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; explicit release acceptance remains a separate #610 action",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
     "ts/test/v09-structural-rules.test.ts",
     "ts/test/v09-context-integration.test.ts",
-    "ts/test/v09-readiness.test.ts"
+    "ts/test/v09-readiness.test.ts",
+    "ts/test/v09-f1-axiom-aset.test.ts"
   ],
   "implementedEvidence": {
     "606": {
@@ -89,6 +90,22 @@
       "identicalUnboundEqualityUsesMemberRepresentative": true,
       "wrongBeforeContextRejected": true,
       "readOnlyReconciliationReplay": true
+    },
+    "594": {
+      "test": "ts/test/v09-f1-axiom-aset.test.ts",
+      "document": "docs/research/MTS v0.9 F1 — замкнутый axiom-aset.md",
+      "internalSignCount": 10,
+      "exactCarrierPerInternalSign": true,
+      "distinctSignEntryAcrossMeaningCollisions": true,
+      "recursiveMeaningDependenciesClosed": true,
+      "colonSelfIntroduction": true,
+      "formalArrowSelfIntroduction": true,
+      "ordinaryTheoryLink": true,
+      "explicitQAndFormalInterpreters": true,
+      "hostBootstrapOrderUsed": false,
+      "hiddenClassicalEqualityUsed": false,
+      "readOnlyClosureVerification": true,
+      "simultaneousSolutionProofDeferredTo": [582, 583]
     }
   },
   "requiredNegativeVectors": [
@@ -178,6 +195,17 @@
     "close-recovers-explicit-lexical-parent",
     "run-carries-time-not-context-parent",
     "same-semantic-value-repeated-with-distinct-occurrence-evidence"
+  ],
+  "requiredFoundationVectors": [
+    "minimal-internal-sign-registry-exact",
+    "recursive-sign-dependencies-closed",
+    "sign-entry-distinct-from-meaning",
+    "colon-self-introducing-axiom",
+    "formal-arrow-self-introducing-axiom",
+    "axiom-aset-is-ordinary-theory-link",
+    "q-formal-context-selection-explicit",
+    "meta-deferred-signs-excluded",
+    "f1-closure-read-only-verification"
   ],
   "vectorEvidence": {
     "negative": {
@@ -302,7 +330,27 @@
       "ts/test/v09-readiness.test.ts": [
         "same-semantic-value-repeated-with-distinct-occurrence-evidence"
       ]
+    },
+    "foundation": {
+      "ts/test/v09-f1-axiom-aset.test.ts": [
+        "minimal-internal-sign-registry-exact",
+        "recursive-sign-dependencies-closed",
+        "sign-entry-distinct-from-meaning",
+        "colon-self-introducing-axiom",
+        "formal-arrow-self-introducing-axiom",
+        "axiom-aset-is-ordinary-theory-link",
+        "q-formal-context-selection-explicit",
+        "meta-deferred-signs-excluded",
+        "f1-closure-read-only-verification"
+      ]
     }
+  },
+  "semanticClosure": {
+    "ownerIssue": 594,
+    "document": "docs/research/MTS v0.9 F1 — замкнутый axiom-aset.md",
+    "evidence": "ts/test/v09-f1-axiom-aset.test.ts",
+    "complete": true,
+    "simultaneousSolutionProofDeferredTo": [582, 583]
   },
   "baselineV08Invariants": {
     "linkIdentityByOrderedPoles": true,
@@ -321,7 +369,8 @@
     "608": {"status": "candidate-green", "requiredForAcceptance": true},
     "609": {"status": "candidate-green", "requiredForAcceptance": true},
     "597": {"status": "candidate-green", "requiredForAcceptance": true},
-    "610": {"status": "blocked", "requiredForAcceptance": true}
+    "594": {"status": "candidate-green", "requiredForAcceptance": true},
+    "610": {"status": "ready", "requiredForAcceptance": true}
   },
   "acceptance": {
     "performedHere": false,
@@ -331,6 +380,6 @@
     "observableSemanticDelta": true,
     "typeScriptCandidate": true,
     "candidateRuntimeSelectable": false,
-    "acceptanceReady": false
+    "acceptanceReady": true
   }
 }

--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -7,9 +7,9 @@
   "contract": "mts-contract/v0.9",
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
-  "acceptanceReady": true,
+  "acceptanceReady": false,
   "coverageState": "complete",
-  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; explicit release acceptance remains a separate #610 action",
+  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; acceptance readiness remains owned by the explicit #610 lifecycle step",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
@@ -370,7 +370,7 @@
     "609": {"status": "candidate-green", "requiredForAcceptance": true},
     "597": {"status": "candidate-green", "requiredForAcceptance": true},
     "594": {"status": "candidate-green", "requiredForAcceptance": true},
-    "610": {"status": "ready", "requiredForAcceptance": true}
+    "610": {"status": "blocked", "requiredForAcceptance": true}
   },
   "acceptance": {
     "performedHere": false,
@@ -380,6 +380,6 @@
     "observableSemanticDelta": true,
     "typeScriptCandidate": true,
     "candidateRuntimeSelectable": false,
-    "acceptanceReady": true
+    "acceptanceReady": false
   }
 }

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -8,7 +8,7 @@
   "observableSemanticDelta": true,
   "conformanceCorpus": "contracts/mts-conformance-v0.9.json",
   "acceptedCurrent": "mts-contract/v0.8",
-  "acceptanceReady": true,
+  "acceptanceReady": false,
   "implementation": {
     "language": "TypeScript",
     "package": "@mts/core",
@@ -42,7 +42,6 @@
     "contextIntegration": "ts/src/context-integration.ts",
     "contextIntegrationEvidence": "ts/test/v09-context-integration.test.ts",
     "machineReadinessEvidence": "ts/test/v09-readiness.test.ts",
-    "f1AxiomAsetDocument": "docs/research/MTS v0.9 F1 — замкнутый axiom-aset.md",
     "f1AxiomAsetEvidence": "ts/test/v09-f1-axiom-aset.test.ts"
   },
   "semanticIdentity": {
@@ -238,6 +237,6 @@
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "candidate-green"},
     {"issue": 597, "name": "machine reconciliation and executable evidence completeness", "status": "candidate-green"},
     {"issue": 594, "name": "closed self-introducing F1 axiom-aset", "status": "candidate-green"},
-    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "ready"}
+    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
   ]
 }

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -8,7 +8,7 @@
   "observableSemanticDelta": true,
   "conformanceCorpus": "contracts/mts-conformance-v0.9.json",
   "acceptedCurrent": "mts-contract/v0.8",
-  "acceptanceReady": false,
+  "acceptanceReady": true,
   "implementation": {
     "language": "TypeScript",
     "package": "@mts/core",
@@ -41,7 +41,9 @@
     "structuralRuleEvidence": "ts/test/v09-structural-rules.test.ts",
     "contextIntegration": "ts/src/context-integration.ts",
     "contextIntegrationEvidence": "ts/test/v09-context-integration.test.ts",
-    "machineReadinessEvidence": "ts/test/v09-readiness.test.ts"
+    "machineReadinessEvidence": "ts/test/v09-readiness.test.ts",
+    "f1AxiomAsetDocument": "docs/research/MTS v0.9 F1 — замкнутый axiom-aset.md",
+    "f1AxiomAsetEvidence": "ts/test/v09-f1-axiom-aset.test.ts"
   },
   "semanticIdentity": {
     "acceptedV08TargetPreserved": true,
@@ -70,7 +72,21 @@
     "singleFormalArrow": "⟼",
     "canonicalSourceFullyContextual": true,
     "implicitPrecedenceIsFoundationPrimitive": false,
-    "dedicatedStringQuoteSignRequired": false
+    "dedicatedStringQuoteSignRequired": false,
+    "closedAxiomAset": {
+      "ownerIssue": 594,
+      "document": "docs/research/MTS v0.9 F1 — замкнутый axiom-aset.md",
+      "evidence": "ts/test/v09-f1-axiom-aset.test.ts",
+      "internalSignCount": 10,
+      "signEntry": "E_g = c_g ⟼ m_g",
+      "axiomForm": "A_g = ExactSequence(c_g,E_:,ExactSequence(m_start,E_⟼,m_end))",
+      "theory": "T_F1 = T_F1 ⟼ ExactSequence(A_g...)",
+      "simultaneousSelfIntroduction": true,
+      "hostBootstrapOrderIsSemanticAuthority": false,
+      "hiddenClassicalEqualityPrimitive": false,
+      "semanticClosureComplete": true,
+      "simultaneousSolutionProofDeferredTo": [582, 583]
+    }
   },
   "canonicalStringQuaternaryCarrier": {
     "ownerIssue": 602,
@@ -202,8 +218,9 @@
     "ownerIssue": 597,
     "evidence": "ts/test/v09-readiness.test.ts",
     "executableCoverageComplete": true,
-    "semanticClosureComplete": false,
+    "semanticClosureComplete": true,
     "semanticClosureOwner": 594,
+    "semanticClosureEvidence": "ts/test/v09-f1-axiom-aset.test.ts",
     "acceptedV08Preserved": true,
     "candidateAcceptanceAuthorized": false
   },
@@ -219,6 +236,8 @@
     {"issue": 607, "name": "per-byte carrier and canonical byte vocabulary", "status": "candidate-green"},
     {"issue": 608, "name": "structural interpreter/rule and generic replay", "status": "candidate-green"},
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "candidate-green"},
-    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
+    {"issue": 597, "name": "machine reconciliation and executable evidence completeness", "status": "candidate-green"},
+    {"issue": 594, "name": "closed self-introducing F1 axiom-aset", "status": "candidate-green"},
+    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "ready"}
   ]
 }


### PR DESCRIPTION
Governance PR для #594 после green implementation/research PR #633.

## Что фиксируется

- closed F1 axiom-aset получает явный document reference и executable evidence owner;
- `ts/test/v09-f1-axiom-aset.test.ts` становится обязательным executable gate;
- добавляются foundation vectors и их точное evidence mapping;
- `machineReconciliation.semanticClosureComplete=true`;
- #594 становится `candidate-green`;
- `acceptanceReady=false` сохраняется, потому что текущая repo-policy явно оставляет readiness/acceptance lifecycle за #610;
- `accepted=false`, accepted current v0.8 и все current/previous/cutover pointers остаются неизменными;
- proof obligations #582/#583 остаются deferred и не выводятся из runtime.

GovernanceGrant находится в issue #594 и разрешает только `contracts/**`, без policy relaxation.

```repo-guard-yaml
change_type: governance
scope:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
must_touch:
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - repo-policy.json
  - cutover/**
  - ts/src/**
  - ts/test/**
  - docs/**
  - .github/**
expected_effects:
  - bind already-green closed F1 axiom-aset document and executable evidence to v0.9 candidate governance
  - mark semantic closure complete while keeping simultaneous-solution and no-instance proofs deferred to 582 and 583
  - keep acceptanceReady false because readiness and accepted cutover remain owned by 610 policy lifecycle
  - mark 594 candidate gate green without changing accepted current previous or cutover pointers
  - preserve accepted v0.8 runtime and public facade
```

Resolves #594