### PR TITLE
governance(v0.10): lifecycle bridge перед accepted cutover

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -142,30 +142,6 @@
         "value": "mts-conformance/v0.9"
       },
       {
-        "id": "v010-contract-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v010-conformance-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v010-contract-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v010-conformance-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
         "id": "v010-contract-ready",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v010-contract", "pointer": "/acceptanceReady", "type": "boolean"},


### PR DESCRIPTION
Closes #699. Refs #657, #697.

Policy-only bridge перед accepted flip v0.10. Удалены ровно четыре candidate lifecycle literals:

```text
v010-contract-status-candidate
v010-conformance-status-candidate
v010-contract-not-accepted
v010-conformance-not-accepted
```

При этом сохраняются enforced:

```text
acceptanceReady=true
coverageState=complete
semanticBase=v0.9
observableSemanticDelta=true
current=v0.9
previous=v0.8
cutover=v0.9
```

Сами v0.10 contract/conformance в этом PR не меняются и остаются candidate/unaccepted. Следующий отдельный M7-B1 выполняет atomic accepted cutover.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - .github/**
  - README.md
  - docs/**
  - ts/**
expected_effects:
  - remove exactly four v0.10 candidate lifecycle literals
  - preserve readiness and coverage-complete constraints
  - preserve accepted/current v0.9 until separate atomic cutover
```