### PR TITLE
fix(#730): отделить ROOT от канонических START-носителей

### DIFF
--- a/ts/src/source.ts
+++ b/ts/src/source.ts
@@ -168,7 +168,9 @@ export function readSourceForm(
 ): LinkHandle {
   try {
     const link = memory.poles(source);
-    if (link.start !== source) {
+    // SourceForm имеет именно однополюсную форму START(content). ROOT может
+    // быть пустым content, но не альтернативным source-wrapper для него.
+    if (link.start !== source || link.end === source) {
       throw new SourceError("invalid-source");
     }
     return link.end;

--- a/ts/src/structural-readers.ts
+++ b/ts/src/structural-readers.ts
@@ -46,7 +46,9 @@ export function readActHeader(
   act: LinkHandle,
 ): ActHeader {
   const actLink = memory.poles(act);
-  if (actLink.start !== act) {
+  // Act имеет именно однополюсную форму START(header). Полностью
+  // самозамкнутый ROOT не является альтернативной кодировкой Act.
+  if (actLink.start !== act || actLink.end === act) {
     throw new StructuralReadError("invalid-act-header");
   }
 

--- a/ts/src/structural-rule.ts
+++ b/ts/src/structural-rule.ts
@@ -143,7 +143,9 @@ export function readStructuralRoleDictionary(
 ): StructuralRoleDictionary {
   try {
     const dictionary = memory.poles(roleDictionary);
-    if (dictionary.start !== roleDictionary) {
+    // DR имеет именно форму START(RoleSequence); ROOT не является вторым
+    // представлением пустого словаря ролей.
+    if (dictionary.start !== roleDictionary || dictionary.end === roleDictionary) {
       throw new StructuralRuleError("invalid-role-dictionary");
     }
     const sequence = readExactSequence(memory, dictionary.end);

--- a/ts/test/v010-start-carrier-canonicality.test.ts
+++ b/ts/test/v010-start-carrier-canonicality.test.ts
@@ -1,0 +1,108 @@
+import { defineContext, readContext, StateError } from "../src/state.js";
+import {
+  defineDictionaryScope,
+  readDictionaryScope,
+  DictionaryError,
+} from "../src/dictionary.js";
+import {
+  defineSourceForm,
+  readSourceForm,
+  SourceError,
+} from "../src/source.js";
+import {
+  defineActHeader,
+  readActHeader,
+  StructuralReadError,
+} from "../src/structural-readers.js";
+import {
+  defineStructuralRoleDictionary,
+  readStructuralRoleDictionary,
+  StructuralRuleError,
+} from "../src/structural-rule.js";
+import { readExactSequence } from "../src/exact-sequence.js";
+import { Memory } from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function reject<T extends Error>(
+  effect: () => unknown,
+  ctor: new (...args: never[]) => T,
+  code: string,
+  message: string,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof ctor, `${message}: unexpected error ${String(error)}`);
+    same((error as T & { readonly code?: string }).code, code, `${message}: error code`);
+    return;
+  }
+  throw new Error(`${message}: expected rejection`);
+}
+
+const memory = new Memory();
+const R = memory.root;
+const O = memory.ensureStartSelfClosed(R);
+
+// F2/F3 distinguish ROOT from START(R). Higher-level roles do not create
+// semantic copies: with payload R all canonical START wrappers are the same O.
+const source = defineSourceForm(memory, R);
+const act = defineActHeader(memory, R, R, R);
+const roleDictionary = defineStructuralRoleDictionary(memory, []);
+const context = defineContext(memory, R, R);
+const dictionary = defineDictionaryScope(memory, R, R);
+
+same(source, O, "empty SourceForm is START(R)=O");
+same(act, O, "degenerate Act header is START(R)=O");
+same(roleDictionary, O, "empty DR is START(R)=O");
+same(context, O, "root-state context is START(R)=O");
+same(dictionary, O, "empty dictionary scope is START(R)=O");
+
+// The selected use-role determines how the same semantic O is read.
+same(readSourceForm(memory, O), R, "O reads as SourceForm(R) in source role");
+const header = readActHeader(memory, O);
+same(header.interpreter, R, "O Act interpreter");
+same(header.roleDictionary, R, "O Act role dictionary");
+same(header.afterContext, R, "O Act after context");
+const dr = readStructuralRoleDictionary(memory, O);
+same(dr.roleSequence, R, "O empty DR role sequence");
+same(dr.roles.length, 0, "O empty DR has no roles");
+const k = readContext(memory, O);
+same(k.parent, R, "O context parent");
+same(k.current, R, "O context current");
+const scope = readDictionaryScope(memory, O);
+same(scope.parentScope, R, "O dictionary parent");
+same(scope.localHistory, R, "O dictionary history");
+
+// ROOT itself remains the intentional empty ExactSequence carrier, but it is
+// not an alias for any role whose canonical topology is START(payload).
+same(readExactSequence(memory, R).values.length, 0, "R remains empty ExactSequence");
+
+reject(() => readSourceForm(memory, R), SourceError, "invalid-source",
+  "ROOT must not masquerade as SourceForm");
+reject(() => readActHeader(memory, R), StructuralReadError, "invalid-act-header",
+  "ROOT must not masquerade as Act");
+reject(() => readStructuralRoleDictionary(memory, R), StructuralRuleError, "invalid-role-dictionary",
+  "ROOT must not masquerade as DR");
+reject(() => readContext(memory, R), StateError, "invalid-context",
+  "ROOT must not masquerade as context");
+reject(() => readDictionaryScope(memory, R), DictionaryError, "invalid-scope",
+  "ROOT must not masquerade as dictionary scope");
+
+// Every valid wrapper round-trips through its role-specific reader/constructor.
+same(defineSourceForm(memory, readSourceForm(memory, O)), O,
+  "SourceForm decode/encode round-trip");
+same(defineActHeader(memory, header.interpreter, header.roleDictionary, header.afterContext), O,
+  "Act decode/encode round-trip");
+same(defineStructuralRoleDictionary(memory, dr.roles), O,
+  "DR decode/encode round-trip");
+same(defineContext(memory, k.parent, k.current), O,
+  "context decode/encode round-trip");
+same(defineDictionaryScope(memory, scope.parentScope, scope.localHistory), O,
+  "dictionary decode/encode round-trip");


### PR DESCRIPTION
Closes #730. Refs #657, #728, #729, #466, #474, #480, #608.

Продолжение доказанной в #728/#729 границы `ROOT != START(F)` для остальных higher-level носителей, которые уже конструируются как `START(payload)`.

Исправляются три слишком слабых reader-а:

```text
SourceForm(content) = START(content)
Act(header)         = START(header)
DR(RoleSequence)    = START(RoleSequence)
```

Ранее каждый из них проверял только `start===self` и поэтому принимал `R=ROOT` как второй alias. Теперь требуется однополюсная START-форма: `start===self && end!==self`.

Ключевой cross-surface witness:

```text
payload = R
START(R) = O

empty SourceForm = O
degenerate Act   = O
empty DR         = O
root-state K     = O
empty dict scope = O
```

Это одна semantic Link в разных use-role, а не пять экземпляров. При этом `R` остаётся каноническим `ROOT` и намеренно допустимым empty carrier для `ExactSequence([])`, но не alias wrapper-а.

Проверяется:
- `readSourceForm(R)` -> `invalid-source`;
- `readActHeader(R)` -> `invalid-act-header`;
- `readStructuralRoleDictionary(R)` -> `invalid-role-dictionary`;
- существующие `readContext(R)` / `readDictionaryScope(R)` также отвергают ROOT;
- `readExactSequence(R)` по-прежнему возвращает пустую sequence;
- все пять valid `START(R)=O` wrappers проходят role-specific decode/encode round-trip;
- новых tags/types/semantic copies нет.

Классификация при green corpus:

```text
accepted theory delta       = NONE
runtime valid-domain delta  = NONE
malformed-evidence handling = corrected
contract delta              = NONE
MTS v0.11                   = NOT REQUIRED
classification              = NO-DELTA conformance correction
```

```repo-guard-yaml
change_type: research
scope:
  - ts/src/source.ts
  - ts/src/structural-readers.ts
  - ts/src/structural-rule.ts
  - ts/test/v010-start-carrier-canonicality.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 140
must_touch:
  - ts/src/source.ts
  - ts/src/structural-readers.ts
  - ts/src/structural-rule.ts
  - ts/test/v010-start-carrier-canonicality.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - reject fully selfclosed ROOT only in roles canonically defined as START(payload)
  - preserve intentional ROOT empty carriers such as ExactSequence([])
  - preserve one semantic START(R) Link across distinct use-roles
  - preserve valid Source/Act/DR behavior and read-only replay
  - no semantic release lifecycle change
```