### PR TITLE
feat(proof): add portable structural derivation transport

### DIFF
--- a/ts/src/portable-derivation.ts
+++ b/ts/src/portable-derivation.ts
@@ -1,0 +1,402 @@
+import {
+  CanonicalTopologyError,
+  exportCanonicalTopology,
+} from "./canonical-topology.js";
+import {
+  replayStructuralDerivation,
+  type StructuralDerivationEvidence,
+  type StructuralDerivationReplayResult,
+} from "./derivation.js";
+import {
+  Memory,
+  type EnumerableReadMemory,
+  type LinkHandle,
+} from "./memory.js";
+import {
+  PersistenceTopologyError,
+  STORAGE_TOPOLOGY_SCHEMA,
+  restoreTopology,
+  type StorageTopologyImage,
+} from "./persistence-topology.js";
+
+export const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA =
+  "mts-portable-structural-derivation/v0.1" as const;
+export const PORTABLE_MTS_SEMANTIC_BASE = "mts-contract/v0.11" as const;
+
+export interface PortableStructuralInterpreterCoordinates {
+  readonly dictionary: number;
+  readonly grammar: number;
+  readonly theory: number;
+}
+
+export interface PortableStructuralRuleApplicationCoordinates {
+  readonly act: number;
+  readonly rule: number;
+  readonly ruleAdmission: number;
+  readonly claimedBody: number;
+  readonly expectedInterpreter: PortableStructuralInterpreterCoordinates;
+  readonly expectedAfterContext: number;
+}
+
+export interface PortableStructuralJudgmentCoordinates {
+  readonly theory: number;
+  readonly context: number;
+  readonly claim: number;
+}
+
+export interface PortableStructuralJudgmentEvidence {
+  readonly application: PortableStructuralRuleApplicationCoordinates;
+  readonly judgment: PortableStructuralJudgmentCoordinates;
+}
+
+export interface PortableStructuralDerivationNode {
+  readonly occurrence: number;
+  readonly judgment: PortableStructuralJudgmentEvidence;
+  readonly derivationRule: number;
+  readonly derivationRuleAdmission: number;
+  readonly premiseOccurrenceSequence: number;
+}
+
+export interface PortableStructuralDerivationArtifact {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+  readonly theoryCoordinate: number;
+  readonly targetOccurrenceCoordinate: number;
+  readonly nodes: readonly PortableStructuralDerivationNode[];
+}
+
+export type PortableStructuralDerivationErrorCode =
+  | "invalid-envelope"
+  | "unsupported-schema"
+  | "unsupported-semantic-base"
+  | "invalid-topology"
+  | "noncanonical-topology"
+  | "invalid-coordinate"
+  | "noncanonical-node-order";
+
+export class PortableStructuralDerivationError extends Error {
+  override readonly name = "PortableStructuralDerivationError";
+
+  constructor(readonly code: PortableStructuralDerivationErrorCode) {
+    super(code);
+  }
+}
+
+export interface PortableStructuralDerivationReplayResult {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationEvidence;
+  readonly replay: StructuralDerivationReplayResult;
+}
+
+function fail(code: PortableStructuralDerivationErrorCode): never {
+  throw new PortableStructuralDerivationError(code);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail("invalid-envelope");
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactRecord(value: unknown, keys: readonly string[]): Record<string, unknown> {
+  const candidate = record(value);
+  const actual = Object.keys(candidate).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    fail("invalid-envelope");
+  }
+  return candidate;
+}
+
+function coordinate(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    fail("invalid-coordinate");
+  }
+  return value;
+}
+
+function parseTopology(value: unknown): StorageTopologyImage {
+  const image = exactRecord(value, ["schema", "root", "links"]);
+  if (image.schema !== STORAGE_TOPOLOGY_SCHEMA) fail("invalid-topology");
+  const root = coordinate(image.root);
+  if (!Array.isArray(image.links) || image.links.length === 0) fail("invalid-topology");
+  const links = image.links.map((value) => {
+    if (!Array.isArray(value) || value.length !== 2) fail("invalid-topology");
+    return Object.freeze([coordinate(value[0]), coordinate(value[1])] as const);
+  });
+  return Object.freeze({
+    schema: STORAGE_TOPOLOGY_SCHEMA,
+    root,
+    links: Object.freeze(links),
+  });
+}
+
+function parseInterpreter(value: unknown): PortableStructuralInterpreterCoordinates {
+  const item = exactRecord(value, ["dictionary", "grammar", "theory"]);
+  return Object.freeze({
+    dictionary: coordinate(item.dictionary),
+    grammar: coordinate(item.grammar),
+    theory: coordinate(item.theory),
+  });
+}
+
+function parseApplication(value: unknown): PortableStructuralRuleApplicationCoordinates {
+  const item = exactRecord(value, [
+    "act",
+    "rule",
+    "ruleAdmission",
+    "claimedBody",
+    "expectedInterpreter",
+    "expectedAfterContext",
+  ]);
+  return Object.freeze({
+    act: coordinate(item.act),
+    rule: coordinate(item.rule),
+    ruleAdmission: coordinate(item.ruleAdmission),
+    claimedBody: coordinate(item.claimedBody),
+    expectedInterpreter: parseInterpreter(item.expectedInterpreter),
+    expectedAfterContext: coordinate(item.expectedAfterContext),
+  });
+}
+
+function parseJudgmentCoordinates(value: unknown): PortableStructuralJudgmentCoordinates {
+  const item = exactRecord(value, ["theory", "context", "claim"]);
+  return Object.freeze({
+    theory: coordinate(item.theory),
+    context: coordinate(item.context),
+    claim: coordinate(item.claim),
+  });
+}
+
+function parseJudgment(value: unknown): PortableStructuralJudgmentEvidence {
+  const item = exactRecord(value, ["application", "judgment"]);
+  return Object.freeze({
+    application: parseApplication(item.application),
+    judgment: parseJudgmentCoordinates(item.judgment),
+  });
+}
+
+function parseNode(value: unknown): PortableStructuralDerivationNode {
+  const item = exactRecord(value, [
+    "occurrence",
+    "judgment",
+    "derivationRule",
+    "derivationRuleAdmission",
+    "premiseOccurrenceSequence",
+  ]);
+  return Object.freeze({
+    occurrence: coordinate(item.occurrence),
+    judgment: parseJudgment(item.judgment),
+    derivationRule: coordinate(item.derivationRule),
+    derivationRuleAdmission: coordinate(item.derivationRuleAdmission),
+    premiseOccurrenceSequence: coordinate(item.premiseOccurrenceSequence),
+  });
+}
+
+function parseArtifact(input: unknown): PortableStructuralDerivationArtifact {
+  const item = exactRecord(input, [
+    "schema",
+    "mtsSemanticBase",
+    "topology",
+    "theoryCoordinate",
+    "targetOccurrenceCoordinate",
+    "nodes",
+  ]);
+  if (item.schema !== PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+    fail("unsupported-schema");
+  }
+  if (item.mtsSemanticBase !== PORTABLE_MTS_SEMANTIC_BASE) {
+    fail("unsupported-semantic-base");
+  }
+  if (!Array.isArray(item.nodes)) fail("invalid-envelope");
+  const nodes = item.nodes.map(parseNode);
+  for (let index = 1; index < nodes.length; index += 1) {
+    if (nodes[index - 1]!.occurrence >= nodes[index]!.occurrence) {
+      fail("noncanonical-node-order");
+    }
+  }
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+    mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+    topology: parseTopology(item.topology),
+    theoryCoordinate: coordinate(item.theoryCoordinate),
+    targetOccurrenceCoordinate: coordinate(item.targetOccurrenceCoordinate),
+    nodes: Object.freeze(nodes),
+  });
+}
+
+function sameTopology(left: StorageTopologyImage, right: StorageTopologyImage): boolean {
+  if (
+    left.schema !== right.schema ||
+    left.root !== right.root ||
+    left.links.length !== right.links.length
+  ) {
+    return false;
+  }
+  return left.links.every((pair, index) => {
+    const other = right.links[index];
+    return other !== undefined && pair[0] === other[0] && pair[1] === other[1];
+  });
+}
+
+function sourceCoordinate(
+  coordinates: ReadonlyMap<LinkHandle, number>,
+  handle: LinkHandle,
+): number {
+  const found = coordinates.get(handle);
+  if (found === undefined) fail("invalid-coordinate");
+  return found;
+}
+
+function encodeNode(
+  coordinates: ReadonlyMap<LinkHandle, number>,
+  node: StructuralDerivationEvidence["nodes"][number],
+): PortableStructuralDerivationNode {
+  const c = (handle: LinkHandle): number => sourceCoordinate(coordinates, handle);
+  return Object.freeze({
+    occurrence: c(node.occurrence),
+    judgment: Object.freeze({
+      application: Object.freeze({
+        act: c(node.judgment.application.act),
+        rule: c(node.judgment.application.rule),
+        ruleAdmission: c(node.judgment.application.ruleAdmission),
+        claimedBody: c(node.judgment.application.claimedBody),
+        expectedInterpreter: Object.freeze({
+          dictionary: c(node.judgment.application.expectedInterpreter.dictionary),
+          grammar: c(node.judgment.application.expectedInterpreter.grammar),
+          theory: c(node.judgment.application.expectedInterpreter.theory),
+        }),
+        expectedAfterContext: c(node.judgment.application.expectedAfterContext),
+      }),
+      judgment: Object.freeze({
+        theory: c(node.judgment.judgment.theory),
+        context: c(node.judgment.judgment.context),
+        claim: c(node.judgment.judgment.claim),
+      }),
+    }),
+    derivationRule: c(node.derivationRule),
+    derivationRuleAdmission: c(node.derivationRuleAdmission),
+    premiseOccurrenceSequence: c(node.premiseOccurrenceSequence),
+  });
+}
+
+export function exportPortableStructuralDerivation(
+  memory: EnumerableReadMemory,
+  evidence: StructuralDerivationEvidence,
+): PortableStructuralDerivationArtifact {
+  const before = memory.linkCount;
+  try {
+    const canonical = exportCanonicalTopology(memory);
+    const c = (handle: LinkHandle): number => sourceCoordinate(canonical.coordinates, handle);
+    const nodes = evidence.nodes
+      .map((node) => encodeNode(canonical.coordinates, node))
+      .sort((left, right) => left.occurrence - right.occurrence);
+    for (let index = 1; index < nodes.length; index += 1) {
+      if (nodes[index - 1]!.occurrence === nodes[index]!.occurrence) {
+        fail("noncanonical-node-order");
+      }
+    }
+    if (memory.linkCount !== before) fail("invalid-envelope");
+    return Object.freeze({
+      schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+      mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+      topology: canonical.topology,
+      theoryCoordinate: c(evidence.theory),
+      targetOccurrenceCoordinate: c(evidence.targetOccurrence),
+      nodes: Object.freeze(nodes),
+    });
+  } catch (error) {
+    if (error instanceof PortableStructuralDerivationError) throw error;
+    if (error instanceof CanonicalTopologyError) fail("invalid-topology");
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) fail("invalid-envelope");
+  }
+}
+
+function restoreCanonicalTopology(topology: StorageTopologyImage): {
+  readonly memory: Memory;
+  readonly refs: ReadonlyMap<number, LinkHandle>;
+} {
+  let memory: Memory;
+  try {
+    memory = restoreTopology(topology);
+  } catch (error) {
+    if (error instanceof PersistenceTopologyError) fail("invalid-topology");
+    throw error;
+  }
+
+  let canonical;
+  try {
+    canonical = exportCanonicalTopology(memory);
+  } catch (error) {
+    if (error instanceof CanonicalTopologyError) fail("invalid-topology");
+    throw error;
+  }
+  if (!sameTopology(canonical.topology, topology)) fail("noncanonical-topology");
+
+  const refs = new Map<number, LinkHandle>();
+  for (const [handle, local] of canonical.coordinates) {
+    if (refs.has(local)) fail("invalid-topology");
+    refs.set(local, handle);
+  }
+  if (refs.size !== topology.links.length) fail("invalid-topology");
+  return Object.freeze({ memory, refs });
+}
+
+function freshHandle(refs: ReadonlyMap<number, LinkHandle>, local: number): LinkHandle {
+  const handle = refs.get(local);
+  if (handle === undefined) fail("invalid-coordinate");
+  return handle;
+}
+
+export function replayPortableStructuralDerivation(
+  input: unknown,
+): PortableStructuralDerivationReplayResult {
+  const artifact = parseArtifact(input);
+  const restored = restoreCanonicalTopology(artifact.topology);
+  const h = (local: number): LinkHandle => freshHandle(restored.refs, local);
+  const evidence: StructuralDerivationEvidence = Object.freeze({
+    theory: h(artifact.theoryCoordinate),
+    targetOccurrence: h(artifact.targetOccurrenceCoordinate),
+    nodes: Object.freeze(artifact.nodes.map((node) => Object.freeze({
+      occurrence: h(node.occurrence),
+      judgment: Object.freeze({
+        application: Object.freeze({
+          act: h(node.judgment.application.act),
+          rule: h(node.judgment.application.rule),
+          ruleAdmission: h(node.judgment.application.ruleAdmission),
+          claimedBody: h(node.judgment.application.claimedBody),
+          expectedInterpreter: Object.freeze({
+            dictionary: h(node.judgment.application.expectedInterpreter.dictionary),
+            grammar: h(node.judgment.application.expectedInterpreter.grammar),
+            theory: h(node.judgment.application.expectedInterpreter.theory),
+          }),
+          expectedAfterContext: h(node.judgment.application.expectedAfterContext),
+        }),
+        judgment: Object.freeze({
+          theory: h(node.judgment.judgment.theory),
+          context: h(node.judgment.judgment.context),
+          claim: h(node.judgment.judgment.claim),
+        }),
+      }),
+      derivationRule: h(node.derivationRule),
+      derivationRuleAdmission: h(node.derivationRuleAdmission),
+      premiseOccurrenceSequence: h(node.premiseOccurrenceSequence),
+    }))),
+  });
+
+  const beforeReplay = restored.memory.linkCount;
+  const replay = replayStructuralDerivation(restored.memory, evidence);
+  if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+  return Object.freeze({
+    memory: restored.memory,
+    evidence,
+    replay,
+  });
+}

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -170,6 +170,15 @@ export type {
 } from "./derivation.js";
 
 export {
+  PORTABLE_MTS_SEMANTIC_BASE,
+  PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+  PortableStructuralDerivationError,
+  exportPortableStructuralDerivation,
+  replayPortableStructuralDerivation,
+} from "./portable-derivation.js";
+export type { PortableStructuralDerivationArtifact, PortableStructuralDerivationErrorCode, PortableStructuralDerivationReplayResult } from "./portable-derivation.js";
+
+export {
   ProofRuleReplayError,
   replayDecomposeEqualRelations,
 } from "./proof.js";

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -170,15 +170,6 @@ export type {
 } from "./derivation.js";
 
 export {
-  PORTABLE_MTS_SEMANTIC_BASE,
-  PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
-  PortableStructuralDerivationError,
-  exportPortableStructuralDerivation,
-  replayPortableStructuralDerivation,
-} from "./portable-derivation.js";
-export type { PortableStructuralDerivationArtifact, PortableStructuralDerivationErrorCode, PortableStructuralDerivationReplayResult } from "./portable-derivation.js";
-
-export {
   ProofRuleReplayError,
   replayDecomposeEqualRelations,
 } from "./proof.js";

