### PR TITLE
governance(v0.9): принять v0.9 current #642

### DIFF
--- a/contracts/mts-conformance-v0.9.json
+++ b/contracts/mts-conformance-v0.9.json
@@ -1,15 +1,20 @@
 {
   "schema": "mts-conformance/v0.9",
-  "status": "candidate",
-  "accepted": false,
-  "issue": 597,
+  "status": "accepted",
+  "accepted": true,
+  "issue": 610,
   "candidateLifecycleIssue": 605,
   "contract": "mts-contract/v0.9",
   "semanticBase": "mts-conformance/v0.8",
   "observableSemanticDelta": true,
+  "previousAcceptedRelease": {
+    "contract": "mts-contract/v0.8",
+    "conformance": "mts-conformance/v0.8",
+    "immutable": true
+  },
   "acceptanceReady": true,
   "coverageState": "complete",
-  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; candidate is acceptance-ready and the accepted cutover remains a separate #610 M6-B action",
+  "coverageStateMeaning": "all required v0.9 executable vectors and the closed F1 semantic gate are green; v0.9 is the accepted current release",
   "requiredExecutableGates": [
     "ts/test/v09-structural-carriers.test.ts",
     "ts/test/v09-byte-carrier.test.ts",
@@ -370,16 +375,18 @@
     "609": {"status": "candidate-green", "requiredForAcceptance": true},
     "597": {"status": "candidate-green", "requiredForAcceptance": true},
     "594": {"status": "candidate-green", "requiredForAcceptance": true},
-    "610": {"status": "ready", "requiredForAcceptance": true}
+    "610": {"status": "accepted", "requiredForAcceptance": true}
   },
   "acceptance": {
-    "performedHere": false,
-    "acceptedMtsVersion": "mts-contract/v0.8",
+    "performedHere": true,
+    "acceptedMtsVersion": "mts-contract/v0.9",
+    "previousAcceptedMtsVersion": "mts-contract/v0.8",
     "candidateMtsVersion": "mts-contract/v0.9",
     "semanticBase": "mts-contract/v0.8",
     "observableSemanticDelta": true,
-    "typeScriptCandidate": true,
+    "typeScriptAccepted": true,
     "candidateRuntimeSelectable": false,
-    "acceptanceReady": true
+    "acceptanceReady": true,
+    "cutoverIssue": 610
   }
 }

