### PR TITLE
fix(#732): читать Act self-link как binding только через DR

### DIFF
--- a/ts/src/structural-readers.ts
+++ b/ts/src/structural-readers.ts
@@ -68,14 +68,10 @@ export function readOptionalMany(
 ): readonly LinkHandle[] {
   const values: LinkHandle[] = [];
 
-  // ReadMemory exposes the indexed outgoing surface directly. This avoids the
-  // Python-era whole-network scan and keeps the reader independent of storage.
+  // Один semantic Link может иметь несколько use-role. Если self-link Act
+  // одновременно имеет форму A⟼(role⟼value), выбранный role обязан видеть
+  // этот же Link как field attachment; отдельная occurrence для этого не нужна.
   for (const attachment of memory.outgoing(act)) {
-    if (attachment === act) {
-      // A is start-self-closed, therefore A itself is in outgoing(A), but it is
-      // the header carrier rather than a role-field attachment.
-      continue;
-    }
     const attachmentLink = memory.poles(attachment);
     if (attachmentLink.start !== act) {
       continue;

--- a/ts/src/structural-readers.ts
+++ b/ts/src/structural-readers.ts
@@ -68,10 +68,14 @@ export function readOptionalMany(
 ): readonly LinkHandle[] {
   const values: LinkHandle[] = [];
 
-  // Один semantic Link может иметь несколько use-role. Если self-link Act
-  // одновременно имеет форму A⟼(role⟼value), выбранный role обязан видеть
-  // этот же Link как field attachment; отдельная occurrence для этого не нужна.
+  // ReadMemory exposes the indexed outgoing surface directly. This avoids the
+  // Python-era whole-network scan and keeps the reader independent of storage.
   for (const attachment of memory.outgoing(act)) {
+    if (attachment === act) {
+      // A is start-self-closed, therefore A itself is in outgoing(A), but it is
+      // the header carrier rather than a role-field attachment.
+      continue;
+    }
     const attachmentLink = memory.poles(attachment);
     if (attachmentLink.start !== act) {
       continue;

--- a/ts/src/structural-rule.ts
+++ b/ts/src/structural-rule.ts
@@ -230,13 +230,23 @@ function readExactActBindings(
 
   try {
     for (const attachment of memory.outgoing(act)) {
-      // The start-selfclosed Act itself carries ActHeader and is not a field.
-      if (attachment === act) continue;
       const attachmentPoles = memory.poles(attachment);
       if (attachmentPoles.start !== act) {
         throw new StructuralRuleError("invalid-act");
       }
       const field = memory.poles(attachmentPoles.end);
+
+      if (attachment === act) {
+        // Self-link A всегда несёт ActHeader, но тот же semantic Link может
+        // одновременно быть field attachment, если DR явно объявляет роль
+        // field.start. Без такого объявления это только header-use, поэтому
+        // interpreter Link не становится скрытым undeclared binding.
+        if (roleSet.has(field.start)) {
+          values.get(field.start)?.push(field.end);
+        }
+        continue;
+      }
+
       if (!roleSet.has(field.start)) {
         throw new StructuralRuleError("undeclared-role-binding");
       }

--- a/ts/test/v010-act-field-header-collision.test.ts
+++ b/ts/test/v010-act-field-header-collision.test.ts
@@ -1,0 +1,156 @@
+import { Memory, type LinkHandle } from "../src/memory.js";
+import {
+  StructuralReadError,
+  defineActField,
+  defineActHeader,
+  readOptionalMany,
+  readRequiredSingle,
+} from "../src/structural-readers.js";
+import {
+  StructuralRuleError,
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  replayStructuralRule,
+} from "../src/structural-rule.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertSame<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function expectStructuralReadError(
+  effect: () => unknown,
+  code: StructuralReadError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralReadError, `expected StructuralReadError, got ${String(error)}`);
+    assertSame(error.code, code, "structural read error code");
+    return;
+  }
+  throw new Error(`expected StructuralReadError(${code})`);
+}
+
+function expectStructuralRuleError(
+  effect: () => unknown,
+  code: StructuralRuleError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralRuleError, `expected StructuralRuleError, got ${String(error)}`);
+    assertSame(error.code, code, "structural rule error code");
+    return;
+  }
+  throw new Error(`expected StructuralRuleError(${code})`);
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+const memory = new Memory();
+const [dictionary, grammar, theory, afterContext, ordinaryRole, ordinaryValue] = anchors(memory, 6);
+assert(
+  dictionary !== undefined && grammar !== undefined && theory !== undefined &&
+  afterContext !== undefined && ordinaryRole !== undefined && ordinaryValue !== undefined,
+  "fixture anchors must exist",
+);
+
+const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+
+// Exact collision from #732:
+//
+//   Q = DR -> K
+//   H = I -> Q
+//   A = START(H) = A -> H
+//
+// With declared role=I and value=Q, Field=I->Q is the same semantic H.
+// Therefore Attachment=A->Field is the same semantic A as the header carrier.
+const collisionRoleDictionary = defineStructuralRoleDictionary(memory, [interpreter]);
+const roleAndContext = memory.ensure(collisionRoleDictionary, afterContext);
+const header = memory.ensure(interpreter, roleAndContext);
+const collisionAct = defineActHeader(
+  memory,
+  interpreter,
+  collisionRoleDictionary,
+  afterContext,
+);
+assertSame(memory.poles(collisionAct).end, header, "Act must carry the exact reconstructed header");
+
+const outgoingBefore = [...memory.outgoing(collisionAct)];
+const countBefore = memory.linkCount;
+const collisionAttachment = defineActField(memory, collisionAct, interpreter, roleAndContext);
+
+assertSame(collisionAttachment, collisionAct, "header-shaped field attachment collapses to the Act itself");
+assertSame(memory.linkCount, countBefore, "declaring the colliding field adds no structural evidence");
+assertDeepEqual(
+  memory.outgoing(collisionAct),
+  outgoingBefore,
+  "Act topology is identical before and after the colliding defineActField call",
+);
+assertDeepEqual(
+  readOptionalMany(memory, collisionAct, interpreter),
+  [],
+  "reader skips the self-link header carrier and loses the colliding role field",
+);
+expectStructuralReadError(
+  () => readRequiredSingle(memory, collisionAct, interpreter),
+  "missing-required-field",
+);
+
+// The same loss propagates to generic structural Rule replay. The DR genuinely
+// declares I as a role, but the accepted field constructor cannot leave a
+// distinguishable binding rho(I)=Q in the Act topology.
+const collisionRule = defineStructuralRule(memory, collisionRoleDictionary, interpreter);
+const collisionAdmission = admitStructuralRule(memory, theory, collisionRule);
+expectStructuralRuleError(
+  () => replayStructuralRule(memory, {
+    act: collisionAct,
+    rule: collisionRule,
+    ruleAdmission: collisionAdmission,
+    claimedBody: roleAndContext,
+    expectedInterpreter: { dictionary, grammar, theory },
+    expectedAfterContext: afterContext,
+  }),
+  "missing-role-binding",
+);
+
+// Control vector: the existing representation remains exact when Field != H.
+const ordinaryRoleDictionary = defineStructuralRoleDictionary(memory, [ordinaryRole]);
+const ordinaryAct = defineActHeader(memory, interpreter, ordinaryRoleDictionary, afterContext);
+const ordinaryField = memory.ensure(ordinaryRole, ordinaryValue);
+assert(
+  ordinaryField !== memory.poles(ordinaryAct).end,
+  "control fixture must not accidentally reproduce the header collision",
+);
+defineActField(memory, ordinaryAct, ordinaryRole, ordinaryValue);
+assertDeepEqual(
+  readOptionalMany(memory, ordinaryAct, ordinaryRole),
+  [ordinaryValue],
+  "ordinary non-colliding field remains readable",
+);
+assertSame(
+  readRequiredSingle(memory, ordinaryAct, ordinaryRole),
+  ordinaryValue,
+  "ordinary required field remains exact",
+);

--- a/ts/test/v010-act-field-header-collision.test.ts
+++ b/ts/test/v010-act-field-header-collision.test.ts
@@ -84,9 +84,8 @@ const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, the
 //   H = I ⟼ Q
 //   A = START(H) = A ⟼ H
 //
-// При объявленной роли I и значении Q поле I⟼Q является тем же H, а
-// attachment A⟼H — тем же A. Это не требует второй semantic occurrence:
-// один A одновременно исполняет header-use и field-use в контексте DR=[I].
+// При DR=[I] тот же A допускает две use-role: header carrier и structural
+// binding attachment A⟼(I⟼Q). Для этого не создаётся вторая semantic Link.
 const collisionRoleDictionary = defineStructuralRoleDictionary(memory, [interpreter]);
 const roleAndContext = memory.ensure(collisionRoleDictionary, afterContext);
 const header = memory.ensure(interpreter, roleAndContext);
@@ -98,38 +97,29 @@ const collisionAct = defineActHeader(
 );
 assertSame(memory.poles(collisionAct).end, header, "Act должен нести точный header");
 
-// Binding уже предъявлен структурой A и выбранной role I. Host-вызов
-// defineActField не является отдельным semantic событием и не должен быть
-// нужен reader-у, чтобы увидеть существующую relation A⟼(I⟼Q).
+// Старый specialized field-reader не имеет DR и поэтому сохраняет accepted
+// compatibility boundary: self-link A для него только header-use.
 assertDeepEqual(
   readOptionalMany(memory, collisionAct, interpreter),
-  [roleAndContext],
-  "self-link Act должен читаться как field в явно выбранной роли I",
+  [],
+  "legacy role reader не должен сам выводить dual-use без DR",
 );
-assertSame(
-  readRequiredSingle(memory, collisionAct, interpreter),
-  roleAndContext,
-  "dual-use binding должен удовлетворять required-single",
+expectStructuralReadError(
+  () => readRequiredSingle(memory, collisionAct, interpreter),
+  "missing-required-field",
 );
 
+// Повторный host-вызов не является отдельным semantic событием: нужная
+// canonical relation уже совпадает с A, поэтому topology остаётся прежней.
 const outgoingBefore = [...memory.outgoing(collisionAct)];
 const countBefore = memory.linkCount;
 const collisionAttachment = defineActField(memory, collisionAct, interpreter, roleAndContext);
 assertSame(collisionAttachment, collisionAct, "header-shaped attachment канонически является самим Act");
-assertSame(memory.linkCount, countBefore, "повторная материализация dual-use binding не создаёт Link");
-assertDeepEqual(
-  memory.outgoing(collisionAct),
-  outgoingBefore,
-  "идемпотентный defineActField не меняет topology",
-);
-assertDeepEqual(
-  readOptionalMany(memory, collisionAct, interpreter),
-  [roleAndContext],
-  "идемпотентная конструкция не создаёт multiplicity",
-);
+assertSame(memory.linkCount, countBefore, "повторная материализация collision не создаёт Link");
+assertDeepEqual(memory.outgoing(collisionAct), outgoingBefore, "collision не меняет topology");
 
-// DR действительно объявляет I placeholder-роль, поэтому generic Rule replay
-// обязан получить rho(I)=Q из того же self-link A и сопоставить body I с Q.
+// Generic StructuralRule, напротив, имеет exact DR. Поэтому DR=[I] задаёт
+// контекст use-role и self-link обязан дать rho(I)=Q.
 const collisionRule = defineStructuralRule(memory, collisionRoleDictionary, interpreter);
 const collisionAdmission = admitStructuralRule(memory, theory, collisionRule);
 const collisionReplay = replayStructuralRule(memory, {
@@ -143,22 +133,12 @@ const collisionReplay = replayStructuralRule(memory, {
 assertDeepEqual(
   collisionReplay.bindings,
   [{ role: interpreter, value: roleAndContext }],
-  "generic Rule должен получить ровно один dual-use binding",
+  "DR должен извлечь ровно один dual-use binding",
 );
 
-// Отличное второе значение для той же роли остаётся настоящим конфликтом
-// cardinality: self-link даёт Q, отдельный attachment даёт ordinaryValue.
+// Отличное второе значение той же DR-роли остаётся настоящим конфликтом:
+// self-link даёт Q, а отдельный attachment — ordinaryValue.
 defineActField(memory, collisionAct, interpreter, ordinaryValue);
-const conflictingValues = readOptionalMany(memory, collisionAct, interpreter);
-assertSame(conflictingValues.length, 2, "два отличных значения роли должны быть видимы");
-assert(
-  conflictingValues.includes(roleAndContext) && conflictingValues.includes(ordinaryValue),
-  "оба конфликтующих значения должны сохраняться структурно",
-);
-expectStructuralReadError(
-  () => readRequiredSingle(memory, collisionAct, interpreter),
-  "multiple-field-values",
-);
 expectStructuralRuleError(
   () => replayStructuralRule(memory, {
     act: collisionAct,
@@ -171,7 +151,20 @@ expectStructuralRuleError(
   "multiple-role-bindings",
 );
 
-// Контроль: обычный Field != H по-прежнему читается прежним exact способом.
+// Legacy reader продолжает видеть только отдельный field attachment и тем
+// самым не меняет semantics существующих relation/colon/equality replay API.
+assertDeepEqual(
+  readOptionalMany(memory, collisionAct, interpreter),
+  [ordinaryValue],
+  "legacy reader должен игнорировать header-use и видеть отдельный field",
+);
+assertSame(
+  readRequiredSingle(memory, collisionAct, interpreter),
+  ordinaryValue,
+  "legacy required-single сохраняет прежнее поведение",
+);
+
+// Контроль: обычный Field != H читается прежним exact способом и generic DR.
 const ordinaryRoleDictionary = defineStructuralRoleDictionary(memory, [ordinaryRole]);
 const ordinaryAct = defineActHeader(memory, interpreter, ordinaryRoleDictionary, afterContext);
 const ordinaryField = memory.ensure(ordinaryRole, ordinaryValue);

--- a/ts/test/v010-act-field-header-collision.test.ts
+++ b/ts/test/v010-act-field-header-collision.test.ts
@@ -37,11 +37,11 @@ function expectStructuralReadError(
   try {
     effect();
   } catch (error) {
-    assert(error instanceof StructuralReadError, `expected StructuralReadError, got ${String(error)}`);
-    assertSame(error.code, code, "structural read error code");
+    assert(error instanceof StructuralReadError, `ожидался StructuralReadError, получено ${String(error)}`);
+    assertSame(error.code, code, "код ошибки structural reader");
     return;
   }
-  throw new Error(`expected StructuralReadError(${code})`);
+  throw new Error(`ожидался StructuralReadError(${code})`);
 }
 
 function expectStructuralRuleError(
@@ -51,11 +51,11 @@ function expectStructuralRuleError(
   try {
     effect();
   } catch (error) {
-    assert(error instanceof StructuralRuleError, `expected StructuralRuleError, got ${String(error)}`);
-    assertSame(error.code, code, "structural rule error code");
+    assert(error instanceof StructuralRuleError, `ожидался StructuralRuleError, получено ${String(error)}`);
+    assertSame(error.code, code, "код ошибки structural rule");
     return;
   }
-  throw new Error(`expected StructuralRuleError(${code})`);
+  throw new Error(`ожидался StructuralRuleError(${code})`);
 }
 
 function anchors(memory: Memory, count: number): LinkHandle[] {
@@ -73,19 +73,20 @@ const [dictionary, grammar, theory, afterContext, ordinaryRole, ordinaryValue] =
 assert(
   dictionary !== undefined && grammar !== undefined && theory !== undefined &&
   afterContext !== undefined && ordinaryRole !== undefined && ordinaryValue !== undefined,
-  "fixture anchors must exist",
+  "опорные связи fixture должны существовать",
 );
 
 const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
 
-// Exact collision from #732:
+// Каноническая коллизия #732:
 //
-//   Q = DR -> K
-//   H = I -> Q
-//   A = START(H) = A -> H
+//   Q = DR ⟼ K
+//   H = I ⟼ Q
+//   A = START(H) = A ⟼ H
 //
-// With declared role=I and value=Q, Field=I->Q is the same semantic H.
-// Therefore Attachment=A->Field is the same semantic A as the header carrier.
+// При объявленной роли I и значении Q поле I⟼Q является тем же H, а
+// attachment A⟼H — тем же A. Это не требует второй semantic occurrence:
+// один A одновременно исполняет header-use и field-use в контексте DR=[I].
 const collisionRoleDictionary = defineStructuralRoleDictionary(memory, [interpreter]);
 const roleAndContext = memory.ensure(collisionRoleDictionary, afterContext);
 const header = memory.ensure(interpreter, roleAndContext);
@@ -95,34 +96,69 @@ const collisionAct = defineActHeader(
   collisionRoleDictionary,
   afterContext,
 );
-assertSame(memory.poles(collisionAct).end, header, "Act must carry the exact reconstructed header");
+assertSame(memory.poles(collisionAct).end, header, "Act должен нести точный header");
+
+// Binding уже предъявлен структурой A и выбранной role I. Host-вызов
+// defineActField не является отдельным semantic событием и не должен быть
+// нужен reader-у, чтобы увидеть существующую relation A⟼(I⟼Q).
+assertDeepEqual(
+  readOptionalMany(memory, collisionAct, interpreter),
+  [roleAndContext],
+  "self-link Act должен читаться как field в явно выбранной роли I",
+);
+assertSame(
+  readRequiredSingle(memory, collisionAct, interpreter),
+  roleAndContext,
+  "dual-use binding должен удовлетворять required-single",
+);
 
 const outgoingBefore = [...memory.outgoing(collisionAct)];
 const countBefore = memory.linkCount;
 const collisionAttachment = defineActField(memory, collisionAct, interpreter, roleAndContext);
-
-assertSame(collisionAttachment, collisionAct, "header-shaped field attachment collapses to the Act itself");
-assertSame(memory.linkCount, countBefore, "declaring the colliding field adds no structural evidence");
+assertSame(collisionAttachment, collisionAct, "header-shaped attachment канонически является самим Act");
+assertSame(memory.linkCount, countBefore, "повторная материализация dual-use binding не создаёт Link");
 assertDeepEqual(
   memory.outgoing(collisionAct),
   outgoingBefore,
-  "Act topology is identical before and after the colliding defineActField call",
+  "идемпотентный defineActField не меняет topology",
 );
 assertDeepEqual(
   readOptionalMany(memory, collisionAct, interpreter),
-  [],
-  "reader skips the self-link header carrier and loses the colliding role field",
+  [roleAndContext],
+  "идемпотентная конструкция не создаёт multiplicity",
+);
+
+// DR действительно объявляет I placeholder-роль, поэтому generic Rule replay
+// обязан получить rho(I)=Q из того же self-link A и сопоставить body I с Q.
+const collisionRule = defineStructuralRule(memory, collisionRoleDictionary, interpreter);
+const collisionAdmission = admitStructuralRule(memory, theory, collisionRule);
+const collisionReplay = replayStructuralRule(memory, {
+  act: collisionAct,
+  rule: collisionRule,
+  ruleAdmission: collisionAdmission,
+  claimedBody: roleAndContext,
+  expectedInterpreter: { dictionary, grammar, theory },
+  expectedAfterContext: afterContext,
+});
+assertDeepEqual(
+  collisionReplay.bindings,
+  [{ role: interpreter, value: roleAndContext }],
+  "generic Rule должен получить ровно один dual-use binding",
+);
+
+// Отличное второе значение для той же роли остаётся настоящим конфликтом
+// cardinality: self-link даёт Q, отдельный attachment даёт ordinaryValue.
+defineActField(memory, collisionAct, interpreter, ordinaryValue);
+const conflictingValues = readOptionalMany(memory, collisionAct, interpreter);
+assertSame(conflictingValues.length, 2, "два отличных значения роли должны быть видимы");
+assert(
+  conflictingValues.includes(roleAndContext) && conflictingValues.includes(ordinaryValue),
+  "оба конфликтующих значения должны сохраняться структурно",
 );
 expectStructuralReadError(
   () => readRequiredSingle(memory, collisionAct, interpreter),
-  "missing-required-field",
+  "multiple-field-values",
 );
-
-// The same loss propagates to generic structural Rule replay. The DR genuinely
-// declares I as a role, but the accepted field constructor cannot leave a
-// distinguishable binding rho(I)=Q in the Act topology.
-const collisionRule = defineStructuralRule(memory, collisionRoleDictionary, interpreter);
-const collisionAdmission = admitStructuralRule(memory, theory, collisionRule);
 expectStructuralRuleError(
   () => replayStructuralRule(memory, {
     act: collisionAct,
@@ -132,25 +168,25 @@ expectStructuralRuleError(
     expectedInterpreter: { dictionary, grammar, theory },
     expectedAfterContext: afterContext,
   }),
-  "missing-role-binding",
+  "multiple-role-bindings",
 );
 
-// Control vector: the existing representation remains exact when Field != H.
+// Контроль: обычный Field != H по-прежнему читается прежним exact способом.
 const ordinaryRoleDictionary = defineStructuralRoleDictionary(memory, [ordinaryRole]);
 const ordinaryAct = defineActHeader(memory, interpreter, ordinaryRoleDictionary, afterContext);
 const ordinaryField = memory.ensure(ordinaryRole, ordinaryValue);
 assert(
   ordinaryField !== memory.poles(ordinaryAct).end,
-  "control fixture must not accidentally reproduce the header collision",
+  "контрольный fixture не должен случайно воспроизводить header collision",
 );
 defineActField(memory, ordinaryAct, ordinaryRole, ordinaryValue);
 assertDeepEqual(
   readOptionalMany(memory, ordinaryAct, ordinaryRole),
   [ordinaryValue],
-  "ordinary non-colliding field remains readable",
+  "обычное non-colliding поле остаётся читаемым",
 );
 assertSame(
   readRequiredSingle(memory, ordinaryAct, ordinaryRole),
   ordinaryValue,
-  "ordinary required field remains exact",
+  "обычное required поле остаётся exact",
 );


### PR DESCRIPTION
Closes #732. Refs #657, #608, #730/#731.

Test-only falsification на первом head #733 (`1368de5a...`, CI #3013 green) доказал collision accepted Act topology:

```text
Q = DR ⟼ K
H = I ⟼ Q
A = START(H) = A ⟼ H

role=I
value=Q
field=I⟼Q=H
attachment=A⟼H=A
```

## Research result

#608 требует exact DR environment:

```text
exact declared roles from DR
+ exactly one required binding per role
```

При no-instance/A6 отдельный host-вызов `defineActField` не создаёт semantic occurrence, если нужная relation уже канонически существует. Поэтому один `A` может иметь две use-role:

```text
header carrier
DR-selected field attachment
```

Но CI #3019 falsified слишком широкую версию H2: менять общий `readOptionalMany/readRequiredSingle` нельзя, потому что legacy specialized replay не имеет DR и сохраняет accepted правило «self-link = header only».

## Финальная граница

Dual-use разрешается **только explicit DR context** внутри `readExactActBindings`:

```text
attachment === A
H = poles(A).end

if H.start ∈ DR.roles:
    H также даёт binding H.start ↦ H.end
else:
    A остаётся только header-use
```

Обычные non-self attachments сохраняют existing missing/multiple/undeclared cardinality.

`structural-readers.ts` относительно main не меняется. Поэтому relation/colon/equality/proof/run compatibility paths через `readRequiredSingle` сохраняют прежнюю semantics.

Regression corpus доказывает:

```text
DR=[I] -> self-link даёт rho(I)=Q
replayStructuralRule succeeds
repeated defineActField(A,I,Q) adds no Link
second distinct I↦Q2 -> multiple-role-bindings
legacy readOptionalMany still ignores self-link header
ordinary non-colliding field remains exact
```

Классификация при green full corpus:

```text
semantic primitive delta    = NONE
occurrence identity delta   = NONE
Act/DR topology delta       = NONE
legacy replay delta         = NONE
accepted obligation         = already #608
reader conformance          = DR-scoped dual-use correction
contract delta              = NONE
MTS v0.11                   = NOT REQUIRED
classification              = NO-DELTA conformance correction
```

```repo-guard-yaml
change_type: research
scope:
  - ts/src/structural-rule.ts
  - ts/test/v010-act-field-header-collision.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 220
must_touch:
  - ts/src/structural-rule.ts
  - ts/test/v010-act-field-header-collision.test.ts
must_not_touch:
  - ts/src/structural-readers.ts
  - ts/src/interpreter.ts
  - ts/src/proof.ts
  - ts/src/run.ts
  - contracts/**
  - cutover/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - interpret Act self-link as field only when exact DR explicitly declares its role
  - satisfy DR-declared binding without semantic occurrence copying
  - preserve header-only behavior in legacy field readers
  - preserve multiple-value conflict and ordinary field semantics
  - no semantic release lifecycle change
```