### PR TITLE
feat(proof): add generic structural judgment replay

### DIFF
--- a/ts/src/derivation.ts
+++ b/ts/src/derivation.ts
@@ -1,0 +1,121 @@
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+} from "./memory.js";
+import { StateError, readContext } from "./state.js";
+import {
+  StructuralRuleError,
+  replayStructuralRule,
+  type StructuralRuleReplayEvidence,
+  type StructuralRuleReplayResult,
+} from "./structural-rule.js";
+
+export interface StructuralJudgment {
+  readonly theory: LinkHandle;
+  readonly context: LinkHandle;
+  readonly claim: LinkHandle;
+}
+
+export interface StructuralJudgmentEvidence {
+  readonly application: StructuralRuleReplayEvidence;
+  readonly judgment: StructuralJudgment;
+}
+
+export interface StructuralJudgmentReplayResult {
+  readonly judgment: StructuralJudgment;
+  readonly application: StructuralRuleReplayResult;
+}
+
+export type StructuralJudgmentReplayErrorCode =
+  | "invalid-judgment-evidence"
+  | "invalid-judgment-context"
+  | "invalid-rule-application"
+  | "judgment-theory-mismatch"
+  | "judgment-context-mismatch"
+  | "judgment-claim-mismatch";
+
+export class StructuralJudgmentReplayError extends Error {
+  override readonly name = "StructuralJudgmentReplayError";
+
+  constructor(readonly code: StructuralJudgmentReplayErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: StructuralJudgmentReplayErrorCode): never {
+  throw new StructuralJudgmentReplayError(code);
+}
+
+/**
+ * Generic one-step mathematical judgment replay.
+ *
+ * The Rule semantics remain entirely in replayStructuralRule. This layer only
+ * binds the verified application to an explicit (Theory, Context, Claim)
+ * selection. Premise/dependency semantics intentionally belong to the later
+ * derivation layer rather than being inferred from host ordering here.
+ */
+export function replayStructuralJudgment(
+  memory: ReadMemory,
+  evidence: StructuralJudgmentEvidence,
+): StructuralJudgmentReplayResult {
+  const beforeCount = memory.linkCount;
+  try {
+    try {
+      memory.poles(evidence.judgment.theory);
+      memory.poles(evidence.judgment.claim);
+    } catch (error) {
+      if (error instanceof MemoryError) {
+        fail("invalid-judgment-evidence");
+      }
+      throw error;
+    }
+
+    try {
+      readContext(memory, evidence.judgment.context);
+    } catch (error) {
+      if (error instanceof StateError || error instanceof MemoryError) {
+        fail("invalid-judgment-context");
+      }
+      throw error;
+    }
+
+    let application: StructuralRuleReplayResult;
+    try {
+      application = replayStructuralRule(memory, evidence.application);
+    } catch (error) {
+      if (error instanceof StructuralRuleError || error instanceof MemoryError) {
+        fail("invalid-rule-application");
+      }
+      throw error;
+    }
+
+    if (application.interpreterStructure.theory !== evidence.judgment.theory) {
+      fail("judgment-theory-mismatch");
+    }
+    if (application.afterContext !== evidence.judgment.context) {
+      fail("judgment-context-mismatch");
+    }
+    if (application.claimedBody !== evidence.judgment.claim) {
+      fail("judgment-claim-mismatch");
+    }
+    if (memory.linkCount !== beforeCount) {
+      fail("invalid-judgment-evidence");
+    }
+
+    return Object.freeze({
+      judgment: Object.freeze({ ...evidence.judgment }),
+      application,
+    });
+  } catch (error) {
+    if (error instanceof StructuralJudgmentReplayError) throw error;
+    if (error instanceof MemoryError) {
+      throw new StructuralJudgmentReplayError("invalid-judgment-evidence");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== beforeCount) {
+      throw new StructuralJudgmentReplayError("invalid-judgment-evidence");
+    }
+  }
+}

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -137,6 +137,17 @@ export type {
 } from "./run.js";
 
 export {
+  StructuralJudgmentReplayError,
+  replayStructuralJudgment,
+} from "./derivation.js";
+export type {
+  StructuralJudgment,
+  StructuralJudgmentEvidence,
+  StructuralJudgmentReplayErrorCode,
+  StructuralJudgmentReplayResult,
+} from "./derivation.js";
+
+export {
   ProofRuleReplayError,
   replayDecomposeEqualRelations,
 } from "./proof.js";

--- a/ts/test/derivation.test.ts
+++ b/ts/test/derivation.test.ts
@@ -1,0 +1,171 @@
+import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralJudgmentReplayError,
+  replayStructuralJudgment,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectJudgmentError(
+  code: StructuralJudgmentReplayError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralJudgmentReplayError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected StructuralJudgmentReplayError`);
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly evidence: StructuralJudgmentEvidence;
+  readonly fresh: () => LinkHandle;
+  readonly rule: LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => {
+    cursor = memory.ensure(cursor, R);
+    return cursor;
+  };
+
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const leftRole = fresh();
+  const rightRole = fresh();
+  const left = fresh();
+  const right = fresh();
+  const context = defineContext(memory, fresh(), fresh());
+
+  const expectedInterpreter: StructuralInterpreter = Object.freeze({ dictionary, grammar, theory });
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [leftRole, rightRole]);
+  const templateBody = memory.ensure(leftRole, rightRole);
+  const rule = defineStructuralRule(memory, roleDictionary, templateBody);
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+  const claim = memory.ensure(left, right);
+  const act = defineActHeader(memory, interpreter, roleDictionary, context);
+  defineActField(memory, act, leftRole, left);
+  defineActField(memory, act, rightRole, right);
+
+  const evidence: StructuralJudgmentEvidence = Object.freeze({
+    application: Object.freeze({
+      act,
+      rule,
+      ruleAdmission,
+      claimedBody: claim,
+      expectedInterpreter,
+      expectedAfterContext: context,
+    }),
+    judgment: Object.freeze({ theory, context, claim }),
+  });
+  return { memory, evidence, fresh, rule };
+}
+
+// Positive generic one-step judgment: exact claim and zero writes.
+{
+  const fx = fixture();
+  const before = fx.memory.linkCount;
+  const result = replayStructuralJudgment(fx.memory, fx.evidence);
+  same(result.judgment.theory, fx.evidence.judgment.theory, "exact theory");
+  same(result.judgment.context, fx.evidence.judgment.context, "exact context");
+  same(result.judgment.claim, fx.evidence.judgment.claim, "exact claim");
+  same(result.application.claimedBody, fx.evidence.judgment.claim, "application binds exact claim");
+  same(fx.memory.linkCount, before, "judgment replay must be read-only");
+}
+
+// Judgment theory is independent from the application interpreter theory.
+{
+  const fx = fixture();
+  expectJudgmentError("judgment-theory-mismatch", () => replayStructuralJudgment(
+    fx.memory,
+    { ...fx.evidence, judgment: { ...fx.evidence.judgment, theory: fx.fresh() } },
+  ));
+}
+
+// A different valid Context cannot be silently accepted as the judgment Context.
+{
+  const fx = fixture();
+  const otherContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  expectJudgmentError("judgment-context-mismatch", () => replayStructuralJudgment(
+    fx.memory,
+    { ...fx.evidence, judgment: { ...fx.evidence.judgment, context: otherContext } },
+  ));
+}
+
+// An ordinary relation is not an alternative encoding of Context K.
+{
+  const fx = fixture();
+  const invalidContext = fx.memory.ensure(fx.fresh(), fx.fresh());
+  expectJudgmentError("invalid-judgment-context", () => replayStructuralJudgment(
+    fx.memory,
+    { ...fx.evidence, judgment: { ...fx.evidence.judgment, context: invalidContext } },
+  ));
+}
+
+// A valid application cannot prove a different selected claim.
+{
+  const fx = fixture();
+  const forgedClaim = fx.memory.ensure(fx.fresh(), fx.fresh());
+  expectJudgmentError("judgment-claim-mismatch", () => replayStructuralJudgment(
+    fx.memory,
+    { ...fx.evidence, judgment: { ...fx.evidence.judgment, claim: forgedClaim } },
+  ));
+}
+
+// Admission remains structural T ⟼ Rule evidence, never a host callback name.
+{
+  const fx = fixture();
+  const forgedAdmission = fx.memory.ensure(fx.fresh(), fx.rule);
+  expectJudgmentError("invalid-rule-application", () => replayStructuralJudgment(
+    fx.memory,
+    { ...fx.evidence, application: { ...fx.evidence.application, ruleAdmission: forgedAdmission } },
+  ));
+}
+
+// Even when the selected judgment repeats a forged body, exact Act bindings win.
+{
+  const fx = fixture();
+  const forgedClaim = fx.memory.ensure(fx.fresh(), fx.fresh());
+  expectJudgmentError("invalid-rule-application", () => replayStructuralJudgment(
+    fx.memory,
+    {
+      application: { ...fx.evidence.application, claimedBody: forgedClaim },
+      judgment: { ...fx.evidence.judgment, claim: forgedClaim },
+    },
+  ));
+}
+
+// Foreign handles cannot cross the Memory boundary as judgment evidence.
+{
+  const fx = fixture();
+  const foreign = new Memory().root;
+  expectJudgmentError("invalid-judgment-evidence", () => replayStructuralJudgment(
+    fx.memory,
+    { ...fx.evidence, judgment: { ...fx.evidence.judgment, claim: foreign } },
+  ));
+}

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -15,6 +15,7 @@ import type {
   SequenceDescription,
   StackAlgebra,
   StoredDataset,
+  StructuralJudgmentEvidence,
   WriteMemory,
 } from "../src/public.js";
 
@@ -48,6 +49,7 @@ const expectedRuntimeExports = [
   "RunReplayError",
   "SequenceReplayError",
   "StreamError",
+  "StructuralJudgmentReplayError",
   "ValueBundleReplayError",
   "analyzeDirectDeixisCarrier",
   "bundleRoleAt",
@@ -75,6 +77,7 @@ const expectedRuntimeExports = [
   "replayRootOpeningRestoration",
   "replayRun",
   "replaySequenceMaterialization",
+  "replayStructuralJudgment",
   "resolveFlatBundle",
   "symbolicStackAlgebra",
   "valuesEqual",
@@ -106,6 +109,7 @@ const definition: DefinitionReplayEvidence | undefined = undefined;
 const deixis: DirectDeixisVocabulary | undefined = undefined;
 const value: MtsValue | undefined = undefined;
 const run: RunEvidence | undefined = undefined;
+const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
 const integrated: IntegratedProofEvidence | undefined = undefined;
 void [
@@ -123,6 +127,7 @@ void [
   deixis,
   value,
   run,
+  judgment,
   proof,
   integrated,
 ];


### PR DESCRIPTION
Closes #812. Refs #779, #657, #777.

P0/P1 implementation slice for the generic MTS proof-calculus boundary. This does not open v0.12 and does not modify accepted MTS v0.11 semantics or lifecycle evidence.

Exact starting baseline:

```text
main = 6b7f616c7b275310aebdbe998da13c5811c91391
current accepted = MTS v0.11
previous immutable evidence = MTS v0.10
active candidate lifecycle = NONE
active contract files = 4
contract budget = 4/0
exact workflows on main = NONE
```

Exact branch head before PR creation:

```text
3e7164b9a0fea84a0d1dd6a8e787f927c3c4d30d
```

Exact diff surface:

```text
ts/src/derivation.ts          NEW      +121
ts/src/public.ts              MODIFY   +11
ts/test/derivation.test.ts    NEW      +171
ts/test/public-api.test.ts    MODIFY   +5
TOTAL                                  +308/-0
```

The new layer is deliberately thin:

```text
admitted StructuralRule + explicit Act bindings
                |
                v
       replayStructuralRule
                |
                v
StructuralJudgment(theory, context, claim)
```

`replayStructuralJudgment` delegates rule semantics to the existing generic `replayStructuralRule`; it only binds the verified result to an explicit `(Theory, Context, Claim)` selection and checks Context validity, same-Memory evidence, and zero writes.

Negative evidence covers wrong theory, wrong/damaged context, forged claim, forged admission, binding/template forgery, foreign Memory handles, and read-only replay.

No premise dependency graph is introduced here; P2 remains a separate slice under #779. No theorem/lemma admission, binder extension, hard-coded logical system, callback/opcode/RuleKind authority, or rewrite of the existing specialized equality proof/checker occurs in this PR.

```repo-guard-yaml
change_type: implementation
scope:
  - ts/src/derivation.ts
  - ts/test/derivation.test.ts
  - ts/src/public.ts
  - ts/test/public-api.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 420
must_touch:
  - ts/src/derivation.ts
  - ts/test/derivation.test.ts
  - ts/src/public.ts
  - ts/test/public-api.test.ts
must_not_touch:
  - contracts/**
  - repo-policy.json
  - README.md
  - docs/**
  - cutover/**
  - .github/**
expected_effects:
  - add a generic read-only StructuralJudgment replay boundary over existing admitted StructuralRule semantics
  - expose only the top-level consumer evidence/replay surface from @mts/core
  - keep theorem-specific equality decomposition as legacy/specialized evidence rather than semantic authority
  - preserve accepted MTS v0.11 and all release evidence byte-for-byte
  - create no new candidate release
```

Merge gates remain mandatory: full CI green, new ready-state blocking repo-guard green, behind_by=0, mergeable=true, stable exact head, expected-head merge, exact new-main confirmation, and post-merge CI claimed only if workflows actually exist on the merge SHA.