--- a/contracts/mts-contract-v0.9.json
+++ b/contracts/mts-contract-v0.9.json
@@ -1,13 +1,21 @@
 {
   "schema": "mts-contract/v0.9",
-  "status": "candidate",
-  "accepted": false,
-  "issue": 597,
+  "status": "accepted",
+  "accepted": true,
+  "issue": 610,
   "candidateLifecycleIssue": 605,
   "semanticBase": "mts-contract/v0.8",
   "observableSemanticDelta": true,
+  "previousAcceptedRelease": {
+    "contract": "mts-contract/v0.8",
+    "conformance": "mts-conformance/v0.8",
+    "immutable": true,
+    "liveRuntimeSelectable": false
+  },
   "conformanceCorpus": "contracts/mts-conformance-v0.9.json",
-  "acceptedCurrent": "mts-contract/v0.8",
+  "currentPointer": "cutover/typescript-c1-acceptance-v0.2.json",
+  "acceptedMtsVersion": "mts-contract/v0.9",
+  "acceptedCurrent": "mts-contract/v0.9",
   "acceptanceReady": true,
   "implementation": {
     "language": "TypeScript",
@@ -17,6 +25,29 @@
     "singleLiveSemanticRuntime": true,
     "pythonRuntimePresent": false,
     "compatibilityRuntimeSelectable": false
+  },
+  "owners": {
+    "publicFacade": "ts/src/public.ts",
+    "memory": "ts/src/memory.ts",
+    "anum": "ts/src/anum.ts",
+    "source": "ts/src/source.ts",
+    "state": "ts/src/state.ts",
+    "dictionary": "ts/src/dictionary.ts",
+    "interpreter": "ts/src/interpreter.ts",
+    "sequence": "ts/src/sequence.ts",
+    "run": "ts/src/run.ts",
+    "proof": "ts/src/proof.ts",
+    "checker": "ts/src/checker.ts",
+    "directDeixis": "ts/src/direct-deixis.ts",
+    "valueBundle": "ts/src/value-bundle.ts",
+    "persistenceTopology": "ts/src/persistence-topology.ts",
+    "persistenceStore": "ts/src/persistent-store.ts",
+    "persistenceSequence": "ts/src/persistent-sequence.ts",
+    "exactSequence": "ts/src/exact-sequence.ts",
+    "quaternaryState": "ts/src/quaternary-state.ts",
+    "byteCarrier": "ts/src/byte-carrier.ts",
+    "structuralRule": "ts/src/structural-rule.ts",
+    "contextIntegration": "ts/src/context-integration.ts"
   },
   "baselineOwners": {
     "publicFacade": "ts/src/public.ts",
@@ -221,7 +252,7 @@
     "semanticClosureOwner": 594,
     "semanticClosureEvidence": "ts/test/v09-f1-axiom-aset.test.ts",
     "acceptedV08Preserved": true,
-    "candidateAcceptanceAuthorized": false
+    "candidateAcceptanceAuthorized": true
   },
   "effects": {
     "findEqualsMaterialize": false,
@@ -237,6 +268,6 @@
     {"issue": 609, "name": "FORMAL contexts and cross-context integration", "status": "candidate-green"},
     {"issue": 597, "name": "machine reconciliation and executable evidence completeness", "status": "candidate-green"},
     {"issue": 594, "name": "closed self-introducing F1 axiom-aset", "status": "candidate-green"},
-    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "ready"}
+    {"issue": 610, "name": "acceptance cutover and governance debt repayment", "status": "accepted"}
   ]
 }

--- a/cutover/typescript-c1-acceptance-v0.2.json
+++ b/cutover/typescript-c1-acceptance-v0.2.json
@@ -1,0 +1,53 @@
+{
+  "schema": "typescript-c1-acceptance/v0.2",
+  "issue": 610,
+  "parentIssue": 597,
+  "decision": "ACCEPT_MTS_V0_9",
+  "versionDecision": {
+    "previousAcceptedVersion": "mts-contract/v0.8",
+    "acceptedVersion": "mts-contract/v0.9",
+    "semanticBase": "mts-contract/v0.8",
+    "observableSemanticDelta": true,
+    "reason": "closed F1 sign/axiom-aset semantics, exact carriers, structural rules and explicit cross-context integration have complete executable candidate evidence and a separately merged acceptanceReady state"
+  },
+  "current": {
+    "contract": "contracts/mts-contract-v0.9.json",
+    "conformance": "contracts/mts-conformance-v0.9.json",
+    "publicFacade": "ts/src/public.ts",
+    "packageManifest": "ts/package.json"
+  },
+  "previousReleaseEvidence": {
+    "contract": "contracts/mts-contract-v0.8.json",
+    "conformance": "contracts/mts-conformance-v0.8.json",
+    "immutable": true,
+    "liveRuntimeSelectable": false
+  },
+  "evidence": {
+    "candidateLifecycleIssue": 605,
+    "machineReconciliationIssue": 597,
+    "f1ClosureIssue": 594,
+    "readinessIssue": 638,
+    "cutoverIssue": 610,
+    "preAcceptanceReadyMainSha": "db46b78188b01dd43134aa6c7f8cd349bb292198",
+    "migrationHistoryInGitOnly": true
+  },
+  "acceptance": {
+    "typeScriptAccepted": true,
+    "cutoverPerformed": true,
+    "downstreamRepinAllowed": true,
+    "singleLiveSemanticRuntime": true,
+    "pythonRuntimePresent": false,
+    "pythonOraclePresent": false,
+    "compatibilityRuntimeAllowed": false,
+    "acceptanceReadyWasProvenBeforeCutover": true
+  },
+  "veto": {
+    "runtimeOrStorageIdAsSemanticIdentity": false,
+    "sourcePositionOccurrenceOrPathAsSemanticIdentity": false,
+    "readOrReplayMayMaterialize": false,
+    "secondLiveRuntime": false,
+    "pythonCompatibilityRuntime": false,
+    "hiddenClassicalEqualityAsFoundation": false,
+    "hostParserOrCallbackAsSemanticAuthority": false
+  }
+}

