### PR TITLE
fix(#734): запретить ROOT в restricted source byte vocabulary

### DIFF
--- a/ts/src/source.ts
+++ b/ts/src/source.ts
@@ -86,7 +86,10 @@ function byteVocabulary(
   const inverse = new Map<LinkHandle, number>();
   for (let value = 0; value < byteRefs.length; value += 1) {
     const ref = byteRefs[value];
-    if (ref === undefined) {
+    // Этот compatibility carrier — restricted root-starting fold. ROOT не
+    // может быть его value: R ⟼ R = R стирает позицию и делает [R] = [].
+    // Это локальное ограничение byteRefs, не запрет ROOT в ExactSequence.
+    if (ref === undefined || ref === memory.root) {
       throw new SourceError("invalid-byte-vocabulary");
     }
     try {

--- a/ts/test/v010-source-root-byte-vocabulary.test.ts
+++ b/ts/test/v010-source-root-byte-vocabulary.test.ts
@@ -4,13 +4,20 @@ import {
   readCanonicalByteSequence,
 } from "../src/byte-carrier.js";
 import {
+  InterpreterReplayError,
+  replayRelationStep,
+} from "../src/interpreter.js";
+import {
   Memory,
   ensureRootBasis,
   type LinkHandle,
 } from "../src/memory.js";
 import {
+  SourceError,
+  defineSourceForm,
   materializeSourceContent,
   readSourceContent,
+  type SourceFrontEndEvidence,
 } from "../src/source.js";
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -28,6 +35,31 @@ function deepSame(actual: unknown, expected: unknown, message: string): void {
   );
 }
 
+function expectSourceError(effect: () => unknown, code: SourceError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof SourceError, `expected SourceError, got ${String(error)}`);
+    same(error.code, code, "source error code");
+    return;
+  }
+  throw new Error(`expected SourceError(${code})`);
+}
+
+function expectInterpreterError(
+  effect: () => unknown,
+  code: InterpreterReplayError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof InterpreterReplayError, `expected InterpreterReplayError, got ${String(error)}`);
+    same(error.code, code, "interpreter replay error code");
+    return;
+  }
+  throw new Error(`expected InterpreterReplayError(${code})`);
+}
+
 function anchors(memory: Memory, count: number): LinkHandle[] {
   const result: LinkHandle[] = [];
   let current = memory.root;
@@ -40,42 +72,62 @@ function anchors(memory: Memory, count: number): LinkHandle[] {
 
 const memory = new Memory();
 
-// `0` below is the physical-byte array index 0x00, not the MTS abit `0`.
-// The current compatibility validator accepts any 256 unique owned Links, so
-// ROOT can presently masquerade as the semantic reference for byte 0x00.
+// `0x00` below is the physical-byte index, not the MTS abit `0`.
+// CI #3026 on the test-only witness proved the old behavior:
+// byteRefs[0x00]=ROOT made content([0x00]) collapse to content([])=ROOT.
 const malformedByteRefs = [memory.root, ...anchors(memory, 255)];
 same(malformedByteRefs.length, 256, "malformed vocabulary has all physical byte slots");
 same(new Set(malformedByteRefs).size, 256, "malformed vocabulary is otherwise unique");
 
-const empty = materializeSourceContent(memory, malformedByteRefs, new Uint8Array());
-const oneZeroByte = materializeSourceContent(memory, malformedByteRefs, new Uint8Array([0x00]));
-
-same(empty, memory.root, "empty restricted source carrier is ROOT");
-same(
-  oneZeroByte,
-  empty,
-  "current validator admits byteRefs[0x00]=ROOT, so one byte collapses to empty",
+expectSourceError(
+  () => materializeSourceContent(memory, malformedByteRefs, new Uint8Array([0x00])),
+  "invalid-byte-vocabulary",
 );
-deepSame(
-  Array.from(readSourceContent(memory, malformedByteRefs, oneZeroByte).bytes),
-  [],
-  "reader cannot recover the collapsed physical byte",
+expectSourceError(
+  () => readSourceContent(memory, malformedByteRefs, memory.root),
+  "invalid-byte-vocabulary",
 );
 
-const oneByte = materializeSourceContent(memory, malformedByteRefs, new Uint8Array([0x01]));
-const leadingZeroThenOne = materializeSourceContent(
-  memory,
-  malformedByteRefs,
-  new Uint8Array([0x00, 0x01]),
-);
-same(
-  leadingZeroThenOne,
-  oneByte,
-  "leading ROOT-valued byte also disappears before a following byte",
+// The fail-closed boundary propagates through the selected public replay path:
+// source evidence is rejected before any Act/role semantics can be trusted.
+const emptySource = defineSourceForm(memory, memory.root);
+const sourceEvidence: SourceFrontEndEvidence = Object.freeze({
+  content: memory.root,
+  source: emptySource,
+  dictionary: memory.root,
+  grammar: memory.root,
+  theory: memory.root,
+  segments: Object.freeze([]),
+  selectionSequence: memory.root,
+  formSequence: memory.root,
+  grammarMembership: memory.root,
+  theoryMembership: memory.root,
+});
+expectInterpreterError(
+  () => replayRelationStep(memory, malformedByteRefs, {
+    sourceEvidence,
+    act: memory.root,
+    roles: {
+      source: memory.root,
+      sourceSelection: memory.root,
+      formSequence: memory.root,
+      dictionary: memory.root,
+      grammar: memory.root,
+      theory: memory.root,
+      form: memory.root,
+      beforeContext: memory.root,
+      binding: memory.root,
+      result: memory.root,
+      afterContext: memory.root,
+    },
+    interpreter: memory.root,
+    roleDictionary: memory.root,
+  }),
+  "invalid-relation-evidence",
 );
 
-// Control: the legacy restricted carrier remains injective on its accepted
-// root-excluded value domain.
+// Control: the compatibility restricted carrier remains exact on its already
+// accepted root-excluded domain.
 const rootFreeByteRefs = anchors(memory, 256);
 assert(rootFreeByteRefs.every((ref) => ref !== memory.root), "control vocabulary excludes ROOT");
 const rootFreeZero = materializeSourceContent(memory, rootFreeByteRefs, new Uint8Array([0x00]));
@@ -86,9 +138,8 @@ deepSame(
   "root-free compatibility vocabulary round-trips byte 0x00",
 );
 
-// The accepted canonical v0.9 byte carrier is a different class:
-// Byte(p)=Denote_Q([p]) and source content is ExactSequence<Byte(p)>.
-// It must stay unaffected by the restricted-carrier negative witness.
+// Canonical v0.9+ Byte(p)/ExactSequence is a different carrier class and must
+// remain unaffected; ROOT is legal as an ExactSequence value in general.
 const basis = ensureRootBasis(memory);
 const canonicalByteRefs = materializeByteVocabulary(memory, basis);
 assert(canonicalByteRefs.every((ref) => ref !== memory.root), "canonical Byte(p) vocabulary contains no ROOT");

--- a/ts/test/v010-source-root-byte-vocabulary.test.ts
+++ b/ts/test/v010-source-root-byte-vocabulary.test.ts
@@ -1,0 +1,101 @@
+import {
+  materializeByteVocabulary,
+  materializeCanonicalByteSequence,
+  readCanonicalByteSequence,
+} from "../src/byte-carrier.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+} from "../src/memory.js";
+import {
+  materializeSourceContent,
+  readSourceContent,
+} from "../src/source.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function deepSame(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+const memory = new Memory();
+
+// `0` below is the physical-byte array index 0x00, not the MTS abit `0`.
+// The current compatibility validator accepts any 256 unique owned Links, so
+// ROOT can presently masquerade as the semantic reference for byte 0x00.
+const malformedByteRefs = [memory.root, ...anchors(memory, 255)];
+same(malformedByteRefs.length, 256, "malformed vocabulary has all physical byte slots");
+same(new Set(malformedByteRefs).size, 256, "malformed vocabulary is otherwise unique");
+
+const empty = materializeSourceContent(memory, malformedByteRefs, new Uint8Array());
+const oneZeroByte = materializeSourceContent(memory, malformedByteRefs, new Uint8Array([0x00]));
+
+same(empty, memory.root, "empty restricted source carrier is ROOT");
+same(
+  oneZeroByte,
+  empty,
+  "current validator admits byteRefs[0x00]=ROOT, so one byte collapses to empty",
+);
+deepSame(
+  Array.from(readSourceContent(memory, malformedByteRefs, oneZeroByte).bytes),
+  [],
+  "reader cannot recover the collapsed physical byte",
+);
+
+const oneByte = materializeSourceContent(memory, malformedByteRefs, new Uint8Array([0x01]));
+const leadingZeroThenOne = materializeSourceContent(
+  memory,
+  malformedByteRefs,
+  new Uint8Array([0x00, 0x01]),
+);
+same(
+  leadingZeroThenOne,
+  oneByte,
+  "leading ROOT-valued byte also disappears before a following byte",
+);
+
+// Control: the legacy restricted carrier remains injective on its accepted
+// root-excluded value domain.
+const rootFreeByteRefs = anchors(memory, 256);
+assert(rootFreeByteRefs.every((ref) => ref !== memory.root), "control vocabulary excludes ROOT");
+const rootFreeZero = materializeSourceContent(memory, rootFreeByteRefs, new Uint8Array([0x00]));
+assert(rootFreeZero !== memory.root, "root-free byte 0x00 remains distinguishable from empty");
+deepSame(
+  Array.from(readSourceContent(memory, rootFreeByteRefs, rootFreeZero).bytes),
+  [0x00],
+  "root-free compatibility vocabulary round-trips byte 0x00",
+);
+
+// The accepted canonical v0.9 byte carrier is a different class:
+// Byte(p)=Denote_Q([p]) and source content is ExactSequence<Byte(p)>.
+// It must stay unaffected by the restricted-carrier negative witness.
+const basis = ensureRootBasis(memory);
+const canonicalByteRefs = materializeByteVocabulary(memory, basis);
+assert(canonicalByteRefs.every((ref) => ref !== memory.root), "canonical Byte(p) vocabulary contains no ROOT");
+const canonicalZero = materializeCanonicalByteSequence(memory, basis, new Uint8Array([0x00]));
+assert(canonicalZero !== memory.root, "ExactSequence preserves the canonical zero-byte position");
+deepSame(
+  Array.from(readCanonicalByteSequence(memory, basis, canonicalZero).bytes),
+  [0x00],
+  "canonical exact byte sequence round-trips byte 0x00",
+);


### PR DESCRIPTION
Closes #734. Refs #657, #597/#607/#631.

Test-only witness на первом head `b317ae967836ebd3249260702b39a0983537b714` прошёл CI #3026 и доказал текущую коллизию:

```text
malformedByteRefs[0x00] = R
content([])        = R
content([0x00])    = R ⟼ R = R
content([0x00,01]) = content([01])
```

`0x00` здесь — физический байт, не abit `0`.

Accepted v0.9 уже задаёт для legacy restricted rooted sequence:

```text
requiresRootExcludedValueDomain = true
```

поэтому выбран H0: narrow fail-closed correction.

Изменение:
- `source.ts::byteVocabulary` отклоняет `memory.root` как `invalid-byte-vocabulary`;
- valid root-free injected vocabulary не меняется;
- selected public replay получает reject до доверия malformed source evidence;
- canonical `Byte(p)=Denote_Q([p])` + `ExactSequence<Byte(p)>` не меняются;
- это не глобальный запрет ROOT как sequence value.

Regression corpus:
```text
ROOT in injected byteRefs -> invalid-byte-vocabulary
public relation replay -> invalid-relation-evidence
root-free compatibility vocabulary -> exact round-trip
canonical Byte(p) vocabulary -> no ROOT
canonical ExactSequence zero-byte -> exact round-trip
```

Классификация:
```text
semantic primitive delta        = NONE
valid-domain delta              = NONE (root-exclusion already accepted)
malformed evidence handling     = corrected
public signature delta          = NONE
canonical carrier topology      = NONE
contract delta                  = NONE
MTS v0.11                       = NOT REQUIRED
classification                  = NO-DELTA conformance correction
```

H1 — полноценную миграцию legacy selected replay на canonical `ExactSequence<Byte(p)>` — намеренно не смешиваем с этим исправлением.

Первый blocking repo-guard #567 отклонил только декларативный budget `150 < actual 155`; все остальные 55 checks прошли. Budget ниже исправлен без изменения head/code.

```repo-guard-yaml
change_type: research
scope:
  - ts/src/source.ts
  - ts/test/v010-source-root-byte-vocabulary.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 170
must_touch:
  - ts/src/source.ts
  - ts/test/v010-source-root-byte-vocabulary.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - reject ROOT only from legacy injected source byte vocabulary
  - preserve already-valid root-free selected replay behavior
  - preserve canonical Byte(p)/ExactSequence semantics including legal ROOT positions generally
  - no semantic release lifecycle change
```