### PR TITLE
chore(#756): open temporary v0.11 contract slots

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -236,8 +236,8 @@
       "scope": "directory",
       "metric": "files",
       "glob": "contracts/**",
-      "max": 4,
-      "max_growth": 0,
+      "max": 6,
+      "max_growth": 2,
       "count": "all_tracked",
       "level": "blocking"
     },


### PR DESCRIPTION
Closes #756.

Governance-only preparation for MTS v0.11 candidate lifecycle (#755).

Exact diff:

```text
repo-policy.json only
contracts-file-count-no-growth.max:        4 -> 6
contracts-file-count-no-growth.max_growth: 0 -> 2
```

No `contracts/**` files are added or changed here. Accepted MTS v0.10 remains current; v0.9 remains previous immutable evidence. Current/previous/cutover pointers, runtime, docs, workflows, document relations and evidence bindings are unchanged.

The two temporary slots will be consumed only by a separate M1 candidate-pair PR after this governance step is merged and reverified. This repeats the repository's existing safe candidate lifecycle pattern.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 2
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - .github/**
  - ts/**
  - README.md
  - docs/**
expected_effects:
  - reserve two temporary contract slots for v0.11 candidate coexistence
  - preserve v0.10 current and v0.9 previous pointers
```

```repo-guard-grant
authorized_governance_paths:
  - repo-policy.json
allow_policy_relaxation:
  - /size_rules/contracts-file-count-no-growth/max
  - /size_rules/contracts-file-count-no-growth/max_growth
```

No other policy relaxation is authorized. The temporary `6/2` budget is lifecycle debt and must return to `4/0` after v0.11 acceptance/rotation (or candidate abandonment).