--- a/cutover/typescript-c1-acceptance-v0.2.json
+++ b/cutover/typescript-c1-acceptance-v0.2.json
@@ -28,6 +28,7 @@
     "f1ClosureIssue": 594,
     "readinessIssue": 638,
     "cutoverIssue": 610,
+    "atomicCutoverAuthorizationIssue": 642,
     "preAcceptanceReadyMainSha": "db46b78188b01dd43134aa6c7f8cd349bb292198",
     "migrationHistoryInGitOnly": true
   },

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -21,12 +21,12 @@
   },
   "contract_conformance": {
     "current": {
-      "contract": {"path": "contracts/mts-contract-v0.8.json", "format": "json"},
-      "conformance": {"path": "contracts/mts-conformance-v0.8.json", "format": "json"}
+      "contract": {"path": "contracts/mts-contract-v0.9.json", "format": "json"},
+      "conformance": {"path": "contracts/mts-conformance-v0.9.json", "format": "json"}
     },
     "previous": {
-      "contract": {"path": "contracts/mts-contract-v0.7.json", "format": "json"},
-      "conformance": {"path": "contracts/mts-conformance-v0.7.json", "format": "json"}
+      "contract": {"path": "contracts/mts-contract-v0.8.json", "format": "json"},
+      "conformance": {"path": "contracts/mts-conformance-v0.8.json", "format": "json"}
     },
     "pair_fields": {
       "contract_id": "/schema",
@@ -39,7 +39,7 @@
     },
     "accepted_state": {"status": "accepted", "accepted": true},
     "acceptance": {
-      "document": {"path": "cutover/typescript-c1-acceptance-v0.1.json", "format": "json"},
+      "document": {"path": "cutover/typescript-c1-acceptance-v0.2.json", "format": "json"},
       "current_contract_path": "/current/contract",
       "current_conformance_path": "/current/conformance"
     },

--- a/ts/test/release-cutover.test.ts
+++ b/ts/test/release-cutover.test.ts
@@ -61,17 +61,47 @@ assert(
   "package root must expose matching declaration and runtime outputs",
 );
 
-const contract = JSON.parse(readFileSync(join(repoRoot, "contracts/mts-contract-v0.8.json"), "utf8")) as {
+const contract = JSON.parse(readFileSync(join(repoRoot, "contracts/mts-contract-v0.9.json"), "utf8")) as {
   readonly schema?: string;
+  readonly status?: string;
+  readonly accepted?: boolean;
   readonly semanticBase?: string;
   readonly observableSemanticDelta?: boolean;
-  readonly implementation?: { readonly language?: string; readonly pythonRuntimePresent?: boolean };
+  readonly acceptanceReady?: boolean;
+  readonly implementation?: {
+    readonly language?: string;
+    readonly pythonRuntimePresent?: boolean;
+    readonly singleLiveSemanticRuntime?: boolean;
+  };
 };
-assert(contract.schema === "mts-contract/v0.8", "current contract must be v0.8");
-assert(contract.semanticBase === "mts-contract/v0.7", "semantic base must remain accepted v0.7");
-assert(contract.observableSemanticDelta === false, "cutover must not claim a semantic delta");
+assert(contract.schema === "mts-contract/v0.9", "current contract must be v0.9");
+assert(contract.status === "accepted" && contract.accepted === true, "current v0.9 contract must be accepted");
+assert(contract.semanticBase === "mts-contract/v0.8", "v0.9 semantic base must be accepted v0.8");
+assert(contract.observableSemanticDelta === true, "v0.9 must retain its explicit semantic delta");
+assert(contract.acceptanceReady === true, "accepted v0.9 must retain proven readiness");
 assert(contract.implementation?.language === "TypeScript", "current implementation must be TypeScript");
 assert(contract.implementation?.pythonRuntimePresent === false, "current contract must reject Python runtime ownership");
+assert(contract.implementation?.singleLiveSemanticRuntime === true, "accepted runtime must remain single");
+
+const conformance = JSON.parse(readFileSync(join(repoRoot, "contracts/mts-conformance-v0.9.json"), "utf8")) as {
+  readonly status?: string;
+  readonly accepted?: boolean;
+  readonly acceptanceReady?: boolean;
+  readonly requiredExecutableGates?: readonly string[];
+  readonly requiredNegativeVectors?: readonly string[];
+  readonly vectorEvidence?: {
+    readonly negative?: Readonly<Record<string, readonly string[]>>;
+  };
+};
+assert(conformance.status === "accepted" && conformance.accepted === true, "current v0.9 conformance must be accepted");
+assert(conformance.acceptanceReady === true, "accepted v0.9 conformance must retain proven readiness");
+
+function mappedNegativeVector(id: string): boolean {
+  if (!conformance.requiredNegativeVectors?.includes(id)) return false;
+  const requiredGates = new Set(conformance.requiredExecutableGates ?? []);
+  const evidence = conformance.vectorEvidence?.negative ?? {};
+  return Object.entries(evidence).some(([testPath, ids]) => requiredGates.has(testPath) && ids.includes(id));
+}
 
 const currentPython = pythonFiles(repoRoot);
 negativeVector("python-runtime-present", currentPython.length === 0);
@@ -85,6 +115,8 @@ assert(memory.poles(basis.C).start === basis.R && memory.poles(basis.C).end === 
 assert(memory.poles(basis.L).start === basis.O && memory.poles(basis.L).end === basis.C, "L basis mismatch");
 assert(memory.poles(basis.U).start === basis.C && memory.poles(basis.U).end === basis.O, "U basis mismatch");
 
+// Retain the accepted-v0.8 physical safety anchors so trusted base policy remains
+// independently checkable during the atomic cutover.
 negativeVector("second-fully-self-closed-by-physical-id", rejectsTopology([[0, 0], [1, 1]]));
 negativeVector("duplicate-same-pair", rejectsTopology([[0, 0], [1, 0], [0, 2], [1, 2], [1, 2]]));
 
@@ -99,7 +131,7 @@ const countBeforeRead = memory.linkCount;
 memory.find(basis.L, basis.U);
 memory.outgoing(basis.L);
 memory.incoming(basis.U);
-negativeVector("read-or-replay-materializes", memory.linkCount === countBeforeRead);
+negativeVector("read-or-replay-materializes", memory.linkCount === countBeforeRead && mappedNegativeVector("read-or-replay-materializes"));
 
 let rootRejected = false;
 try {
@@ -109,3 +141,30 @@ try {
 }
 negativeVector("root-as-fifth-abit", rootRejected);
 negativeVector("empty-group-rejected", deserializeStream("[]", symbolicStackAlgebra).denotation === "R");
+
+// The following accepted-v0.9 anchors do not duplicate semantic execution.
+// They prove that every current negative vector is bound to one of the exact
+// executable gates that full CI runs. The semantic checks stay in those gates.
+negativeVector("exact-sequence-empty-vs-single-root", mappedNegativeVector("exact-sequence-empty-vs-single-root"));
+negativeVector("exact-sequence-leading-root-loss", mappedNegativeVector("exact-sequence-leading-root-loss"));
+negativeVector("restricted-rooted-sequence-admits-root", mappedNegativeVector("restricted-rooted-sequence-admits-root"));
+negativeVector("exact-sequence-malformed-cell", mappedNegativeVector("exact-sequence-malformed-cell"));
+negativeVector("exact-sequence-predecessor-cycle", mappedNegativeVector("exact-sequence-predecessor-cycle"));
+negativeVector("q-state-hidden-started-disagrees", mappedNegativeVector("q-state-hidden-started-disagrees"));
+negativeVector("canonical-string-carrier-codepoint-envelope", mappedNegativeVector("canonical-string-carrier-codepoint-envelope"));
+negativeVector("canonical-byte-opaque-runtime-id", mappedNegativeVector("canonical-byte-opaque-runtime-id"));
+negativeVector("forged-interpreter-configuration", mappedNegativeVector("forged-interpreter-configuration"));
+negativeVector("interpreter-components-disagree-with-evidence", mappedNegativeVector("interpreter-components-disagree-with-evidence"));
+negativeVector("forged-role-dictionary", mappedNegativeVector("forged-role-dictionary"));
+negativeVector("rule-not-admitted-by-theory", mappedNegativeVector("rule-not-admitted-by-theory"));
+negativeVector("rule-missing-required-role", mappedNegativeVector("rule-missing-required-role"));
+negativeVector("rule-conflicting-role-binding", mappedNegativeVector("rule-conflicting-role-binding"));
+negativeVector("rule-undeclared-role-binding", mappedNegativeVector("rule-undeclared-role-binding"));
+negativeVector("rule-wrong-result", mappedNegativeVector("rule-wrong-result"));
+negativeVector("rule-wrong-before-context", mappedNegativeVector("rule-wrong-before-context"));
+negativeVector("rule-wrong-after-context", mappedNegativeVector("rule-wrong-after-context"));
+negativeVector("context-close-wrong-parent", mappedNegativeVector("context-close-wrong-parent"));
+negativeVector("parent-continuation-wrong-interpreter", mappedNegativeVector("parent-continuation-wrong-interpreter"));
+negativeVector("returned-root-disappears-from-exact-parent-sequence", mappedNegativeVector("returned-root-disappears-from-exact-parent-sequence"));
+negativeVector("noncanonical-unparenthesized-formal-relation", mappedNegativeVector("noncanonical-unparenthesized-formal-relation"));
+negativeVector("empty-formal-context-admitted", mappedNegativeVector("empty-formal-context-admitted"));


### PR DESCRIPTION
M6-B1 выполняет atomic accepted cutover только после отдельно смерженного и green состояния `acceptanceReady=true`.

## Результат этого PR

```text
current  -> MTS v0.9 accepted
previous -> MTS v0.8 immutable evidence
v0.9 acceptanceReady=true сохраняется
single live TypeScript runtime сохраняется
v0.7 pair пока остаётся tracked до отдельного B2 cleanup
```

Изменения:
- v0.9 contract/conformance получают `status=accepted`, `accepted=true` и accepted-release metadata;
- в contract добавляется единый `/owners`, требуемый generic current-contract policy;
- `repo-policy.json` вращает current/previous и acceptance manifest pointers;
- добавляется `cutover/typescript-c1-acceptance-v0.2.json`;
- `release-cutover.test.ts` переключается на accepted v0.9 и сохраняет old v0.8 negative anchors для trusted base policy, одновременно привязывая каждый v0.9 negative vector к его обязательному executable gate. Семантические проверки не дублируются: они остаются в M2–M5 gate-файлах, которые full CI исполняет напрямую.

Contract-budget debt и удаление v0.7 выполняются только последующим B2 после успешного accepted rotation.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
  - cutover/typescript-c1-acceptance-v0.2.json
  - ts/test/release-cutover.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 200
must_touch:
  - repo-policy.json
  - contracts/mts-contract-v0.9.json
  - contracts/mts-conformance-v0.9.json
  - cutover/typescript-c1-acceptance-v0.2.json
  - ts/test/release-cutover.test.ts
must_not_touch:
  - contracts/mts-contract-v0.7.json
  - contracts/mts-conformance-v0.7.json
  - contracts/mts-contract-v0.8.json
  - contracts/mts-conformance-v0.8.json
  - ts/src/**
  - docs/**
  - .github/**
expected_effects:
  - rotate accepted current from v0.8 to the separately proven ready v0.9 pair
  - rotate previous evidence from v0.7 to immutable v0.8 without keeping a selectable compatibility runtime
  - point acceptance governance at the new v0.2 manifest
  - make current v0.9 executable gates and negative evidence subject to the generic accepted contract-conformance policy
  - preserve all F2 and F3 proof obligations as deferred research rather than importing runtime identity
  - leave v0.7 deletion and contract budget repayment to a separate post-rotation cleanup
```

Resolves #642