### PR TITLE
governance(v0.11): bridge accepted flip trusted-base pins

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -210,30 +210,6 @@
         "value": "mts-conformance/v0.10"
       },
       {
-        "id": "v011-contract-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v011-conformance-status-candidate",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/status", "type": "string"},
-        "value": "candidate"
-      },
-      {
-        "id": "v011-contract-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-contract", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
-        "id": "v011-conformance-not-accepted",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v011-conformance", "pointer": "/accepted", "type": "boolean"},
-        "value": false
-      },
-      {
         "id": "v011-contract-ready",
         "kind": "scalar_equals_literal",
         "source": {"document": "candidate-v011-contract", "pointer": "/acceptanceReady", "type": "boolean"},


### PR DESCRIPTION
Closes #802 after merge.

C6-B0 governance bridge for #797. Removes only the four trusted-base literals that pin v0.11 as `status=candidate` / `accepted=false`, so C6-B1 can later perform the accepted cutover in a separately merged change.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - README.md
  - .github/**
expected_effects:
  - remove only v011-contract-status-candidate
  - remove only v011-conformance-status-candidate
  - remove only v011-contract-not-accepted
  - remove only v011-conformance-not-accepted
  - preserve v0.11 acceptanceReady=true
  - preserve complete C5 evidence pins
  - preserve current v0.10 / previous v0.9 / cutover v0.10
  - preserve contract budget 6/2
```

Trusted GovernanceGrant is in linked issue #802 and authorizes only `repo-policy.json` plus these four exact document-relation rule relaxations.

Candidate control data is intentionally unchanged in this PR: `status=candidate`, `accepted=false`, `acceptanceReady=true`. Only C6-B1 may perform the accepted/current rotation.