### PR TITLE
feat(proof): add proof-carrying theorem reuse

### DIFF
--- a/ts/src/derivation.ts
+++ b/ts/src/derivation.ts
@@ -472,3 +472,201 @@ export function replayStructuralDerivation(
     }
   }
 }
+
+export interface StructuralTheorem {
+  readonly claim: LinkHandle;
+  readonly theory: LinkHandle;
+}
+
+export interface StructuralTheoremEvidence {
+  readonly theorem: LinkHandle;
+  readonly proof: StructuralDerivationEvidence;
+}
+
+export interface StructuralTheoremReplayResult {
+  readonly theorem: LinkHandle;
+  readonly identity: StructuralTheorem;
+  readonly proof: StructuralDerivationReplayResult;
+}
+
+export type StructuralTheoremReplayErrorCode =
+  | "invalid-theorem-evidence"
+  | "theorem-proof-theory-mismatch"
+  | "invalid-theorem-proof"
+  | "theorem-claim-mismatch"
+  | "theorem-replay-wrote";
+
+export class StructuralTheoremReplayError extends Error {
+  override readonly name = "StructuralTheoremReplayError";
+
+  constructor(readonly code: StructuralTheoremReplayErrorCode) {
+    super(code);
+  }
+}
+
+function theoremFail(code: StructuralTheoremReplayErrorCode): never {
+  throw new StructuralTheoremReplayError(code);
+}
+
+/**
+ * Derived theorem identity = Pair(Claim, Theory). The Claim-first orientation
+ * keeps theorem metadata out of outgoing(Theory), which is reserved for
+ * explicit theory admissions. The Link alone has no proof authority.
+ */
+export function defineStructuralTheorem(
+  memory: WriteMemory,
+  claim: LinkHandle,
+  theory: LinkHandle,
+): LinkHandle {
+  return memory.ensure(claim, theory);
+}
+
+export function readStructuralTheorem(
+  memory: ReadMemory,
+  theorem: LinkHandle,
+): StructuralTheorem {
+  try {
+    const poles = memory.poles(theorem);
+    return Object.freeze({ claim: poles.start, theory: poles.end });
+  } catch (error) {
+    if (error instanceof MemoryError) {
+      theoremFail("invalid-theorem-evidence");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read-only proof-carrying theorem replay. The theorem Link is only structural
+ * identity; truth is established every time by replaying its complete P2 proof.
+ */
+export function replayStructuralTheorem(
+  memory: ReadMemory,
+  evidence: StructuralTheoremEvidence,
+): StructuralTheoremReplayResult {
+  const beforeCount = memory.linkCount;
+  try {
+    const identity = readStructuralTheorem(memory, evidence.theorem);
+    if (evidence.proof.theory !== identity.theory) {
+      theoremFail("theorem-proof-theory-mismatch");
+    }
+
+    let proof: StructuralDerivationReplayResult;
+    try {
+      proof = replayStructuralDerivation(memory, evidence.proof);
+    } catch (error) {
+      if (error instanceof StructuralDerivationReplayError || error instanceof MemoryError) {
+        theoremFail("invalid-theorem-proof");
+      }
+      throw error;
+    }
+
+    if (proof.target.judgment.claim !== identity.claim) {
+      theoremFail("theorem-claim-mismatch");
+    }
+    if (memory.linkCount !== beforeCount) {
+      theoremFail("theorem-replay-wrote");
+    }
+
+    return Object.freeze({ theorem: evidence.theorem, identity, proof });
+  } catch (error) {
+    if (error instanceof StructuralTheoremReplayError) throw error;
+    if (error instanceof MemoryError) {
+      throw new StructuralTheoremReplayError("invalid-theorem-evidence");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== beforeCount) {
+      throw new StructuralTheoremReplayError("theorem-replay-wrote");
+    }
+  }
+}
+
+export interface StructuralDerivationWithTheoremsEvidence {
+  readonly derivation: StructuralDerivationEvidence;
+  readonly theorems: readonly StructuralTheoremEvidence[];
+}
+
+export interface StructuralDerivationWithTheoremsReplayResult {
+  readonly derivation: StructuralDerivationReplayResult;
+  readonly theorems: readonly StructuralTheoremReplayResult[];
+}
+
+export type StructuralTheoremReuseReplayErrorCode =
+  | "invalid-reused-theorem"
+  | "theorem-reuse-theory-mismatch"
+  | "theorem-reuse-replay-wrote";
+
+export class StructuralTheoremReuseReplayError extends Error {
+  override readonly name = "StructuralTheoremReuseReplayError";
+
+  constructor(readonly code: StructuralTheoremReuseReplayErrorCode) {
+    super(code);
+  }
+}
+
+function theoremReuseFail(code: StructuralTheoremReuseReplayErrorCode): never {
+  throw new StructuralTheoremReuseReplayError(code);
+}
+
+/**
+ * Proof-carrying theorem reuse by expansion. Reusable theorem proofs are first
+ * replayed independently, then their complete P2 nodes are grafted into the
+ * consuming derivation and the final exact target closure is replayed again.
+ * No theorem/cache/hash boolean can replace the proof nodes.
+ */
+export function replayStructuralDerivationWithTheorems(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithTheoremsEvidence,
+): StructuralDerivationWithTheoremsReplayResult {
+  const beforeCount = memory.linkCount;
+  try {
+    const theoremResults: StructuralTheoremReplayResult[] = [];
+    const theoremNodes: StructuralDerivationNodeEvidence[] = [];
+
+    for (const theoremEvidence of evidence.theorems) {
+      let theorem: StructuralTheoremReplayResult;
+      try {
+        theorem = replayStructuralTheorem(memory, theoremEvidence);
+      } catch (error) {
+        if (error instanceof StructuralTheoremReplayError || error instanceof MemoryError) {
+          theoremReuseFail("invalid-reused-theorem");
+        }
+        throw error;
+      }
+      if (theorem.identity.theory !== evidence.derivation.theory) {
+        theoremReuseFail("theorem-reuse-theory-mismatch");
+      }
+      theoremResults.push(theorem);
+      theoremNodes.push(...theoremEvidence.proof.nodes);
+    }
+
+    const derivation = replayStructuralDerivation(memory, {
+      ...evidence.derivation,
+      nodes: Object.freeze([...evidence.derivation.nodes, ...theoremNodes]),
+    });
+
+    if (memory.linkCount !== beforeCount) {
+      theoremReuseFail("theorem-reuse-replay-wrote");
+    }
+    return Object.freeze({
+      derivation,
+      theorems: Object.freeze([...theoremResults]),
+    });
+  } catch (error) {
+    if (
+      error instanceof StructuralTheoremReuseReplayError ||
+      error instanceof StructuralDerivationReplayError
+    ) {
+      throw error;
+    }
+    if (error instanceof MemoryError) {
+      throw new StructuralTheoremReuseReplayError("invalid-reused-theorem");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== beforeCount) {
+      throw new StructuralTheoremReuseReplayError("theorem-reuse-replay-wrote");
+    }
+  }
+}

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -139,18 +139,29 @@ export type {
 export {
   StructuralDerivationReplayError,
   StructuralJudgmentReplayError,
+  StructuralTheoremReplayError,
+  StructuralTheoremReuseReplayError,
   replayStructuralDerivation,
+  replayStructuralDerivationWithTheorems,
   replayStructuralJudgment,
+  replayStructuralTheorem,
 } from "./derivation.js";
 export type {
   StructuralDerivationEvidence,
   StructuralDerivationNodeEvidence,
   StructuralDerivationReplayErrorCode,
   StructuralDerivationReplayResult,
+  StructuralDerivationWithTheoremsEvidence,
+  StructuralDerivationWithTheoremsReplayResult,
   StructuralJudgment,
   StructuralJudgmentEvidence,
   StructuralJudgmentReplayErrorCode,
   StructuralJudgmentReplayResult,
+  StructuralTheorem,
+  StructuralTheoremEvidence,
+  StructuralTheoremReplayErrorCode,
+  StructuralTheoremReplayResult,
+  StructuralTheoremReuseReplayErrorCode,
 } from "./derivation.js";
 
 export {

--- a/ts/test/derivation.test.ts
+++ b/ts/test/derivation.test.ts
@@ -12,11 +12,16 @@ import {
 import {
   StructuralDerivationReplayError,
   StructuralJudgmentReplayError,
+  StructuralTheoremReplayError,
+  StructuralTheoremReuseReplayError,
   admitStructuralDerivationRule,
   defineStructuralDerivationRule,
   defineStructuralProofOccurrence,
+  defineStructuralTheorem,
   replayStructuralDerivation,
+  replayStructuralDerivationWithTheorems,
   replayStructuralJudgment,
+  replayStructuralTheorem,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
 
@@ -54,6 +59,34 @@ function expectDerivationError(
     return;
   }
   throw new Error(`${code}: expected StructuralDerivationReplayError`);
+}
+
+function expectTheoremError(
+  code: StructuralTheoremReplayError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralTheoremReplayError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected StructuralTheoremReplayError`);
+}
+
+function expectTheoremReuseError(
+  code: StructuralTheoremReuseReplayError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralTheoremReuseReplayError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected StructuralTheoremReuseReplayError`);
 }
 
 interface Fixture {
@@ -276,7 +309,7 @@ function derivationFixture() {
     );
     return { l, r, target, evidence: { theory, targetOccurrence: target.occurrence, nodes: [target.node, r.node, l.node] } };
   };
-  return { memory, fresh, theory, leftRole, rightRole, left, right, main, environment, node, rootLeft, branch };
+  return { memory, fresh, theory, leftRole, rightRole, left, right, main, environment, node, rootLeft, rootRight, branch };
 }
 
 // Positive P2: zero-premise root, linear reuse, branching, host-order independence, read-only replay.
@@ -384,4 +417,211 @@ function derivationFixture() {
 
   const foreign = new Memory().root;
   expectDerivationError("invalid-derivation-evidence", () => replayStructuralDerivation(fx.memory, { theory: fx.theory, targetOccurrence: foreign, nodes: [fx.rootLeft().node] }));
+}
+
+// P3a theorem identity is Claim-under-Theory while proof history remains replayable evidence.
+{
+  const fx = derivationFixture();
+  const first = fx.rootLeft();
+  const theorem = defineStructuralTheorem(fx.memory, fx.left, fx.theory);
+  const firstProof = { theory: fx.theory, targetOccurrence: first.occurrence, nodes: [first.node] };
+  const before = fx.memory.linkCount;
+  const firstResult = replayStructuralTheorem(fx.memory, { theorem, proof: firstProof });
+  same(firstResult.identity.claim, fx.left, "theorem exact claim");
+  same(firstResult.identity.theory, fx.theory, "theorem exact theory");
+  same(firstResult.proof.targetOccurrence, first.occurrence, "theorem proof target");
+  same(fx.memory.linkCount, before, "theorem replay read-only");
+
+  const secondContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const second = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [],
+    [],
+    secondContext,
+  );
+  assert(first.occurrence !== second.occurrence, "same theorem must allow distinct proof histories");
+  const secondResult = replayStructuralTheorem(fx.memory, {
+    theorem,
+    proof: { theory: fx.theory, targetOccurrence: second.occurrence, nodes: [second.node] },
+  });
+  same(secondResult.theorem, firstResult.theorem, "proof history must not change theorem identity");
+}
+
+// Branching P2 proof is a valid proof-carrying theorem without theorem-specific replay.
+{
+  const fx = derivationFixture();
+  const b = fx.branch();
+  const theorem = defineStructuralTheorem(fx.memory, b.target.claim, fx.theory);
+  const before = fx.memory.linkCount;
+  const result = replayStructuralTheorem(fx.memory, { theorem, proof: b.evidence });
+  same(result.proof.occurrenceCount, 3, "branching theorem closure");
+  same(result.identity.claim, b.target.claim, "branching theorem target");
+  same(fx.memory.linkCount, before, "branching theorem replay read-only");
+}
+
+// Later proof reuses theorem only by expanding its complete P2 proof closure.
+{
+  const fx = derivationFixture();
+  const lemma = fx.rootLeft();
+  const lemmaTheorem = defineStructuralTheorem(fx.memory, fx.left, fx.theory);
+  const lemmaEvidence = {
+    theorem: lemmaTheorem,
+    proof: { theory: fx.theory, targetOccurrence: lemma.occurrence, nodes: [lemma.node] },
+  };
+  const right = fx.rootRight();
+  const targetClaim = fx.memory.ensure(fx.left, fx.right);
+  const target = fx.node(
+    fx.main,
+    [fx.leftRole, fx.rightRole],
+    [[fx.leftRole, fx.left], [fx.rightRole, fx.right]],
+    fx.memory.ensure(fx.leftRole, fx.rightRole),
+    targetClaim,
+    [fx.leftRole, fx.rightRole],
+    [lemma.occurrence, right.occurrence],
+  );
+  const before = fx.memory.linkCount;
+  const result = replayStructuralDerivationWithTheorems(fx.memory, {
+    derivation: { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node, right.node] },
+    theorems: [lemmaEvidence],
+  });
+  same(result.derivation.target.judgment.claim, targetClaim, "lemma reuse target");
+  same(result.derivation.occurrenceCount, 3, "expanded theorem closure");
+  same(result.theorems.length, 1, "one replayed theorem");
+  same(fx.memory.linkCount, before, "theorem reuse read-only");
+}
+
+// One theorem target may satisfy multiple explicit premise positions of an admitted rule.
+{
+  const fx = derivationFixture();
+  const lemma = fx.rootLeft();
+  const theorem = defineStructuralTheorem(fx.memory, fx.left, fx.theory);
+  const targetContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const target = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole, fx.leftRole],
+    [lemma.occurrence, lemma.occurrence],
+    targetContext,
+  );
+  const result = replayStructuralDerivationWithTheorems(fx.memory, {
+    derivation: { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node] },
+    theorems: [{ theorem, proof: { theory: fx.theory, targetOccurrence: lemma.occurrence, nodes: [lemma.node] } }],
+  });
+  same(result.derivation.occurrenceCount, 2, "shared theorem dependency counted once");
+}
+
+// Theorem-record host order is transport only when both theorem proofs are structurally required.
+{
+  const fx = derivationFixture();
+  const left = fx.rootLeft();
+  const right = fx.rootRight();
+  const leftTheorem = {
+    theorem: defineStructuralTheorem(fx.memory, fx.left, fx.theory),
+    proof: { theory: fx.theory, targetOccurrence: left.occurrence, nodes: [left.node] },
+  };
+  const rightTheorem = {
+    theorem: defineStructuralTheorem(fx.memory, fx.right, fx.theory),
+    proof: { theory: fx.theory, targetOccurrence: right.occurrence, nodes: [right.node] },
+  };
+  const claim = fx.memory.ensure(fx.left, fx.right);
+  const target = fx.node(
+    fx.main,
+    [fx.leftRole, fx.rightRole],
+    [[fx.leftRole, fx.left], [fx.rightRole, fx.right]],
+    fx.memory.ensure(fx.leftRole, fx.rightRole),
+    claim,
+    [fx.leftRole, fx.rightRole],
+    [left.occurrence, right.occurrence],
+  );
+  const derivation = { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node] };
+  const first = replayStructuralDerivationWithTheorems(fx.memory, { derivation, theorems: [leftTheorem, rightTheorem] });
+  const second = replayStructuralDerivationWithTheorems(fx.memory, { derivation, theorems: [rightTheorem, leftTheorem] });
+  same(first.derivation.target.judgment.claim, second.derivation.target.judgment.claim, "theorem host order non-semantic");
+  same(first.derivation.occurrenceCount, 3, "two theorem closures expanded");
+}
+
+// A theorem Link is identity only: forged/missing/wrong proof evidence never grants truth.
+{
+  const fx = derivationFixture();
+  const root = fx.rootLeft();
+  const theorem = defineStructuralTheorem(fx.memory, fx.left, fx.theory);
+  expectTheoremError("invalid-theorem-proof", () => replayStructuralTheorem(fx.memory, {
+    theorem,
+    proof: { theory: fx.theory, targetOccurrence: root.occurrence, nodes: [] },
+  }));
+
+  const wrongClaimTheorem = defineStructuralTheorem(fx.memory, fx.right, fx.theory);
+  expectTheoremError("theorem-claim-mismatch", () => replayStructuralTheorem(fx.memory, {
+    theorem: wrongClaimTheorem,
+    proof: { theory: fx.theory, targetOccurrence: root.occurrence, nodes: [root.node] },
+  }));
+
+  const otherTheory = fx.fresh();
+  const wrongTheoryTheorem = defineStructuralTheorem(fx.memory, fx.left, otherTheory);
+  expectTheoremError("theorem-proof-theory-mismatch", () => replayStructuralTheorem(fx.memory, {
+    theorem: wrongTheoryTheorem,
+    proof: { theory: fx.theory, targetOccurrence: root.occurrence, nodes: [root.node] },
+  }));
+
+  const foreignTheorem = new Memory().root;
+  expectTheoremError("invalid-theorem-evidence", () => replayStructuralTheorem(fx.memory, {
+    theorem: foreignTheorem,
+    proof: { theory: fx.theory, targetOccurrence: root.occurrence, nodes: [root.node] },
+  }));
+}
+
+// Reuse is exact same-theory expansion: missing, unsupplied and unused theorem evidence fail closed.
+{
+  const fx = derivationFixture();
+  const lemma = fx.rootLeft();
+  const theoremEvidence = {
+    theorem: defineStructuralTheorem(fx.memory, fx.left, fx.theory),
+    proof: { theory: fx.theory, targetOccurrence: lemma.occurrence, nodes: [lemma.node] },
+  };
+  const targetContext = defineContext(fx.memory, fx.fresh(), fx.fresh());
+  const target = fx.node(
+    fx.main,
+    [fx.leftRole],
+    [[fx.leftRole, fx.left]],
+    fx.leftRole,
+    fx.left,
+    [fx.leftRole],
+    [lemma.occurrence],
+    targetContext,
+  );
+
+  expectDerivationError("dependency-occurrence-not-found", () => replayStructuralDerivationWithTheorems(fx.memory, {
+    derivation: { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node] },
+    theorems: [],
+  }));
+
+  const unrelated = fx.rootRight();
+  expectDerivationError("unreachable-node", () => replayStructuralDerivationWithTheorems(fx.memory, {
+    derivation: { theory: fx.theory, targetOccurrence: unrelated.occurrence, nodes: [unrelated.node] },
+    theorems: [theoremEvidence],
+  }));
+
+  const otherTheory = fx.fresh();
+  const other = fx.environment(otherTheory);
+  const otherRoot = fx.node(other, [fx.leftRole], [[fx.leftRole, fx.left]], fx.leftRole, fx.left);
+  expectTheoremReuseError("theorem-reuse-theory-mismatch", () => replayStructuralDerivationWithTheorems(fx.memory, {
+    derivation: { theory: otherTheory, targetOccurrence: otherRoot.occurrence, nodes: [otherRoot.node] },
+    theorems: [theoremEvidence],
+  }));
+
+  const incompleteTheorem = {
+    ...theoremEvidence,
+    proof: { ...theoremEvidence.proof, nodes: [] },
+  };
+  expectTheoremReuseError("invalid-reused-theorem", () => replayStructuralDerivationWithTheorems(fx.memory, {
+    derivation: { theory: fx.theory, targetOccurrence: target.occurrence, nodes: [target.node] },
+    theorems: [incompleteTheorem],
+  }));
 }

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -16,7 +16,9 @@ import type {
   StackAlgebra,
   StoredDataset,
   StructuralDerivationEvidence,
+  StructuralDerivationWithTheoremsEvidence,
   StructuralJudgmentEvidence,
+  StructuralTheoremEvidence,
   WriteMemory,
 } from "../src/public.js";
 
