### PR TITLE
governance: открыть accepted lifecycle bridge #640

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -80,30 +80,6 @@
         "value": "contracts/mts-conformance-v0.9.json"
       },
       {
-        "id": "v09-contract-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v09-conformance-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v09-contract-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v09-conformance-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
         "id": "v09-contract-semantic-base-v08",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v09-contract", "pointer": "/semanticBase", "type": "string"},


### PR DESCRIPTION
Удаляет только четыре candidate lifecycle literals, которые должны смениться при последующем accepted cutover. v0.9 data в этом PR не меняются и остаются `candidate`, `accepted=false`, `acceptanceReady=true`.

Сохраняются под policy:
- pair/conformance path;
- semanticBase=v0.8;
- observableSemanticDelta=true;
- acceptanceReady=true;
- owner/gate paths;
- candidate executable gates;
- accepted current=v0.8, previous=v0.7, cutover pointer=v0.8.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - .github/**
expected_effects:
  - remove exactly four obsolete candidate lifecycle literals before accepted cutover
  - preserve readiness semantic delta pair owner and executable evidence constraints
  - leave v0.9 candidate ready and unaccepted
  - leave v0.8 accepted current v0.7 previous and current cutover pointer unchanged
```

Resolves #640