### PR TITLE
governance: подготовить slots для MTS v0.10 candidate

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -168,8 +168,8 @@
       "scope": "directory",
       "metric": "files",
       "glob": "contracts/**",
-      "max": 4,
-      "max_growth": 0,
+      "max": 6,
+      "max_growth": 2,
       "count": "all_tracked",
       "level": "blocking"
     },


### PR DESCRIPTION
Closes #679. Refs #663.

Governance-only PR A из двухшагового candidate lifecycle MTS v0.10. Меняет только временный budget `contracts/**`:

```text
max        4 -> 6
max_growth 0 -> 2
```

Candidate-файлы не добавляются. Accepted current остаётся MTS v0.9, previous — v0.8. Trusted GovernanceGrant находится в #679; parent lifecycle — #663.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 2
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - .github/**
  - ts/**
  - README.md
  - docs/**
expected_effects:
  - reserve two temporary contract slots for v0.10 candidate coexistence
  - preserve v0.9 current and v0.8 previous pointers
```