### PR TITLE
feat(v0.11): preserve nested explicit contextual binding

### DIFF
--- a/ts/src/interpreter.ts
+++ b/ts/src/interpreter.ts
@@ -179,17 +179,22 @@ export interface FlatReadingEvidence {
 }
 
 /**
- * v0.11 top-level contextual reading keeps source admission and contextual
- * binding separate. The host schema names the Act field; the admitted
- * Role_ctx value itself is explicit Act evidence, not host-only authority.
+ * v0.11 contextual reading keeps source admission and contextual binding
+ * separate. The Act names both the explicit K and the admitted Role_ctx;
+ * neither glyph shape nor ambient host state is semantic authority.
  */
-export interface TopLevelContextualReadingRoles extends FlatReadingRoles {
+export interface ContextualReadingRoles extends FlatReadingRoles {
   readonly contextualRole: LinkHandle;
 }
 
-export interface TopLevelContextualReadingEvidence extends Omit<FlatReadingEvidence, "roles"> {
-  readonly roles: TopLevelContextualReadingRoles;
+export interface ContextualReadingEvidence extends Omit<FlatReadingEvidence, "roles"> {
+  readonly roles: ContextualReadingRoles;
 }
+
+// The top-level operation has the same evidence shape; its extra invariant is
+// checked by replayTopLevelContextualReading rather than encoded as a host type.
+export type TopLevelContextualReadingRoles = ContextualReadingRoles;
+export type TopLevelContextualReadingEvidence = ContextualReadingEvidence;
 
 interface FlatSelection {
   readonly selectionSequence: LinkHandle;
@@ -277,47 +282,67 @@ export function replayFlatReading(
   ));
 }
 
+function replayExplicitContextualReading(
+  memory: ReadMemory,
+  evidence: ContextualReadingEvidence,
+  topLevelOnly: boolean,
+): LinkHandle {
+  const before = memory.linkCount;
+  const forms = replaySelectedSourceEvidence(memory, evidence.sourceEvidence);
+  const beforeContextRef = readRequiredSingle(
+    memory,
+    evidence.act,
+    evidence.roles.beforeContext,
+  );
+  const contextualRole = readRequiredSingle(
+    memory,
+    evidence.act,
+    evidence.roles.contextualRole,
+  );
+  const context = readContext(memory, beforeContextRef);
+  if (topLevelOnly && (context.parent !== memory.root || context.current !== memory.root)) {
+    invalidFlat();
+  }
+  if (!forms.includes(contextualRole)) invalidFlat();
+
+  const resolvedForms = Object.freeze(forms.map((form) =>
+    form === contextualRole ? context.current : form
+  ));
+  const result = replaySelectedFlat(
+    memory,
+    evidence,
+    evidence.sourceEvidence,
+    resolvedForms,
+    false,
+  );
+  if (memory.linkCount !== before) invalidFlat();
+  return result;
+}
+
 /**
- * Candidate v0.11 TopBind(R,S) replay. The Act must name the canonical
- * top-level K with explicit `parent=R,current=R`; K itself remains O=START(R).
- * Only forms equal to the explicitly evidenced contextual Role_ctx are
- * substituted. The existing flat verifier still owns fold/result/context/header
- * checks, so this adds no second fold or context engine.
+ * Replays an admitted contextual occurrence against the K explicitly named by
+ * the Act. This is the production boundary for accepted `A:E` compatibility:
+ * Role_ctx resolves to that K.current only. Parent traversal, ambient current,
+ * host stack discovery and a second fold engine are deliberately absent.
+ */
+export function replayContextualReading(
+  memory: ReadMemory,
+  evidence: ContextualReadingEvidence,
+): LinkHandle {
+  return normalizeFlat(() => replayExplicitContextualReading(memory, evidence, false));
+}
+
+/**
+ * Candidate v0.11 TopBind(R,S) replay. It reuses the same explicit-context
+ * kernel but additionally requires `parent(K)=R,current(K)=R`; K itself remains
+ * O=START(R). A nested A:E context therefore cannot be captured by this
+ * automatic top-level rule.
  */
 export function replayTopLevelContextualReading(
   memory: ReadMemory,
   evidence: TopLevelContextualReadingEvidence,
 ): LinkHandle {
-  return normalizeFlat(() => {
-    const before = memory.linkCount;
-    const forms = replaySelectedSourceEvidence(memory, evidence.sourceEvidence);
-    const beforeContextRef = readRequiredSingle(
-      memory,
-      evidence.act,
-      evidence.roles.beforeContext,
-    );
-    const contextualRole = readRequiredSingle(
-      memory,
-      evidence.act,
-      evidence.roles.contextualRole,
-    );
-    const top = readContext(memory, beforeContextRef);
-    if (top.parent !== memory.root || top.current !== memory.root) invalidFlat();
-    if (!forms.includes(contextualRole)) invalidFlat();
-
-    const resolvedForms = Object.freeze(forms.map((form) =>
-      form === contextualRole ? top.current : form
-    ));
-    const result = replaySelectedFlat(
-      memory,
-      evidence,
-      evidence.sourceEvidence,
-      resolvedForms,
-      false,
-    );
-    if (memory.linkCount !== before) invalidFlat();
-    return result;
-  });
+  return normalizeFlat(() => replayExplicitContextualReading(memory, evidence, true));
 }
 
 function replayFlatSubselection(

--- a/ts/test/v011-nested-explicit-binding-compatibility.test.ts
+++ b/ts/test/v011-nested-explicit-binding-compatibility.test.ts
@@ -1,0 +1,332 @@
+import {
+  defineDictionaryEffect,
+  defineDictionaryScope,
+} from "../src/dictionary.js";
+import { readExactSequence } from "../src/exact-sequence.js";
+import {
+  InterpreterReplayError,
+  replayContextualReading,
+  replayTopLevelContextualReading,
+  type ContextualReadingEvidence,
+  type ContextualReadingRoles,
+} from "../src/interpreter.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+  type RootBasis,
+} from "../src/memory.js";
+import {
+  buildSelectedSourceEvidence,
+  defineSourceForm,
+  materializeSourceContent,
+  readSourceContent,
+  replaySelectedSourceEvidence,
+  type SelectedSegmentSpec,
+  type SourceFrontEndEvidence,
+} from "../src/source.js";
+import { defineContext, readContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+} from "../src/structural-rule.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`v0.11 nested explicit binding: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function deepSame(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function reject(message: string, effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof InterpreterReplayError, `${message}: expected InterpreterReplayError`);
+    same(error.code, "invalid-flat-evidence", `${message}: error code`);
+    return;
+  }
+  throw new Error(`v0.11 nested explicit binding: ${message}: expected rejection`);
+}
+
+class Probe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined {
+    throw new Error("C4 contextual replay must not use find/ambient lookup");
+  }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    return this.source.outgoing(start);
+  }
+  incoming(): readonly LinkHandle[] {
+    throw new Error("C4 contextual replay must not scan incoming");
+  }
+}
+
+function anchors(memory: Memory, count: number): readonly LinkHandle[] {
+  const result: LinkHandle[] = [];
+  const seed = memory.ensureEndSelfClosed(memory.root);
+  let tag = memory.ensureStartSelfClosed(memory.root);
+  for (let index = 0; index < count; index += 1) {
+    tag = memory.ensureStartSelfClosed(tag);
+    result.push(memory.ensure(seed, tag));
+  }
+  return Object.freeze(result);
+}
+
+interface DictionaryFixture {
+  readonly dictionary: LinkHandle;
+  readonly occurrence: LinkHandle;
+}
+
+function oneEntryDictionary(
+  memory: Memory,
+  sourceContent: LinkHandle,
+  form: LinkHandle,
+): DictionaryFixture {
+  const before = defineDictionaryScope(memory, memory.root, memory.root);
+  const effect = defineDictionaryEffect(
+    memory,
+    before,
+    memory.root,
+    memory.root,
+    sourceContent,
+    form,
+  );
+  return Object.freeze({ dictionary: effect.afterScope, occurrence: effect.occurrence });
+}
+
+function sourceEvidence(
+  memory: Memory,
+  form: LinkHandle,
+  dictionary: DictionaryFixture,
+  grammar: LinkHandle,
+  theory: LinkHandle,
+): SourceFrontEndEvidence {
+  const bytes = new Uint8Array([0x2e]);
+  const content = materializeSourceContent(memory, bytes);
+  const source = defineSourceForm(memory, content);
+  const specs: readonly SelectedSegmentSpec[] = Object.freeze([
+    Object.freeze({
+      start: 0,
+      end: 1,
+      form,
+      dictionaryOccurrence: dictionary.occurrence,
+    }),
+  ]);
+  return buildSelectedSourceEvidence(
+    memory,
+    source,
+    specs,
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+}
+
+function roles(memory: Memory): ContextualReadingRoles {
+  const values = anchors(memory, 20).slice(10);
+  assert(values.length === 10, "role vocabulary");
+  return Object.freeze({
+    source: values[0]!,
+    sourceSelection: values[1]!,
+    formSequence: values[2]!,
+    dictionary: values[3]!,
+    grammar: values[4]!,
+    theory: values[5]!,
+    beforeContext: values[6]!,
+    contextualRole: values[7]!,
+    result: values[8]!,
+    afterContext: values[9]!,
+  });
+}
+
+function roleList(value: ContextualReadingRoles): readonly LinkHandle[] {
+  return Object.freeze([
+    value.source,
+    value.sourceSelection,
+    value.formSequence,
+    value.dictionary,
+    value.grammar,
+    value.theory,
+    value.beforeContext,
+    value.contextualRole,
+    value.result,
+    value.afterContext,
+  ]);
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly basis: RootBasis;
+  readonly dotRole: LinkHandle;
+  readonly A: LinkHandle;
+  readonly B: LinkHandle;
+  readonly grammar: LinkHandle;
+  readonly theory: LinkHandle;
+  readonly sourceEvidence: SourceFrontEndEvidence;
+  readonly vocabulary: ContextualReadingRoles;
+  readonly outerContext: LinkHandle;
+  readonly innerContext: LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const basis = ensureRootBasis(memory);
+  const pool = anchors(memory, 10);
+  const dotRole = pool[0];
+  const A = pool[1];
+  const B = pool[2];
+  const grammar = pool[3];
+  const theory = pool[4];
+  assert(dotRole && A && B && grammar && theory, "fixture anchors");
+  assert(A !== B, "outer and inner contextual wholes must differ");
+
+  const dotMeaning = memory.ensure(basis.L, basis.R);
+  assert(dotRole !== dotMeaning, "Role_ctx must remain distinct from DotMeaning=L⟼R");
+  assert(
+    ![basis.O, basis.C, basis.L, basis.U].includes(dotRole),
+    "Role_ctx must remain outside Q=[ ]10",
+  );
+
+  const dotContent = materializeSourceContent(memory, new Uint8Array([0x2e]));
+  const dictionary = oneEntryDictionary(memory, dotContent, dotRole);
+  const admittedSource = sourceEvidence(memory, dotRole, dictionary, grammar, theory);
+  const vocabulary = roles(memory);
+
+  const outerContext = defineContext(memory, memory.root, A);
+  const innerContext = defineContext(memory, outerContext, B);
+  const outer = readContext(memory, outerContext);
+  const inner = readContext(memory, innerContext);
+  same(outer.parent, memory.root, "outer K parent");
+  same(outer.current, A, "outer K current");
+  same(inner.parent, outerContext, "v011-production-inner-parent-is-explicit-outer-K");
+  same(inner.current, B, "inner K current");
+  same(readContext(memory, outerContext).current, A, "v011-production-outer-current-remains-unchanged");
+
+  return Object.freeze({
+    memory,
+    basis,
+    dotRole,
+    A,
+    B,
+    grammar,
+    theory,
+    sourceEvidence: admittedSource,
+    vocabulary,
+    outerContext,
+    innerContext,
+  });
+}
+
+function act(
+  f: Fixture,
+  beforeContext: LinkHandle,
+  result: LinkHandle,
+  afterContext: LinkHandle,
+): ContextualReadingEvidence {
+  const { memory, vocabulary, sourceEvidence: source } = f;
+  const interpreter = defineStructuralInterpreter(
+    memory,
+    source.dictionary,
+    source.grammar,
+    source.theory,
+  );
+  const roleDictionary = defineStructuralRoleDictionary(memory, roleList(vocabulary));
+  const value = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+  const fields: readonly [LinkHandle, LinkHandle][] = [
+    [vocabulary.source, source.source],
+    [vocabulary.sourceSelection, source.selectionSequence],
+    [vocabulary.formSequence, source.formSequence],
+    [vocabulary.dictionary, source.dictionary],
+    [vocabulary.grammar, source.grammar],
+    [vocabulary.theory, source.theory],
+    [vocabulary.beforeContext, beforeContext],
+    [vocabulary.contextualRole, f.dotRole],
+    [vocabulary.result, result],
+    [vocabulary.afterContext, afterContext],
+  ];
+  for (const [role, fieldValue] of fields) {
+    defineActField(memory, value, role, fieldValue);
+  }
+  return Object.freeze({
+    sourceEvidence: source,
+    act: value,
+    roles: vocabulary,
+    interpreter,
+    roleDictionary,
+  });
+}
+
+{
+  const f = fixture();
+  const probe = new Probe(f.memory);
+
+  deepSame(
+    replaySelectedSourceEvidence(probe, f.sourceEvidence),
+    [f.dotRole],
+    "v011-production-nested-source-admission-remains-explicit",
+  );
+  deepSame(
+    readExactSequence(probe, f.sourceEvidence.formSequence).values,
+    [f.dotRole],
+    "physical dot keeps one explicit Role_ctx occurrence",
+  );
+  deepSame(
+    Array.from(readSourceContent(probe, f.basis, f.sourceEvidence.content).bytes),
+    [0x2e],
+    "physical source remains exact dot byte",
+  );
+
+  const innerEvidence = act(f, f.innerContext, f.B, f.innerContext);
+  const before = f.memory.linkCount;
+  same(
+    replayContextualReading(probe, innerEvidence),
+    f.B,
+    "v011-production-nested-dot-uses-inner-explicit-current",
+  );
+  same(f.memory.linkCount, before, "v011-production-nested-replay-is-read-only");
+  same(readContext(probe, f.outerContext).current, f.A, "outer current remains A after inner replay");
+
+  // The v0.11 automatic ROOT binder is a strict wrapper over the same kernel.
+  // It must not reinterpret a nested explicit A:E context as TopBind(R,S).
+  reject("v011-production-top-level-resolver-rejects-inner-K", () =>
+    replayTopLevelContextualReading(probe, innerEvidence)
+  );
+  same(f.memory.linkCount, before, "top-level rejection must remain read-only");
+}
+
+{
+  const f = fixture();
+  const probe = new Probe(f.memory);
+  const outerEvidence = act(f, f.outerContext, f.A, f.outerContext);
+  const before = f.memory.linkCount;
+  same(
+    replayContextualReading(probe, outerEvidence),
+    f.A,
+    "v011-production-outer-dot-still-uses-outer-explicit-current",
+  );
+  same(f.memory.linkCount, before, "outer replay is read-only");
+
+  // An Act naming the outer K cannot claim the inner whole B: there is no
+  // ambient nearest/current lookup that can silently replace the named K.
+  const forgedAfter = defineContext(f.memory, f.memory.root, f.B);
+  const wrongAuthority = act(f, f.outerContext, f.B, forgedAfter);
+  const afterConstruction = f.memory.linkCount;
+  reject("outer K cannot claim inner current", () =>
+    replayContextualReading(new Probe(f.memory), wrongAuthority)
+  );
+  same(f.memory.linkCount, afterConstruction, "wrong-authority rejection is read-only");
+}


### PR DESCRIPTION
Closes #787. Refs #755, #657, #783, #786, #775, #782.

## Purpose

Complete the C4 production compatibility implementation/evidence slice for accepted explicit nested `A:E` semantics under the v0.11 top-level ROOT-binding delta.

Exact opening baseline:

```text
main = fbbdbe55120620165480d980a42e535bc383f6e1
accepted current = MTS v0.10
previous = MTS v0.9
v0.11 = candidate / NOT ACCEPTED
C1 = green-supported / machine-bound
C2 = green-classified / machine-bound
C3 = green-implemented / machine-bound
C4 = research-green / production evidence pending
Q compatibility = pending
```

## Falsified initial hypothesis

Read-only inspection first preferred a test-only C4 witness. That was rejected after inspecting the production boundary:

```text
v0.10 nested A:E semantics
  existed as production-module composition in v010-contextual-dot.test.ts

interpreter.ts before this PR
  had replayTopLevelContextualReading
  mapped admitted Role_ctx -> explicit K.current
  BUT intentionally accepted only parent(K)=R,current(K)=R

missing production boundary
  no interpreter replay for the same accepted operation over an arbitrary explicit K
```

A test-only PR would therefore have reimplemented the missing binding step in test code rather than proving production compatibility.

## Minimal production delta

`ts/src/interpreter.ts` now factors one shared explicit-context kernel:

```text
Act explicitly names K
Act explicitly names contextual Role_ctx
source front-end replays admitted forms
Role_ctx positions -> readContext(K).current
existing replaySelectedFlat owns fold/result/afterContext/header verification
```

Two entry points use that one kernel:

```text
replayContextualReading(...)
  accepted explicit A:E compatibility
  arbitrary valid Act-named K

replayTopLevelContextualReading(...)
  same kernel
  + strict parent(K)=R,current(K)=R guard
```

Therefore C3 is not weakened: a nested K cannot become an automatic `TopBind(R,S)`.

No context discovery was added. The generic replay does not scan parents, consult a host stack, read an ambient current, use glyph shape as authority, materialize links, or create a second fold engine.

## Focused C4 production evidence

New test:

```text
ts/test/v011-nested-explicit-binding-compatibility.test.ts
```

It composes the real source/dictionary/interpreter/context boundaries and proves:

```text
physical 0x2E -> exact admitted Role_ctx
Role_ctx != DotMeaning=L⟼R
Role_ctx remains outside Q=[ ]10

outer K: parent=R, current=A
inner K: parent=outer K, current=B
A != B

replayContextualReading(inner K) -> B
replayContextualReading(outer K) -> A
outer K cannot claim B
replayTopLevelContextualReading(inner K) -> reject
all replay/rejection paths remain read-only
```

This is the required C4 interaction proof: nearest explicitly selected structural K remains authoritative and the v0.11 automatic top-level rule cannot capture a nested explicit binder/view scope.

## Lifecycle separation

This PR changes production code + focused executable evidence only. It deliberately does **not** modify the v0.11 contract/conformance lifecycle. After green merge, C4 evidence will be machine-bound in a separate governance slice.

## Invariants deliberately unchanged

```text
accepted v0.9/v0.10 untouched
v0.11 accepted=false
v0.11 acceptanceReady=false
Q alphabet=[ ]10
no public.ts delta
no context topology delta
no colon PUSH/POP lifecycle
no ambient current
no host stack semantic authority
no parent-navigation semantics for dot
no hidden ROOT prefix
READ/replay remains read-only
```

```repo-guard-yaml
change_type: implementation
scope:
  - ts/src/interpreter.ts
  - ts/test/v011-nested-explicit-binding-compatibility.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 420
must_touch:
  - ts/src/interpreter.ts
  - ts/test/v011-nested-explicit-binding-compatibility.test.ts
must_not_touch:
  - contracts/**
  - repo-policy.json
  - README.md
  - docs/**
  - cutover/**
  - .github/**
  - ts/src/public.ts
expected_effects:
  - add one production replay boundary for contextual Role_ctx against an explicitly Act-named K
  - reuse the existing flat fold/result/context/header verifier rather than introduce a second engine
  - preserve strict TopBind(R,S) root/root guard for automatic top-level binding
  - prove nested explicit A:E binding remains authoritative and read-only
  - preserve Q alphabet, accepted v0.10 and current candidate lifecycle state
```

## Merge gates

```text
full CI green
blocking repo-guard green
behind_by=0
PR mergeable
stable final head
merge with expected_head_sha
confirm exact new main
claim exact post-merge CI only if workflows exist for merge SHA
```