### PR TITLE
feat(proof): canonicalize topology independent of allocation order

### DIFF
--- a/ts/src/canonical-topology.ts
+++ b/ts/src/canonical-topology.ts
@@ -1,0 +1,133 @@
+import {
+  MemoryError,
+  type EnumerableReadMemory,
+  type LinkHandle,
+} from "./memory.js";
+import {
+  STORAGE_TOPOLOGY_SCHEMA,
+  type StorageTopologyImage,
+} from "./persistence-topology.js";
+
+export interface CanonicalTopologyExport {
+  readonly topology: StorageTopologyImage;
+  readonly coordinates: ReadonlyMap<LinkHandle, number>;
+}
+
+export class CanonicalTopologyError extends Error {
+  override readonly name = "CanonicalTopologyError";
+}
+
+type ReadyKind = 0 | 1 | 2;
+
+interface ReadyLink {
+  readonly link: LinkHandle;
+  readonly kind: ReadyKind;
+  readonly first: number;
+  readonly second: number;
+}
+
+function invalid(message: string): never {
+  throw new CanonicalTopologyError(message);
+}
+
+function compareReady(left: ReadyLink, right: ReadyLink): number {
+  return left.kind - right.kind || left.first - right.first || left.second - right.second;
+}
+
+function sameKey(left: ReadyLink, right: ReadyLink): boolean {
+  return left.kind === right.kind && left.first === right.first && left.second === right.second;
+}
+
+/**
+ * Produces allocation-independent coordinates for one rooted finite MTS topology.
+ * The coordinate map is builder-side bookkeeping only; portable proof evidence
+ * must serialize coordinates, never LinkHandle or host callbacks.
+ */
+export function exportCanonicalTopology(memory: EnumerableReadMemory): CanonicalTopologyExport {
+  const before = memory.linkCount;
+  try {
+    const all = memory.allLinks();
+    if (all.length !== before || new Set(all).size !== all.length || !all.includes(memory.root)) {
+      invalid("enumeration does not match selected Memory");
+    }
+
+    const coordinates = new Map<LinkHandle, number>([[memory.root, 0]]);
+    const links: Array<readonly [number, number]> = [Object.freeze([0, 0] as const)];
+    const remaining = new Set(all.filter((link) => link !== memory.root));
+
+    while (remaining.size > 0) {
+      const ready: ReadyLink[] = [];
+
+      for (const link of remaining) {
+        const poles = memory.poles(link);
+        if (poles.start === link && poles.end === link) {
+          invalid("second fully self-closed Link is not canonical");
+        }
+
+        const startSelf = poles.start === link;
+        const endSelf = poles.end === link;
+        const start = startSelf ? undefined : coordinates.get(poles.start);
+        const end = endSelf ? undefined : coordinates.get(poles.end);
+
+        if (startSelf && end !== undefined) {
+          ready.push({ link, kind: 0, first: end, second: 0 });
+        } else if (endSelf && start !== undefined) {
+          ready.push({ link, kind: 1, first: start, second: 0 });
+        } else if (!startSelf && !endSelf && start !== undefined && end !== undefined) {
+          ready.push({ link, kind: 2, first: start, second: end });
+        }
+      }
+
+      if (ready.length === 0) {
+        invalid("topology is not rooted dependency-respecting MTS");
+      }
+
+      ready.sort(compareReady);
+      for (let index = 1; index < ready.length; index += 1) {
+        if (sameKey(ready[index - 1]!, ready[index]!)) {
+          invalid("duplicate canonical structural key");
+        }
+      }
+
+      // Assign one dependency-closed round atomically. A Link made ready by this
+      // round is deliberately deferred to the next round, so enumeration order
+      // cannot become semantic/canonical ordering authority.
+      for (const item of ready) {
+        const coordinate = links.length;
+        coordinates.set(item.link, coordinate);
+        if (item.kind === 0) {
+          links.push(Object.freeze([coordinate, item.first] as const));
+        } else if (item.kind === 1) {
+          links.push(Object.freeze([item.first, coordinate] as const));
+        } else {
+          links.push(Object.freeze([item.first, item.second] as const));
+        }
+        remaining.delete(item.link);
+      }
+    }
+
+    if (coordinates.size !== all.length || links.length !== all.length) {
+      invalid("canonical topology cardinality mismatch");
+    }
+    if (memory.linkCount !== before) invalid("canonical topology export mutated Memory");
+
+    return Object.freeze({
+      topology: Object.freeze({
+        schema: STORAGE_TOPOLOGY_SCHEMA,
+        root: 0,
+        links: Object.freeze(links),
+      }),
+      coordinates,
+    });
+  } catch (error) {
+    if (error instanceof CanonicalTopologyError) throw error;
+    if (error instanceof MemoryError) {
+      throw new CanonicalTopologyError("invalid selected Memory topology");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new CanonicalTopologyError("canonical topology export mutated Memory");
+    }
+  }
+}

