### PR TITLE
feat(proof): add structural derivation dependency DAG

### DIFF
--- a/ts/src/derivation.ts
+++ b/ts/src/derivation.ts
@@ -190,13 +190,16 @@ function derivationFail(code: StructuralDerivationReplayErrorCode): never {
   throw new StructuralDerivationReplayError(code);
 }
 
-/** Proof-history occurrence. Claim identity remains independent of proof history. */
+/**
+ * Proof-history occurrence = Pair(Claim, Act). Claim starts the relation so
+ * occurrence metadata cannot enter the structural outgoing(Act) field namespace.
+ */
 export function defineStructuralProofOccurrence(
   memory: WriteMemory,
   act: LinkHandle,
   claim: LinkHandle,
 ): LinkHandle {
-  return memory.ensure(act, claim);
+  return memory.ensure(claim, act);
 }
 
 export function readStructuralProofOccurrence(
@@ -205,7 +208,7 @@ export function readStructuralProofOccurrence(
 ): StructuralProofOccurrence {
   try {
     const poles = memory.poles(occurrence);
-    return Object.freeze({ act: poles.start, claim: poles.end });
+    return Object.freeze({ act: poles.end, claim: poles.start });
   } catch (error) {
     if (error instanceof MemoryError) {
       throw new StructuralDerivationReplayError("invalid-derivation-evidence");

--- a/ts/src/derivation.ts
+++ b/ts/src/derivation.ts
@@ -1,11 +1,18 @@
 import {
+  ExactSequenceError,
+  materializeExactSequence,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
   MemoryError,
   type LinkHandle,
   type ReadMemory,
+  type WriteMemory,
 } from "./memory.js";
 import { StateError, readContext } from "./state.js";
 import {
   StructuralRuleError,
+  matchStructuralTemplate,
   replayStructuralRule,
   type StructuralRuleReplayEvidence,
   type StructuralRuleReplayResult,
@@ -116,6 +123,349 @@ export function replayStructuralJudgment(
   } finally {
     if (memory.linkCount !== beforeCount) {
       throw new StructuralJudgmentReplayError("invalid-judgment-evidence");
+    }
+  }
+}
+
+export interface StructuralProofOccurrence {
+  readonly act: LinkHandle;
+  readonly claim: LinkHandle;
+}
+
+export interface StructuralDerivationRule {
+  readonly structuralRule: LinkHandle;
+  readonly premiseTemplateSequence: LinkHandle;
+  readonly premiseTemplates: readonly LinkHandle[];
+}
+
+export interface StructuralDerivationNodeEvidence {
+  readonly occurrence: LinkHandle;
+  readonly judgment: StructuralJudgmentEvidence;
+  readonly derivationRule: LinkHandle;
+  readonly derivationRuleAdmission: LinkHandle;
+  readonly premiseOccurrenceSequence: LinkHandle;
+}
+
+export interface StructuralDerivationEvidence {
+  readonly theory: LinkHandle;
+  readonly targetOccurrence: LinkHandle;
+  /** Transport only: proof identity/dependencies come from structural Links. */
+  readonly nodes: readonly StructuralDerivationNodeEvidence[];
+}
+
+export interface StructuralDerivationReplayResult {
+  readonly theory: LinkHandle;
+  readonly targetOccurrence: LinkHandle;
+  readonly target: StructuralJudgmentReplayResult;
+  readonly occurrenceCount: number;
+}
+
+export type StructuralDerivationReplayErrorCode =
+  | "invalid-derivation-evidence"
+  | "duplicate-occurrence"
+  | "target-occurrence-not-found"
+  | "invalid-node-judgment"
+  | "cross-theory-node"
+  | "occurrence-mismatch"
+  | "invalid-derivation-rule"
+  | "derivation-rule-mismatch"
+  | "derivation-rule-not-admitted"
+  | "missing-premise"
+  | "extra-premise"
+  | "dependency-occurrence-not-found"
+  | "premise-claim-mismatch"
+  | "cyclic-dependency"
+  | "unreachable-node"
+  | "derivation-replay-wrote";
+
+export class StructuralDerivationReplayError extends Error {
+  override readonly name = "StructuralDerivationReplayError";
+
+  constructor(readonly code: StructuralDerivationReplayErrorCode) {
+    super(code);
+  }
+}
+
+function derivationFail(code: StructuralDerivationReplayErrorCode): never {
+  throw new StructuralDerivationReplayError(code);
+}
+
+/** Proof-history occurrence. Claim identity remains independent of proof history. */
+export function defineStructuralProofOccurrence(
+  memory: WriteMemory,
+  act: LinkHandle,
+  claim: LinkHandle,
+): LinkHandle {
+  return memory.ensure(act, claim);
+}
+
+export function readStructuralProofOccurrence(
+  memory: ReadMemory,
+  occurrence: LinkHandle,
+): StructuralProofOccurrence {
+  try {
+    const poles = memory.poles(occurrence);
+    return Object.freeze({ act: poles.start, claim: poles.end });
+  } catch (error) {
+    if (error instanceof MemoryError) {
+      throw new StructuralDerivationReplayError("invalid-derivation-evidence");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Extends an existing StructuralRule with explicit premise templates. The
+ * conclusion matcher remains the existing StructuralRule/replay kernel.
+ */
+export function defineStructuralDerivationRule(
+  memory: WriteMemory,
+  structuralRule: LinkHandle,
+  premiseTemplates: readonly LinkHandle[],
+): LinkHandle {
+  const premiseTemplateSequence = materializeExactSequence(memory, premiseTemplates);
+  return memory.ensure(structuralRule, premiseTemplateSequence);
+}
+
+export function readStructuralDerivationRule(
+  memory: ReadMemory,
+  derivationRule: LinkHandle,
+): StructuralDerivationRule {
+  try {
+    const poles = memory.poles(derivationRule);
+    const sequence = readExactSequence(memory, poles.end);
+    return Object.freeze({
+      structuralRule: poles.start,
+      premiseTemplateSequence: poles.end,
+      premiseTemplates: Object.freeze([...sequence.values]),
+    });
+  } catch (error) {
+    if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+      throw new StructuralDerivationReplayError("invalid-derivation-rule");
+    }
+    throw error;
+  }
+}
+
+export function admitStructuralDerivationRule(
+  memory: WriteMemory,
+  theory: LinkHandle,
+  derivationRule: LinkHandle,
+): LinkHandle {
+  return memory.ensure(theory, derivationRule);
+}
+
+function verifyStructuralDerivationRuleAdmission(
+  memory: ReadMemory,
+  theory: LinkHandle,
+  derivationRule: LinkHandle,
+  admission: LinkHandle,
+): void {
+  try {
+    const poles = memory.poles(admission);
+    if (poles.start !== theory || poles.end !== derivationRule) {
+      derivationFail("derivation-rule-not-admitted");
+    }
+  } catch (error) {
+    if (error instanceof StructuralDerivationReplayError) throw error;
+    if (error instanceof MemoryError) {
+      derivationFail("derivation-rule-not-admitted");
+    }
+    throw error;
+  }
+}
+
+interface VerifiedDerivationNode {
+  readonly evidence: StructuralDerivationNodeEvidence;
+  readonly judgment: StructuralJudgmentReplayResult;
+  readonly premiseOccurrences: readonly LinkHandle[];
+  readonly premiseTemplates: readonly LinkHandle[];
+}
+
+/**
+ * Read-only replay of the exact dependency closure selected by targetOccurrence.
+ * `nodes[]` is transport only: it is indexed by structural ProofOccurrence Links,
+ * while premise order comes from two structural ExactSequence values.
+ */
+export function replayStructuralDerivation(
+  memory: ReadMemory,
+  evidence: StructuralDerivationEvidence,
+): StructuralDerivationReplayResult {
+  const beforeCount = memory.linkCount;
+  try {
+    try {
+      memory.poles(evidence.theory);
+      memory.poles(evidence.targetOccurrence);
+    } catch (error) {
+      if (error instanceof MemoryError) {
+        derivationFail("invalid-derivation-evidence");
+      }
+      throw error;
+    }
+
+    const nodes = new Map<LinkHandle, StructuralDerivationNodeEvidence>();
+    for (const node of evidence.nodes) {
+      try {
+        memory.poles(node.occurrence);
+      } catch (error) {
+        if (error instanceof MemoryError) {
+          derivationFail("invalid-derivation-evidence");
+        }
+        throw error;
+      }
+      if (nodes.has(node.occurrence)) {
+        derivationFail("duplicate-occurrence");
+      }
+      nodes.set(node.occurrence, node);
+    }
+
+    if (!nodes.has(evidence.targetOccurrence)) {
+      derivationFail("target-occurrence-not-found");
+    }
+
+    const active = new Set<LinkHandle>();
+    const verified = new Map<LinkHandle, VerifiedDerivationNode>();
+
+    const verifyNode = (occurrence: LinkHandle): VerifiedDerivationNode => {
+      const cached = verified.get(occurrence);
+      if (cached !== undefined) return cached;
+      if (active.has(occurrence)) {
+        derivationFail("cyclic-dependency");
+      }
+
+      const node = nodes.get(occurrence);
+      if (node === undefined) {
+        try {
+          memory.poles(occurrence);
+        } catch (error) {
+          if (error instanceof MemoryError) {
+            derivationFail("invalid-derivation-evidence");
+          }
+          throw error;
+        }
+        derivationFail("dependency-occurrence-not-found");
+      }
+
+      active.add(occurrence);
+      try {
+        let judgment: StructuralJudgmentReplayResult;
+        try {
+          judgment = replayStructuralJudgment(memory, node.judgment);
+        } catch (error) {
+          if (error instanceof StructuralJudgmentReplayError || error instanceof MemoryError) {
+            derivationFail("invalid-node-judgment");
+          }
+          throw error;
+        }
+
+        if (judgment.judgment.theory !== evidence.theory) {
+          derivationFail("cross-theory-node");
+        }
+
+        const occurrenceStructure = readStructuralProofOccurrence(memory, occurrence);
+        if (
+          occurrenceStructure.act !== node.judgment.application.act ||
+          occurrenceStructure.claim !== judgment.judgment.claim
+        ) {
+          derivationFail("occurrence-mismatch");
+        }
+
+        const derivationRule = readStructuralDerivationRule(memory, node.derivationRule);
+        if (derivationRule.structuralRule !== node.judgment.application.rule) {
+          derivationFail("derivation-rule-mismatch");
+        }
+        verifyStructuralDerivationRuleAdmission(
+          memory,
+          evidence.theory,
+          node.derivationRule,
+          node.derivationRuleAdmission,
+        );
+
+        let premiseOccurrences: readonly LinkHandle[];
+        try {
+          premiseOccurrences = Object.freeze([
+            ...readExactSequence(memory, node.premiseOccurrenceSequence).values,
+          ]);
+        } catch (error) {
+          if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+            derivationFail("invalid-derivation-evidence");
+          }
+          throw error;
+        }
+
+        if (premiseOccurrences.length < derivationRule.premiseTemplates.length) {
+          derivationFail("missing-premise");
+        }
+        if (premiseOccurrences.length > derivationRule.premiseTemplates.length) {
+          derivationFail("extra-premise");
+        }
+
+        premiseOccurrences.forEach((dependencyOccurrence, index) => {
+          try {
+            memory.poles(dependencyOccurrence);
+          } catch (error) {
+            if (error instanceof MemoryError) {
+              derivationFail("invalid-derivation-evidence");
+            }
+            throw error;
+          }
+
+          const dependency = verifyNode(dependencyOccurrence);
+          const template = derivationRule.premiseTemplates[index];
+          if (template === undefined) {
+            derivationFail("extra-premise");
+          }
+          try {
+            matchStructuralTemplate(
+              memory,
+              template,
+              dependency.judgment.judgment.claim,
+              judgment.application.bindings,
+            );
+          } catch (error) {
+            if (error instanceof StructuralRuleError || error instanceof MemoryError) {
+              derivationFail("premise-claim-mismatch");
+            }
+            throw error;
+          }
+        });
+
+        const result: VerifiedDerivationNode = Object.freeze({
+          evidence: node,
+          judgment,
+          premiseOccurrences,
+          premiseTemplates: derivationRule.premiseTemplates,
+        });
+        verified.set(occurrence, result);
+        return result;
+      } finally {
+        active.delete(occurrence);
+      }
+    };
+
+    const target = verifyNode(evidence.targetOccurrence);
+    if (verified.size !== nodes.size) {
+      derivationFail("unreachable-node");
+    }
+    if (memory.linkCount !== beforeCount) {
+      derivationFail("derivation-replay-wrote");
+    }
+
+    return Object.freeze({
+      theory: evidence.theory,
+      targetOccurrence: evidence.targetOccurrence,
+      target: target.judgment,
+      occurrenceCount: verified.size,
+    });
+  } catch (error) {
+    if (error instanceof StructuralDerivationReplayError) throw error;
+    if (error instanceof MemoryError || error instanceof ExactSequenceError) {
+      throw new StructuralDerivationReplayError("invalid-derivation-evidence");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== beforeCount) {
+      throw new StructuralDerivationReplayError("derivation-replay-wrote");
     }
   }
 }

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -137,10 +137,16 @@ export type {
 } from "./run.js";
 
 export {
+  StructuralDerivationReplayError,
   StructuralJudgmentReplayError,
+  replayStructuralDerivation,
   replayStructuralJudgment,
 } from "./derivation.js";
 export type {
+  StructuralDerivationEvidence,
+  StructuralDerivationNodeEvidence,
+  StructuralDerivationReplayErrorCode,
+  StructuralDerivationReplayResult,
   StructuralJudgment,
   StructuralJudgmentEvidence,
   StructuralJudgmentReplayErrorCode,

--- a/ts/test/derivation.test.ts
+++ b/ts/test/derivation.test.ts
@@ -224,11 +224,12 @@ function derivationFixture() {
     claim: LinkHandle,
     premiseTemplates: readonly LinkHandle[] = [],
     premiseOccurrences: readonly LinkHandle[] = [],
+    selectedContext: LinkHandle = context,
   ) => {
     const roleDictionary = defineStructuralRoleDictionary(memory, roles);
     const rule = defineStructuralRule(memory, roleDictionary, template);
     const ruleAdmission = admitStructuralRule(memory, env.theory, rule);
-    const act = defineActHeader(memory, env.interpreter, roleDictionary, context);
+    const act = defineActHeader(memory, env.interpreter, roleDictionary, selectedContext);
     bindings.forEach(([role, value]) => defineActField(memory, act, role, value));
     const judgment: StructuralJudgmentEvidence = {
       application: {
@@ -237,9 +238,9 @@ function derivationFixture() {
         ruleAdmission,
         claimedBody: claim,
         expectedInterpreter: env.expectedInterpreter,
-        expectedAfterContext: context,
+        expectedAfterContext: selectedContext,
       },
-      judgment: { theory: env.theory, context, claim },
+      judgment: { theory: env.theory, context: selectedContext, claim },
     };
     const occurrence = defineStructuralProofOccurrence(memory, act, claim);
     const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
@@ -286,7 +287,17 @@ function derivationFixture() {
   same(replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: root.occurrence, nodes: [root.node] }).occurrenceCount, 1, "root closure");
   same(fx.memory.linkCount, beforeRoot, "root replay read-only");
 
-  const step = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole], [root.occurrence]);
+  const stepContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const step = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [root.occurrence],
+    stepContext,
+  );
   assert(step.act !== root.act && step.occurrence !== root.occurrence, "same Claim must allow distinct proof histories");
   same(step.claim, root.claim, "proof history != theorem identity");
   same(replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: step.occurrence, nodes: [step.node, root.node] }).occurrenceCount, 2, "linear closure");
@@ -319,7 +330,17 @@ function derivationFixture() {
 
   const forgedAdmission = fx.memory.ensure(fx.fresh(), b.l.derivationRule);
   expectDerivationError("derivation-rule-not-admitted", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: b.l.occurrence, nodes: [{ ...b.l.node, derivationRuleAdmission: forgedAdmission }] }));
-  const unrelated = fx.rootLeft();
+  const unrelatedContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const unrelated = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [],
+    [],
+    unrelatedContext,
+  );
   expectDerivationError("unreachable-node", () => replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [...b.evidence.nodes, unrelated.node] }));
 }
 
