### PR TITLE
test(#738): зафиксировать границу left-fold operation vs ExactSequence carrier

### DIFF
--- a/ts/test/v010-sequence-left-fold-collision.test.ts
+++ b/ts/test/v010-sequence-left-fold-collision.test.ts
@@ -1,0 +1,75 @@
+import {
+  materializeExactSequence,
+  readExactSequence,
+} from "../src/exact-sequence.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+} from "../src/memory.js";
+import {
+  materializeSequence,
+  replaySequenceMaterialization,
+  type SequenceDescription,
+  type SequenceItem,
+} from "../src/sequence.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+const atom = (value: LinkHandle): SequenceItem => Object.freeze({ kind: "atom", value });
+const description = (memory: Memory, ...items: SequenceItem[]): SequenceDescription =>
+  Object.freeze({ root: memory.root, items: Object.freeze(items) });
+
+const memory = new Memory();
+const { L, U } = ensureRootBasis(memory);
+
+// Concrete non-ROOT collision. A is an ordinary canonical START(B) Link:
+// A = A -> B. Therefore the left-fold operation for [A,B] reuses A itself.
+const B = L;
+const A = memory.ensureStartSelfClosed(B);
+assert(B !== memory.root, "B must be non-ROOT");
+const polesA = memory.poles(A);
+same(polesA.start, A, "A is START(B)");
+same(polesA.end, B, "A payload is B");
+
+const singleton = materializeSequence(memory, description(memory, atom(A)));
+same(singleton.result, A, "left-fold singleton result");
+same(singleton.created.length, 0, "singleton creates no fold edge");
+
+const pair = materializeSequence(memory, description(memory, atom(A), atom(B)));
+same(pair.result, A, "left-fold [A,B] collapses to the same result as [A]");
+same(pair.created.length, 0, "A->B already exists as selfclosed A");
+same(singleton.result, pair.result, "different descriptions share one left-fold result");
+
+const beforeReplay = memory.linkCount;
+same(replaySequenceMaterialization(memory, pair), A, "trusted replay accepts exact left-fold effect");
+same(memory.linkCount, beforeReplay, "left-fold replay stays read-only");
+
+// Accepted ExactSequence has a different responsibility: position-preserving
+// carrier identity. It must distinguish [A] from [A,B] even though the explicit
+// left-fold network materialization above has the same final Link.
+const exactSingleton = materializeExactSequence(memory, [A]);
+const exactPair = materializeExactSequence(memory, [A, B]);
+assert(exactSingleton !== exactPair, "ExactSequence distinguishes [A] from [A,B]");
+const decodedSingleton = readExactSequence(memory, exactSingleton);
+const decodedPair = readExactSequence(memory, exactPair);
+same(decodedSingleton.values.length, 1, "ExactSequence singleton length");
+same(decodedSingleton.values[0], A, "ExactSequence singleton value");
+same(decodedPair.values.length, 2, "ExactSequence pair length");
+same(decodedPair.values[0], A, "ExactSequence pair first value");
+same(decodedPair.values[1], B, "ExactSequence pair second value");
+
+// Control: ordinary left-fold materialization is still a real write effect when
+// the required pair does not already exist. The witness is about operation
+// non-injectivity, not about materialization being generally inert.
+assert(memory.find(L, U) === undefined, "control pair must start absent");
+const ordinary = materializeSequence(memory, description(memory, atom(L), atom(U)));
+same(ordinary.created.length, 1, "ordinary two-value fold creates one missing pair");
+same(memory.poles(ordinary.result).start, L, "ordinary fold start");
+same(memory.poles(ordinary.result).end, U, "ordinary fold end");

--- a/ts/test/v010-sequence-left-fold-collision.test.ts
+++ b/ts/test/v010-sequence-left-fold-collision.test.ts
@@ -8,6 +8,17 @@ import {
   type LinkHandle,
 } from "../src/memory.js";
 import {
+  PersistentStore,
+  type PersistentLinkId,
+  type PersistentTopologyBackend,
+  type StoredDataset,
+} from "../src/persistent-store.js";
+import {
+  materializePersistentSequence,
+  replayPersistentSequenceMaterialization,
+  type PersistentSequenceDescription,
+} from "../src/persistent-sequence.js";
+import {
   materializeSequence,
   replaySequenceMaterialization,
   type SequenceDescription,
@@ -20,6 +31,13 @@ function assert(condition: unknown, message: string): asserts condition {
 
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function sameId(actual: PersistentLinkId, expected: PersistentLinkId, message: string): void {
+  assert(
+    actual.lineage === expected.lineage && actual.local === expected.local,
+    `${message}: (${actual.lineage},${actual.local}) !== (${expected.lineage},${expected.local})`,
+  );
 }
 
 const atom = (value: LinkHandle): SequenceItem => Object.freeze({ kind: "atom", value });
@@ -73,3 +91,57 @@ const ordinary = materializeSequence(memory, description(memory, atom(L), atom(U
 same(ordinary.created.length, 1, "ordinary two-value fold creates one missing pair");
 same(memory.poles(ordinary.result).start, L, "ordinary fold start");
 same(memory.poles(ordinary.result).end, U, "ordinary fold end");
+
+// Persistent sequence deliberately reuses the same generic left-fold operation.
+// Its final result is therefore equally non-injective, while the operation
+// evidence still carries the exact host description and write-effect boundary.
+function clone(dataset: StoredDataset): StoredDataset {
+  return JSON.parse(JSON.stringify(dataset)) as StoredDataset;
+}
+
+class Backend implements PersistentTopologyBackend {
+  dataset: StoredDataset | undefined;
+  commits = 0;
+  load(): StoredDataset | undefined {
+    return this.dataset === undefined ? undefined : clone(this.dataset);
+  }
+  commit(dataset: StoredDataset): void {
+    this.dataset = clone(dataset);
+    this.commits += 1;
+  }
+}
+
+const backend = new Backend();
+const store = PersistentStore.create(backend, "left-fold-collision");
+const pR = store.root;
+const pO = store.materializeStartSelfClosed(pR);
+const pC = store.materializeEndSelfClosed(pR);
+const pL = store.materialize(pO, pC);
+store.materialize(pC, pO); // complete the ordinary root basis
+const pB = pL;
+const pA = store.materializeStartSelfClosed(pB);
+
+const persistent = (...values: PersistentLinkId[]): PersistentSequenceDescription =>
+  Object.freeze({
+    root: store.root,
+    items: Object.freeze(values.map((value) => Object.freeze({ kind: "atom" as const, value }))),
+  });
+
+const pSingleton = materializePersistentSequence(store, persistent(pA));
+const pPair = materializePersistentSequence(store, persistent(pA, pB));
+sameId(pSingleton.result, pA, "persistent singleton result");
+sameId(pPair.result, pA, "persistent [A,B] shares singleton result");
+same(pSingleton.created.length, 0, "persistent singleton creates no fold edge");
+same(pPair.created.length, 0, "persistent A->B reuses existing selfclosed A");
+same(pSingleton.description.items.length, 1, "persistent evidence keeps singleton description");
+same(pPair.description.items.length, 2, "persistent evidence keeps two-position description");
+
+const countBeforePersistentReplay = store.count;
+const commitsBeforePersistentReplay = backend.commits;
+sameId(
+  replayPersistentSequenceMaterialization(store, pPair),
+  pA,
+  "persistent trusted replay accepts exact zero-write effect",
+);
+same(store.count, countBeforePersistentReplay, "persistent replay stays read-only");
+same(backend.commits, commitsBeforePersistentReplay, "persistent replay does not commit");


### PR DESCRIPTION
Closes #738. Refs #657, #486/#537, #513/#551, #559, #604, #736/#737.

## Исполнимый результат

Counterexample подтверждён fresh CI:

```text
B=L != R
A=START(B)=A⟼B

materializeSequence([A]).result   = A
materializeSequence([A,B]).result = A
created([A,B])                    = []
replay([A,B])                     = A, read-only
```

Тот же exact effect подтверждён для `materializePersistentSequence`: final result совпадает, write-effect нулевой, но evidence продолжает содержать разные descriptions (`items.length=1` и `items.length=2`). Persistent replay остаётся read-only и не commit-ит.

Одновременно accepted ExactSequence различает:

```text
ExactSequence([A]) != ExactSequence([A,B])
```

и читает обе позиции точно.

## H0/H1/H2 classification

Принят **H0**:

```text
materializeSequence
= explicit left-fold network write operation
!= position-preserving sequence carrier
```

Historical #486/#537 уже задаёт именно left-fold write-effect + exact `created` evidence. Persistent #513/#551 наследует ту же operation semantics. F1-D #604 вводит ExactSequence для другого обязательства: сохранения positions.

Поэтому non-injective final `result` не является потерей carrier semantics: identity проверяемой операции задаётся всей evidence boundary (`description`, counts/effect, `created`, `result`), а не одним result Link.

H1 (заменить/перевести left-fold API на ExactSequence) отвергнут: это смешало бы две разные операции и изменило accepted write-effect semantics.

H2 (запретить START-shaped values) отвергнут как искусственное domain restriction без теоретического основания.

Final classification:

```text
theory semantic delta      = NONE
left-fold operation delta  = NONE
public API delta           = NONE
persistent semantics delta = NONE
new primitive              = NONE
ExactSequence delta        = NONE
MTS v0.11                  = NOT REQUIRED
result                     = BOUNDARY REGRESSION / NO-DELTA
```

## Что меняется

Только executable boundary regression:
- non-ROOT `START(B),B` collision;
- exact replay read-only;
- persistent inherited behavior;
- evidence descriptions остаются различными;
- ExactSequence contrast;
- ordinary missing-pair left-fold control.

Production/contracts/docs/cutover не меняются.

Evidence:

```text
initial witness CI #3068 green
persistent witness CI #3070 green
stable head ca12c2ae1e2f70bcaab599f75a4f7887c32dd717
```

```repo-guard-yaml
change_type: research
scope:
  - ts/test/v010-sequence-left-fold-collision.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 170
must_touch:
  - ts/test/v010-sequence-left-fold-collision.test.ts
must_not_touch:
  - ts/src/**
  - contracts/**
  - cutover/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - freeze intentional noninjectivity of explicit left-fold operation result
  - distinguish left-fold write-effect evidence from ExactSequence carrier identity
  - prove in-memory and persistent replay remain read-only for zero-write collision
  - preserve ordinary missing-pair materialization behavior
  - no production, public API, contract or release lifecycle change
```