--- a/ts/test/portable-derivation.test.ts
+++ b/ts/test/portable-derivation.test.ts
@@ -1,0 +1,291 @@
+import { exportCanonicalTopology } from "../src/canonical-topology.js";
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  MemoryError,
+  ensureRootBasis,
+  type LinkHandle,
+} from "../src/memory.js";
+import { exportTopology } from "../src/persistence-topology.js";
+import {
+  PortableStructuralDerivationError,
+  exportPortableStructuralDerivation,
+  replayPortableStructuralDerivation,
+} from "../src/portable-derivation.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralDerivationReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  type StructuralDerivationEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectPortable(
+  code: PortableStructuralDerivationError["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof PortableStructuralDerivationError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected portable transport rejection`);
+}
+
+function expectReplayReject(effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralDerivationReplayError, "expected generic derivation replay rejection");
+    return;
+  }
+  throw new Error("expected generic derivation replay rejection");
+}
+
+type Binding = readonly [LinkHandle, LinkHandle];
+
+function branchFixture(): {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationEvidence;
+} {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const context = defineContext(memory, fresh(), fresh());
+  const leftRole = fresh();
+  const rightRole = fresh();
+  const left = fresh();
+  const right = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+
+  const node = (
+    roles: readonly LinkHandle[],
+    bindings: readonly Binding[],
+    template: LinkHandle,
+    claim: LinkHandle,
+    premiseTemplates: readonly LinkHandle[] = [],
+    premiseOccurrences: readonly LinkHandle[] = [],
+  ) => {
+    const roleDictionary = defineStructuralRoleDictionary(memory, roles);
+    const rule = defineStructuralRule(memory, roleDictionary, template);
+    const ruleAdmission = admitStructuralRule(memory, theory, rule);
+    const act = defineActHeader(memory, interpreter, roleDictionary, context);
+    bindings.forEach(([role, value]) => defineActField(memory, act, role, value));
+    const judgment: StructuralJudgmentEvidence = {
+      application: {
+        act,
+        rule,
+        ruleAdmission,
+        claimedBody: claim,
+        expectedInterpreter,
+        expectedAfterContext: context,
+      },
+      judgment: { theory, context, claim },
+    };
+    const occurrence = defineStructuralProofOccurrence(memory, act, claim);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    return {
+      occurrence,
+      node: {
+        occurrence,
+        judgment,
+        derivationRule,
+        derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule),
+        premiseOccurrenceSequence: materializeExactSequence(memory, premiseOccurrences),
+      },
+    };
+  };
+
+  const leftNode = node([leftRole], [[leftRole, left]], leftRole, left);
+  const rightNode = node([rightRole], [[rightRole, right]], rightRole, right);
+  const targetClaim = memory.ensure(left, right);
+  const target = node(
+    [leftRole, rightRole],
+    [[leftRole, left], [rightRole, right]],
+    memory.ensure(leftRole, rightRole),
+    targetClaim,
+    [leftRole, rightRole],
+    [leftNode.occurrence, rightNode.occurrence],
+  );
+
+  return {
+    memory,
+    evidence: {
+      theory,
+      targetOccurrence: target.occurrence,
+      nodes: [target.node, rightNode.node, leftNode.node],
+    },
+  };
+}
+
+function siblingFixture(reverse: boolean): Memory {
+  const memory = new Memory();
+  const { O, C } = ensureRootBasis(memory);
+  let x: LinkHandle;
+  let y: LinkHandle;
+  if (reverse) {
+    y = memory.ensure(C, C);
+    x = memory.ensure(O, O);
+  } else {
+    x = memory.ensure(O, O);
+    y = memory.ensure(C, C);
+  }
+  memory.ensure(x, y);
+  return memory;
+}
+
+// A real three-node branching P2 proof crosses the owner boundary through
+// canonical coordinates, reconstructs in a fresh Memory and replays read-only.
+{
+  const fx = branchFixture();
+  const beforeExport = fx.memory.linkCount;
+  const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  same(fx.memory.linkCount, beforeExport, "portable export is source read-only");
+  same(artifact.nodes.length, 3, "complete branching node closure transported");
+  assert(
+    artifact.nodes.every((node, index) => index === 0 || artifact.nodes[index - 1]!.occurrence < node.occurrence),
+    "portable nodes are canonical by occurrence coordinate",
+  );
+
+  const imported = replayPortableStructuralDerivation(artifact);
+  same(imported.replay.occurrenceCount, 3, "fresh replay preserves dependency closure");
+  same(imported.memory.linkCount, artifact.topology.links.length, "fresh topology remains read-only after replay");
+
+  try {
+    imported.memory.poles(fx.evidence.theory);
+  } catch (error) {
+    assert(error instanceof MemoryError, "source handles must remain foreign to imported Memory");
+  }
+  let acceptedForeign = true;
+  try {
+    imported.memory.poles(fx.evidence.theory);
+  } catch {
+    acceptedForeign = false;
+  }
+  assert(!acceptedForeign, "portable replay must not reuse source owner handles");
+
+  const reexported = exportPortableStructuralDerivation(imported.memory, imported.evidence);
+  same(JSON.stringify(reexported), JSON.stringify(artifact), "portable import/re-export is stable");
+}
+
+// P2 host nodes[] order is transport-only: opposite source order emits the same artifact.
+{
+  const fx = branchFixture();
+  const a = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  const b = exportPortableStructuralDerivation(fx.memory, {
+    ...fx.evidence,
+    nodes: [...fx.evidence.nodes].reverse(),
+  });
+  same(JSON.stringify(a), JSON.stringify(b), "source node order has no portable authority");
+}
+
+// Strict envelope validation is fail-closed before structural replay.
+{
+  const fx = branchFixture();
+  const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  expectPortable("unsupported-schema", () => replayPortableStructuralDerivation({
+    ...artifact,
+    schema: "mts-portable-structural-derivation/v999",
+  }));
+  expectPortable("unsupported-semantic-base", () => replayPortableStructuralDerivation({
+    ...artifact,
+    mtsSemanticBase: "mts-contract/v0.10",
+  }));
+  expectPortable("invalid-envelope", () => replayPortableStructuralDerivation({
+    ...artifact,
+    unexpectedAuthority: true,
+  }));
+  expectPortable("invalid-envelope", () => replayPortableStructuralDerivation({
+    schema: artifact.schema,
+    mtsSemanticBase: artifact.mtsSemanticBase,
+    topology: artifact.topology,
+    theoryCoordinate: artifact.theoryCoordinate,
+    nodes: artifact.nodes,
+  }));
+  expectPortable("invalid-coordinate", () => replayPortableStructuralDerivation({
+    ...artifact,
+    targetOccurrenceCoordinate: 1.5,
+  }));
+  expectPortable("invalid-coordinate", () => replayPortableStructuralDerivation({
+    ...artifact,
+    targetOccurrenceCoordinate: artifact.topology.links.length + 1,
+  }));
+  expectPortable("noncanonical-node-order", () => replayPortableStructuralDerivation({
+    ...artifact,
+    nodes: [...artifact.nodes].reverse(),
+  }));
+  expectPortable("noncanonical-node-order", () => replayPortableStructuralDerivation({
+    ...artifact,
+    nodes: [artifact.nodes[0], artifact.nodes[0], ...artifact.nodes.slice(1)],
+  }));
+}
+
+// A valid persistence image is not automatically canonical proof transport.
+{
+  const fx = branchFixture();
+  const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  const first = siblingFixture(false);
+  const second = siblingFixture(true);
+  const canonical = JSON.stringify(exportCanonicalTopology(first).topology);
+  const rawFirst = exportTopology(first);
+  const rawSecond = exportTopology(second);
+  const noncanonical = JSON.stringify(rawFirst) === canonical ? rawSecond : rawFirst;
+  assert(JSON.stringify(noncanonical) !== canonical, "adversarial raw topology must be noncanonical");
+  expectPortable("noncanonical-topology", () => replayPortableStructuralDerivation({
+    ...artifact,
+    topology: noncanonical,
+  }));
+}
+
+// Once transport is structurally valid, forged coordinates do not gain authority:
+// the existing generic derivation kernel rejects the reconstructed proof.
+{
+  const fx = branchFixture();
+  const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  expectReplayReject(() => replayPortableStructuralDerivation({
+    ...artifact,
+    theoryCoordinate: 0,
+  }));
+  expectReplayReject(() => replayPortableStructuralDerivation({
+    ...artifact,
+    targetOccurrenceCoordinate: 0,
+  }));
+  const targetIndex = artifact.nodes.findIndex((node) => node.occurrence === artifact.targetOccurrenceCoordinate);
+  assert(targetIndex >= 0, "target portable node exists");
+  const target = artifact.nodes[targetIndex]!;
+  const forgedTarget = {
+    ...target,
+    derivationRuleAdmission: 0,
+  };
+  const forgedNodes = [...artifact.nodes];
+  forgedNodes[targetIndex] = forgedTarget;
+  expectReplayReject(() => replayPortableStructuralDerivation({
+    ...artifact,
+    nodes: forgedNodes,
+  }));
+}

