### PR TITLE
governance(v0.10): bridge coverage completion

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -176,12 +176,6 @@
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v010-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
         "value": true
-      },
-      {
-        "id": "v010-conformance-incomplete",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/coverageState", "type": "string"},
-        "value": "incomplete"
       }
     ]
   },


### PR DESCRIPTION
Closes #695. Refs #657, #693.

Второй узкий readiness bridge. PR меняет только `repo-policy.json` и временно удаляет один literal constraint:

```text
v010-conformance-incomplete
```

Candidate data не меняются. Следующий M7-A1 обязан восстановить более сильные constraints `v010-*-ready=true` и `v010-conformance-complete=complete` одновременно с candidate data.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - .github/**
  - README.md
  - docs/**
  - ts/**
expected_effects:
  - remove exactly one v0.10 incomplete coverage literal constraint
  - preserve candidate and accepted state
  - prepare stronger readiness=true plus coverage=complete transition
```