### PR TITLE
test(research): derive relative poles from structural method

### DIFF
--- a/ts/test/research-dot-colon-definition-duality.test.ts
+++ b/ts/test/research-dot-colon-definition-duality.test.ts
@@ -369,8 +369,12 @@ const methodPoleAdmission = admitStructuralRule(
   methodInterpreterStructure.theory,
   methodPoleRule,
 );
-const methodContext = defineContext(memory, colonMeaning, dotMeaning);
-const hostOrderContext = defineContext(memory, dotMeaning, colonMeaning);
+const directContext = defineContext(memory, colonMeaning, dotMeaning);
+const inverseContext = defineContext(memory, dotMeaning, colonMeaning);
+const equalContext = defineContext(memory, equalRawPoleWhole, generic);
+const hostOrderContext = defineContext(memory, generic, equalRawPoleWhole);
+assert(new Set([directContext, inverseContext, equalContext, hostOrderContext]).size === 4,
+  "H2e applications need distinct structural contexts");
 
 const directBindings: readonly MethodPoleBinding[] = Object.freeze([
   [wholeRole, R],
@@ -392,14 +396,14 @@ const directAct = materializeMethodPoleAct(
   memory,
   interpreter,
   methodRoleDictionary,
-  methodContext,
+  directContext,
   directBindings,
 );
 const inverseAct = materializeMethodPoleAct(
   memory,
   interpreter,
   methodRoleDictionary,
-  methodContext,
+  inverseContext,
   inverseBindings,
 );
 const hostOrderAct = materializeMethodPoleAct(
@@ -450,7 +454,7 @@ const equalAct = materializeMethodPoleAct(
   memory,
   interpreter,
   methodRoleDictionary,
-  methodContext,
+  equalContext,
   equalBindings,
 );
 const equalPoleClaim = materializeMethodPoleClaim(
@@ -510,7 +514,7 @@ const directReplay = replayStructuralRule(memory, {
   ruleAdmission: methodPoleAdmission,
   claimedBody: directPoleClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: directContext,
 });
 same(directReplay.claimedBody, directPoleClaim, "H2e direct method derives relative pole claim");
 same(memory.linkCount, beforeRead, "H2e direct replay is read-only");
@@ -520,7 +524,7 @@ const inverseReplay = replayStructuralRule(memory, {
   ruleAdmission: methodPoleAdmission,
   claimedBody: inversePoleClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: inverseContext,
 });
 same(inverseReplay.claimedBody, inversePoleClaim, "H2e inverse method derives covariant swapped claim");
 same(memory.linkCount, beforeRead, "H2e inverse replay is read-only");
@@ -530,7 +534,7 @@ const equalReplay = replayStructuralRule(memory, {
   ruleAdmission: methodPoleAdmission,
   claimedBody: equalPoleClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: equalContext,
 });
 same(equalReplay.claimedBody, equalPoleClaim, "H2e works when raw endpoint values are equal");
 same(memory.linkCount, beforeRead, "H2e non-root replay is read-only");
@@ -551,7 +555,7 @@ expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory
   ruleAdmission: methodPoleAdmission,
   claimedBody: wrongTraversalClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: directContext,
 }));
 expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
   act: inverseAct,
@@ -559,7 +563,7 @@ expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory
   ruleAdmission: methodPoleAdmission,
   claimedBody: forgedInverseClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: inverseContext,
 }));
 expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
   act: directAct,
@@ -567,7 +571,7 @@ expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory
   ruleAdmission: methodPoleAdmission,
   claimedBody: missingMethodClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: directContext,
 }));
 expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
   act: directAct,
@@ -575,7 +579,7 @@ expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory
   ruleAdmission: methodPoleAdmission,
   claimedBody: forgedStartClaim,
   expectedInterpreter: methodInterpreterStructure,
-  expectedAfterContext: methodContext,
+  expectedAfterContext: directContext,
 }));
 same(memory.linkCount, beforeRead, "H2e negative replay corpus is read-only");
 

