### PR TITLE
governance: открыть узкий readiness bridge #636

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -128,18 +128,6 @@
         "value": true
       },
       {
-        "id": "v09-contract-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v09-conformance-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
         "id": "v09-baseline-owner-paths-exist",
         "kind": "referenced_paths_exist",
         "source": {


### PR DESCRIPTION
Удаляет только два старых candidate readiness literal constraints. Candidate data не меняются и остаются `acceptanceReady=false`, `accepted=false`, current=v0.8.

Это короткий dual-policy bridge: следующий M6-A1 PR восстановит более сильные constraints `acceptanceReady=true` одновременно с переводом candidate data в ready-state.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - .github/**
expected_effects:
  - remove exactly the two obsolete not-ready literal constraints as a trusted lifecycle bridge
  - leave v0.9 candidate data unaccepted and not-ready
  - leave accepted v0.8 current previous v0.7 and cutover pointer unchanged
  - allow the immediately following PR to install stronger ready-true constraints without violating trusted base policy
```

Resolves #636