### PR TITLE
[superseded] governance(v0.9): readiness transition #610

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -7,9 +7,9 @@
   "contract": "mts-contract/v0.9",
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
-  "acceptanceReady": false,
+  "acceptanceReady": true,
   "coverageState": "complete",
-  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; acceptance readiness remains owned by the explicit #610 lifecycle step",
+  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; candidate is acceptance-ready and the accepted cutover remains a separate #610 M6-B action",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
@@ -370,7 +370,7 @@
     "609": {"status": "candidate-green", "requiredForAcceptance": true},
     "597": {"status": "candidate-green", "requiredForAcceptance": true},
     "594": {"status": "candidate-green", "requiredForAcceptance": true},
-    "610": {"status": "blocked", "requiredForAcceptance": true}
+    "610": {"status": "ready", "requiredForAcceptance": true}
   },
   "acceptance": {
     "performedHere": false,
@@ -380,6 +380,6 @@
     "observableSemanticDelta": true,
     "typeScriptCandidate": true,
     "candidateRuntimeSelectable": false,
-    "acceptanceReady": false
+    "acceptanceReady": true
   }
 }

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -8,7 +8,7 @@
   "observableSemanticDelta": true,
   "conformanceCorpus": "contracts/mts-conformance-v0.9.json",
   "acceptedCurrent": "mts-contract/v0.8",
-  "acceptanceReady": false,
+  "acceptanceReady": true,
   "implementation": {
     "language": "TypeScript",
     "package": "@mts/core",
@@ -237,6 +237,6 @@
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "candidate-green"},
     {"issue": 597, "name": "machine reconciliation and executable evidence completeness", "status": "candidate-green"},
     {"issue": 594, "name": "closed self-introducing F1 axiom-aset", "status": "candidate-green"},
-    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
+    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "ready"}
   ]
 }

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -128,16 +128,16 @@
         "value": true
       },
       {
-        "id": "v09-contract-not-ready",
+        "id": "v09-contract-ready",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v09-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
+        "value": true
       },
       {
-        "id": "v09-conformance-not-ready",
+        "id": "v09-conformance-ready",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
+        "value": true
       },
       {
         "id": "v09-baseline-owner-paths-exist",


### PR DESCRIPTION
Superseded after repo-guard dual-policy analysis. This PR tried to replace `acceptanceReady=false` with `true` in one step, but trusted base policy must still validate the head state, so the old literal relation correctly vetoes it.

No merge. Replacement is the two-phase generic lifecycle bridge tracked by #636, followed by M6-A1.

The failed run was informative: proposed head policy itself passed 53/53; the veto came from trusted-base relations/governance authorization, exactly as fail-closed design intends.