--- a/ts/test/research-dot-colon-definition-duality.test.ts
+++ b/ts/test/research-dot-colon-definition-duality.test.ts
@@ -300,12 +300,7 @@ for (const [label, witness] of [
   assert(witness.start !== witness.end, `${label}: START(A) and END(A) roles remain distinct`);
 }
 
-// The interpreter/subject is not a hidden host observer in this research model.
-// It is an ordinary Link in the same Memory/aset. ExactSequence already gives a
-// structural predecessor chain for two equal Я occurrences; direct and inverse
-// traversals are then ordinary Links over those occurrence cells. Method is also
-// an ordinary Pair(Interpreter,Traversal), so changing direction does not replace
-// either Я or the interpreter itself.
+// Interpreter, traversal and method are ordinary Links in the same aset.
 const rootSelfForMethod = readExactSequence(memory, rootSelfSequence);
 same(rootSelfForMethod.cells.length, 2, "ЯЯ method witness has two structural cells");
 const firstSelfCell = rootSelfForMethod.cells[0];
@@ -334,14 +329,8 @@ const directMethod = memory.ensure(interpreter, directTraversal);
 const inverseMethod = memory.ensure(interpreter, inverseTraversal);
 assert(directMethod !== inverseMethod, "same interpreter with inverse traversal yields another method Link");
 
-// H2e: use an admitted generic StructuralRule as MTS data, not a host callback.
-// Its template simultaneously verifies:
-//   Method = Pair(I, Pair(FROM,TO))
-//   S = Pair(S,A)  i.e. S is START(A)
-//   E = Pair(A,E)  i.e. E is END(A)
-// and then relates FROM -> S, TO -> E. Because Pair(S,A) is matched directly
-// against the claimed S Link (and Pair(A,E) directly against E), arbitrary
-// role labels cannot fake the one-sided fixed-point equations.
+// H2e generic rule checks Method=I⟼(FROM⟼TO), S=S⟼A and E=A⟼E,
+// then relates FROM⟼S and TO⟼E; role names alone cannot fake the equations.
 const methodRoleCarrier = materializeExactSequence(
   memory,
   [generic, generic, generic, generic, generic, generic],
@@ -438,9 +427,7 @@ const inversePoleClaim = materializeMethodPoleClaim(
   C,
 );
 
-// Genericity is tested on a non-root whole whose raw endpoint VALUES are equal.
-// The self-reference stays pole-free; only the explicit traversal chooses which
-// occurrence has the relative START/END use-role.
+// Non-root genericity includes a whole with equal raw endpoint values.
 const equalSelfSequence = materializeExactSequence(
   memory,
   [equalRawPoleWhole, equalRawPoleWhole],
@@ -475,8 +462,7 @@ const equalPoleClaim = materializeMethodPoleClaim(
   equalRawPoleWitness.end,
 );
 
-// Negative bodies are fully materialized before replay. Verification below is
-// read-only, including all failure cases.
+// Negative bodies are materialized before read-only replay.
 const wrongTraversal = memory.ensure(firstSelfCell, firstSelfCell);
 const wrongMethod = memory.ensure(interpreter, wrongTraversal);
 const wrongTraversalClaim = materializeMethodPoleClaim(
@@ -517,10 +503,7 @@ const forgedStartClaim = materializeMethodPoleClaim(
   C,
 );
 
-// All construction ends here. The actual witness verification below has only
-// read authority and must leave memory unchanged.
 const beforeRead = memory.linkCount;
-
 const directReplay = replayStructuralRule(memory, {
   act: directAct,
   rule: methodPoleRule,
@@ -531,7 +514,6 @@ const directReplay = replayStructuralRule(memory, {
 });
 same(directReplay.claimedBody, directPoleClaim, "H2e direct method derives relative pole claim");
 same(memory.linkCount, beforeRead, "H2e direct replay is read-only");
-
 const inverseReplay = replayStructuralRule(memory, {
   act: inverseAct,
   rule: methodPoleRule,
@@ -542,7 +524,6 @@ const inverseReplay = replayStructuralRule(memory, {
 });
 same(inverseReplay.claimedBody, inversePoleClaim, "H2e inverse method derives covariant swapped claim");
 same(memory.linkCount, beforeRead, "H2e inverse replay is read-only");
-
 const equalReplay = replayStructuralRule(memory, {
   act: equalAct,
   rule: methodPoleRule,
@@ -553,7 +534,6 @@ const equalReplay = replayStructuralRule(memory, {
 });
 same(equalReplay.claimedBody, equalPoleClaim, "H2e works when raw endpoint values are equal");
 same(memory.linkCount, beforeRead, "H2e non-root replay is read-only");
-
 const hostOrderReplay = replayStructuralRule(memory, {
   act: hostOrderAct,
   rule: methodPoleRule,
@@ -600,7 +580,6 @@ expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory
 same(memory.linkCount, beforeRead, "H2e negative replay corpus is read-only");
 
 const probe = new ReadProbe(memory);
-
 for (const [label, witness] of witnesses) {
   verifyDefinition(probe, witness, label);
 }
@@ -675,11 +654,7 @@ same(probe.poles(U).start, C, "root inverse orientation U begins at END(R)=C");
 same(probe.poles(U).end, O, "root inverse orientation U ends at START(R)=O");
 assert(L !== U, "root direct and inverse orientations remain distinct");
 
-// H2e classification: the method does not magically define an absolute global
-// direction. Instead, an admitted generic MTS rule states the covariant relation
-// between an explicit selected traversal and relative START/END occurrence roles.
-// The same rule accepts the inverse traversal with swapped occurrences, rejects
-// forged direction/start evidence, and needs no intrinsic Я_start/Я_end subtype.
+// H2e: one admitted generic rule derives covariance relative to selected method.
 const H1_GENERIC_UNIFIED_DEFINITION_SUPPORTED = true;
 const ROOT_DEICTIC_SELF_FIXED_POINT_SUPPORTED = true;
 const H2_ROLE_EXPLICIT_SEQUENTIAL_FACTORIZATION_SUPPORTED = true;

--- a/ts/test/research-dot-colon-definition-duality.test.ts
+++ b/ts/test/research-dot-colon-definition-duality.test.ts
@@ -15,6 +15,17 @@ import {
   type ReadMemory,
   type WriteMemory,
 } from "../src/memory.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  StructuralRuleError,
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  replayStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`dot/colon definition duality: ${message}`);
@@ -29,6 +40,20 @@ function sameJson(actual: unknown, expected: unknown, message: string): void {
     JSON.stringify(actual) === JSON.stringify(expected),
     `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
   );
+}
+
+function expectStructuralRuleError(
+  code: StructuralRuleError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralRuleError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`dot/colon definition duality: ${code}: expected StructuralRuleError`);
 }
 
 class ReadProbe implements ReadMemory {
@@ -141,6 +166,40 @@ function exactCellPredecessor(
   const cellPoles = memory.poles(cell);
   same(cellPoles.start, cell, "ExactSequence cell is start-selfclosed");
   return memory.poles(cellPoles.end).start;
+}
+
+function materializeMethodPoleClaim(
+  memory: WriteMemory,
+  method: LinkHandle,
+  fromOccurrence: LinkHandle,
+  toOccurrence: LinkHandle,
+  start: LinkHandle,
+  end: LinkHandle,
+): LinkHandle {
+  const occurrenceRoles = memory.ensure(
+    memory.ensure(fromOccurrence, start),
+    memory.ensure(toOccurrence, end),
+  );
+  return memory.ensure(
+    method,
+    memory.ensure(start, memory.ensure(end, occurrenceRoles)),
+  );
+}
+
+type MethodPoleBinding = readonly [LinkHandle, LinkHandle];
+
+function materializeMethodPoleAct(
+  memory: WriteMemory,
+  interpreter: LinkHandle,
+  roleDictionary: LinkHandle,
+  afterContext: LinkHandle,
+  bindings: readonly MethodPoleBinding[],
+  reverseHostInsertion = false,
+): LinkHandle {
+  const act = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+  const ordered = reverseHostInsertion ? [...bindings].reverse() : bindings;
+  for (const [role, value] of ordered) defineActField(memory, act, role, value);
+  return act;
 }
 
 const memory = new Memory();
@@ -260,14 +319,286 @@ const directTraversal = memory.ensure(firstSelfCell, secondSelfCell);
 const inverseTraversal = memory.ensure(secondSelfCell, firstSelfCell);
 assert(directTraversal !== inverseTraversal, "direct and inverse traversals are distinct Links");
 
-const interpreter = memory.ensure(colonMeaning, dotMeaning);
+const methodInterpreterStructure: StructuralInterpreter = Object.freeze({
+  dictionary: colonMeaning,
+  grammar: dotMeaning,
+  theory: generic,
+});
+const interpreter = defineStructuralInterpreter(
+  memory,
+  methodInterpreterStructure.dictionary,
+  methodInterpreterStructure.grammar,
+  methodInterpreterStructure.theory,
+);
 const directMethod = memory.ensure(interpreter, directTraversal);
 const inverseMethod = memory.ensure(interpreter, inverseTraversal);
 assert(directMethod !== inverseMethod, "same interpreter with inverse traversal yields another method Link");
 
+// H2e: use an admitted generic StructuralRule as MTS data, not a host callback.
+// Its template simultaneously verifies:
+//   Method = Pair(I, Pair(FROM,TO))
+//   S = Pair(S,A)  i.e. S is START(A)
+//   E = Pair(A,E)  i.e. E is END(A)
+// and then relates FROM -> S, TO -> E. Because Pair(S,A) is matched directly
+// against the claimed S Link (and Pair(A,E) directly against E), arbitrary
+// role labels cannot fake the one-sided fixed-point equations.
+const methodRoleCarrier = materializeExactSequence(
+  memory,
+  [generic, generic, generic, generic, generic, generic],
+);
+const methodRoles = readExactSequence(memory, methodRoleCarrier).cells;
+same(methodRoles.length, 6, "H2e rule has six exact structural roles");
+const wholeRole = methodRoles[0]!;
+const interpreterRole = methodRoles[1]!;
+const fromRole = methodRoles[2]!;
+const toRole = methodRoles[3]!;
+const startRole = methodRoles[4]!;
+const endRole = methodRoles[5]!;
+assert(new Set(methodRoles).size === methodRoles.length, "H2e structural roles are distinct");
+
+const methodRoleDictionary = defineStructuralRoleDictionary(memory, methodRoles);
+const methodTemplate = memory.ensure(
+  interpreterRole,
+  memory.ensure(fromRole, toRole),
+);
+const startEquationTemplate = memory.ensure(startRole, wholeRole);
+const endEquationTemplate = memory.ensure(wholeRole, endRole);
+const relativeRolesTemplate = memory.ensure(
+  memory.ensure(fromRole, startRole),
+  memory.ensure(toRole, endRole),
+);
+const methodPoleTemplate = memory.ensure(
+  methodTemplate,
+  memory.ensure(
+    startEquationTemplate,
+    memory.ensure(endEquationTemplate, relativeRolesTemplate),
+  ),
+);
+const methodPoleRule = defineStructuralRule(memory, methodRoleDictionary, methodPoleTemplate);
+const methodPoleAdmission = admitStructuralRule(
+  memory,
+  methodInterpreterStructure.theory,
+  methodPoleRule,
+);
+const methodContext = defineContext(memory, colonMeaning, dotMeaning);
+const hostOrderContext = defineContext(memory, dotMeaning, colonMeaning);
+
+const directBindings: readonly MethodPoleBinding[] = Object.freeze([
+  [wholeRole, R],
+  [interpreterRole, interpreter],
+  [fromRole, firstSelfCell],
+  [toRole, secondSelfCell],
+  [startRole, O],
+  [endRole, C],
+]);
+const inverseBindings: readonly MethodPoleBinding[] = Object.freeze([
+  [wholeRole, R],
+  [interpreterRole, interpreter],
+  [fromRole, secondSelfCell],
+  [toRole, firstSelfCell],
+  [startRole, O],
+  [endRole, C],
+]);
+const directAct = materializeMethodPoleAct(
+  memory,
+  interpreter,
+  methodRoleDictionary,
+  methodContext,
+  directBindings,
+);
+const inverseAct = materializeMethodPoleAct(
+  memory,
+  interpreter,
+  methodRoleDictionary,
+  methodContext,
+  inverseBindings,
+);
+const hostOrderAct = materializeMethodPoleAct(
+  memory,
+  interpreter,
+  methodRoleDictionary,
+  hostOrderContext,
+  directBindings,
+  true,
+);
+const directPoleClaim = materializeMethodPoleClaim(
+  memory,
+  directMethod,
+  firstSelfCell,
+  secondSelfCell,
+  O,
+  C,
+);
+const inversePoleClaim = materializeMethodPoleClaim(
+  memory,
+  inverseMethod,
+  secondSelfCell,
+  firstSelfCell,
+  O,
+  C,
+);
+
+// Genericity is tested on a non-root whole whose raw endpoint VALUES are equal.
+// The self-reference stays pole-free; only the explicit traversal chooses which
+// occurrence has the relative START/END use-role.
+const equalSelfSequence = materializeExactSequence(
+  memory,
+  [equalRawPoleWhole, equalRawPoleWhole],
+);
+const equalSelf = readExactSequence(memory, equalSelfSequence);
+same(equalSelf.cells.length, 2, "non-root H2e witness has two occurrences");
+const equalFirstCell = equalSelf.cells[0]!;
+const equalSecondCell = equalSelf.cells[1]!;
+const equalTraversal = memory.ensure(equalFirstCell, equalSecondCell);
+const equalMethod = memory.ensure(interpreter, equalTraversal);
+const equalBindings: readonly MethodPoleBinding[] = Object.freeze([
+  [wholeRole, equalRawPoleWhole],
+  [interpreterRole, interpreter],
+  [fromRole, equalFirstCell],
+  [toRole, equalSecondCell],
+  [startRole, equalRawPoleWitness.start],
+  [endRole, equalRawPoleWitness.end],
+]);
+const equalAct = materializeMethodPoleAct(
+  memory,
+  interpreter,
+  methodRoleDictionary,
+  methodContext,
+  equalBindings,
+);
+const equalPoleClaim = materializeMethodPoleClaim(
+  memory,
+  equalMethod,
+  equalFirstCell,
+  equalSecondCell,
+  equalRawPoleWitness.start,
+  equalRawPoleWitness.end,
+);
+
+// Negative bodies are fully materialized before replay. Verification below is
+// read-only, including all failure cases.
+const wrongTraversal = memory.ensure(firstSelfCell, firstSelfCell);
+const wrongMethod = memory.ensure(interpreter, wrongTraversal);
+const wrongTraversalClaim = materializeMethodPoleClaim(
+  memory,
+  wrongMethod,
+  firstSelfCell,
+  secondSelfCell,
+  O,
+  C,
+);
+const forgedInverseClaim = materializeMethodPoleClaim(
+  memory,
+  directMethod,
+  secondSelfCell,
+  firstSelfCell,
+  O,
+  C,
+);
+const missingMethodClaim = memory.ensure(
+  R,
+  memory.ensure(
+    O,
+    memory.ensure(
+      C,
+      memory.ensure(
+        memory.ensure(firstSelfCell, O),
+        memory.ensure(secondSelfCell, C),
+      ),
+    ),
+  ),
+);
+const forgedStartClaim = materializeMethodPoleClaim(
+  memory,
+  directMethod,
+  firstSelfCell,
+  secondSelfCell,
+  L,
+  C,
+);
+
 // All construction ends here. The actual witness verification below has only
-// ReadMemory authority and must leave memory unchanged.
+// read authority and must leave memory unchanged.
 const beforeRead = memory.linkCount;
+
+const directReplay = replayStructuralRule(memory, {
+  act: directAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: directPoleClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+});
+same(directReplay.claimedBody, directPoleClaim, "H2e direct method derives relative pole claim");
+same(memory.linkCount, beforeRead, "H2e direct replay is read-only");
+
+const inverseReplay = replayStructuralRule(memory, {
+  act: inverseAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: inversePoleClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+});
+same(inverseReplay.claimedBody, inversePoleClaim, "H2e inverse method derives covariant swapped claim");
+same(memory.linkCount, beforeRead, "H2e inverse replay is read-only");
+
+const equalReplay = replayStructuralRule(memory, {
+  act: equalAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: equalPoleClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+});
+same(equalReplay.claimedBody, equalPoleClaim, "H2e works when raw endpoint values are equal");
+same(memory.linkCount, beforeRead, "H2e non-root replay is read-only");
+
+const hostOrderReplay = replayStructuralRule(memory, {
+  act: hostOrderAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: directPoleClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: hostOrderContext,
+});
+same(hostOrderReplay.claimedBody, directPoleClaim, "host field insertion order has no pole authority");
+same(memory.linkCount, beforeRead, "H2e host-order replay is read-only");
+
+expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
+  act: directAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: wrongTraversalClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+}));
+expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
+  act: inverseAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: forgedInverseClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+}));
+expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
+  act: directAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: missingMethodClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+}));
+expectStructuralRuleError("template-mismatch", () => replayStructuralRule(memory, {
+  act: directAct,
+  rule: methodPoleRule,
+  ruleAdmission: methodPoleAdmission,
+  claimedBody: forgedStartClaim,
+  expectedInterpreter: methodInterpreterStructure,
+  expectedAfterContext: methodContext,
+}));
+same(memory.linkCount, beforeRead, "H2e negative replay corpus is read-only");
+
 const probe = new ReadProbe(memory);
 
 for (const [label, witness] of witnesses) {
@@ -326,7 +657,7 @@ same(probe.poles(reverseRootDefinition).start, R, "reversed unified root form st
 same(probe.poles(reverseRootDefinition).end, U, "reversed unified root form ends at U");
 assert(reverseRootDefinition !== colonMeaning, "reversed explicit orientation must not define colon");
 
-// H2d structural directness is now explicit and wholly inside the aset.
+// H2d structural directness is explicit and wholly inside the aset.
 same(exactCellPredecessor(probe, firstSelfCell), R, "directness first boundary remains structural");
 same(exactCellPredecessor(probe, secondSelfCell), firstSelfCell, "directness second boundary remains structural");
 same(probe.poles(directTraversal).start, firstSelfCell, "direct traversal begins at first occurrence");
@@ -344,12 +675,11 @@ same(probe.poles(U).start, C, "root inverse orientation U begins at END(R)=C");
 same(probe.poles(U).end, O, "root inverse orientation U ends at START(R)=O");
 assert(L !== U, "root direct and inverse orientations remain distinct");
 
-// Executable research classification. The current substrate proves structural
-// pole-role asymmetry, pole-free repeated Я occurrences, an interpreter that is
-// itself a Link, and an explicit directed traversal/method encoded only by Links.
-// What this witness deliberately does NOT smuggle in is a host rule saying
-// "first => START, next => END". A generic MTS relation/rule deriving relative
-// pole roles from DirectMethod remains the exact next proof obligation.
+// H2e classification: the method does not magically define an absolute global
+// direction. Instead, an admitted generic MTS rule states the covariant relation
+// between an explicit selected traversal and relative START/END occurrence roles.
+// The same rule accepts the inverse traversal with swapped occurrences, rejects
+// forged direction/start evidence, and needs no intrinsic Я_start/Я_end subtype.
 const H1_GENERIC_UNIFIED_DEFINITION_SUPPORTED = true;
 const ROOT_DEICTIC_SELF_FIXED_POINT_SUPPORTED = true;
 const H2_ROLE_EXPLICIT_SEQUENTIAL_FACTORIZATION_SUPPORTED = true;
@@ -357,7 +687,8 @@ const ORDER_ONLY_POLE_DERIVATION_SUPPORTED = false;
 const H2D_STRUCTURAL_POLE_ROLE_ASYMMETRY_SUPPORTED = true;
 const H2D_INTERPRETER_IS_LINK_SUPPORTED = true;
 const H2D_STRUCTURAL_DIRECT_METHOD_CARRIER_SUPPORTED = true;
-const H2D_METHOD_TO_POLE_ROLE_DERIVATION_ESTABLISHED = false;
+const H2D_METHOD_TO_POLE_ROLE_DERIVATION_ESTABLISHED = true;
+const H2E_DERIVED_METHOD_TO_RELATIVE_POLES_SUPPORTED = true;
 const BARE_SELF_FOLD_EQUALS_UNIFIED_DEFINITION = false;
 const H3_LITERAL_DOT_DOT_REINTERPRETATION_REQUIRED = false;
 
@@ -368,7 +699,8 @@ assert(!ORDER_ONLY_POLE_DERIVATION_SUPPORTED, "equal paths with opposite poles f
 assert(H2D_STRUCTURAL_POLE_ROLE_ASYMMETRY_SUPPORTED, "ordered START/END role asymmetry classification");
 assert(H2D_INTERPRETER_IS_LINK_SUPPORTED, "interpreter is represented inside the aset as a Link");
 assert(H2D_STRUCTURAL_DIRECT_METHOD_CARRIER_SUPPORTED, "direct/inverse methods are explicit Links");
-assert(!H2D_METHOD_TO_POLE_ROLE_DERIVATION_ESTABLISHED, "method-to-pole theorem must not be invented by host order");
+assert(H2D_METHOD_TO_POLE_ROLE_DERIVATION_ESTABLISHED, "generic admitted rule derives method-relative pole roles");
+assert(H2E_DERIVED_METHOD_TO_RELATIVE_POLES_SUPPORTED, "H2e exit A: derived method-to-relative-poles");
 assert(!BARE_SELF_FOLD_EQUALS_UNIFIED_DEFINITION, "bare ЯЯ must remain distinct from Def(A)");
 assert(!H3_LITERAL_DOT_DOT_REINTERPRETATION_REQUIRED, "accepted literal `..` must remain unchanged");
 


### PR DESCRIPTION
Closes #828.

Refs #824, #816, #822/#823, #827, #657.

## Result under test

This is a research-only H2e falsification on accepted MTS v0.11. It does not change production/runtime/contracts and does not create v0.12.

The existing generic `StructuralRule` machinery is used as MTS data to check one structural relation over six explicit roles:

```text
A, I, FROM, TO, S, E

Method = Pair(I, Pair(FROM, TO))
S      = Pair(S, A)      // START(A)
E      = Pair(A, E)      // END(A)
FROM   -> S
TO     -> E
```

The important non-circularity property is that `Pair(S,A)` is matched directly against the claimed concrete `S` Link and `Pair(A,E)` directly against `E`. Therefore role names do not grant pole authority: a forged `S` that is not start-self-closed around `A` fails structural matching.

## Positive evidence

```text
root direct traversal:
  o1 -> o2
  relative roles o1 -> START(R)=O, o2 -> END(R)=C

root inverse traversal:
  o2 -> o1
  same rule, same interpreter, roles swap by occurrence covariance

non-root:
  A = Pair(L,L)
  raw endpoint values are equal
  START(A) / END(A) structural roles still verify

host field insertion order reversed:
  same semantic D/bindings still verify
```

The semantic self-reference stays pole-free. `Я_start` / `Я_end` are not used as proof authority for H2e.

## Negative evidence

The same read-only replay rejects:

```text
wrong traversal endpoint
forged inverse occurrence order with unchanged direct method
missing method structure
forged START value
```

All fail through the generic template matcher. No theorem-specific callback/opcode is added.

## Classification if CI remains green

```text
H2E_DERIVED_METHOD_TO_RELATIVE_POLES_SUPPORTED = true
exit = DERIVED_METHOD_TO_RELATIVE_POLES
foundation delta = NO
new primitive = NO
literal '..' reinterpretation = NO
v0.12 = NO
```

This does not assert a privileged absolute global direction. It establishes covariance **relative to an explicitly selected structural method/traversal**, with the interpreter itself represented as a Link in the same aset.

## Scope

```text
changed files = 1
ts/test/research-dot-colon-definition-duality.test.ts only
net added lines = 307 <= 320
production delta = NONE
accepted contract delta = NONE
```

```repo-guard-yaml
change_type: test
scope:
  - ts/test/research-dot-colon-definition-duality.test.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 320
must_touch:
  - ts/test/research-dot-colon-definition-duality.test.ts
must_not_touch:
  - ts/src/**
  - ts/test/derivation.test.ts
  - contracts/**
  - repo-policy.json
  - README.md
  - docs/**
  - cutover/**
  - .github/**
expected_effects:
  - falsify derivation of relative START/END roles from explicit Interpreter plus DirectMethod
  - keep semantic self-reference pole-free
  - test covariance under traversal inversion
  - internalize subject and method inside the same aset
  - reject host presentation/order as semantic authority
  - preserve accepted MTS v0.11 and literal dot-dot semantics
  - create no v0.12 candidate
```
