### PR TITLE
governance(v0.9): погасить contract-budget debt #646

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -68,18 +68,6 @@
     },
     "rules": [
       {
-        "id": "v09-candidate-pair-id",
-        "kind": "scalar_equal",
-        "left": {"document": "candidate-v09-contract", "pointer": "/schema", "type": "string"},
-        "right": {"document": "candidate-v09-conformance", "pointer": "/contract", "type": "string"}
-      },
-      {
-        "id": "v09-candidate-conformance-path",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/conformanceCorpus", "type": "string"},
-        "value": "contracts/mts-conformance-v0.9.json"
-      },
-      {
         "id": "v09-contract-semantic-base-v08",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v09-contract", "pointer": "/semanticBase", "type": "string"},
@@ -114,36 +102,6 @@
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
         "value": true
-      },
-      {
-        "id": "v09-baseline-owner-paths-exist",
-        "kind": "referenced_paths_exist",
-        "source": {
-          "document": "candidate-v09-contract",
-          "pointer": "/baselineOwners",
-          "projection": "object_values",
-          "type": "repository_path_set"
-        }
-      },
-      {
-        "id": "v09-candidate-owner-paths-exist",
-        "kind": "referenced_paths_exist",
-        "source": {
-          "document": "candidate-v09-contract",
-          "pointer": "/candidateOwners",
-          "projection": "object_values",
-          "type": "repository_path_set"
-        }
-      },
-      {
-        "id": "v09-candidate-gate-paths-exist",
-        "kind": "referenced_paths_exist",
-        "source": {
-          "document": "candidate-v09-conformance",
-          "pointer": "/requiredExecutableGates",
-          "projection": "array_items",
-          "type": "repository_path_set"
-        }
       }
     ]
   },
@@ -170,18 +128,6 @@
         "type": "string_set"
       },
       "target_anchor_type": "negative_vector_test"
-    },
-    {
-      "id": "v09-candidate-gates-covered-by-project-ci",
-      "kind": "workflow_path_coverage",
-      "source": {
-        "document": "candidate-v09-conformance",
-        "pointer": "/requiredExecutableGates",
-        "projection": "array_items",
-        "type": "repository_path_set"
-      },
-      "workflow": "project-ci",
-      "covers": ["ts/test/**"]
     }
   ],
   "anchors": {
@@ -222,8 +168,8 @@
       "scope": "directory",
       "metric": "files",
       "glob": "contracts/**",
-      "max": 6,
-      "max_growth": 2,
+      "max": 4,
+      "max_growth": 0,
       "count": "all_tracked",
       "level": "blocking"
     },


### PR DESCRIPTION
Финальный lifecycle cleanup после accepted v0.9 cutover и удаления tracked v0.7 pair.

Изменения:

```text
contracts-file-count.max        6 -> 4
contracts-file-count.max_growth 2 -> 0
```

Удаляются только candidate-era constraints, уже полностью дублируемые accepted `contract_conformance.current` macro:
- pair id / conformance path;
- baseline/candidate owner path checks;
- candidate gate path check;
- candidate-specific CI gate coverage.

Сохраняются отдельные v0.9 constraints, которых accepted macro сам не выражает:

```text
semanticBase = v0.8
observableSemanticDelta = true
acceptanceReady = true
```

Также сохраняются generic current executable-gate coverage, current negative-vector anchor coverage и explicit v0.9 cochange rules.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - .github/**
expected_effects:
  - restore the tracked contract budget to exactly four files with zero growth allowance
  - remove only candidate-era pair owner and gate constraints already enforced by the accepted current macro
  - retain v0.9 semantic base observable-delta and acceptance-readiness constraints
  - retain current required-gate CI coverage and current negative-vector anchor coverage
  - preserve accepted v0.9 current immutable v0.8 previous and acceptance v0.2 pointers
```

Resolves #646