### PR TITLE
fix(#744): migrate source formSequence to ExactSequence

### DIFF
--- a/ts/src/source.ts
+++ b/ts/src/source.ts
@@ -4,6 +4,11 @@ import {
   readCanonicalByteSequence,
 } from "./byte-carrier.js";
 import {
+  ExactSequenceError,
+  materializeExactSequence,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
   ensureRootBasis,
   type LinkHandle,
   type ReadMemory,
@@ -266,7 +271,9 @@ export function buildSelectedSourceEvidence(
   }
 
   const selectionSequence = fold(memory, segments.map((segment) => segment.selection));
-  const formSequence = fold(memory, segments.map((segment) => segment.form));
+  // Forms are position-sensitive evidence and ROOT is a legal semantic value,
+  // therefore the restricted rooted fold is not a valid carrier here.
+  const formSequence = materializeExactSequence(memory, segments.map((segment) => segment.form));
   const grammarMembership = memory.ensure(options.grammar, formSequence);
   const theoryMembership = memory.ensure(options.theory, formSequence);
 
@@ -307,6 +314,30 @@ function verifyFold(
       throw error;
     }
     if (error instanceof RootedSequenceError) {
+      throw new SourceError("invalid-source-evidence");
+    }
+    throw error;
+  }
+}
+
+function verifyExactSequence(
+  memory: ReadMemory,
+  final: LinkHandle,
+  values: readonly LinkHandle[],
+): void {
+  try {
+    const sequence = readExactSequence(memory, final);
+    if (
+      sequence.values.length !== values.length ||
+      sequence.values.some((value, index) => value !== values[index])
+    ) {
+      throw new SourceError("invalid-source-evidence");
+    }
+  } catch (error) {
+    if (error instanceof SourceError) {
+      throw error;
+    }
+    if (error instanceof ExactSequenceError) {
       throw new SourceError("invalid-source-evidence");
     }
     throw error;
@@ -417,7 +448,7 @@ export function replaySelectedSourceEvidence(
   }
 
   verifyFold(memory, evidence.selectionSequence, selections);
-  verifyFold(memory, evidence.formSequence, forms);
+  verifyExactSequence(memory, evidence.formSequence, forms);
   verifyMembership(memory, evidence.grammarMembership, evidence.grammar, evidence.formSequence);
   verifyMembership(memory, evidence.theoryMembership, evidence.theory, evidence.formSequence);
 
@@ -457,7 +488,7 @@ export function replaySourceSubselection(
     subselection.selectionSequence,
     segments.map((segment) => segment.selection),
   );
-  verifyFold(memory, subselection.formSequence, selectedForms);
+  verifyExactSequence(memory, subselection.formSequence, selectedForms);
   verifyMembership(
     memory,
     subselection.grammarMembership,

--- a/ts/test/interpreter-relation.test.ts
+++ b/ts/test/interpreter-relation.test.ts
@@ -17,6 +17,7 @@ import {
   defineDictionaryEffect,
   defineDictionaryScope,
 } from "../src/dictionary.js";
+import { materializeExactSequence } from "../src/exact-sequence.js";
 import { defineContext } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
 import {
@@ -388,7 +389,7 @@ for (const makeForm of [
   const roles = relationRoles(memory);
   const segment = source.evidence.segments[1]!;
   const selectionSequence = fold(memory, [segment.selection]);
-  const formSequence = fold(memory, [form]);
+  const formSequence = materializeExactSequence(memory, [form]);
   const subselection: SourceSubselectionEvidence = Object.freeze({
     startSegment: 1,
     endSegment: 2,

--- a/ts/test/source-subselection.test.ts
+++ b/ts/test/source-subselection.test.ts
@@ -11,6 +11,7 @@ import {
   defineDictionaryEffect,
   defineDictionaryScope,
 } from "../src/dictionary.js";
+import { materializeExactSequence } from "../src/exact-sequence.js";
 import {
   Memory,
   type LinkHandle,
@@ -135,7 +136,7 @@ function subselection(
 }
 
 const middleSelection = fold(memory, [evidence.segments[1]!.selection]);
-const middleForms = fold(memory, [formB]);
+const middleForms = materializeExactSequence(memory, [formB]);
 const middleGrammar = memory.ensure(grammar, middleForms);
 const middleTheory = memory.ensure(theory, middleForms);
 const middle = subselection(1, 2, middleSelection, middleForms, middleGrammar, middleTheory);
@@ -176,7 +177,7 @@ assertDeepEqual(
     subselection(1, 1, memory.root, memory.root, emptyGrammar, emptyTheory),
   ),
   [],
-  "empty subselection uses root folds",
+  "empty subselection uses root carriers",
 );
 
 for (const [start, end] of [[-1, 1], [2, 1], [0, 4]] as const) {

--- a/ts/test/v010-source-root-form-sequence-collision.test.ts
+++ b/ts/test/v010-source-root-form-sequence-collision.test.ts
@@ -3,13 +3,13 @@ import {
   defineSourceForm,
   materializeSourceContent,
   replaySelectedSourceEvidence,
-  SourceError,
 } from "../src/source.js";
 import {
   defineDictionaryEffect,
   defineDictionaryScope,
   lookupScopedDictionary,
 } from "../src/dictionary.js";
+import { readExactSequence } from "../src/exact-sequence.js";
 import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
 import { readRootedSequence } from "../src/rooted-sequence.js";
 
@@ -30,20 +30,8 @@ function sameHandles(
   actual.forEach((value, index) => same(value, expected[index], `${message}[${index}]`));
 }
 
-function expectSourceError(effect: () => unknown, code: SourceError["code"]): void {
-  try {
-    effect();
-  } catch (error) {
-    assert(error instanceof SourceError, `expected SourceError, got ${String(error)}`);
-    same(error.code, code, "source error code");
-    return;
-  }
-  throw new Error(`expected SourceError(${code})`);
-}
-
-// #744 exact witness: ROOT is a valid dictionary form, but the legacy
-// formSequence carrier is a restricted rooted left-fold. Therefore one selected
-// ROOT form collapses to the same semantic Link as the empty form sequence.
+// #744 regression: ROOT is a valid dictionary form. A restricted rooted fold
+// loses its position, while the accepted ExactSequence carrier preserves it.
 {
   const memory = new Memory();
   const basis = ensureRootBasis(memory);
@@ -64,6 +52,10 @@ function expectSourceError(effect: () => unknown, code: SourceError["code"]): vo
   same(visible.form, basis.R, "dictionary accepts ROOT as the selected form");
   assert(visible.occurrences.includes(effect.occurrence), "dictionary exposes exact ROOT-form occurrence");
 
+  const legacyRooted = memory.ensure(basis.R, basis.R);
+  same(legacyRooted, basis.R, "legacy rooted fold collapses one ROOT position to empty R");
+  sameHandles(readRootedSequence(memory, legacyRooted).values, [], "legacy rooted reader sees empty sequence");
+
   const source = defineSourceForm(
     memory,
     materializeSourceContent(memory, new Uint8Array([0x61])),
@@ -80,21 +72,26 @@ function expectSourceError(effect: () => unknown, code: SourceError["code"]): vo
     { dictionary: effect.afterScope, grammar: basis.L, theory: basis.U },
   );
 
-  same(evidence.segments.length, 1, "builder preserves one selected segment in host evidence");
+  same(evidence.segments.length, 1, "builder preserves one selected segment");
   same(evidence.segments[0]?.form, basis.R, "builder preserves ROOT form on segment");
-  same(evidence.formSequence, basis.R, "legacy rooted fold collapses [R] to empty carrier R");
-  sameHandles(readRootedSequence(memory, evidence.formSequence).values, [], "reader sees collapsed form sequence as empty");
+  assert(evidence.formSequence !== basis.R, "ExactSequence([R]) must differ from empty sequence R");
+  sameHandles(
+    readExactSequence(memory, evidence.formSequence).values,
+    [basis.R],
+    "exact formSequence preserves ROOT position",
+  );
 
   const beforeReplay = memory.linkCount;
-  expectSourceError(
-    () => replaySelectedSourceEvidence(memory, evidence),
-    "invalid-source-evidence",
+  sameHandles(
+    replaySelectedSourceEvidence(memory, evidence),
+    [basis.R],
+    "ROOT-form builder/replay round-trip",
   );
-  same(memory.linkCount, beforeReplay, "failed replay remains read-only");
+  same(memory.linkCount, beforeReplay, "ROOT-form replay remains read-only");
 }
 
-// Control: the same one-segment builder/replay path round-trips when the form is
-// outside the restricted carrier's ROOT collision.
+// Control: ordinary non-ROOT forms use the same exact carrier and preserve the
+// existing source-selection behavior.
 {
   const memory = new Memory();
   const basis = ensureRootBasis(memory);
@@ -126,7 +123,7 @@ function expectSourceError(effect: () => unknown, code: SourceError["code"]): vo
     { dictionary: effect.afterScope, grammar: basis.C, theory: basis.U },
   );
 
-  sameHandles(readRootedSequence(memory, evidence.formSequence).values, [form], "non-ROOT form carrier");
+  sameHandles(readExactSequence(memory, evidence.formSequence).values, [form], "non-ROOT exact form carrier");
   const beforeReplay = memory.linkCount;
   sameHandles(replaySelectedSourceEvidence(memory, evidence), [form], "non-ROOT builder/replay round-trip");
   same(memory.linkCount, beforeReplay, "successful replay remains read-only");

--- a/ts/test/v010-source-root-form-sequence-collision.test.ts
+++ b/ts/test/v010-source-root-form-sequence-collision.test.ts
@@ -1,0 +1,133 @@
+import {
+  buildSelectedSourceEvidence,
+  defineSourceForm,
+  materializeSourceContent,
+  replaySelectedSourceEvidence,
+  SourceError,
+} from "../src/source.js";
+import {
+  defineDictionaryEffect,
+  defineDictionaryScope,
+  lookupScopedDictionary,
+} from "../src/dictionary.js";
+import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
+import { readRootedSequence } from "../src/rooted-sequence.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function sameHandles(
+  actual: readonly LinkHandle[],
+  expected: readonly LinkHandle[],
+  message: string,
+): void {
+  assert(actual.length === expected.length, `${message}: length ${actual.length} !== ${expected.length}`);
+  actual.forEach((value, index) => same(value, expected[index], `${message}[${index}]`));
+}
+
+function expectSourceError(effect: () => unknown, code: SourceError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof SourceError, `expected SourceError, got ${String(error)}`);
+    same(error.code, code, "source error code");
+    return;
+  }
+  throw new Error(`expected SourceError(${code})`);
+}
+
+// #744 exact witness: ROOT is a valid dictionary form, but the legacy
+// formSequence carrier is a restricted rooted left-fold. Therefore one selected
+// ROOT form collapses to the same semantic Link as the empty form sequence.
+{
+  const memory = new Memory();
+  const basis = ensureRootBasis(memory);
+  const sliceContent = materializeSourceContent(memory, new Uint8Array([0x61]));
+
+  const beforeScope = defineDictionaryScope(memory, basis.R, basis.R);
+  const effect = defineDictionaryEffect(
+    memory,
+    beforeScope,
+    basis.R,
+    basis.R,
+    sliceContent,
+    basis.R,
+  );
+
+  const visible = lookupScopedDictionary(memory, effect.afterScope, sliceContent);
+  assert(visible !== undefined, "ROOT form must be visible in dictionary before source replay");
+  same(visible.form, basis.R, "dictionary accepts ROOT as the selected form");
+  assert(visible.occurrences.includes(effect.occurrence), "dictionary exposes exact ROOT-form occurrence");
+
+  const source = defineSourceForm(
+    memory,
+    materializeSourceContent(memory, new Uint8Array([0x61])),
+  );
+  const evidence = buildSelectedSourceEvidence(
+    memory,
+    source,
+    [{
+      start: 0,
+      end: 1,
+      form: basis.R,
+      dictionaryOccurrence: effect.occurrence,
+    }],
+    { dictionary: effect.afterScope, grammar: basis.L, theory: basis.U },
+  );
+
+  same(evidence.segments.length, 1, "builder preserves one selected segment in host evidence");
+  same(evidence.segments[0]?.form, basis.R, "builder preserves ROOT form on segment");
+  same(evidence.formSequence, basis.R, "legacy rooted fold collapses [R] to empty carrier R");
+  sameHandles(readRootedSequence(memory, evidence.formSequence).values, [], "reader sees collapsed form sequence as empty");
+
+  const beforeReplay = memory.linkCount;
+  expectSourceError(
+    () => replaySelectedSourceEvidence(memory, evidence),
+    "invalid-source-evidence",
+  );
+  same(memory.linkCount, beforeReplay, "failed replay remains read-only");
+}
+
+// Control: the same one-segment builder/replay path round-trips when the form is
+// outside the restricted carrier's ROOT collision.
+{
+  const memory = new Memory();
+  const basis = ensureRootBasis(memory);
+  const sliceContent = materializeSourceContent(memory, new Uint8Array([0x62]));
+  const form = basis.L;
+
+  const beforeScope = defineDictionaryScope(memory, basis.R, basis.R);
+  const effect = defineDictionaryEffect(
+    memory,
+    beforeScope,
+    basis.R,
+    basis.R,
+    sliceContent,
+    form,
+  );
+  const source = defineSourceForm(
+    memory,
+    materializeSourceContent(memory, new Uint8Array([0x62])),
+  );
+  const evidence = buildSelectedSourceEvidence(
+    memory,
+    source,
+    [{
+      start: 0,
+      end: 1,
+      form,
+      dictionaryOccurrence: effect.occurrence,
+    }],
+    { dictionary: effect.afterScope, grammar: basis.C, theory: basis.U },
+  );
+
+  sameHandles(readRootedSequence(memory, evidence.formSequence).values, [form], "non-ROOT form carrier");
+  const beforeReplay = memory.linkCount;
+  sameHandles(replaySelectedSourceEvidence(memory, evidence), [form], "non-ROOT builder/replay round-trip");
+  same(memory.linkCount, beforeReplay, "successful replay remains read-only");
+}


### PR DESCRIPTION
Closes #744. Refs #657, #606, #734/#735, #736/#737, #738/#739.

## Counterexample

`formSequence` was still using the restricted rooted left-fold even though dictionary `form` may legally be `R`:

```text
Fold([])  = R
Fold([R]) = R⟼R = R
```

Initial test-only witness on head `e050ed0f8edf4a08f1502ef8d683bee313bac222` proved:
- dictionary resolves `sourceContent -> R` as valid visible evidence;
- `buildSelectedSourceEvidence` accepts one segment with `form=R`;
- legacy `formSequence` collapses to `R` and reads back as `[]`;
- replay then rejects its own builder output as `invalid-source-evidence`;
- non-ROOT control round-trips;
- replay remains read-only.

Witness CI #3091 was green.

## Classification

Accepted v0.9 authority already distinguishes:

```text
EXACT_SEQUENCE
FOLD_RESULT
RESTRICTED_ROOTED_SEQUENCE
```

with:

```text
ExactSequence positions containing R are preserved
RestrictedRootedSequence requires a root-excluded value domain
```

Issue #606 explicitly named `FORMAL/formSequence evidence` as a minimum use-site for ExactSequence when positional identity may contain R.

Therefore:

- H0 (forbid ROOT forms) is rejected: no accepted form-domain restriction justifies it;
- H2 (host length/order/call identity) is rejected: it imports external occurrence/history and does not fix structural membership identity;
- H1 is accepted: position-sensitive `formSequence` uses the already accepted `ExactSequence<form>` carrier.

`selectionSequence` intentionally remains the restricted rooted fold: a valid selection cannot be `R` because it is `dictionaryOccurrence ⟼ resolution`, and a valid dictionary occurrence cannot itself be ROOT (its start is a valid non-ROOT dictionary scope).

Final classification:

```text
theory semantic delta                 = NONE
new primitive                         = NONE
form domain delta                     = NONE
formSequence evidence/topology delta  = YES
public TypeScript signature delta     = NONE
public evidence compatibility delta   = YES for legacy manually supplied formSequence
accepted contract delta               = NONE
MTS v0.11                             = NOT REQUIRED
result                                = EVIDENCE/CARRIER MIGRATION / NO THEORY DELTA
```

## Implementation

`ts/src/source.ts` now:
- materializes selected forms with `materializeExactSequence`;
- verifies full and subselection form carriers with `readExactSequence`;
- keeps `selectionSequence` on the rooted restricted carrier;
- keeps grammar/theory membership shape unchanged (`container ⟼ formSequence`);
- keeps replay read-only.

Fixtures that manually construct `SourceSubselectionEvidence` were migrated narrowly to ExactSequence forms. The new regression retains an explicit witness of the old rooted `[R] -> R` collision and requires successful `ExactSequence([R])` builder/replay round-trip.

CI history:

```text
#3091 green  — test-only witness
#3097 red    — correctly exposed one stale relation-subselection fixture
#3099 green  — final migration, all 5 jobs success
```

Current final head before ready transition:

```text
b8287fefaf4ebee71c34a6a9b041153c84c571ef
```

```repo-guard-yaml
change_type: fix
scope:
  - ts/src/source.ts
  - ts/test/v010-source-root-form-sequence-collision.test.ts
  - ts/test/source-subselection.test.ts
  - ts/test/interpreter-relation.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 190
must_touch:
  - ts/src/source.ts
  - ts/test/v010-source-root-form-sequence-collision.test.ts
  - ts/test/source-subselection.test.ts
  - ts/test/interpreter-relation.test.ts
must_not_touch:
  - contracts/**
  - docs/**
  - cutover/**
  - repo-policy.json
  - .github/**
expected_effects:
  - migrate position-sensitive source formSequence to accepted ExactSequence carrier
  - preserve ROOT as a legal dictionary form
  - restore builder-to-replay round-trip for ROOT forms
  - preserve selectionSequence restricted rooted carrier
  - preserve grammar/theory structural memberships over formSequence
  - preserve read-only replay
  - no theory, primitive, contract, public signature or release lifecycle delta
```