### PR TITLE
research(#705): structural READ через read-only unification

### DIFF
--- a/ts/src/structural-unification.ts
+++ b/ts/src/structural-unification.ts
@@ -1,0 +1,117 @@
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+} from "./memory.js";
+import {
+  StructuralRuleError,
+  type StructuralRoleBinding,
+} from "./structural-rule.js";
+
+/**
+ * Read-only structural unification for already-grounded Links.
+ *
+ * Declared roles are placeholders. Their values are inferred from the claimed
+ * Link instead of being supplied by an Act. Grounded template subtrees still
+ * obey the same canonical-identity rule as matchStructuralTemplate: if a
+ * subtree contains no role, it must be the same semantic Link.
+ *
+ * This is deliberately projection-only. It does not find, ensure, materialize,
+ * navigate a context, or assign semantic identity from a runtime handle.
+ */
+export function unifyStructuralTemplate(
+  memory: ReadMemory,
+  template: LinkHandle,
+  claimed: LinkHandle,
+  roles: readonly LinkHandle[],
+): readonly StructuralRoleBinding[] {
+  if (new Set(roles).size !== roles.length) {
+    throw new StructuralRuleError("duplicate-role");
+  }
+
+  const before = memory.linkCount;
+  const roleSet = new Set(roles);
+  const inferred = new Map<LinkHandle, LinkHandle>();
+  const containsMemo = new Map<LinkHandle, boolean>();
+  const containsActive = new Set<LinkHandle>();
+
+  const containsRole = (node: LinkHandle): boolean => {
+    if (roleSet.has(node)) return true;
+    const cached = containsMemo.get(node);
+    if (cached !== undefined) return cached;
+    if (containsActive.has(node)) return false;
+
+    containsActive.add(node);
+    try {
+      const poles = memory.poles(node);
+      const result = containsRole(poles.start) || containsRole(poles.end);
+      containsMemo.set(node, result);
+      return result;
+    } finally {
+      containsActive.delete(node);
+    }
+  };
+
+  const visited = new Map<LinkHandle, Set<LinkHandle>>();
+  const markVisited = (left: LinkHandle, right: LinkHandle): boolean => {
+    let rights = visited.get(left);
+    if (rights === undefined) {
+      rights = new Set<LinkHandle>();
+      visited.set(left, rights);
+    }
+    if (rights.has(right)) return true;
+    rights.add(right);
+    return false;
+  };
+
+  const unify = (left: LinkHandle, right: LinkHandle): void => {
+    if (roleSet.has(left)) {
+      const previous = inferred.get(left);
+      if (previous !== undefined && previous !== right) {
+        throw new StructuralRuleError("template-mismatch");
+      }
+      inferred.set(left, right);
+      return;
+    }
+
+    if (!containsRole(left)) {
+      if (left !== right) {
+        throw new StructuralRuleError("template-mismatch");
+      }
+      return;
+    }
+
+    if (markVisited(left, right)) return;
+
+    try {
+      const leftPoles = memory.poles(left);
+      const rightPoles = memory.poles(right);
+      unify(leftPoles.start, rightPoles.start);
+      unify(leftPoles.end, rightPoles.end);
+    } catch (error) {
+      if (error instanceof StructuralRuleError) throw error;
+      if (error instanceof MemoryError) {
+        throw new StructuralRuleError("template-mismatch");
+      }
+      throw error;
+    }
+  };
+
+  try {
+    unify(template, claimed);
+
+    const bindings = roles.map((role): StructuralRoleBinding => {
+      const value = inferred.get(role);
+      if (value === undefined) {
+        throw new StructuralRuleError("missing-role-binding");
+      }
+      return Object.freeze({ role, value });
+    });
+
+    return Object.freeze(bindings);
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new StructuralRuleError("replay-wrote");
+    }
+  }
+}