--- a/ts/test/canonical-topology.test.ts
+++ b/ts/test/canonical-topology.test.ts
@@ -1,0 +1,189 @@
+import { exportCanonicalTopology, CanonicalTopologyError } from "../src/canonical-topology.js";
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type EnumerableReadMemory,
+  type LinkHandle,
+} from "../src/memory.js";
+import { exportTopology, restoreTopology } from "../src/persistence-topology.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function image(memory: Memory): string {
+  return JSON.stringify(exportCanonicalTopology(memory).topology);
+}
+
+function expectCanonicalError(effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof CanonicalTopologyError, "expected CanonicalTopologyError");
+    return;
+  }
+  throw new Error("expected canonical topology rejection");
+}
+
+function siblingFixture(reverse: boolean): Memory {
+  const memory = new Memory();
+  const { O, C } = ensureRootBasis(memory);
+  let x: LinkHandle;
+  let y: LinkHandle;
+  if (reverse) {
+    y = memory.ensure(C, C);
+    x = memory.ensure(O, O);
+  } else {
+    x = memory.ensure(O, O);
+    y = memory.ensure(C, C);
+  }
+  memory.ensure(x, y);
+  return memory;
+}
+
+function layeredFixture(reverse: boolean): Memory {
+  const memory = new Memory();
+  const { O, C } = ensureRootBasis(memory);
+  let x: LinkHandle;
+  let y: LinkHandle;
+  let z: LinkHandle;
+
+  if (reverse) {
+    z = memory.ensure(C, C);
+    y = memory.ensure(C, O);
+    x = memory.ensure(O, O);
+  } else {
+    x = memory.ensure(O, O);
+    y = memory.ensure(C, O);
+    z = memory.ensure(C, C);
+  }
+
+  let left: LinkHandle;
+  let right: LinkHandle;
+  if (reverse) {
+    right = memory.ensure(y, z);
+    left = memory.ensure(x, y);
+  } else {
+    left = memory.ensure(x, y);
+    right = memory.ensure(y, z);
+  }
+  memory.ensure(left, right);
+  return memory;
+}
+
+function pairOrientationFixture(reverse: boolean): Memory {
+  const memory = new Memory();
+  const { O, C } = ensureRootBasis(memory);
+  const x = memory.ensure(O, O);
+  const y = memory.ensure(C, C);
+  memory.ensure(reverse ? y : x, reverse ? x : y);
+  return memory;
+}
+
+function selfOrientationFixture(startSelf: boolean): Memory {
+  const memory = new Memory();
+  const { O } = ensureRootBasis(memory);
+  const x = memory.ensure(O, O);
+  if (startSelf) memory.ensureStartSelfClosed(x);
+  else memory.ensureEndSelfClosed(x);
+  return memory;
+}
+
+function sequenceFixture(reverse: boolean): Memory {
+  const memory = new Memory();
+  const { O, C } = ensureRootBasis(memory);
+  const x = memory.ensure(O, O);
+  const y = memory.ensure(C, C);
+  materializeExactSequence(memory, reverse ? [y, x] : [x, y]);
+  return memory;
+}
+
+// P6a witness: historical storage coordinates remain allocation-sensitive while
+// the new canonical normalization is byte-identical for the same semantic net.
+{
+  const forward = siblingFixture(false);
+  const reverse = siblingFixture(true);
+  assert(
+    JSON.stringify(exportTopology(forward)) !== JSON.stringify(exportTopology(reverse)),
+    "ordinary persistence images should retain the P6a allocation-order distinction",
+  );
+
+  const beforeForward = forward.linkCount;
+  const beforeReverse = reverse.linkCount;
+  same(image(forward), image(reverse), "canonical sibling topology ignores allocation order");
+  same(forward.linkCount, beforeForward, "forward canonical export is read-only");
+  same(reverse.linkCount, beforeReverse, "reverse canonical export is read-only");
+}
+
+// Multiple independent siblings and a second dependent layer remain canonical
+// without using issuance order as a tie-breaker.
+{
+  const forward = layeredFixture(false);
+  const reverse = layeredFixture(true);
+  same(image(forward), image(reverse), "layered topology canonicalizes across creation orders");
+}
+
+// Builder-side remap is complete, one-to-one, rooted at coordinate 0, and the
+// normalized storage image reconstructs in a fresh Memory idempotently.
+{
+  const memory = layeredFixture(true);
+  const before = memory.linkCount;
+  const canonical = exportCanonicalTopology(memory);
+  same(memory.linkCount, before, "canonical export does not write");
+  same(canonical.coordinates.size, memory.linkCount, "remap covers every source Link");
+  same(canonical.coordinates.get(memory.root), 0, "ROOT canonical coordinate");
+
+  const seen = new Set<number>();
+  for (const link of memory.allLinks()) {
+    const coordinate = canonical.coordinates.get(link);
+    assert(coordinate !== undefined, "every source Link has a canonical coordinate");
+    seen.add(coordinate);
+  }
+  same(seen.size, memory.linkCount, "canonical coordinates are one-to-one");
+
+  const restored = restoreTopology(canonical.topology);
+  const beforeRestored = restored.linkCount;
+  same(image(restored), JSON.stringify(canonical.topology), "canonical re-export is idempotent");
+  same(restored.linkCount, beforeRestored, "fresh canonical re-export is read-only");
+}
+
+// Ordered Pair orientation, self-closure pole orientation, and explicitly
+// materialized ExactSequence order remain semantic distinctions.
+{
+  assert(
+    image(pairOrientationFixture(false)) !== image(pairOrientationFixture(true)),
+    "Pair(X,Y) must differ from Pair(Y,X)",
+  );
+  assert(
+    image(selfOrientationFixture(true)) !== image(selfOrientationFixture(false)),
+    "START-self must differ from END-self",
+  );
+  assert(
+    image(sequenceFixture(false)) !== image(sequenceFixture(true)),
+    "ExactSequence([X,Y]) must differ from ExactSequence([Y,X])",
+  );
+}
+
+// An enumerable view that omits the dependencies of one selected Link is not a
+// rooted closed topology. Canonicalization fails closed rather than falling back
+// to source issuance order.
+{
+  const source = new Memory();
+  const { O } = ensureRootBasis(source);
+  const orphaned = source.ensure(O, O);
+  const broken: EnumerableReadMemory = {
+    root: source.root,
+    linkCount: 2,
+    allLinks: () => Object.freeze([source.root, orphaned]),
+    poles: (link) => source.poles(link),
+    find: (start, end) => source.find(start, end),
+    outgoing: (start) => source.outgoing(start),
+    incoming: (end) => source.incoming(end),
+  };
+  expectCanonicalError(() => exportCanonicalTopology(broken));
+}


