### PR TITLE
governance: требовать theory/README co-change при contract lifecycle

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -210,6 +210,30 @@
     {
       "if_changed": ["contracts/mts-conformance-v0.9.json"],
       "must_change_any": ["contracts/mts-contract-v0.9.json"]
+    },
+    {
+      "if_changed": [
+        "contracts/mts-contract-v*.json",
+        "contracts/mts-conformance-v*.json",
+        "cutover/typescript-c1-acceptance-v*.json"
+      ],
+      "must_change_any": ["README.md"]
+    },
+    {
+      "if_changed": [
+        "contracts/mts-contract-v*.json",
+        "contracts/mts-conformance-v*.json",
+        "cutover/typescript-c1-acceptance-v*.json"
+      ],
+      "must_change_any": ["docs/theory/Основания МТС.md"]
+    },
+    {
+      "if_changed": [
+        "contracts/mts-contract-v*.json",
+        "contracts/mts-conformance-v*.json",
+        "cutover/typescript-c1-acceptance-v*.json"
+      ],
+      "must_change_any": ["docs/theory/Система аксиом МТС.md"]
     }
   ]
 }


### PR DESCRIPTION
Closes #655. Refs #653.

Фаза 2 contract-driven docs gate.

Policy-only изменение:
- сохраняет существующие v0.9 contract/conformance co-change rules;
- добавляет три generic `cochange_rules` для semantic contract lifecycle;
- любое изменение versioned contract/conformance или acceptance manifest обязано отдельно затронуть README, `Основания МТС` и `Система аксиом МТС`;
- singleton `must_change_any` используется намеренно, чтобы требовать все три документа, а не любой один;
- runtime, contracts, cutover, docs и workflows в этом PR не меняются;
- MTS-specific validator не добавляется.

Trusted GovernanceGrant находится в #655. Текущий repo-guard может классифицировать изменение `cochange_rules` как `policy_incomparable` на `/`; #655 содержит узкий explicit root-review grant для этого заранее описанного tightening.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 80
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - README.md
  - .github/**
expected_effects:
  - require README reconciliation for semantic contract lifecycle changes
  - require Основания МТС reconciliation for semantic contract lifecycle changes
  - require Система аксиом МТС reconciliation for semantic contract lifecycle changes
  - preserve all existing governance constraints
```