--- a/ts/test/v010-structural-unification.test.ts
+++ b/ts/test/v010-structural-unification.test.ts
@@ -1,5 +1,6 @@
 import {
   Memory,
+  ensureRootBasis,
   type LinkHandle,
   type LinkPoles,
   type ReadMemory,
@@ -64,20 +65,20 @@ function bindingValue(
   return found.value;
 }
 
-function distinct(memory: Memory, count: number): LinkHandle[] {
-  const result: LinkHandle[] = [];
-  let cursor = memory.ensureStartSelfClosed(memory.root);
-  for (let index = 0; index < count; index += 1) {
-    cursor = memory.ensureStartSelfClosed(cursor);
-    result.push(cursor);
-  }
-  return result;
-}
-
 const memory = new Memory();
-const refs = distinct(memory, 8);
-const [beginRole, endRole, A, B, E, fixed, other, spare] = refs;
-assert(beginRole && endRole && A && B && E && fixed && other && spare, "fixture refs");
+const basis = ensureRootBasis(memory);
+
+// Independent anchors contain only root-basis Links. None contains another
+// anchor, so a declared role cannot accidentally occur inside a grounded
+// constant merely because of fixture construction order.
+const beginRole = memory.ensure(basis.O, basis.O);
+const endRole = memory.ensure(basis.C, basis.C);
+const A = memory.ensure(basis.L, basis.L);
+const B = memory.ensure(basis.U, basis.U);
+const E = memory.ensure(basis.O, basis.L);
+const fixed = memory.ensure(basis.C, basis.U);
+const other = memory.ensure(basis.L, basis.O);
+const spare = memory.ensure(basis.U, basis.C);
 
 const pairTemplate = memory.ensure(beginRole, endRole);
 const ordinary = memory.ensure(A, B);

--- a/ts/test/v010-structural-unification.test.ts
+++ b/ts/test/v010-structural-unification.test.ts
@@ -1,0 +1,183 @@
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  StructuralRuleError,
+  type StructuralRoleBinding,
+} from "../src/structural-rule.js";
+import { unifyStructuralTemplate } from "../src/structural-unification.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectRuleError(code: StructuralRuleError["code"], effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralRuleError, `expected StructuralRuleError, got ${String(error)}`);
+    same(error.code, code, "structural unification error code");
+    return;
+  }
+  throw new Error(`expected StructuralRuleError(${code})`);
+}
+
+class ReadProbe implements ReadMemory {
+  polesCalls = 0;
+
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+
+  poles(link: LinkHandle): LinkPoles {
+    this.polesCalls += 1;
+    return this.source.poles(link);
+  }
+
+  find(): LinkHandle | undefined {
+    throw new Error("structural READ must not call find");
+  }
+
+  outgoing(): readonly LinkHandle[] {
+    throw new Error("structural READ must not scan outgoing links");
+  }
+
+  incoming(): readonly LinkHandle[] {
+    throw new Error("structural READ must not scan incoming links");
+  }
+}
+
+function bindingValue(
+  bindings: readonly StructuralRoleBinding[],
+  role: LinkHandle,
+): LinkHandle {
+  const found = bindings.find((binding) => binding.role === role);
+  assert(found !== undefined, "missing inferred binding");
+  return found.value;
+}
+
+function distinct(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let cursor = memory.ensureStartSelfClosed(memory.root);
+  for (let index = 0; index < count; index += 1) {
+    cursor = memory.ensureStartSelfClosed(cursor);
+    result.push(cursor);
+  }
+  return result;
+}
+
+const memory = new Memory();
+const refs = distinct(memory, 8);
+const [beginRole, endRole, A, B, E, fixed, other, spare] = refs;
+assert(beginRole && endRole && A && B && E && fixed && other && spare, "fixture refs");
+
+const pairTemplate = memory.ensure(beginRole, endRole);
+const ordinary = memory.ensure(A, B);
+const startSelfClosed = memory.ensureStartSelfClosed(E);
+const endSelfClosed = memory.ensureEndSelfClosed(B);
+const inverse = memory.ensure(B, A);
+
+// Generic structural READ projects the two ordered poles from an already given Link.
+{
+  const probe = new ReadProbe(memory);
+  const before = memory.linkCount;
+  const bindings = unifyStructuralTemplate(probe, pairTemplate, ordinary, [beginRole, endRole]);
+  same(bindingValue(bindings, beginRole), A, "ordinary begin projection");
+  same(bindingValue(bindings, endRole), B, "ordinary end projection");
+  same(memory.linkCount, before, "ordinary READ is read-only");
+  assert(probe.polesCalls > 0, "ordinary READ observes Link structure through poles");
+}
+
+// Full recursion is finite for READ: R=R⟼R yields the same whole at both poles.
+{
+  const bindings = unifyStructuralTemplate(new ReadProbe(memory), pairTemplate, memory.root, [beginRole, endRole]);
+  same(bindingValue(bindings, beginRole), memory.root, "R begin is R");
+  same(bindingValue(bindings, endRole), memory.root, "R end is R");
+}
+
+// One-sided recursive Links expose the self-reference as one pole without unfolding it.
+{
+  const startBindings = unifyStructuralTemplate(
+    new ReadProbe(memory), pairTemplate, startSelfClosed, [beginRole, endRole],
+  );
+  same(bindingValue(startBindings, beginRole), startSelfClosed, "S=S⟼E reads S as begin");
+  same(bindingValue(startBindings, endRole), E, "S=S⟼E reads E as end");
+
+  const endBindings = unifyStructuralTemplate(
+    new ReadProbe(memory), pairTemplate, endSelfClosed, [beginRole, endRole],
+  );
+  same(bindingValue(endBindings, beginRole), B, "T=B⟼T reads B as begin");
+  same(bindingValue(endBindings, endRole), endSelfClosed, "T=B⟼T reads T as end");
+}
+
+// A grounded template component is not a wildcard. Only declared roles project values.
+{
+  const oneRoleTemplate = memory.ensure(fixed, beginRole);
+  const matching = memory.ensure(fixed, A);
+  const bindings = unifyStructuralTemplate(new ReadProbe(memory), oneRoleTemplate, matching, [beginRole]);
+  same(bindingValue(bindings, beginRole), A, "single role projection");
+
+  const mismatch = memory.ensure(other, A);
+  expectRuleError("template-mismatch", () =>
+    unifyStructuralTemplate(new ReadProbe(memory), oneRoleTemplate, mismatch, [beginRole]),
+  );
+}
+
+// Repeated role occurrences must denote one semantic Link, not two occurrences.
+{
+  const repeatedTemplate = memory.ensure(beginRole, beginRole);
+  const samePair = memory.ensure(A, A);
+  const bindings = unifyStructuralTemplate(new ReadProbe(memory), repeatedTemplate, samePair, [beginRole]);
+  same(bindingValue(bindings, beginRole), A, "repeated role reuses one binding");
+
+  const differentPair = memory.ensure(A, B);
+  expectRuleError("template-mismatch", () =>
+    unifyStructuralTemplate(new ReadProbe(memory), repeatedTemplate, differentPair, [beginRole]),
+  );
+}
+
+// Declared but absent roles are rejected instead of receiving ambient/runtime values.
+{
+  expectRuleError("missing-role-binding", () =>
+    unifyStructuralTemplate(new ReadProbe(memory), beginRole, A, [beginRole, endRole]),
+  );
+  expectRuleError("duplicate-role", () =>
+    unifyStructuralTemplate(new ReadProbe(memory), pairTemplate, ordinary, [beginRole, beginRole]),
+  );
+}
+
+// WRITE/READ round-trip is semantic ordered-pole identity: projected poles are exactly X's poles.
+{
+  const bindings = unifyStructuralTemplate(new ReadProbe(memory), pairTemplate, ordinary, [beginRole, endRole]);
+  const poles = memory.poles(ordinary);
+  same(bindingValue(bindings, beginRole), poles.start, "round-trip begin equals X.start");
+  same(bindingValue(bindings, endRole), poles.end, "round-trip end equals X.end");
+  same(memory.ensure(bindingValue(bindings, beginRole), bindingValue(bindings, endRole)), ordinary,
+    "construct(project(X)) reuses X by ordered-pair identity");
+}
+
+// Pole-swap is READ followed by the already-grounded inverse construction.
+{
+  const bindings = unifyStructuralTemplate(new ReadProbe(memory), pairTemplate, ordinary, [beginRole, endRole]);
+  const inversePoles = memory.poles(inverse);
+  same(inversePoles.start, bindingValue(bindings, endRole), "Inv start is projected end");
+  same(inversePoles.end, bindingValue(bindings, beginRole), "Inv end is projected begin");
+}
+
+// Dot/context semantics are not involved: projection requires only explicit template roles and X.
+{
+  const before = memory.linkCount;
+  const bindings = unifyStructuralTemplate(new ReadProbe(memory), pairTemplate, spare, [beginRole, endRole]);
+  const sparePoles = memory.poles(spare);
+  same(bindingValue(bindings, beginRole), sparePoles.start, "projection does not need contextual dot");
+  same(bindingValue(bindings, endRole), sparePoles.end, "projection does not need ambient current");
+  same(memory.linkCount, before, "dot-free projection stays read-only");
+}


