### PR TITLE
governance(v0.10): bridge readiness transition

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -166,18 +166,6 @@
         "value": false
       },
       {
-        "id": "v010-contract-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v010-conformance-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
         "id": "v010-contract-is-semantic-delta",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v010-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},


### PR DESCRIPTION
Closes #693. Refs #657, #690.

Двухфазный readiness bridge для v0.10. Этот PR меняет только `repo-policy.json` и временно удаляет ровно два literal constraint:

```text
v010-contract-not-ready
v010-conformance-not-ready
```

Candidate data остаются неизменными:

```text
status=candidate
accepted=false
acceptanceReady=false
coverageState=incomplete
current=v0.9
cutover=v0.9
```

Следующий отдельный PR обязан восстановить более сильные `v010-*-ready => true` constraints одновременно с candidate readiness data. Никакого acceptance/cutover здесь нет.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - .github/**
  - README.md
  - docs/**
  - ts/**
expected_effects:
  - remove exactly two v0.10 not-ready literal constraints
  - preserve all accepted/current/cutover state
  - prepare immediate stronger readiness=true transition
```