### PR TITLE
policy(v0.11): remove obsolete incomplete coverage pin

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,9 +1,7 @@
 {
   "policy_format_version": "0.3.0",
   "repository_kind": "documentation",
-  "enforcement": {
-    "mode": "blocking"
-  },
+  "enforcement": {"mode": "blocking"},
   "integration": {
     "workflows": [
       {
@@ -57,278 +55,54 @@
   },
   "document_relations": {
     "documents": {
-      "candidate-v09-contract": {
-        "path": "contracts/mts-contract-v0.9.json",
-        "format": "json"
-      },
-      "candidate-v09-conformance": {
-        "path": "contracts/mts-conformance-v0.9.json",
-        "format": "json"
-      },
-      "candidate-v010-contract": {
-        "path": "contracts/mts-contract-v0.10.json",
-        "format": "json"
-      },
-      "candidate-v010-conformance": {
-        "path": "contracts/mts-conformance-v0.10.json",
-        "format": "json"
-      },
-      "candidate-v011-contract": {
-        "path": "contracts/mts-contract-v0.11.json",
-        "format": "json"
-      },
-      "candidate-v011-conformance": {
-        "path": "contracts/mts-conformance-v0.11.json",
-        "format": "json"
-      }
+      "candidate-v09-contract": {"path": "contracts/mts-contract-v0.9.json", "format": "json"},
+      "candidate-v09-conformance": {"path": "contracts/mts-conformance-v0.9.json", "format": "json"},
+      "candidate-v010-contract": {"path": "contracts/mts-contract-v0.10.json", "format": "json"},
+      "candidate-v010-conformance": {"path": "contracts/mts-conformance-v0.10.json", "format": "json"},
+      "candidate-v011-contract": {"path": "contracts/mts-contract-v0.11.json", "format": "json"},
+      "candidate-v011-conformance": {"path": "contracts/mts-conformance-v0.11.json", "format": "json"}
     },
     "rules": [
-      {
-        "id": "v09-contract-semantic-base-v08",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-contract/v0.8"
-      },
-      {
-        "id": "v09-conformance-semantic-base-v08",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-conformance/v0.8"
-      },
-      {
-        "id": "v09-contract-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v09-conformance-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v09-contract-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v09-conformance-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v010-contract-schema",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/schema", "type": "string"},
-        "value": "mts-contract/v0.10"
-      },
-      {
-        "id": "v010-conformance-contract",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/contract", "type": "string"},
-        "value": "mts-contract/v0.10"
-      },
-      {
-        "id": "v010-contract-corpus",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/conformanceCorpus", "type": "string"},
-        "value": "contracts/mts-conformance-v0.10.json"
-      },
-      {
-        "id": "v010-contract-semantic-base-v09",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-contract/v0.9"
-      },
-      {
-        "id": "v010-conformance-semantic-base-v09",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-conformance/v0.9"
-      },
-      {
-        "id": "v010-contract-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v010-conformance-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v010-contract-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v010-conformance-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v010-conformance-complete",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v010-conformance", "pointer": "/coverageState", "type": "string"},
-        "value": "complete"
-      },
-      {
-        "id": "v011-contract-schema",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/schema", "type": "string"},
-        "value": "mts-contract/v0.11"
-      },
-      {
-        "id": "v011-conformance-contract",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/contract", "type": "string"},
-        "value": "mts-contract/v0.11"
-      },
-      {
-        "id": "v011-contract-corpus",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/conformanceCorpus", "type": "string"},
-        "value": "contracts/mts-conformance-v0.11.json"
-      },
-      {
-        "id": "v011-contract-semantic-base-v010",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-contract/v0.10"
-      },
-      {
-        "id": "v011-conformance-semantic-base-v010",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-conformance/v0.10"
-      },
-      {
-        "id": "v011-contract-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v011-conformance-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v011-contract-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-conformance-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-contract-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-conformance-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-contract-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v011-conformance-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v011-conformance-incomplete",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/coverageState", "type": "string"},
-        "value": "incomplete"
-      },
-      {
-        "id": "v011-top-bind-is-root-structural-binding",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/topLevelBinding", "type": "string"},
-        "value": "TopBind(R,S)"
-      },
-      {
-        "id": "v011-top-dot-resolves-root",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/topLevelDotResolution", "type": "string"},
-        "value": "resolve_top(.) = R"
-      },
-      {
-        "id": "v011-zero-whole-not-frame",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/wholeEqualsExecutionFrame", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-no-ambient-runtime-current",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/ambientRuntimeCurrentIsSemanticAuthority", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-no-hidden-root-prefix",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/hiddenLiteralRootPrefixInserted", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-dot-not-q-abit",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/foundation/dotIsQAbit", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-colon-not-q-abit",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/foundation/colonIsQAbit", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-c1-supported",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/representationBootstrap/firstPhysicalDotAdmissionStatus", "type": "string"},
-        "value": "supported-c1"
-      },
-      {
-        "id": "v011-c2-classified",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/foundation/minimalSignBasisStatus", "type": "string"},
-        "value": "classified-c2-semantic-derived-presentation-cycle-retained"
-      },
-      {
-        "id": "v011-production-behavior-changed-in-c3",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/implementation/productionBehaviorChanged", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v011-runtime-implementation-complete-after-c4",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/implementation/implementationComplete", "type": "boolean"},
-        "value": true
-      }
+      {"id":"v09-contract-semantic-base-v08","kind":"scalar_equals_literal","source":{"document":"candidate-v09-contract","pointer":"/semanticBase","type":"string"},"value":"mts-contract/v0.8"},
+      {"id":"v09-conformance-semantic-base-v08","kind":"scalar_equals_literal","source":{"document":"candidate-v09-conformance","pointer":"/semanticBase","type":"string"},"value":"mts-conformance/v0.8"},
+      {"id":"v09-contract-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v09-contract","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
+      {"id":"v09-conformance-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v09-conformance","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
+      {"id":"v09-contract-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v09-contract","pointer":"/acceptanceReady","type":"boolean"},"value":true},
+      {"id":"v09-conformance-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v09-conformance","pointer":"/acceptanceReady","type":"boolean"},"value":true},
+      {"id":"v010-contract-schema","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/schema","type":"string"},"value":"mts-contract/v0.10"},
+      {"id":"v010-conformance-contract","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/contract","type":"string"},"value":"mts-contract/v0.10"},
+      {"id":"v010-contract-corpus","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/conformanceCorpus","type":"string"},"value":"contracts/mts-conformance-v0.10.json"},
+      {"id":"v010-contract-semantic-base-v09","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/semanticBase","type":"string"},"value":"mts-contract/v0.9"},
+      {"id":"v010-conformance-semantic-base-v09","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/semanticBase","type":"string"},"value":"mts-conformance/v0.9"},
+      {"id":"v010-contract-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/acceptanceReady","type":"boolean"},"value":true},
+      {"id":"v010-conformance-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/acceptanceReady","type":"boolean"},"value":true},
+      {"id":"v010-contract-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
+      {"id":"v010-conformance-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
+      {"id":"v010-conformance-complete","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/coverageState","type":"string"},"value":"complete"},
+      {"id":"v011-contract-schema","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/schema","type":"string"},"value":"mts-contract/v0.11"},
+      {"id":"v011-conformance-contract","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/contract","type":"string"},"value":"mts-contract/v0.11"},
+      {"id":"v011-contract-corpus","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/conformanceCorpus","type":"string"},"value":"contracts/mts-conformance-v0.11.json"},
+      {"id":"v011-contract-semantic-base-v010","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/semanticBase","type":"string"},"value":"mts-contract/v0.10"},
+      {"id":"v011-conformance-semantic-base-v010","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/semanticBase","type":"string"},"value":"mts-conformance/v0.10"},
+      {"id":"v011-contract-status-candidate","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/status","type":"string"},"value":"candidate"},
+      {"id":"v011-conformance-status-candidate","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/status","type":"string"},"value":"candidate"},
+      {"id":"v011-contract-not-accepted","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/accepted","type":"boolean"},"value":false},
+      {"id":"v011-conformance-not-accepted","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/accepted","type":"boolean"},"value":false},
+      {"id":"v011-contract-not-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/acceptanceReady","type":"boolean"},"value":false},
+      {"id":"v011-conformance-not-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/acceptanceReady","type":"boolean"},"value":false},
+      {"id":"v011-contract-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
+      {"id":"v011-conformance-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
+      {"id":"v011-top-bind-is-root-structural-binding","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/topLevelBinding","type":"string"},"value":"TopBind(R,S)"},
+      {"id":"v011-top-dot-resolves-root","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/topLevelDotResolution","type":"string"},"value":"resolve_top(.) = R"},
+      {"id":"v011-zero-whole-not-frame","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/wholeEqualsExecutionFrame","type":"boolean"},"value":false},
+      {"id":"v011-no-ambient-runtime-current","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/ambientRuntimeCurrentIsSemanticAuthority","type":"boolean"},"value":false},
+      {"id":"v011-no-hidden-root-prefix","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/hiddenLiteralRootPrefixInserted","type":"boolean"},"value":false},
+      {"id":"v011-dot-not-q-abit","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/foundation/dotIsQAbit","type":"boolean"},"value":false},
+      {"id":"v011-colon-not-q-abit","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/foundation/colonIsQAbit","type":"boolean"},"value":false},
+      {"id":"v011-c1-supported","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/representationBootstrap/firstPhysicalDotAdmissionStatus","type":"string"},"value":"supported-c1"},
+      {"id":"v011-c2-classified","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/foundation/minimalSignBasisStatus","type":"string"},"value":"classified-c2-semantic-derived-presentation-cycle-retained"},
+      {"id":"v011-production-behavior-changed-in-c3","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/implementation/productionBehaviorChanged","type":"boolean"},"value":true},
+      {"id":"v011-runtime-implementation-complete-after-c4","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/implementation/implementationComplete","type":"boolean"},"value":true}
     ]
   },
   "evidence_bindings": [
@@ -429,36 +203,18 @@
     }
   ],
   "cochange_rules": [
+    {"if_changed": ["contracts/mts-contract-v0.9.json"], "must_change_any": ["contracts/mts-conformance-v0.9.json"]},
+    {"if_changed": ["contracts/mts-conformance-v0.9.json"], "must_change_any": ["contracts/mts-contract-v0.9.json"]},
     {
-      "if_changed": ["contracts/mts-contract-v0.9.json"],
-      "must_change_any": ["contracts/mts-conformance-v0.9.json"]
-    },
-    {
-      "if_changed": ["contracts/mts-conformance-v0.9.json"],
-      "must_change_any": ["contracts/mts-contract-v0.9.json"]
-    },
-    {
-      "if_changed": [
-        "contracts/mts-contract-v*.json",
-        "contracts/mts-conformance-v*.json",
-        "cutover/typescript-c1-acceptance-v*.json"
-      ],
+      "if_changed": ["contracts/mts-contract-v*.json", "contracts/mts-conformance-v*.json", "cutover/typescript-c1-acceptance-v*.json"],
       "must_change_any": ["README.md"]
     },
     {
-      "if_changed": [
-        "contracts/mts-contract-v*.json",
-        "contracts/mts-conformance-v*.json",
-        "cutover/typescript-c1-acceptance-v*.json"
-      ],
+      "if_changed": ["contracts/mts-contract-v*.json", "contracts/mts-conformance-v*.json", "cutover/typescript-c1-acceptance-v*.json"],
       "must_change_any": ["docs/theory/Основания МТС.md"]
     },
     {
-      "if_changed": [
-        "contracts/mts-contract-v*.json",
-        "contracts/mts-conformance-v*.json",
-        "cutover/typescript-c1-acceptance-v*.json"
-      ],
+      "if_changed": ["contracts/mts-contract-v*.json", "contracts/mts-conformance-v*.json", "cutover/typescript-c1-acceptance-v*.json"],
       "must_change_any": ["docs/theory/Система аксиом МТС.md"]
     }
   ]

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,7 +1,9 @@
 {
   "policy_format_version": "0.3.0",
   "repository_kind": "documentation",
-  "enforcement": {"mode": "blocking"},
+  "enforcement": {
+    "mode": "blocking"
+  },
   "integration": {
     "workflows": [
       {
@@ -55,54 +57,272 @@
   },
   "document_relations": {
     "documents": {
-      "candidate-v09-contract": {"path": "contracts/mts-contract-v0.9.json", "format": "json"},
-      "candidate-v09-conformance": {"path": "contracts/mts-conformance-v0.9.json", "format": "json"},
-      "candidate-v010-contract": {"path": "contracts/mts-contract-v0.10.json", "format": "json"},
-      "candidate-v010-conformance": {"path": "contracts/mts-conformance-v0.10.json", "format": "json"},
-      "candidate-v011-contract": {"path": "contracts/mts-contract-v0.11.json", "format": "json"},
-      "candidate-v011-conformance": {"path": "contracts/mts-conformance-v0.11.json", "format": "json"}
+      "candidate-v09-contract": {
+        "path": "contracts/mts-contract-v0.9.json",
+        "format": "json"
+      },
+      "candidate-v09-conformance": {
+        "path": "contracts/mts-conformance-v0.9.json",
+        "format": "json"
+      },
+      "candidate-v010-contract": {
+        "path": "contracts/mts-contract-v0.10.json",
+        "format": "json"
+      },
+      "candidate-v010-conformance": {
+        "path": "contracts/mts-conformance-v0.10.json",
+        "format": "json"
+      },
+      "candidate-v011-contract": {
+        "path": "contracts/mts-contract-v0.11.json",
+        "format": "json"
+      },
+      "candidate-v011-conformance": {
+        "path": "contracts/mts-conformance-v0.11.json",
+        "format": "json"
+      }
     },
     "rules": [
-      {"id":"v09-contract-semantic-base-v08","kind":"scalar_equals_literal","source":{"document":"candidate-v09-contract","pointer":"/semanticBase","type":"string"},"value":"mts-contract/v0.8"},
-      {"id":"v09-conformance-semantic-base-v08","kind":"scalar_equals_literal","source":{"document":"candidate-v09-conformance","pointer":"/semanticBase","type":"string"},"value":"mts-conformance/v0.8"},
-      {"id":"v09-contract-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v09-contract","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
-      {"id":"v09-conformance-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v09-conformance","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
-      {"id":"v09-contract-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v09-contract","pointer":"/acceptanceReady","type":"boolean"},"value":true},
-      {"id":"v09-conformance-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v09-conformance","pointer":"/acceptanceReady","type":"boolean"},"value":true},
-      {"id":"v010-contract-schema","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/schema","type":"string"},"value":"mts-contract/v0.10"},
-      {"id":"v010-conformance-contract","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/contract","type":"string"},"value":"mts-contract/v0.10"},
-      {"id":"v010-contract-corpus","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/conformanceCorpus","type":"string"},"value":"contracts/mts-conformance-v0.10.json"},
-      {"id":"v010-contract-semantic-base-v09","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/semanticBase","type":"string"},"value":"mts-contract/v0.9"},
-      {"id":"v010-conformance-semantic-base-v09","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/semanticBase","type":"string"},"value":"mts-conformance/v0.9"},
-      {"id":"v010-contract-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/acceptanceReady","type":"boolean"},"value":true},
-      {"id":"v010-conformance-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/acceptanceReady","type":"boolean"},"value":true},
-      {"id":"v010-contract-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v010-contract","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
-      {"id":"v010-conformance-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
-      {"id":"v010-conformance-complete","kind":"scalar_equals_literal","source":{"document":"candidate-v010-conformance","pointer":"/coverageState","type":"string"},"value":"complete"},
-      {"id":"v011-contract-schema","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/schema","type":"string"},"value":"mts-contract/v0.11"},
-      {"id":"v011-conformance-contract","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/contract","type":"string"},"value":"mts-contract/v0.11"},
-      {"id":"v011-contract-corpus","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/conformanceCorpus","type":"string"},"value":"contracts/mts-conformance-v0.11.json"},
-      {"id":"v011-contract-semantic-base-v010","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/semanticBase","type":"string"},"value":"mts-contract/v0.10"},
-      {"id":"v011-conformance-semantic-base-v010","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/semanticBase","type":"string"},"value":"mts-conformance/v0.10"},
-      {"id":"v011-contract-status-candidate","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/status","type":"string"},"value":"candidate"},
-      {"id":"v011-conformance-status-candidate","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/status","type":"string"},"value":"candidate"},
-      {"id":"v011-contract-not-accepted","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/accepted","type":"boolean"},"value":false},
-      {"id":"v011-conformance-not-accepted","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/accepted","type":"boolean"},"value":false},
-      {"id":"v011-contract-not-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/acceptanceReady","type":"boolean"},"value":false},
-      {"id":"v011-conformance-not-ready","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/acceptanceReady","type":"boolean"},"value":false},
-      {"id":"v011-contract-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
-      {"id":"v011-conformance-is-semantic-delta","kind":"scalar_equals_literal","source":{"document":"candidate-v011-conformance","pointer":"/observableSemanticDelta","type":"boolean"},"value":true},
-      {"id":"v011-top-bind-is-root-structural-binding","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/topLevelBinding","type":"string"},"value":"TopBind(R,S)"},
-      {"id":"v011-top-dot-resolves-root","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/topLevelDotResolution","type":"string"},"value":"resolve_top(.) = R"},
-      {"id":"v011-zero-whole-not-frame","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/wholeEqualsExecutionFrame","type":"boolean"},"value":false},
-      {"id":"v011-no-ambient-runtime-current","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/ambientRuntimeCurrentIsSemanticAuthority","type":"boolean"},"value":false},
-      {"id":"v011-no-hidden-root-prefix","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/zeroContextGenesis/hiddenLiteralRootPrefixInserted","type":"boolean"},"value":false},
-      {"id":"v011-dot-not-q-abit","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/foundation/dotIsQAbit","type":"boolean"},"value":false},
-      {"id":"v011-colon-not-q-abit","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/foundation/colonIsQAbit","type":"boolean"},"value":false},
-      {"id":"v011-c1-supported","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/representationBootstrap/firstPhysicalDotAdmissionStatus","type":"string"},"value":"supported-c1"},
-      {"id":"v011-c2-classified","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/foundation/minimalSignBasisStatus","type":"string"},"value":"classified-c2-semantic-derived-presentation-cycle-retained"},
-      {"id":"v011-production-behavior-changed-in-c3","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/implementation/productionBehaviorChanged","type":"boolean"},"value":true},
-      {"id":"v011-runtime-implementation-complete-after-c4","kind":"scalar_equals_literal","source":{"document":"candidate-v011-contract","pointer":"/implementation/implementationComplete","type":"boolean"},"value":true}
+      {
+        "id": "v09-contract-semantic-base-v08",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-contract", "pointer": "/semanticBase", "type": "string"},
+        "value": "mts-contract/v0.8"
+      },
+      {
+        "id": "v09-conformance-semantic-base-v08",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-conformance", "pointer": "/semanticBase", "type": "string"},
+        "value": "mts-conformance/v0.8"
+      },
+      {
+        "id": "v09-contract-is-semantic-delta",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v09-conformance-is-semantic-delta",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v09-contract-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-contract", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v09-conformance-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v010-contract-schema",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-contract", "pointer": "/schema", "type": "string"},
+        "value": "mts-contract/v0.10"
+      },
+      {
+        "id": "v010-conformance-contract",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-conformance", "pointer": "/contract", "type": "string"},
+        "value": "mts-contract/v0.10"
+      },
+      {
+        "id": "v010-contract-corpus",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-contract", "pointer": "/conformanceCorpus", "type": "string"},
+        "value": "contracts/mts-conformance-v0.10.json"
+      },
+      {
+        "id": "v010-contract-semantic-base-v09",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-contract", "pointer": "/semanticBase", "type": "string"},
+        "value": "mts-contract/v0.9"
+      },
+      {
+        "id": "v010-conformance-semantic-base-v09",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-conformance", "pointer": "/semanticBase", "type": "string"},
+        "value": "mts-conformance/v0.9"
+      },
+      {
+        "id": "v010-contract-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-contract", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v010-conformance-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v010-contract-is-semantic-delta",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v010-conformance-is-semantic-delta",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v010-conformance-complete",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v010-conformance", "pointer": "/coverageState", "type": "string"},
+        "value": "complete"
+      },
+      {
+        "id": "v011-contract-schema",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/schema", "type": "string"},
+        "value": "mts-contract/v0.11"
+      },
+      {
+        "id": "v011-conformance-contract",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-conformance", "pointer": "/contract", "type": "string"},
+        "value": "mts-contract/v0.11"
+      },
+      {
+        "id": "v011-contract-corpus",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/conformanceCorpus", "type": "string"},
+        "value": "contracts/mts-conformance-v0.11.json"
+      },
+      {
+        "id": "v011-contract-semantic-base-v010",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/semanticBase", "type": "string"},
+        "value": "mts-contract/v0.10"
+      },
+      {
+        "id": "v011-conformance-semantic-base-v010",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-conformance", "pointer": "/semanticBase", "type": "string"},
+        "value": "mts-conformance/v0.10"
+      },
+      {
+        "id": "v011-contract-status-candidate",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/status", "type": "string"},
+        "value": "candidate"
+      },
+      {
+        "id": "v011-conformance-status-candidate",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-conformance", "pointer": "/status", "type": "string"},
+        "value": "candidate"
+      },
+      {
+        "id": "v011-contract-not-accepted",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/accepted", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-conformance-not-accepted",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-conformance", "pointer": "/accepted", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-contract-not-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-conformance-not-ready",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-contract-is-semantic-delta",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v011-conformance-is-semantic-delta",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v011-top-bind-is-root-structural-binding",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/topLevelBinding", "type": "string"},
+        "value": "TopBind(R,S)"
+      },
+      {
+        "id": "v011-top-dot-resolves-root",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/topLevelDotResolution", "type": "string"},
+        "value": "resolve_top(.) = R"
+      },
+      {
+        "id": "v011-zero-whole-not-frame",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/wholeEqualsExecutionFrame", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-no-ambient-runtime-current",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/ambientRuntimeCurrentIsSemanticAuthority", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-no-hidden-root-prefix",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/zeroContextGenesis/hiddenLiteralRootPrefixInserted", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-dot-not-q-abit",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/foundation/dotIsQAbit", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-colon-not-q-abit",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/foundation/colonIsQAbit", "type": "boolean"},
+        "value": false
+      },
+      {
+        "id": "v011-c1-supported",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/representationBootstrap/firstPhysicalDotAdmissionStatus", "type": "string"},
+        "value": "supported-c1"
+      },
+      {
+        "id": "v011-c2-classified",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/foundation/minimalSignBasisStatus", "type": "string"},
+        "value": "classified-c2-semantic-derived-presentation-cycle-retained"
+      },
+      {
+        "id": "v011-production-behavior-changed-in-c3",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/implementation/productionBehaviorChanged", "type": "boolean"},
+        "value": true
+      },
+      {
+        "id": "v011-runtime-implementation-complete-after-c4",
+        "kind": "scalar_equals_literal",
+        "source": {"document": "candidate-v011-contract", "pointer": "/implementation/implementationComplete", "type": "boolean"},
+        "value": true
+      }
     ]
   },
   "evidence_bindings": [
@@ -203,18 +423,36 @@
     }
   ],
   "cochange_rules": [
-    {"if_changed": ["contracts/mts-contract-v0.9.json"], "must_change_any": ["contracts/mts-conformance-v0.9.json"]},
-    {"if_changed": ["contracts/mts-conformance-v0.9.json"], "must_change_any": ["contracts/mts-contract-v0.9.json"]},
     {
-      "if_changed": ["contracts/mts-contract-v*.json", "contracts/mts-conformance-v*.json", "cutover/typescript-c1-acceptance-v*.json"],
+      "if_changed": ["contracts/mts-contract-v0.9.json"],
+      "must_change_any": ["contracts/mts-conformance-v0.9.json"]
+    },
+    {
+      "if_changed": ["contracts/mts-conformance-v0.9.json"],
+      "must_change_any": ["contracts/mts-contract-v0.9.json"]
+    },
+    {
+      "if_changed": [
+        "contracts/mts-contract-v*.json",
+        "contracts/mts-conformance-v*.json",
+        "cutover/typescript-c1-acceptance-v*.json"
+      ],
       "must_change_any": ["README.md"]
     },
     {
-      "if_changed": ["contracts/mts-contract-v*.json", "contracts/mts-conformance-v*.json", "cutover/typescript-c1-acceptance-v*.json"],
+      "if_changed": [
+        "contracts/mts-contract-v*.json",
+        "contracts/mts-conformance-v*.json",
+        "cutover/typescript-c1-acceptance-v*.json"
+      ],
       "must_change_any": ["docs/theory/Основания МТС.md"]
     },
     {
-      "if_changed": ["contracts/mts-contract-v*.json", "contracts/mts-conformance-v*.json", "cutover/typescript-c1-acceptance-v*.json"],
+      "if_changed": [
+        "contracts/mts-contract-v*.json",
+        "contracts/mts-conformance-v*.json",
+        "cutover/typescript-c1-acceptance-v*.json"
+      ],
       "must_change_any": ["docs/theory/Система аксиом МТС.md"]
     }
   ]


### PR DESCRIPTION
Closes #794 after merge.

Phase A governance bridge for C5 lifecycle #793. This PR removes only the obsolete trusted-base rule that forces candidate v0.11 `/coverageState` to remain `incomplete`.

No contract, conformance, cutover, runtime, test, accepted v0.9/v0.10, budget, workflow or enforcement change is included.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - .github/**
expected_effects:
  - remove only v011-conformance-incomplete
  - preserve candidate status and not-accepted/not-ready pins
  - enable a later separately reviewed C5 lifecycle binding to set coverageState=complete
```

```repo-guard-grant
authorized_governance_paths:
  - repo-policy.json
allow_policy_relaxation:
  - /document_relations
allow_atomic_governance_cutover: true
```