### PR DESCRIPTION
Closes #835

## Scope

P6b adds only the allocation-independent canonical-topology layer justified by P6a. It deliberately does **not** define a portable proof schema, digest, theorem cache authority, or MTS v0.12 semantic candidate.

```text
base = 8f7647cd1ef2905f9b2cc2c600e0c8f99a84dddb
head = af8b413622f6e182e580536b55a3f7b02b199209
files = 2 new files
net additions = 322
accepted semantic changes = NONE
v0.12 = NOT OPENED
```

## Production boundary

New `ts/src/canonical-topology.ts` provides `exportCanonicalTopology(memory)` and a builder-side source-handle → canonical-coordinate map.

Canonical coordinates are assigned in dependency-closed rounds:

```text
ROOT = 0

for each round:
  collect the complete currently-ready set
  derive key only from:
    START-self + canonical end coordinate
    END-self   + canonical start coordinate
    Pair       + canonical start/end coordinates
  sort the complete ready set by that structural key
  reject duplicate structural keys
  assign coordinates for the whole round atomically
```

There is no issuance/allocation-order fallback. A Link made ready by the current batch is deferred to the next batch, so host enumeration order cannot gain canonical authority.

The historical `exportTopology()` behavior remains unchanged.

## Executable corpus

`ts/test/canonical-topology.test.ts` verifies:

- the exact P6a opposite-sibling-order fixture still yields different historical storage images but byte-identical canonical images;
- a larger two-layer network remains canonical under reversed sibling/dependent creation order;
- canonical export is read-only;
- the builder-side remap covers every source Link one-to-one and keeps ROOT at coordinate 0;
- canonical topology restores through existing `restoreTopology()` and re-canonicalizes idempotently;
- `Pair(X,Y)` remains distinct from `Pair(Y,X)`;
- START-self remains distinct from END-self;
- explicitly encoded `ExactSequence([X,Y])` remains distinct from `ExactSequence([Y,X])`;
- an enumerable view missing semantic dependencies fails closed instead of falling back to issuance order.

## Expected classification

```text
CANONICAL_TOPOLOGY_NORMALIZATION_SUPPORTED
```

This means allocation-independent canonical coordinates can be derived from the existing rooted MTS topology without changing accepted MTS semantics.

It does **not** mean:

```text
canonical bytes => theorem true
canonical coordinate => global semantic identity
digest => proof authority
storage topology schema => portable proof schema
```

A later P6c may use this layer to define a strictly versioned portable `StructuralDerivationEvidence` envelope, reconstruct fresh-Memory handles, and invoke the existing generic replay kernel.

## Isolation

```text
ts/src/canonical-topology.ts       NEW +133
ts/test/canonical-topology.test.ts NEW +189
```

No existing persistence, Memory, derivation, public API, contracts, policy, docs, cutover, README or workflow files are modified.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- PR mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only for workflows that actually exist on the merge SHA