@@ -52,6 +54,8 @@ const expectedRuntimeExports = [
   "StreamError",
   "StructuralDerivationReplayError",
   "StructuralJudgmentReplayError",
+  "StructuralTheoremReplayError",
+  "StructuralTheoremReuseReplayError",
   "ValueBundleReplayError",
   "analyzeDirectDeixisCarrier",
   "bundleRoleAt",
@@ -80,7 +84,9 @@ const expectedRuntimeExports = [
   "replayRun",
   "replaySequenceMaterialization",
   "replayStructuralDerivation",
+  "replayStructuralDerivationWithTheorems",
   "replayStructuralJudgment",
+  "replayStructuralTheorem",
   "resolveFlatBundle",
   "symbolicStackAlgebra",
   "valuesEqual",
@@ -113,6 +119,8 @@ const deixis: DirectDeixisVocabulary | undefined = undefined;
 const value: MtsValue | undefined = undefined;
 const run: RunEvidence | undefined = undefined;
 const derivation: StructuralDerivationEvidence | undefined = undefined;
+const derivationWithTheorems: StructuralDerivationWithTheoremsEvidence | undefined = undefined;
+const theorem: StructuralTheoremEvidence | undefined = undefined;
 const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
 const integrated: IntegratedProofEvidence | undefined = undefined;
@@ -132,6 +140,8 @@ void [
   value,
   run,
   derivation,
+  derivationWithTheorems,
+  theorem,
   judgment,
   proof,
   integrated,


### PR DESCRIPTION
Closes #817. Refs #779, #657, #777, #814, #815.

P3a implementation slice for proof-carrying `DerivedTheorem` reuse. This does not open v0.12 and does not modify accepted MTS v0.11 contracts/conformance or release evidence.

Exact starting baseline:

```text
main = 2553691c7322f31156a7cf9ee53caa458fdad236
current accepted = MTS v0.11
previous immutable evidence = MTS v0.10
active candidate lifecycle = NONE
exact workflows on main = NONE

P2 final evidence:
  PR #815 head = 3da318a28b265dda7592461a160b739723b7c479
  CI #3299 = SUCCESS
  blocking repo-guard #688 = SUCCESS
  merge/main = 2553691c7322f31156a7cf9ee53caa458fdad236
```

Current branch head at PR opening:

```text
459df0e2699c4b58538ba90520a53ec1fb225a7d
behind_by = 0
```

Current diff surface:

```text
ts/src/derivation.ts       MODIFY +198/-0
ts/src/public.ts           MODIFY  +11/-0
ts/test/derivation.test.ts MODIFY +241/-1
ts/test/public-api.test.ts MODIFY  +10/-0
TOTAL                              +460/-1 (net +459)
```

No new files.

P3a deliberately keeps theorem reuse proof-carrying rather than introducing theorem-as-axiom authority:

```text
DerivedTheorem = Pair(Claim, Theory)
StructuralTheoremEvidence = theorem identity + complete P2 derivation proof
```

The orientation `Pair(Claim, Theory)` is intentional. `Pair(Theory, Claim)` would add theorem metadata to `outgoing(Theory)`, the same structural namespace used by theory admissions such as `T -> StructuralRule` and `T -> DerivationRule`. Keeping `Claim` as the start pole avoids contaminating the Theory admission namespace while preserving exact theorem-under-theory identity.

`replayStructuralTheorem` proves the theorem only by replaying the complete P2 derivation and checking exact Theory and Claim identity. The theorem Link alone, a cache flag, UUID, digest, or any `T -> Theorem`-like metadata is not proof authority.

`replayStructuralDerivationWithTheorems` replays every supplied theorem proof, expands/grafts its complete P2 nodes into the consuming derivation, and then runs the resulting exact target closure through `replayStructuralDerivation` again. This makes theorem reuse reducible to the already generic P2 replay relation rather than adding a second trusted theorem checker.

The corpus covers:

```text
same theorem with distinct proof histories
branching theorem proof
lemma reused in a later proof
one lemma satisfying repeated explicit premise positions
theorem transport order non-semantic
forged theorem identity rejected
wrong theorem Claim/Theory rejected
invalid/incomplete proof rejected
unsupplied theorem target rejected
unused theorem evidence rejected through exact-closure discipline
foreign handles rejected
replay remains read-only
```

External assumptions remain explicitly out of scope for P3a and require a separate P3b slice; no fake proof occurrence or zero-premise theorem is introduced for assumptions.

Public `@mts/core` exposure remains narrow: theorem/reuse replay functions plus top-level evidence/result/error types. Construction/read helpers remain internal package vocabulary.

```repo-guard-yaml
change_type: implementation
scope:
  - ts/src/derivation.ts
  - ts/test/derivation.test.ts
  - ts/src/public.ts
  - ts/test/public-api.test.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 700
must_touch:
  - ts/src/derivation.ts
  - ts/test/derivation.test.ts
  - ts/src/public.ts
  - ts/test/public-api.test.ts
must_not_touch:
  - contracts/**
  - repo-policy.json
  - README.md
  - docs/**
  - cutover/**
  - .github/**
expected_effects:
  - add structural DerivedTheorem identity under an exact Theory
  - make theorem reuse proof-carrying and fully replayable
  - reuse theorem proofs by expansion into the existing P2 exact dependency closure
  - keep theorem identity separate from proof history
  - keep theorem metadata out of the Theory admission namespace
  - prevent theorem/cache/admission metadata from becoming proof authority
  - preserve accepted MTS v0.11 and all release evidence byte-for-byte
  - leave external assumptions to a separate P3b slice
```

Merge gates remain mandatory: full CI green, ready-state blocking repo-guard green, behind_by=0, mergeable=true, stable exact head, merge only with expected_head_sha, exact new-main confirmation, and post-merge CI claimed only if workflows actually exist for the merge SHA.