### PR TITLE
governance(v0.11): detach obsolete v0.9 policy relations

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -57,14 +57,6 @@
   },
   "document_relations": {
     "documents": {
-      "candidate-v09-contract": {
-        "path": "contracts/mts-contract-v0.9.json",
-        "format": "json"
-      },
-      "candidate-v09-conformance": {
-        "path": "contracts/mts-conformance-v0.9.json",
-        "format": "json"
-      },
       "candidate-v010-contract": {
         "path": "contracts/mts-contract-v0.10.json",
         "format": "json"
@@ -83,42 +75,6 @@
       }
     },
     "rules": [
-      {
-        "id": "v09-contract-semantic-base-v08",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-contract/v0.8"
-      },
-      {
-        "id": "v09-conformance-semantic-base-v08",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/semanticBase", "type": "string"},
-        "value": "mts-conformance/v0.8"
-      },
-      {
-        "id": "v09-contract-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v09-conformance-is-semantic-delta",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/observableSemanticDelta", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v09-contract-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-contract", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": true
-      },
-      {
-        "id": "v09-conformance-ready",
-        "kind": "scalar_equals_literal",
-        "source": {"document": "candidate-v09-conformance", "pointer": "/acceptanceReady", "type": "boolean"},
-        "value": true
-      },
       {
         "id": "v010-contract-schema",
         "kind": "scalar_equals_literal",
@@ -411,14 +367,6 @@
     }
   ],
   "cochange_rules": [
-    {
-      "if_changed": ["contracts/mts-contract-v0.9.json"],
-      "must_change_any": ["contracts/mts-conformance-v0.9.json"]
-    },
-    {
-      "if_changed": ["contracts/mts-conformance-v0.9.json"],
-      "must_change_any": ["contracts/mts-contract-v0.9.json"]
-    },
     {
       "if_changed": [
         "contracts/mts-contract-v*.json",


### PR DESCRIPTION
Closes #808. Refs #806, #797, #755, #657, #807.

C6-B2a trusted-base bridge only. This PR does not delete v0.9 contracts and does not repay the temporary contract budget yet.

Exact starting accepted baseline:

```text
main = faba36537f5c87223f3f19d2b04b1f439d877a8b
current accepted = MTS v0.11
previous immutable evidence = MTS v0.10
acceptance manifest = cutover/typescript-c1-acceptance-v0.4.json
active contract files = 6
contract budget = 6/2
```

Exact branch head before PR creation:

```text
dfd06e24045956ef4893bd9e6c9171f90e04eaad
```

Exact diff surface:

```text
repo-policy.json only
+0 / -52
```

This bridge removes only obsolete live v0.9 policy document/rule/cochange bindings while both v0.9 JSON files remain present. Historical scalar `semanticBase(v0.10)=v0.9` identifiers remain intact. Current/previous/acceptance pointers remain v0.11/v0.10/v0.4. Contract budget remains 6/2.

```repo-guard-yaml
change_type: governance
scope:
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
must_touch:
  - repo-policy.json
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - docs/**
  - README.md
  - .github/**
expected_effects:
  - detach obsolete v0.9 live policy relations only
  - preserve v0.9 files and temporary 6/2 budget
  - preserve current v0.11 and previous v0.10
  - preserve acceptance manifest v0.4
  - enable separately gated final B2b deletion and budget repayment
```

```repo-guard-grant
authorized_governance_paths:
  - repo-policy.json
allow_policy_relaxation:
  - /document_relations/rules/v09-contract-semantic-base-v08
  - /document_relations/rules/v09-conformance-semantic-base-v08
  - /document_relations/rules/v09-contract-is-semantic-delta
  - /document_relations/rules/v09-conformance-is-semantic-delta
  - /document_relations/rules/v09-contract-ready
  - /document_relations/rules/v09-conformance-ready
  - /
allow_atomic_governance_cutover: true
```

`/` is only the repo-guard comparator root marker for the already-scoped policy-section removal. It does not authorize any file outside `repo-policy.json` or any enforcement/workflow/current/previous/acceptance change.

Atomic B2 draft #807 proved why this bridge is required: its proposed head policy passed 69/69 checks, but trusted-base evaluation failed because that same PR had already deleted files still required by base v0.9 relations. This PR removes the trusted-base relations first, without deleting their files.

Merge gates remain: full CI green, new ready-state blocking repo-guard green, behind_by=0, mergeable=true, stable exact head, merge only with expected_head_sha, then confirm exact new main. B2b remains separate.