### PR TITLE
fix(#740): reject self-colliding Eq_K local binding

### DIFF
--- a/ts/src/state.ts
+++ b/ts/src/state.ts
@@ -5,7 +5,10 @@ import {
   type WriteMemory,
 } from "./memory.js";
 
-export type StateErrorCode = "invalid-context" | "representative-conflict";
+export type StateErrorCode =
+  | "invalid-context"
+  | "invalid-representative-binding"
+  | "representative-conflict";
 
 export interface ContextState {
   readonly parent: LinkHandle;
@@ -80,7 +83,14 @@ export function defineLocalRepresentativeBinding(
   representative: LinkHandle,
 ): LinkHandle {
   const pair = memory.ensure(member, representative);
-  return memory.ensure(context, pair);
+  const binding = memory.ensure(context, pair);
+  // K self-link is the context header. Канонизация не создаёт отдельное
+  // вхождение/use-role, поэтому host-вызов не может превратить сам K в
+  // предъявленное local-binding evidence.
+  if (binding === context) {
+    throw new StateError("invalid-representative-binding");
+  }
+  return binding;
 }
 
 export function localRepresentativeResolution(

--- a/ts/test/v010-eqk-context-self-binding-collision.test.ts
+++ b/ts/test/v010-eqk-context-self-binding-collision.test.ts
@@ -111,6 +111,27 @@ function expectStateError(effect: () => unknown, code: StateError["code"]): void
   assert(current !== otherRepresentative, "mixed representatives are semantically distinct");
 }
 
+// H0 feasibility control: rejecting the self-colliding orientation does not
+// make Eq_K(parent,current) inexpressible. A distinct reverse binding
+// current->parent gives both references the same one-hop representative while
+// keeping the context header out of RepSet.
+{
+  const memory = new Memory();
+  const [parent, current] = anchors(memory, 2);
+  assert(parent && current && parent !== current, "reverse-binding anchors");
+
+  const context = defineContext(memory, parent, current);
+  const reverseBinding = defineLocalRepresentativeBinding(memory, context, current, parent);
+  assert(reverseBinding !== context, "reverse binding is a distinct attachment");
+  same(localRepresentative(memory, context, parent), parent, "parent remains fallback representative");
+  same(localRepresentative(memory, context, current), parent, "current resolves one hop to parent");
+  same(
+    localRepresentative(memory, context, parent),
+    localRepresentative(memory, context, current),
+    "Eq_K(parent,current) remains expressible without self-colliding binding",
+  );
+}
+
 // Control: ordinary non-colliding local bindings keep the accepted one-hop and
 // conflict behavior. #740 must not weaken that existing boundary.
 {

--- a/ts/test/v010-eqk-context-self-binding-collision.test.ts
+++ b/ts/test/v010-eqk-context-self-binding-collision.test.ts
@@ -53,10 +53,9 @@ function expectStateError(effect: () => unknown, code: StateError["code"]): void
 //   Pair    = member -> representative
 //   Binding = K -> Pair
 //
-// Therefore member=parent and representative=current makes Pair=P and
-// Binding=K. The context carrier and the local-binding carrier become the same
-// semantic Link; there is no occurrence/host-call identity available to tell
-// those two uses apart.
+// member=parent and representative=current makes Pair=P and raw Binding=K.
+// K is already the context header, so the canonical network contains no
+// separate attachment that could witness a local-binding use-role.
 {
   const memory = new Memory();
   const [parent, current, otherRepresentative] = anchors(memory, 3);
@@ -69,30 +68,38 @@ function expectStateError(effect: () => unknown, code: StateError["code"]): void
   same(contextPoles.start, context, "K is START(payload)");
   same(contextPoles.end, payload, "K payload is parent->current");
 
-  // Before any explicit local-binding constructor call the context already has
-  // exactly the topology K -> (parent -> current).
-  const beforeBindingCall = memory.linkCount;
+  // The raw ordered pair K->P is already K itself. This proves the collision
+  // without assigning semantic meaning to a host constructor invocation.
+  const beforeRawCollision = memory.linkCount;
+  const rawSelfAttachment = memory.ensure(context, payload);
+  same(rawSelfAttachment, context, "raw K->payload canonicalizes to K");
+  same(memory.linkCount, beforeRawCollision, "raw collision creates no occurrence");
+
+  // Context topology alone is header evidence, not an implicit Eq_K binding.
   const beforeResolution = localRepresentativeResolution(memory, context, parent);
-  same(beforeResolution.representative, parent, "current reader treats K self-link as header-only");
-  deepSame(beforeResolution.bindings, [], "no local binding is reported before constructor call");
+  same(beforeResolution.representative, parent, "K self-link remains header-only");
+  deepSame(beforeResolution.bindings, [], "context header is not reported as local binding");
   same(localRepresentative(memory, context, current), current, "current itself falls back to itself");
   assert(
     localRepresentative(memory, context, parent) !== localRepresentative(memory, context, current),
-    "current runtime does not make Eq_K(parent,current) true from context topology alone",
+    "context existence alone must not imply Eq_K(parent,current)",
   );
 
-  const selfBinding = defineLocalRepresentativeBinding(memory, context, parent, current);
-  same(selfBinding, context, "canonical self-binding collapses to K");
-  same(memory.linkCount, beforeBindingCall, "explicit self-binding call creates no structural evidence");
+  // The constructor must fail closed. Returning K would falsely report success
+  // even though no distinguishable local-binding evidence was added.
+  const beforeRejectedBinding = memory.linkCount;
+  expectStateError(
+    () => defineLocalRepresentativeBinding(memory, context, parent, current),
+    "invalid-representative-binding",
+  );
+  same(memory.linkCount, beforeRejectedBinding, "rejected self-binding adds no Link");
 
-  // Because the memory is structurally identical before/after the constructor
-  // call, the reader still cannot observe the requested binding.
-  const afterResolution = localRepresentativeResolution(memory, context, parent);
-  same(afterResolution.representative, parent, "constructed parent->current binding is lost by reader");
-  deepSame(afterResolution.bindings, [], "constructed self-binding has no reported evidence handle");
+  const afterRejected = localRepresentativeResolution(memory, context, parent);
+  same(afterRejected.representative, parent, "rejection preserves fallback representative");
+  deepSame(afterRejected.bindings, [], "rejection does not invent binding evidence");
 
-  // Add an ordinary distinct binding for the same member. The resolver sees
-  // only that attachment and silently ignores the canonical self-binding K.
+  // A normal distinct attachment for the same member remains valid and is not
+  // confused with the context header.
   const ordinaryBinding = defineLocalRepresentativeBinding(
     memory,
     context,
@@ -100,21 +107,14 @@ function expectStateError(effect: () => unknown, code: StateError["code"]): void
     otherRepresentative,
   );
   assert(ordinaryBinding !== context, "ordinary binding must be a distinct attachment");
-
-  const mixed = localRepresentativeResolution(memory, context, parent);
-  same(mixed.representative, otherRepresentative, "self-binding is ignored in favor of distinct attachment");
-  deepSame(mixed.bindings, [ordinaryBinding], "only distinct attachment is reported");
-
-  // If K self-link were counted by RepSet_K, current and otherRepresentative
-  // would be A6-distinct representatives and this exact state would be a
-  // representative-conflict. Current runtime does not report that conflict.
-  assert(current !== otherRepresentative, "mixed representatives are semantically distinct");
+  const ordinary = localRepresentativeResolution(memory, context, parent);
+  same(ordinary.representative, otherRepresentative, "ordinary binding still resolves");
+  deepSame(ordinary.bindings, [ordinaryBinding], "ordinary binding evidence is preserved");
 }
 
-// H0 feasibility control: rejecting the self-colliding orientation does not
-// make Eq_K(parent,current) inexpressible. A distinct reverse binding
-// current->parent gives both references the same one-hop representative while
-// keeping the context header out of RepSet.
+// Rejecting the colliding orientation does not make Eq_K(parent,current)=true
+// inexpressible. A distinct reverse binding current->parent gives both
+// references the same one-hop representative while K remains header-only.
 {
   const memory = new Memory();
   const [parent, current] = anchors(memory, 2);
@@ -128,12 +128,12 @@ function expectStateError(effect: () => unknown, code: StateError["code"]): void
   same(
     localRepresentative(memory, context, parent),
     localRepresentative(memory, context, current),
-    "Eq_K(parent,current) remains expressible without self-colliding binding",
+    "Eq_K(parent,current) remains expressible through distinct evidence",
   );
 }
 
-// Control: ordinary non-colliding local bindings keep the accepted one-hop and
-// conflict behavior. #740 must not weaken that existing boundary.
+// Ordinary non-colliding local bindings keep the accepted one-hop/conflict
+// behavior from #726/#727.
 {
   const memory = new Memory();
   const [parent, current, member, representativeA, representativeB] = anchors(memory, 5);

--- a/ts/test/v010-eqk-context-self-binding-collision.test.ts
+++ b/ts/test/v010-eqk-context-self-binding-collision.test.ts
@@ -1,0 +1,131 @@
+import {
+  StateError,
+  defineContext,
+  defineLocalRepresentativeBinding,
+  localRepresentative,
+  localRepresentativeResolution,
+} from "../src/state.js";
+import { Memory, type LinkHandle } from "../src/memory.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function deepSame(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function anchors(memory: Memory, count: number): LinkHandle[] {
+  const result: LinkHandle[] = [];
+  let current = memory.root;
+  for (let index = 0; index < count; index += 1) {
+    current = memory.ensureStartSelfClosed(current);
+    result.push(current);
+  }
+  return result;
+}
+
+function expectStateError(effect: () => unknown, code: StateError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StateError, `expected StateError, got ${String(error)}`);
+    same(error.code, code, "state error code");
+    return;
+  }
+  throw new Error(`expected StateError(${code})`);
+}
+
+// #740 exact PAIR collision:
+//
+//   P = parent -> current
+//   K = START(P) = K -> P
+//
+// Local representative evidence uses:
+//
+//   Pair    = member -> representative
+//   Binding = K -> Pair
+//
+// Therefore member=parent and representative=current makes Pair=P and
+// Binding=K. The context carrier and the local-binding carrier become the same
+// semantic Link; there is no occurrence/host-call identity available to tell
+// those two uses apart.
+{
+  const memory = new Memory();
+  const [parent, current, otherRepresentative] = anchors(memory, 3);
+  assert(parent && current && otherRepresentative, "fixture anchors");
+  assert(parent !== current && current !== otherRepresentative, "fixture values must differ");
+
+  const payload = memory.ensure(parent, current);
+  const context = defineContext(memory, parent, current);
+  const contextPoles = memory.poles(context);
+  same(contextPoles.start, context, "K is START(payload)");
+  same(contextPoles.end, payload, "K payload is parent->current");
+
+  // Before any explicit local-binding constructor call the context already has
+  // exactly the topology K -> (parent -> current).
+  const beforeBindingCall = memory.linkCount;
+  const beforeResolution = localRepresentativeResolution(memory, context, parent);
+  same(beforeResolution.representative, parent, "current reader treats K self-link as header-only");
+  deepSame(beforeResolution.bindings, [], "no local binding is reported before constructor call");
+  same(localRepresentative(memory, context, current), current, "current itself falls back to itself");
+  assert(
+    localRepresentative(memory, context, parent) !== localRepresentative(memory, context, current),
+    "current runtime does not make Eq_K(parent,current) true from context topology alone",
+  );
+
+  const selfBinding = defineLocalRepresentativeBinding(memory, context, parent, current);
+  same(selfBinding, context, "canonical self-binding collapses to K");
+  same(memory.linkCount, beforeBindingCall, "explicit self-binding call creates no structural evidence");
+
+  // Because the memory is structurally identical before/after the constructor
+  // call, the reader still cannot observe the requested binding.
+  const afterResolution = localRepresentativeResolution(memory, context, parent);
+  same(afterResolution.representative, parent, "constructed parent->current binding is lost by reader");
+  deepSame(afterResolution.bindings, [], "constructed self-binding has no reported evidence handle");
+
+  // Add an ordinary distinct binding for the same member. The resolver sees
+  // only that attachment and silently ignores the canonical self-binding K.
+  const ordinaryBinding = defineLocalRepresentativeBinding(
+    memory,
+    context,
+    parent,
+    otherRepresentative,
+  );
+  assert(ordinaryBinding !== context, "ordinary binding must be a distinct attachment");
+
+  const mixed = localRepresentativeResolution(memory, context, parent);
+  same(mixed.representative, otherRepresentative, "self-binding is ignored in favor of distinct attachment");
+  deepSame(mixed.bindings, [ordinaryBinding], "only distinct attachment is reported");
+
+  // If K self-link were counted by RepSet_K, current and otherRepresentative
+  // would be A6-distinct representatives and this exact state would be a
+  // representative-conflict. Current runtime does not report that conflict.
+  assert(current !== otherRepresentative, "mixed representatives are semantically distinct");
+}
+
+// Control: ordinary non-colliding local bindings keep the accepted one-hop and
+// conflict behavior. #740 must not weaken that existing boundary.
+{
+  const memory = new Memory();
+  const [parent, current, member, representativeA, representativeB] = anchors(memory, 5);
+  assert(parent && current && member && representativeA && representativeB, "control anchors");
+
+  const context = defineContext(memory, parent, current);
+  const bindingA = defineLocalRepresentativeBinding(memory, context, member, representativeA);
+  assert(bindingA !== context, "control binding is distinct from K");
+  same(localRepresentative(memory, context, member), representativeA, "ordinary binding round-trip");
+
+  defineLocalRepresentativeBinding(memory, context, member, representativeB);
+  expectStateError(
+    () => localRepresentativeResolution(memory, context, member),
+    "representative-conflict",
+  );
+}


### PR DESCRIPTION
Closes #740. Refs #657, #707/#708, #726/#727, #728/#729.

## Exact collision

```text
P = parent ⟼ current
K = START(P) = K ⟼ P

Pair(member=parent, representative=current) = P
Binding = K ⟼ P = K
```

Research heads proved that before/after the old constructor call semantic topology was identical: no separate attachment/occurrence exists. CI #3073 confirmed the initial witness; CI #3075 confirmed that `Eq_K(parent,current)` remains expressible through the distinct reverse binding `current→parent`.

## Classification

H1 (count K self-link as binding) is rejected: it would make every context automatically imply `Eq_K(parent,current)=true` without explicit equality evidence, contrary to accepted #707/#708 boundary.

H2 (new local-binding topology) is not required: no independent observable obligation needs it, and equality remains expressible through distinct evidence.

H0 is accepted:

```text
Pair    = member ⟼ representative
Binding = K ⟼ Pair
Binding != K
```

Local binding is a strict outgoing attachment-use. K self-link remains context-header-only. If canonical construction collapses `Binding` to K, the constructor must fail closed instead of reporting a binding that cannot be structurally observed.

Final classification:

```text
semantic primitive delta        = NONE
Eq_K judgment delta             = NONE for valid existing evidence
local binding topology delta    = NONE
malformed constructor handling  = fail-closed correction
host/occurrence identity        = NONE
public package API delta        = NONE
accepted contract JSON delta    = NONE
MTS v0.11                       = NOT REQUIRED
result                          = FIX / NO-DELTA
```

## Production change

`ts/src/state.ts` adds internal `invalid-representative-binding` and rejects only `binding===context`. Resolver topology and ordinary one-hop/conflict semantics are unchanged.

Regression proves:
- raw `K⟼payload` canonicalizes to K without creating an occurrence;
- context topology alone does not imply Eq_K(parent,current);
- self-colliding constructor rejects and adds no Link;
- reverse distinct binding can still make parent/current Eq_K-equal;
- ordinary binding and representative-conflict behavior remain intact.

The accepted v0.9/v0.10 JSON evidence is not modified. Normative clarification is recorded in #740/#657; no risky whole-file rewrite is performed merely to edit one sentence.

```repo-guard-yaml
change_type: research
scope:
  - ts/src/state.ts
  - ts/test/v010-eqk-context-self-binding-collision.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 220
must_touch:
  - ts/src/state.ts
  - ts/test/v010-eqk-context-self-binding-collision.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - docs/**
  - repo-policy.json
  - .github/**
expected_effects:
  - reject local representative construction that canonicalizes to context header K
  - preserve context header as non-binding use-role
  - preserve ordinary one-hop Eq_K and conflict semantics
  - preserve read-only representative resolution
  - no semantic release, contract, public package API or topology change
```