### PR TITLE
governance(v0.9): зафиксировать acceptanceReady=true #638

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -7,9 +7,9 @@
   "contract": "mts-contract/v0.9",
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
-  "acceptanceReady": false,
+  "acceptanceReady": true,
   "coverageState": "complete",
-  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; acceptance readiness remains owned by the explicit #610 lifecycle step",
+  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; candidate is acceptance-ready and the accepted cutover remains a separate #610 M6-B action",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
@@ -370,7 +370,7 @@
     "609": {"status": "candidate-green", "requiredForAcceptance": true},
     "597": {"status": "candidate-green", "requiredForAcceptance": true},
     "594": {"status": "candidate-green", "requiredForAcceptance": true},
-    "610": {"status": "blocked", "requiredForAcceptance": true}
+    "610": {"status": "ready", "requiredForAcceptance": true}
   },
   "acceptance": {
     "performedHere": false,
@@ -380,6 +380,6 @@
     "observableSemanticDelta": true,
     "typeScriptCandidate": true,
     "candidateRuntimeSelectable": false,
-    "acceptanceReady": false
+    "acceptanceReady": true
   }
 }

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -8,7 +8,7 @@
   "observableSemanticDelta": true,
   "conformanceCorpus": "contracts/mts-conformance-v0.9.json",
   "acceptedCurrent": "mts-contract/v0.8",
-  "acceptanceReady": false,
+  "acceptanceReady": true,
   "implementation": {
     "language": "TypeScript",
     "package": "@mts/core",
@@ -237,6 +237,6 @@
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "candidate-green"},
     {"issue": 597, "name": "machine reconciliation and executable evidence completeness", "status": "candidate-green"},
     {"issue": 594, "name": "closed self-introducing F1 axiom-aset", "status": "candidate-green"},
-    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "blocked"}
+    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "ready"}
   ]
 }

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -128,6 +128,18 @@
         "value": true
       },
       {
+        "id": "v09-contract-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-contract", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v09-conformance-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": true
+      },
+      {
         "id": "v09-baseline-owner-paths-exist",
         "kind": "referenced_paths_exist",
         "source": {


### PR DESCRIPTION
M6-A1 закрывает readiness bridge #636 более сильным invariant.

После этого PR состояние должно быть:

```text
v0.9 status=candidate
v0.9 accepted=false
v0.9 acceptanceReady=true
repo-policy требует readiness=true
accepted current=v0.8
previous=v0.7
cutover pointer=v0.8
```

Никакого accepted flip здесь нет. Это отдельный hard-gated prerequisite для M6-B.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 20
must_touch:
  - repo-policy.json
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
must_not_touch:
  - cutover/**
  - ts/**
  - docs/**
  - .github/**
expected_effects:
  - restore a stronger readiness invariant after the narrow lifecycle bridge
  - require acceptanceReady true in both candidate documents
  - keep v0.9 candidate and unaccepted
  - preserve v0.8 as accepted current and v0.7 as previous
  - leave accepted cutover and contract budget for later M6-B
```

Resolves #638