### PR TITLE
governance(v0.11): bridge readiness trusted-base pins

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -234,18 +234,6 @@
         "value": false
       },
       {
-        "id": "v011-contract-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-conformance-not-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": false
-      },
-      {
         "id": "v011-contract-is-semantic-delta",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v011-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},


### PR DESCRIPTION
Closes #798 after merge.

C6-A0 governance bridge for #797. Removes only the two obsolete trusted-base literals that force v0.11 `acceptanceReady=false`, so C6-A1 can later establish `acceptanceReady=true` in a separately merged state.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - README.md
  - .github/**
expected_effects:
  - remove only v011-contract-not-ready
  - remove only v011-conformance-not-ready
  - preserve candidate status and accepted=false pins
  - preserve complete C5 evidence pins
  - preserve current v0.10 / previous v0.9 / cutover v0.10
```

Trusted GovernanceGrant is in linked issue #798 and authorizes only `repo-policy.json` plus these two exact document-relation rule relaxations.