--- a/ts/test/portable-derivation.test.ts
+++ b/ts/test/portable-derivation.test.ts
@@ -176,18 +176,14 @@ function siblingFixture(reverse: boolean): Memory {
   same(imported.replay.occurrenceCount, 3, "fresh replay preserves dependency closure");
   same(imported.memory.linkCount, artifact.topology.links.length, "fresh topology remains read-only after replay");
 
+  let foreignRejected = false;
   try {
     imported.memory.poles(fx.evidence.theory);
   } catch (error) {
     assert(error instanceof MemoryError, "source handles must remain foreign to imported Memory");
+    foreignRejected = true;
   }
-  let acceptedForeign = true;
-  try {
-    imported.memory.poles(fx.evidence.theory);
-  } catch {
-    acceptedForeign = false;
-  }
-  assert(!acceptedForeign, "portable replay must not reuse source owner handles");
+  assert(foreignRejected, "portable replay must not reuse source owner handles");
 
   const reexported = exportPortableStructuralDerivation(imported.memory, imported.evidence);
   same(JSON.stringify(reexported), JSON.stringify(artifact), "portable import/re-export is stable");


### PR DESCRIPTION
Closes #837

## Scope

P6c implements the first narrow portable proof family: base `StructuralDerivationEvidence` only.

```text
base = 7fd8e8fb0258fd9c0cc994ba4916ae0d074953c9
head = ba857ce41f25d8b345b77a39afbc8c44371d9f67
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

No theorem-reuse, scoped-assumption, digest/provenance, proof-cache or theorem-specific opcode is introduced.

## Portable envelope

```text
schema = mts-portable-structural-derivation/v0.1
mtsSemanticBase = mts-contract/v0.11
```

The artifact carries canonical topology, `theoryCoordinate`, `targetOccurrenceCoordinate`, and `nodes[]` sorted by canonical proof-occurrence coordinate. Every runtime `LinkHandle` field of the existing `StructuralDerivationEvidence` is encoded as a P6b canonical coordinate, so host input `nodes[]` order has no transport authority.

## Import / replay boundary

```text
strict exact-field/schema/base validation
 -> restoreTopology into fresh Memory
 -> P6b canonical re-export
 -> require supplied topology == canonical topology
 -> canonical coordinate -> fresh LinkHandle remap
 -> reconstruct existing StructuralDerivationEvidence
 -> existing replayStructuralDerivation
 -> accept / reject
```

A valid allocation-sensitive `mts-storage-topology/v0.1` image is rejected as portable proof transport when it is not the P6b canonical image. Once transport is structurally valid, forged theory/target/admission coordinates gain no authority: the existing generic derivation replay kernel rejects them.

## Executable corpus

The new test uses a real three-node branching P2 derivation with two explicit premises and verifies:

- source export is read-only;
- fresh-Memory reconstruction and 3-node dependency replay succeed;
- source handles remain foreign to the imported Memory;
- import -> re-export is stable;
- reversed source `nodes[]` produces the same artifact;
- unknown schema / wrong semantic base reject;
- extra/missing envelope fields reject;
- malformed/out-of-range coordinates reject;
- duplicate/reordered portable nodes reject;
- a P6a-style valid but allocation-sensitive noncanonical topology rejects;
- wrong theory/target/derivation admission reaches generic replay and rejects.

## CI-discovered public API boundary

An initial attempt to export this API from `ts/src/public.ts` was deliberately reverted after CI #3357 failed the existing exact `public-api.test` allowlist. The portable transport itself had already passed typecheck/build/package-check and its new test; the failure showed that widening the package runtime surface is a separate explicit API-contract lifecycle.

Therefore this PR leaves `ts/src/public.ts` byte-for-byte unchanged. Consumer/package exposure is deferred to a dedicated follow-up slice rather than bypassing the existing public API contract.

## Isolation / budget

```text
ts/src/portable-derivation.ts       NEW +402
ts/test/portable-derivation.test.ts NEW +287
------------------------------------------
net additions                       689 / 700
new files                           2 / 2
```

No final diff changes to `public.ts`, Memory, derivation kernel, structural-rule kernel, canonical-topology, persistence-topology, contracts, policy, docs, cutover or workflows.

## Exact final workflow evidence on current head

```text
head = ba857ce41f25d8b345b77a39afbc8c44371d9f67
CI #3359 = SUCCESS
blocking repo-guard #711 = SUCCESS
behind_by = 0
mergeable = true
draft = false
```

## Classification

```text
PORTABLE_BASE_DERIVATION_SUPPORTED
```

This means base structural derivations can be serialized by canonical coordinates, reconstructed in a fresh Memory, and accepted solely by the existing generic replay kernel. It does **not** mean canonical bytes/hash/digest imply theorem truth.

## Deliberate next-stage boundaries

This P6c transports the full canonical selected Memory topology. It does not yet minimize a semantic support subgraph, because replay reads structural fields such as Act entries through graph queries. Support-closure minimization and digest/provenance remain separate falsification slices.

Package/public consumer exposure is also a separate explicit slice because the repository enforces an exact runtime export allowlist.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only for workflows that actually exist on the merge SHA
