### PR TITLE
feat(proof): expose portable derivation package API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -170,6 +170,19 @@ export type {
 } from "./derivation.js";
 
 export {
+  PORTABLE_MTS_SEMANTIC_BASE,
+  PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+  PortableStructuralDerivationError,
+  exportPortableStructuralDerivation,
+  replayPortableStructuralDerivation,
+} from "./portable-derivation.js";
+export type {
+  PortableStructuralDerivationArtifact,
+  PortableStructuralDerivationErrorCode,
+  PortableStructuralDerivationReplayResult,
+} from "./portable-derivation.js";
+
+export {
   ProofRuleReplayError,
   replayDecomposeEqualRelations,
 } from "./proof.js";

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -9,6 +9,9 @@ import type {
   MtsValue,
   PersistentSequenceDescription,
   PersistentTopologyBackend,
+  PortableStructuralDerivationArtifact,
+  PortableStructuralDerivationErrorCode,
+  PortableStructuralDerivationReplayResult,
   ReadMemory,
   RelationReplayEvidence,
   RunEvidence,
@@ -33,6 +36,8 @@ import type { AppendOnlyReadMemory } from "../src/public.js";
 import type { EnumerableReadMemory } from "../src/public.js";
 // @ts-expect-error Consumers use RelationReplayEvidence, not standalone role plumbing.
 import type { RelationRoles } from "../src/public.js";
+// @ts-expect-error P6d keeps nested portable transport coordinate plumbing internal.
+import type { PortableStructuralDerivationNode } from "../src/public.js";
 // @ts-expect-error P3b keeps assumption construction internal; consumers submit materialized evidence.
 type InternalAssumptionContextConstructor = typeof import("../src/public.js").defineStructuralAssumptionContext;
 
@@ -49,8 +54,11 @@ const expectedRuntimeExports = [
   "InterpreterReplayError",
   "Memory",
   "MemoryError",
+  "PORTABLE_MTS_SEMANTIC_BASE",
+  "PORTABLE_STRUCTURAL_DERIVATION_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
+  "PortableStructuralDerivationError",
   "ProofRuleReplayError",
   "QuaternaryDecodeError",
   "RunReplayError",
@@ -69,6 +77,7 @@ const expectedRuntimeExports = [
   "elaborateBundleRoles",
   "ensureRootBasis",
   "executeAbits",
+  "exportPortableStructuralDerivation",
   "materializePersistentSequence",
   "materializeSequence",
   "normalizeRawForm",
@@ -82,6 +91,7 @@ const expectedRuntimeExports = [
   "replayFlatSubselectionReading",
   "replayIntegratedProof",
   "replayPersistentSequenceMaterialization",
+  "replayPortableStructuralDerivation",
   "replayRelationStep",
   "replayRelationSubselectionStep",
   "replayResolvedSequenceGrouping",
@@ -105,6 +115,14 @@ assert(
 assert(
   publicApi.replayDefinitionEffect === publicApi.replayColonEffect,
   "definition replay must be a behavior-preserving alias of legacy colon replay",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_SCHEMA === "mts-portable-structural-derivation/v0.1",
+  "portable derivation schema must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_MTS_SEMANTIC_BASE === "mts-contract/v0.11",
+  "portable derivation semantic base must stay pinned",
 );
 
 // Compile-time smoke for the intended consumer concepts. The top-level evidence
@@ -132,6 +150,9 @@ const theorem: StructuralTheoremEvidence | undefined = undefined;
 const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
 const integrated: IntegratedProofEvidence | undefined = undefined;
+const portableArtifact: PortableStructuralDerivationArtifact | undefined = undefined;
+const portableErrorCode: PortableStructuralDerivationErrorCode | undefined = undefined;
+const portableReplay: PortableStructuralDerivationReplayResult | undefined = undefined;
 void [
   read,
   write,
@@ -155,4 +176,7 @@ void [
   judgment,
   proof,
   integrated,
+  portableArtifact,
+  portableErrorCode,
+  portableReplay,
 ];


### PR DESCRIPTION
Closes #839

## Scope

P6d explicitly widens the exact `@mts/core` package-root API to expose the already-implemented P6c portable base derivation transport.

```text
base = a3ee28a097ae5d3e827b5b07034c63593e86ada1
head = 4da1f2b1536b3b36070527d41bd181cc6e51723a
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

No P6c transport semantics, canonical topology, derivation kernel, Memory, contracts, policy, docs, cutover or workflows are changed.

## Exact package runtime additions

```text
PORTABLE_MTS_SEMANTIC_BASE
PORTABLE_STRUCTURAL_DERIVATION_SCHEMA
PortableStructuralDerivationError
exportPortableStructuralDerivation
replayPortableStructuralDerivation
```

Top-level type additions:

```text
PortableStructuralDerivationArtifact
PortableStructuralDerivationErrorCode
PortableStructuralDerivationReplayResult
```

Nested coordinate/transport plumbing remains internal; `PortableStructuralDerivationNode` is explicitly asserted absent from the package root with `@ts-expect-error`.

## Public API evidence

`public-api.test.ts` now:

- deliberately adds the five runtime exports to the exact allowlist;
- compile-smokes the three intended portable consumer types;
- pins schema = `mts-portable-structural-derivation/v0.1`;
- pins semantic base = `mts-contract/v0.11`;
- preserves all previous internal capability exclusions;
- rejects accidental leakage of nested portable transport vocabulary.

## Isolation / budget

```text
ts/src/public.ts              +13
ts/test/public-api.test.ts    +24
--------------------------------
net additions                 37 / 40
new files                     0 / 0
behind_by                     0 at pre-PR comparison
```

## Classification

```text
PORTABLE_BASE_DERIVATION_PACKAGE_API_SUPPORTED
```

only if full CI and blocking repo-guard are green on the exact PR head.

This classification concerns package accessibility only. Public export, schema stability, or artifact bytes do not create proof authority; acceptance still requires P6c fresh reconstruction followed by the existing generic replay kernel.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on the merge SHA