### PR DESCRIPTION
Closes #705. Refs #657, #660, #661, #662, #671.

Исследовательский NO-DELTA slice для принятой MTS v0.10.

Цель: проверить, можно ли выразить READ полюсов как generic structural projection существующей бинарной Link-структуры, не вводя Begin/End glyphs и не делая host API источником смысла.

Добавлено:

```text
ts/src/structural-unification.ts
ts/test/v010-structural-unification.test.ts
```

`unifyStructuralTemplate`:
- принимает уже существующий template Link, claimed Link и явный список role Links;
- выводит role bindings из структуры claimed Link;
- использует только `ReadMemory.poles` + `linkCount`;
- не вызывает `find`, `ensure`, materialize, outgoing/incoming;
- cycle-safe для `R=R⟼R`, `S=S⟼E`, `T=B⟼T`;
- повторная роль обязана разрешиться в один semantic Link;
- grounded subtree остаётся canonical constant, как в существующем `matchStructuralTemplate`.

Executable corpus проверяет:

```text
ordinary X=A⟼B -> A/B
R=R⟼R -> R/R
S=S⟼E -> S/E
T=B⟼T -> B/T
repeated role consistency
missing/duplicate role veto
grounded constant veto
construct(project(X)) = X by ordered-pair identity
Inv(X) = construct(end(X), begin(X)) on pre-grounded inverse
read-only / no find / no scans
```

Семантическая классификация PR:

```text
NO new glyph
NO new root primitive
NO contract change
NO accepted v0.10 mutation
NO candidate v0.11
```

Этот PR проверяет гипотезу, что Begin/End являются двумя ролями одного бинарного structural pattern, а не двумя новыми смыслами.

```repo-guard-yaml
change_type: research
scope:
  - ts/src/structural-unification.ts
  - ts/test/v010-structural-unification.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 320
must_touch:
  - ts/src/structural-unification.ts
  - ts/test/v010-structural-unification.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - repo-policy.json
  - .github/**
  - docs/**
expected_effects:
  - prove or falsify read-only structural projection on accepted v0.10 runtime
  - preserve contextual dot boundaries
  - preserve semantic identity by ordered poles
  - no release or lifecycle change
```