### PR TITLE
refactor(#709): отделить definition replay от смысла `:`

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -63,6 +63,7 @@ export type {
 export {
   InterpreterReplayError,
   replayColonEffect,
+  replayColonEffect as replayDefinitionEffect,
   replayEqualityEvaluation,
   replayFlatReading,
   replayFlatSubselectionContinuation,
@@ -72,6 +73,7 @@ export {
 } from "./interpreter.js";
 export type {
   ColonReplayEvidence,
+  ColonReplayEvidence as DefinitionReplayEvidence,
   EqualityReplayEvidence,
   FlatReadingEvidence,
   RelationReplayEvidence,

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -2,6 +2,7 @@ import * as publicApi from "../src/public.js";
 import type {
   AnumForm,
   DecomposeEqualityEvidence,
+  DefinitionReplayEvidence,
   DirectDeixisVocabulary,
   IntegratedProofEvidence,
   LinkHandle,
@@ -60,6 +61,7 @@ const expectedRuntimeExports = [
   "normalizeRawForm",
   "parseRawQuaternary",
   "replayColonEffect",
+  "replayDefinitionEffect",
   "replayDecomposeEqualRelations",
   "replayEqualityEvaluation",
   "replayFlatReading",
@@ -82,6 +84,10 @@ assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
 );
+assert(
+  publicApi.replayDefinitionEffect === publicApi.replayColonEffect,
+  "definition replay must be a behavior-preserving alias of legacy colon replay",
+);
 
 // Compile-time smoke for the intended consumer concepts. The top-level evidence
 // shapes are public because callers must provide them, while their nested role
@@ -96,6 +102,7 @@ const dataset: StoredDataset | undefined = undefined;
 const persistentSequence: PersistentSequenceDescription | undefined = undefined;
 const sequence: SequenceDescription | undefined = undefined;
 const relation: RelationReplayEvidence | undefined = undefined;
+const definition: DefinitionReplayEvidence | undefined = undefined;
 const deixis: DirectDeixisVocabulary | undefined = undefined;
 const value: MtsValue | undefined = undefined;
 const run: RunEvidence | undefined = undefined;
@@ -112,6 +119,7 @@ void [
   persistentSequence,
   sequence,
   relation,
+  definition,
   deixis,
   value,
   run,


### PR DESCRIPTION
Closes #709. Refs #657, #596, #658, #669.

Результат исследования: observable semantic delta не найден. Текущий `replayColonEffect` уже является read-only verifier заранее существующего dictionary-definition evidence и сам ничего не материализует. Однако его публичное имя создаёт ложное впечатление, будто definition effect является intrinsic смыслом glyph `:`.

Этот PR делает только additive API clarification:

```text
replayDefinitionEffect === replayColonEffect
DefinitionReplayEvidence = ColonReplayEvidence
```

Старые имена сохраняются без изменения поведения и без deprecation break. Новый consumer-facing термин описывает то, что реально проверяется: explicit definition effect evidence.

Не меняются:

```text
m: = m∞ ⟼ m⟼
A:E / resolve_A(.)
dictionary topology
interpreter behavior
ColonReplayEvidence shape
contracts / conformance / cutover
```

Классификация:

```text
sign meaning `:`                 = v0.10 unity -> duality
contextual role `A:E`            = v0.10 scoped context
explicit dictionary definition   = separate structural effect
replayDefinitionEffect           = read-only verifier of existing effect
replayColonEffect                = compatibility alias
semantic delta                   = NONE
API cleanup                      = additive / behavior-preserving
v0.11                            = NOT REQUIRED
```

```repo-guard-yaml
change_type: research
scope:
  - ts/src/public.ts
  - ts/test/public-api.test.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 12
must_touch:
  - ts/src/public.ts
  - ts/test/public-api.test.ts
must_not_touch:
  - ts/src/interpreter.ts
  - ts/src/dictionary.ts
  - contracts/**
  - cutover/**
  - repo-policy.json
  - docs/**
  - .github/**
expected_effects:
  - expose semantically precise definition-replay alias
  - preserve legacy colon replay compatibility exactly
  - preserve all accepted v0.10 colon/context behavior
  - no semantic release lifecycle change
```