@@ -331,8 +352,28 @@ function derivationFixture() {
   const target = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole], [cross.occurrence]);
   expectDerivationError("cross-theory-node", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node, cross.node] }));
 
-  const first = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole]);
-  const second = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole]);
+  const firstContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const secondContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const first = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [],
+    firstContext,
+  );
+  const second = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [],
+    secondContext,
+  );
   const firstDeps = materializeExactSequence(fx.memory, [second.occurrence]);
   const secondDeps = materializeExactSequence(fx.memory, [first.occurrence]);
   expectDerivationError("cyclic-dependency", () => replayStructuralDerivation(fx.memory, {

--- a/ts/test/derivation.test.ts
+++ b/ts/test/derivation.test.ts
@@ -1,3 +1,4 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
 import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
 import { defineContext } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
@@ -9,8 +10,15 @@ import {
   type StructuralInterpreter,
 } from "../src/structural-rule.js";
 import {
+  StructuralDerivationReplayError,
   StructuralJudgmentReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  replayStructuralDerivation,
   replayStructuralJudgment,
+  type StructuralDerivationEvidence,
+  type StructuralDerivationNodeEvidence,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
 
@@ -34,6 +42,20 @@ function expectJudgmentError(
     return;
   }
   throw new Error(`${code}: expected StructuralJudgmentReplayError`);
+}
+
+function expectDerivationError(
+  code: StructuralDerivationReplayError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralDerivationReplayError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected StructuralDerivationReplayError`);
 }
 
 interface Fixture {
@@ -167,5 +189,475 @@ function fixture(): Fixture {
   expectJudgmentError("invalid-judgment-evidence", () => replayStructuralJudgment(
     fx.memory,
     { ...fx.evidence, judgment: { ...fx.evidence.judgment, claim: foreign } },
+  ));
+}
+
+interface DerivationEnvironment {
+  readonly theory: LinkHandle;
+  readonly interpreter: LinkHandle;
+  readonly expectedInterpreter: StructuralInterpreter;
+}
+
+interface DerivationNodeFixture {
+  readonly node: StructuralDerivationNodeEvidence;
+  readonly occurrence: LinkHandle;
+  readonly act: LinkHandle;
+  readonly claim: LinkHandle;
+  readonly derivationRule: LinkHandle;
+}
+
+interface DerivationFixture {
+  readonly memory: Memory;
+  readonly fresh: () => LinkHandle;
+  readonly theory: LinkHandle;
+  readonly context: LinkHandle;
+  readonly leftRole: LinkHandle;
+  readonly rightRole: LinkHandle;
+  readonly left: LinkHandle;
+  readonly right: LinkHandle;
+  readonly mainEnvironment: DerivationEnvironment;
+  readonly environment: (theory: LinkHandle) => DerivationEnvironment;
+  readonly node: (
+    environment: DerivationEnvironment,
+    roles: readonly LinkHandle[],
+    bindings: readonly (readonly [LinkHandle, LinkHandle])[],
+    template: LinkHandle,
+    claim: LinkHandle,
+    premiseTemplates: readonly LinkHandle[],
+    premiseOccurrences: readonly LinkHandle[],
+  ) => DerivationNodeFixture;
+}
+
+function derivationFixture(): DerivationFixture {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => {
+    cursor = memory.ensure(cursor, R);
+    return cursor;
+  };
+
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const context = defineContext(memory, fresh(), fresh());
+  const leftRole = fresh();
+  const rightRole = fresh();
+  const left = fresh();
+  const right = fresh();
+
+  const environment = (selectedTheory: LinkHandle): DerivationEnvironment => {
+    const expectedInterpreter: StructuralInterpreter = Object.freeze({
+      dictionary,
+      grammar,
+      theory: selectedTheory,
+    });
+    return Object.freeze({
+      theory: selectedTheory,
+      interpreter: defineStructuralInterpreter(memory, dictionary, grammar, selectedTheory),
+      expectedInterpreter,
+    });
+  };
+
+  const mainEnvironment = environment(theory);
+
+  const node = (
+    selectedEnvironment: DerivationEnvironment,
+    roles: readonly LinkHandle[],
+    bindings: readonly (readonly [LinkHandle, LinkHandle])[],
+    template: LinkHandle,
+    claim: LinkHandle,
+    premiseTemplates: readonly LinkHandle[],
+    premiseOccurrences: readonly LinkHandle[],
+  ): DerivationNodeFixture => {
+    const roleDictionary = defineStructuralRoleDictionary(memory, roles);
+    const rule = defineStructuralRule(memory, roleDictionary, template);
+    const ruleAdmission = admitStructuralRule(memory, selectedEnvironment.theory, rule);
+    const act = defineActHeader(
+      memory,
+      selectedEnvironment.interpreter,
+      roleDictionary,
+      context,
+    );
+    for (const [role, value] of bindings) {
+      defineActField(memory, act, role, value);
+    }
+
+    const judgment: StructuralJudgmentEvidence = Object.freeze({
+      application: Object.freeze({
+        act,
+        rule,
+        ruleAdmission,
+        claimedBody: claim,
+        expectedInterpreter: selectedEnvironment.expectedInterpreter,
+        expectedAfterContext: context,
+      }),
+      judgment: Object.freeze({
+        theory: selectedEnvironment.theory,
+        context,
+        claim,
+      }),
+    });
+
+    const occurrence = defineStructuralProofOccurrence(memory, act, claim);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    const derivationRuleAdmission = admitStructuralDerivationRule(
+      memory,
+      selectedEnvironment.theory,
+      derivationRule,
+    );
+    const premiseOccurrenceSequence = materializeExactSequence(memory, premiseOccurrences);
+
+    return Object.freeze({
+      node: Object.freeze({
+        occurrence,
+        judgment,
+        derivationRule,
+        derivationRuleAdmission,
+        premiseOccurrenceSequence,
+      }),
+      occurrence,
+      act,
+      claim,
+      derivationRule,
+    });
+  };
+
+  return {
+    memory,
+    fresh,
+    theory,
+    context,
+    leftRole,
+    rightRole,
+    left,
+    right,
+    mainEnvironment,
+    environment,
+    node,
+  };
+}
+
+function zeroLeft(fx: DerivationFixture): DerivationNodeFixture {
+  return fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [],
+    [],
+  );
+}
+
+function zeroRight(fx: DerivationFixture): DerivationNodeFixture {
+  return fx.node(
+    fx.mainEnvironment,
+    [fx.rightRole],
+    [[fx.rightRole, fx.right]],
+    fx.rightRole,
+    fx.right,
+    [],
+    [],
+  );
+}
+
+function branchEvidence(fx: DerivationFixture): {
+  readonly leftRoot: DerivationNodeFixture;
+  readonly rightRoot: DerivationNodeFixture;
+  readonly target: DerivationNodeFixture;
+  readonly evidence: StructuralDerivationEvidence;
+} {
+  const leftRoot = zeroLeft(fx);
+  const rightRoot = zeroRight(fx);
+  const targetClaim = fx.memory.ensure(fx.left, fx.right);
+  const targetTemplate = fx.memory.ensure(fx.leftRole, fx.rightRole);
+  const target = fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole, fx.rightRole],
+    [[fx.leftRole, fx.left], [fx.rightRole, fx.right]],
+    targetTemplate,
+    targetClaim,
+    [fx.leftRole, fx.rightRole],
+    [leftRoot.occurrence, rightRoot.occurrence],
+  );
+  return {
+    leftRoot,
+    rightRoot,
+    target,
+    evidence: Object.freeze({
+      theory: fx.theory,
+      targetOccurrence: target.occurrence,
+      nodes: Object.freeze([target.node, rightRoot.node, leftRoot.node]),
+    }),
+  };
+}
+
+// Zero-premise admitted DerivationRule is an explicit structural proof root.
+{
+  const fx = derivationFixture();
+  const root = zeroLeft(fx);
+  const before = fx.memory.linkCount;
+  const result = replayStructuralDerivation(fx.memory, {
+    theory: fx.theory,
+    targetOccurrence: root.occurrence,
+    nodes: [root.node],
+  });
+  same(result.targetOccurrence, root.occurrence, "zero-premise target occurrence");
+  same(result.target.judgment.claim, fx.left, "zero-premise target claim");
+  same(result.occurrenceCount, 1, "zero-premise closure size");
+  same(fx.memory.linkCount, before, "derivation replay must be read-only");
+}
+
+// Linear proof: two different Acts can be distinct proof histories for one Claim.
+{
+  const fx = derivationFixture();
+  const root = zeroLeft(fx);
+  const step = fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [root.occurrence],
+  );
+  assert(step.act !== root.act, "linear proof must use a second Act occurrence");
+  assert(step.occurrence !== root.occurrence, "same Claim with different Acts must have distinct occurrences");
+  same(step.claim, root.claim, "proof history must not redefine Claim identity");
+  const result = replayStructuralDerivation(fx.memory, {
+    theory: fx.theory,
+    targetOccurrence: step.occurrence,
+    nodes: [step.node, root.node],
+  });
+  same(result.occurrenceCount, 2, "linear closure size");
+}
+
+// Branching proof and outer host node order are independent.
+{
+  const fx = derivationFixture();
+  const branch = branchEvidence(fx);
+  const before = fx.memory.linkCount;
+  const first = replayStructuralDerivation(fx.memory, branch.evidence);
+  const reordered = replayStructuralDerivation(fx.memory, {
+    ...branch.evidence,
+    nodes: [branch.leftRoot.node, branch.target.node, branch.rightRoot.node],
+  });
+  same(first.target.judgment.claim, branch.target.claim, "branch target claim");
+  same(reordered.target.judgment.claim, branch.target.claim, "reordered host transport target");
+  same(first.occurrenceCount, 3, "branch closure size");
+  same(reordered.occurrenceCount, 3, "reordered branch closure size");
+  same(fx.memory.linkCount, before, "host reorder replay must be read-only");
+}
+
+// Missing dependency node cannot be repaired by a valid target application.
+{
+  const fx = derivationFixture();
+  const branch = branchEvidence(fx);
+  expectDerivationError("dependency-occurrence-not-found", () => replayStructuralDerivation(
+    fx.memory,
+    { ...branch.evidence, nodes: [branch.target.node, branch.leftRoot.node] },
+  ));
+}
+
+// Premise occurrence cardinality is exact against the admitted DerivationRule schema.
+{
+  const fx = derivationFixture();
+  const branch = branchEvidence(fx);
+  const missingSequence = materializeExactSequence(fx.memory, [branch.leftRoot.occurrence]);
+  expectDerivationError("missing-premise", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      ...branch.evidence,
+      nodes: [
+        { ...branch.target.node, premiseOccurrenceSequence: missingSequence },
+        branch.leftRoot.node,
+        branch.rightRoot.node,
+      ],
+    },
+  ));
+
+  const extraSequence = materializeExactSequence(
+    fx.memory,
+    [branch.leftRoot.occurrence, branch.rightRoot.occurrence, branch.leftRoot.occurrence],
+  );
+  expectDerivationError("extra-premise", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      ...branch.evidence,
+      nodes: [
+        { ...branch.target.node, premiseOccurrenceSequence: extraSequence },
+        branch.leftRoot.node,
+        branch.rightRoot.node,
+      ],
+    },
+  ));
+}
+
+// Premise order comes from structural ExactSequence, not host nodes[].
+{
+  const fx = derivationFixture();
+  const branch = branchEvidence(fx);
+  const swapped = materializeExactSequence(
+    fx.memory,
+    [branch.rightRoot.occurrence, branch.leftRoot.occurrence],
+  );
+  expectDerivationError("premise-claim-mismatch", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      ...branch.evidence,
+      nodes: [
+        { ...branch.target.node, premiseOccurrenceSequence: swapped },
+        branch.rightRoot.node,
+        branch.leftRoot.node,
+      ],
+    },
+  ));
+}
+
+// ProofOccurrence must structurally equal Pair(Act, Claim).
+{
+  const fx = derivationFixture();
+  const root = zeroLeft(fx);
+  const forgedOccurrence = fx.memory.ensure(fx.fresh(), fx.fresh());
+  expectDerivationError("occurrence-mismatch", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      theory: fx.theory,
+      targetOccurrence: forgedOccurrence,
+      nodes: [{ ...root.node, occurrence: forgedOccurrence }],
+    },
+  ));
+}
+
+// Structural occurrence identity is unique in the transport set.
+{
+  const fx = derivationFixture();
+  const root = zeroLeft(fx);
+  expectDerivationError("duplicate-occurrence", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      theory: fx.theory,
+      targetOccurrence: root.occurrence,
+      nodes: [root.node, root.node],
+    },
+  ));
+}
+
+// A DerivationRule requires its own exact T ⟼ DerivationRule admission.
+{
+  const fx = derivationFixture();
+  const root = zeroLeft(fx);
+  const forgedAdmission = fx.memory.ensure(fx.fresh(), root.derivationRule);
+  expectDerivationError("derivation-rule-not-admitted", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      theory: fx.theory,
+      targetOccurrence: root.occurrence,
+      nodes: [{ ...root.node, derivationRuleAdmission: forgedAdmission }],
+    },
+  ));
+}
+
+// A valid node from another Theory cannot satisfy a dependency in this derivation.
+{
+  const fx = derivationFixture();
+  const otherTheory = fx.fresh();
+  const otherEnvironment = fx.environment(otherTheory);
+  const foreignTheoryRoot = fx.node(
+    otherEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [],
+    [],
+  );
+  const target = fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [foreignTheoryRoot.occurrence],
+  );
+  expectDerivationError("cross-theory-node", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      theory: fx.theory,
+      targetOccurrence: target.occurrence,
+      nodes: [target.node, foreignTheoryRoot.node],
+    },
+  ));
+}
+
+// Cyclic dependencies fail closed; recursive proof semantics is not implicit.
+{
+  const fx = derivationFixture();
+  const first = fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [],
+  );
+  const second = fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [],
+  );
+  const firstDeps = materializeExactSequence(fx.memory, [second.occurrence]);
+  const secondDeps = materializeExactSequence(fx.memory, [first.occurrence]);
+  expectDerivationError("cyclic-dependency", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      theory: fx.theory,
+      targetOccurrence: first.occurrence,
+      nodes: [
+        { ...first.node, premiseOccurrenceSequence: firstDeps },
+        { ...second.node, premiseOccurrenceSequence: secondDeps },
+      ],
+    },
+  ));
+}
+
+// Supplied evidence must be the exact target closure; unrelated valid nodes are rejected.
+{
+  const fx = derivationFixture();
+  const branch = branchEvidence(fx);
+  const unrelated = fx.node(
+    fx.mainEnvironment,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [],
+    [],
+  );
+  expectDerivationError("unreachable-node", () => replayStructuralDerivation(
+    fx.memory,
+    { ...branch.evidence, nodes: [...branch.evidence.nodes, unrelated.node] },
+  ));
+}
+
+// Foreign target handles fail at the Memory boundary rather than becoming host IDs.
+{
+  const fx = derivationFixture();
+  const root = zeroLeft(fx);
+  const foreign = new Memory().root;
+  expectDerivationError("invalid-derivation-evidence", () => replayStructuralDerivation(
+    fx.memory,
+    {
+      theory: fx.theory,
+      targetOccurrence: foreign,
+      nodes: [root.node],
+    },
   ));
 }

--- a/ts/test/derivation.test.ts
+++ b/ts/test/derivation.test.ts
@@ -17,8 +17,6 @@ import {
   defineStructuralProofOccurrence,
   replayStructuralDerivation,
   replayStructuralJudgment,
-  type StructuralDerivationEvidence,
-  type StructuralDerivationNodeEvidence,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
 
@@ -192,51 +190,13 @@ function fixture(): Fixture {
   ));
 }
 
-interface DerivationEnvironment {
-  readonly theory: LinkHandle;
-  readonly interpreter: LinkHandle;
-  readonly expectedInterpreter: StructuralInterpreter;
-}
+type Binding = readonly [LinkHandle, LinkHandle];
 
-interface DerivationNodeFixture {
-  readonly node: StructuralDerivationNodeEvidence;
-  readonly occurrence: LinkHandle;
-  readonly act: LinkHandle;
-  readonly claim: LinkHandle;
-  readonly derivationRule: LinkHandle;
-}
-
-interface DerivationFixture {
-  readonly memory: Memory;
-  readonly fresh: () => LinkHandle;
-  readonly theory: LinkHandle;
-  readonly context: LinkHandle;
-  readonly leftRole: LinkHandle;
-  readonly rightRole: LinkHandle;
-  readonly left: LinkHandle;
-  readonly right: LinkHandle;
-  readonly mainEnvironment: DerivationEnvironment;
-  readonly environment: (theory: LinkHandle) => DerivationEnvironment;
-  readonly node: (
-    environment: DerivationEnvironment,
-    roles: readonly LinkHandle[],
-    bindings: readonly (readonly [LinkHandle, LinkHandle])[],
-    template: LinkHandle,
-    claim: LinkHandle,
-    premiseTemplates: readonly LinkHandle[],
-    premiseOccurrences: readonly LinkHandle[],
-  ) => DerivationNodeFixture;
-}
-
-function derivationFixture(): DerivationFixture {
+function derivationFixture() {
   const memory = new Memory();
   const { R, U } = ensureRootBasis(memory);
   let cursor = U;
-  const fresh = (): LinkHandle => {
-    cursor = memory.ensure(cursor, R);
-    return cursor;
-  };
-
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
   const dictionary = fresh();
   const grammar = fresh();
   const theory = fresh();
@@ -246,418 +206,141 @@ function derivationFixture(): DerivationFixture {
   const left = fresh();
   const right = fresh();
 
-  const environment = (selectedTheory: LinkHandle): DerivationEnvironment => {
-    const expectedInterpreter: StructuralInterpreter = Object.freeze({
-      dictionary,
-      grammar,
+  const environment = (selectedTheory: LinkHandle) => {
+    const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory: selectedTheory };
+    return {
       theory: selectedTheory,
-    });
-    return Object.freeze({
-      theory: selectedTheory,
-      interpreter: defineStructuralInterpreter(memory, dictionary, grammar, selectedTheory),
       expectedInterpreter,
-    });
+      interpreter: defineStructuralInterpreter(memory, dictionary, grammar, selectedTheory),
+    };
   };
-
-  const mainEnvironment = environment(theory);
+  const main = environment(theory);
 
   const node = (
-    selectedEnvironment: DerivationEnvironment,
+    env: ReturnType<typeof environment>,
     roles: readonly LinkHandle[],
-    bindings: readonly (readonly [LinkHandle, LinkHandle])[],
+    bindings: readonly Binding[],
     template: LinkHandle,
     claim: LinkHandle,
-    premiseTemplates: readonly LinkHandle[],
-    premiseOccurrences: readonly LinkHandle[],
-  ): DerivationNodeFixture => {
+    premiseTemplates: readonly LinkHandle[] = [],
+    premiseOccurrences: readonly LinkHandle[] = [],
+  ) => {
     const roleDictionary = defineStructuralRoleDictionary(memory, roles);
     const rule = defineStructuralRule(memory, roleDictionary, template);
-    const ruleAdmission = admitStructuralRule(memory, selectedEnvironment.theory, rule);
-    const act = defineActHeader(
-      memory,
-      selectedEnvironment.interpreter,
-      roleDictionary,
-      context,
-    );
-    for (const [role, value] of bindings) {
-      defineActField(memory, act, role, value);
-    }
-
-    const judgment: StructuralJudgmentEvidence = Object.freeze({
-      application: Object.freeze({
+    const ruleAdmission = admitStructuralRule(memory, env.theory, rule);
+    const act = defineActHeader(memory, env.interpreter, roleDictionary, context);
+    bindings.forEach(([role, value]) => defineActField(memory, act, role, value));
+    const judgment: StructuralJudgmentEvidence = {
+      application: {
         act,
         rule,
         ruleAdmission,
         claimedBody: claim,
-        expectedInterpreter: selectedEnvironment.expectedInterpreter,
+        expectedInterpreter: env.expectedInterpreter,
         expectedAfterContext: context,
-      }),
-      judgment: Object.freeze({
-        theory: selectedEnvironment.theory,
-        context,
-        claim,
-      }),
-    });
-
+      },
+      judgment: { theory: env.theory, context, claim },
+    };
     const occurrence = defineStructuralProofOccurrence(memory, act, claim);
     const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
-    const derivationRuleAdmission = admitStructuralDerivationRule(
-      memory,
-      selectedEnvironment.theory,
+    return {
+      act,
+      claim,
+      occurrence,
       derivationRule,
-    );
-    const premiseOccurrenceSequence = materializeExactSequence(memory, premiseOccurrences);
-
-    return Object.freeze({
-      node: Object.freeze({
+      node: {
         occurrence,
         judgment,
         derivationRule,
-        derivationRuleAdmission,
-        premiseOccurrenceSequence,
-      }),
-      occurrence,
-      act,
+        derivationRuleAdmission: admitStructuralDerivationRule(memory, env.theory, derivationRule),
+        premiseOccurrenceSequence: materializeExactSequence(memory, premiseOccurrences),
+      },
+    };
+  };
+
+  const rootLeft = () => node(main, [leftRole], [[leftRole, left]], leftRole, left);
+  const rootRight = () => node(main, [rightRole], [[rightRole, right]], rightRole, right);
+  const branch = () => {
+    const l = rootLeft();
+    const r = rootRight();
+    const claim = memory.ensure(left, right);
+    const target = node(
+      main,
+      [leftRole, rightRole],
+      [[leftRole, left], [rightRole, right]],
+      memory.ensure(leftRole, rightRole),
       claim,
-      derivationRule,
-    });
+      [leftRole, rightRole],
+      [l.occurrence, r.occurrence],
+    );
+    return { l, r, target, evidence: { theory, targetOccurrence: target.occurrence, nodes: [target.node, r.node, l.node] } };
   };
-
-  return {
-    memory,
-    fresh,
-    theory,
-    context,
-    leftRole,
-    rightRole,
-    left,
-    right,
-    mainEnvironment,
-    environment,
-    node,
-  };
+  return { memory, fresh, theory, leftRole, rightRole, left, right, main, environment, node, rootLeft, branch };
 }
 
-function zeroLeft(fx: DerivationFixture): DerivationNodeFixture {
-  return fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [],
-    [],
-  );
-}
-
-function zeroRight(fx: DerivationFixture): DerivationNodeFixture {
-  return fx.node(
-    fx.mainEnvironment,
-    [fx.rightRole],
-    [[fx.rightRole, fx.right]],
-    fx.rightRole,
-    fx.right,
-    [],
-    [],
-  );
-}
-
-function branchEvidence(fx: DerivationFixture): {
-  readonly leftRoot: DerivationNodeFixture;
-  readonly rightRoot: DerivationNodeFixture;
-  readonly target: DerivationNodeFixture;
-  readonly evidence: StructuralDerivationEvidence;
-} {
-  const leftRoot = zeroLeft(fx);
-  const rightRoot = zeroRight(fx);
-  const targetClaim = fx.memory.ensure(fx.left, fx.right);
-  const targetTemplate = fx.memory.ensure(fx.leftRole, fx.rightRole);
-  const target = fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole, fx.rightRole],
-    [[fx.leftRole, fx.left], [fx.rightRole, fx.right]],
-    targetTemplate,
-    targetClaim,
-    [fx.leftRole, fx.rightRole],
-    [leftRoot.occurrence, rightRoot.occurrence],
-  );
-  return {
-    leftRoot,
-    rightRoot,
-    target,
-    evidence: Object.freeze({
-      theory: fx.theory,
-      targetOccurrence: target.occurrence,
-      nodes: Object.freeze([target.node, rightRoot.node, leftRoot.node]),
-    }),
-  };
-}
-
-// Zero-premise admitted DerivationRule is an explicit structural proof root.
+// Positive P2: zero-premise root, linear reuse, branching, host-order independence, read-only replay.
 {
   const fx = derivationFixture();
-  const root = zeroLeft(fx);
-  const before = fx.memory.linkCount;
-  const result = replayStructuralDerivation(fx.memory, {
-    theory: fx.theory,
-    targetOccurrence: root.occurrence,
-    nodes: [root.node],
-  });
-  same(result.targetOccurrence, root.occurrence, "zero-premise target occurrence");
-  same(result.target.judgment.claim, fx.left, "zero-premise target claim");
-  same(result.occurrenceCount, 1, "zero-premise closure size");
-  same(fx.memory.linkCount, before, "derivation replay must be read-only");
+  const root = fx.rootLeft();
+  const beforeRoot = fx.memory.linkCount;
+  same(replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: root.occurrence, nodes: [root.node] }).occurrenceCount, 1, "root closure");
+  same(fx.memory.linkCount, beforeRoot, "root replay read-only");
+
+  const step = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole], [root.occurrence]);
+  assert(step.act !== root.act && step.occurrence !== root.occurrence, "same Claim must allow distinct proof histories");
+  same(step.claim, root.claim, "proof history != theorem identity");
+  same(replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: step.occurrence, nodes: [step.node, root.node] }).occurrenceCount, 2, "linear closure");
+
+  const b = fx.branch();
+  const beforeBranch = fx.memory.linkCount;
+  const a = replayStructuralDerivation(fx.memory, b.evidence);
+  const reordered = replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [b.l.node, b.target.node, b.r.node] });
+  same(a.target.judgment.claim, b.target.claim, "branch target");
+  same(reordered.occurrenceCount, 3, "host node order non-semantic");
+  same(fx.memory.linkCount, beforeBranch, "branch replay read-only");
 }
 
-// Linear proof: two different Acts can be distinct proof histories for one Claim.
+// Exact dependency closure, premise cardinality/order, occurrence identity, admission and reachability.
 {
   const fx = derivationFixture();
-  const root = zeroLeft(fx);
-  const step = fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [fx.leftRole],
-    [root.occurrence],
-  );
-  assert(step.act !== root.act, "linear proof must use a second Act occurrence");
-  assert(step.occurrence !== root.occurrence, "same Claim with different Acts must have distinct occurrences");
-  same(step.claim, root.claim, "proof history must not redefine Claim identity");
-  const result = replayStructuralDerivation(fx.memory, {
-    theory: fx.theory,
-    targetOccurrence: step.occurrence,
-    nodes: [step.node, root.node],
-  });
-  same(result.occurrenceCount, 2, "linear closure size");
-}
+  const b = fx.branch();
+  expectDerivationError("dependency-occurrence-not-found", () => replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [b.target.node, b.l.node] }));
 
-// Branching proof and outer host node order are independent.
-{
-  const fx = derivationFixture();
-  const branch = branchEvidence(fx);
-  const before = fx.memory.linkCount;
-  const first = replayStructuralDerivation(fx.memory, branch.evidence);
-  const reordered = replayStructuralDerivation(fx.memory, {
-    ...branch.evidence,
-    nodes: [branch.leftRoot.node, branch.target.node, branch.rightRoot.node],
-  });
-  same(first.target.judgment.claim, branch.target.claim, "branch target claim");
-  same(reordered.target.judgment.claim, branch.target.claim, "reordered host transport target");
-  same(first.occurrenceCount, 3, "branch closure size");
-  same(reordered.occurrenceCount, 3, "reordered branch closure size");
-  same(fx.memory.linkCount, before, "host reorder replay must be read-only");
-}
+  const missing = materializeExactSequence(fx.memory, [b.l.occurrence]);
+  expectDerivationError("missing-premise", () => replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [{ ...b.target.node, premiseOccurrenceSequence: missing }, b.l.node, b.r.node] }));
+  const extra = materializeExactSequence(fx.memory, [b.l.occurrence, b.r.occurrence, b.l.occurrence]);
+  expectDerivationError("extra-premise", () => replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [{ ...b.target.node, premiseOccurrenceSequence: extra }, b.l.node, b.r.node] }));
+  const swapped = materializeExactSequence(fx.memory, [b.r.occurrence, b.l.occurrence]);
+  expectDerivationError("premise-claim-mismatch", () => replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [{ ...b.target.node, premiseOccurrenceSequence: swapped }, b.r.node, b.l.node] }));
 
-// Missing dependency node cannot be repaired by a valid target application.
-{
-  const fx = derivationFixture();
-  const branch = branchEvidence(fx);
-  expectDerivationError("dependency-occurrence-not-found", () => replayStructuralDerivation(
-    fx.memory,
-    { ...branch.evidence, nodes: [branch.target.node, branch.leftRoot.node] },
-  ));
-}
-
-// Premise occurrence cardinality is exact against the admitted DerivationRule schema.
-{
-  const fx = derivationFixture();
-  const branch = branchEvidence(fx);
-  const missingSequence = materializeExactSequence(fx.memory, [branch.leftRoot.occurrence]);
-  expectDerivationError("missing-premise", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      ...branch.evidence,
-      nodes: [
-        { ...branch.target.node, premiseOccurrenceSequence: missingSequence },
-        branch.leftRoot.node,
-        branch.rightRoot.node,
-      ],
-    },
-  ));
-
-  const extraSequence = materializeExactSequence(
-    fx.memory,
-    [branch.leftRoot.occurrence, branch.rightRoot.occurrence, branch.leftRoot.occurrence],
-  );
-  expectDerivationError("extra-premise", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      ...branch.evidence,
-      nodes: [
-        { ...branch.target.node, premiseOccurrenceSequence: extraSequence },
-        branch.leftRoot.node,
-        branch.rightRoot.node,
-      ],
-    },
-  ));
-}
-
-// Premise order comes from structural ExactSequence, not host nodes[].
-{
-  const fx = derivationFixture();
-  const branch = branchEvidence(fx);
-  const swapped = materializeExactSequence(
-    fx.memory,
-    [branch.rightRoot.occurrence, branch.leftRoot.occurrence],
-  );
-  expectDerivationError("premise-claim-mismatch", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      ...branch.evidence,
-      nodes: [
-        { ...branch.target.node, premiseOccurrenceSequence: swapped },
-        branch.rightRoot.node,
-        branch.leftRoot.node,
-      ],
-    },
-  ));
-}
-
-// ProofOccurrence must structurally equal Pair(Act, Claim).
-{
-  const fx = derivationFixture();
-  const root = zeroLeft(fx);
   const forgedOccurrence = fx.memory.ensure(fx.fresh(), fx.fresh());
-  expectDerivationError("occurrence-mismatch", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      theory: fx.theory,
-      targetOccurrence: forgedOccurrence,
-      nodes: [{ ...root.node, occurrence: forgedOccurrence }],
-    },
-  ));
+  expectDerivationError("occurrence-mismatch", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: forgedOccurrence, nodes: [{ ...b.l.node, occurrence: forgedOccurrence }] }));
+  expectDerivationError("duplicate-occurrence", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: b.l.occurrence, nodes: [b.l.node, b.l.node] }));
+
+  const forgedAdmission = fx.memory.ensure(fx.fresh(), b.l.derivationRule);
+  expectDerivationError("derivation-rule-not-admitted", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: b.l.occurrence, nodes: [{ ...b.l.node, derivationRuleAdmission: forgedAdmission }] }));
+  const unrelated = fx.rootLeft();
+  expectDerivationError("unreachable-node", () => replayStructuralDerivation(fx.memory, { ...b.evidence, nodes: [...b.evidence.nodes, unrelated.node] }));
 }
 
-// Structural occurrence identity is unique in the transport set.
+// Cross-theory dependencies, cycles and foreign handles fail closed.
 {
   const fx = derivationFixture();
-  const root = zeroLeft(fx);
-  expectDerivationError("duplicate-occurrence", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      theory: fx.theory,
-      targetOccurrence: root.occurrence,
-      nodes: [root.node, root.node],
-    },
-  ));
-}
+  const other = fx.environment(fx.fresh());
+  const cross = fx.node(other, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left);
+  const target = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole], [cross.occurrence]);
+  expectDerivationError("cross-theory-node", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node, cross.node] }));
 
-// A DerivationRule requires its own exact T ⟼ DerivationRule admission.
-{
-  const fx = derivationFixture();
-  const root = zeroLeft(fx);
-  const forgedAdmission = fx.memory.ensure(fx.fresh(), root.derivationRule);
-  expectDerivationError("derivation-rule-not-admitted", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      theory: fx.theory,
-      targetOccurrence: root.occurrence,
-      nodes: [{ ...root.node, derivationRuleAdmission: forgedAdmission }],
-    },
-  ));
-}
-
-// A valid node from another Theory cannot satisfy a dependency in this derivation.
-{
-  const fx = derivationFixture();
-  const otherTheory = fx.fresh();
-  const otherEnvironment = fx.environment(otherTheory);
-  const foreignTheoryRoot = fx.node(
-    otherEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [],
-    [],
-  );
-  const target = fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [fx.leftRole],
-    [foreignTheoryRoot.occurrence],
-  );
-  expectDerivationError("cross-theory-node", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      theory: fx.theory,
-      targetOccurrence: target.occurrence,
-      nodes: [target.node, foreignTheoryRoot.node],
-    },
-  ));
-}
-
-// Cyclic dependencies fail closed; recursive proof semantics is not implicit.
-{
-  const fx = derivationFixture();
-  const first = fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [fx.leftRole],
-    [],
-  );
-  const second = fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [fx.leftRole],
-    [],
-  );
+  const first = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole]);
+  const second = fx.node(fx.main, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left, [fx.leftRole]);
   const firstDeps = materializeExactSequence(fx.memory, [second.occurrence]);
   const secondDeps = materializeExactSequence(fx.memory, [first.occurrence]);
-  expectDerivationError("cyclic-dependency", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      theory: fx.theory,
-      targetOccurrence: first.occurrence,
-      nodes: [
-        { ...first.node, premiseOccurrenceSequence: firstDeps },
-        { ...second.node, premiseOccurrenceSequence: secondDeps },
-      ],
-    },
-  ));
-}
+  expectDerivationError("cyclic-dependency", () => replayStructuralDerivation(fx.memory, {
+    theory: fx.theory,
+    targetOccurrence: first.occurrence,
+    nodes: [{ ...first.node, premiseOccurrenceSequence: firstDeps }, { ...second.node, premiseOccurrenceSequence: secondDeps }],
+  }));
 
-// Supplied evidence must be the exact target closure; unrelated valid nodes are rejected.
-{
-  const fx = derivationFixture();
-  const branch = branchEvidence(fx);
-  const unrelated = fx.node(
-    fx.mainEnvironment,
-    [fx.leftRole],
-    [[fx.leftRole, fx.left]],
-    fx.leftRole,
-    fx.left,
-    [],
-    [],
-  );
-  expectDerivationError("unreachable-node", () => replayStructuralDerivation(
-    fx.memory,
-    { ...branch.evidence, nodes: [...branch.evidence.nodes, unrelated.node] },
-  ));
-}
-
-// Foreign target handles fail at the Memory boundary rather than becoming host IDs.
-{
-  const fx = derivationFixture();
-  const root = zeroLeft(fx);
   const foreign = new Memory().root;
-  expectDerivationError("invalid-derivation-evidence", () => replayStructuralDerivation(
-    fx.memory,
-    {
-      theory: fx.theory,
-      targetOccurrence: foreign,
-      nodes: [root.node],
-    },
-  ));
+  expectDerivationError("invalid-derivation-evidence", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: foreign, nodes: [fx.rootLeft().node] }));
 }

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -15,6 +15,7 @@ import type {
   SequenceDescription,
   StackAlgebra,
   StoredDataset,
+  StructuralDerivationEvidence,
   StructuralJudgmentEvidence,
   WriteMemory,
 } from "../src/public.js";
@@ -49,6 +50,7 @@ const expectedRuntimeExports = [
   "RunReplayError",
   "SequenceReplayError",
   "StreamError",
+  "StructuralDerivationReplayError",
   "StructuralJudgmentReplayError",
   "ValueBundleReplayError",
   "analyzeDirectDeixisCarrier",
@@ -77,6 +79,7 @@ const expectedRuntimeExports = [
   "replayRootOpeningRestoration",
   "replayRun",
   "replaySequenceMaterialization",
+  "replayStructuralDerivation",
   "replayStructuralJudgment",
   "resolveFlatBundle",
   "symbolicStackAlgebra",
@@ -109,6 +112,7 @@ const definition: DefinitionReplayEvidence | undefined = undefined;
 const deixis: DirectDeixisVocabulary | undefined = undefined;
 const value: MtsValue | undefined = undefined;
 const run: RunEvidence | undefined = undefined;
+const derivation: StructuralDerivationEvidence | undefined = undefined;
 const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
 const integrated: IntegratedProofEvidence | undefined = undefined;
@@ -127,6 +131,7 @@ void [
   deixis,
   value,
   run,
+  derivation,
   judgment,
   proof,
   integrated,


### PR DESCRIPTION
Closes #814. Refs #779, #657, #777, #812, #813.

P2 implementation slice for generic MTS derivation replay. This does not open v0.12 and does not modify accepted MTS v0.11 semantics or release evidence.

Exact starting baseline:

```text
main = 8087136071cf2959afc6ce5e89726efa9f675f92
current accepted = MTS v0.11
previous immutable evidence = MTS v0.10
active candidate lifecycle = NONE
exact workflows on main = NONE
```

Current exact branch head after executable falsification/fixes:

```text
3da318a28b265dda7592461a160b739723b7c479
```

Current exact diff surface:

```text
ts/src/derivation.ts       MODIFY +353
ts/src/public.ts           MODIFY   +6
ts/test/derivation.test.ts MODIFY +216
ts/test/public-api.test.ts MODIFY   +5
TOTAL                              +580/-0
```

No new files. `behind_by=0` at the latest audit. The issue budget remains `max_net_added_lines: 700`.

P2 keeps proof dependencies structural rather than host-authoritative:

```text
ProofOccurrence = Pair(Claim, Act)
DerivationRule  = Pair(StructuralRule, ExactSequence(PremiseTemplates...))
Theory admission = T ⟼ DerivationRule
node dependencies = ExactSequence(ProofOccurrence...)
```

The `Pair(Claim, Act)` orientation is intentional. Draft CI #3295 falsified the initial `Pair(Act, Claim)` orientation because any Link starting at an Act enters the accepted `outgoing(Act)` attachment namespace and correctly makes the Act invalid. The generic Act reader was not weakened. CI #3297 then falsified a test assumption that two structurally identical applications could produce two distinct Acts; canonical `ensure` correctly reuses the same Act. The corrected corpus creates genuinely distinct execution occurrences through distinct valid Context links while keeping the same Rule and Claim. Current CI #3299 is SUCCESS on the exact head above.

The outer `nodes[]` is transport only. Replay indexes nodes by structural occurrence Links; premise positions come from structural ExactSequence data and are matched with the same exact Act bindings used for the conclusion. The verifier rejects missing/extra/wrong premises, missing dependency nodes, forged/duplicate occurrences, wrong derivation-rule admission, cross-theory nodes, cycles, unreachable supplied nodes, foreign handles, and replay writes.

Zero-premise admitted DerivationRules are the only P2 roots. External assumptions and theorem/lemma admission/reuse remain explicitly out of scope for P3.

Public `@mts/core` exposure is deliberately narrow: `StructuralDerivationReplayError`, `replayStructuralDerivation`, and top-level evidence/result/error-code types. Construction/read/admission representation helpers remain internal package vocabulary.

```repo-guard-yaml
change_type: implementation
scope:
  - ts/src/derivation.ts
  - ts/test/derivation.test.ts
  - ts/src/public.ts
  - ts/test/public-api.test.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 700
must_touch:
  - ts/src/derivation.ts
  - ts/test/derivation.test.ts
  - ts/src/public.ts
  - ts/test/public-api.test.ts
must_not_touch:
  - contracts/**
  - repo-policy.json
  - README.md
  - docs/**
  - cutover/**
  - .github/**
expected_effects:
  - add an explicit structural dependency DAG over generic StructuralJudgment replay
  - make premise requirements part of admitted MTS derivation-rule data rather than host graph metadata
  - make proof occurrence identity structural and distinct from theorem Claim identity
  - make host node ordering non-semantic
  - reject missing/wrong/cyclic/unreachable dependency evidence
  - preserve accepted MTS v0.11 and all release evidence byte-for-byte
  - create no new candidate release
```

Merge gates remain mandatory: full CI green, ready-state blocking repo-guard green, behind_by=0, mergeable=true, stable exact head, merge only with expected_head_sha, exact new-main confirmation, and post-merge CI claimed only if workflows actually exist on the merge SHA.