### PR TITLE
feat(proof): canonicalize base derivation replay support

### DIFF
--- a/ts/src/proof-support-topology.ts
+++ b/ts/src/proof-support-topology.ts
@@ -1,0 +1,192 @@
+import {
+  CanonicalTopologyError,
+  exportCanonicalTopology,
+} from "./canonical-topology.js";
+import type { StructuralDerivationEvidence } from "./derivation.js";
+import {
+  MemoryError,
+  type EnumerableReadMemory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "./memory.js";
+import type { StorageTopologyImage } from "./persistence-topology.js";
+
+export interface StructuralDerivationSupportTopologyExport {
+  readonly topology: StorageTopologyImage;
+  readonly coordinates: ReadonlyMap<LinkHandle, number>;
+  /** Support Links ordered by canonical coordinate, never source allocation order. */
+  readonly links: readonly LinkHandle[];
+}
+
+export class StructuralDerivationSupportTopologyError extends Error {
+  override readonly name = "StructuralDerivationSupportTopologyError";
+}
+
+function explicitEvidenceHandles(
+  evidence: StructuralDerivationEvidence,
+): readonly LinkHandle[] {
+  const result: LinkHandle[] = [evidence.theory, evidence.targetOccurrence];
+  for (const node of evidence.nodes) {
+    const application = node.judgment.application;
+    result.push(
+      node.occurrence,
+      application.act,
+      application.rule,
+      application.ruleAdmission,
+      application.claimedBody,
+      application.expectedInterpreter.dictionary,
+      application.expectedInterpreter.grammar,
+      application.expectedInterpreter.theory,
+      application.expectedAfterContext,
+      node.judgment.judgment.theory,
+      node.judgment.judgment.context,
+      node.judgment.judgment.claim,
+      node.derivationRule,
+      node.derivationRuleAdmission,
+      node.premiseOccurrenceSequence,
+    );
+  }
+  return result;
+}
+
+class ReplaySupportView implements EnumerableReadMemory {
+  readonly root: LinkHandle;
+  private readonly support: ReadonlySet<LinkHandle>;
+  private readonly ordered: readonly LinkHandle[];
+
+  constructor(
+    private readonly source: ReadMemory,
+    links: ReadonlySet<LinkHandle>,
+  ) {
+    this.root = source.root;
+    this.support = links;
+    this.ordered = Object.freeze([...links]);
+  }
+
+  get linkCount(): number {
+    return this.ordered.length;
+  }
+
+  private require(link: LinkHandle): void {
+    if (!this.support.has(link)) {
+      throw new MemoryError("Link is outside structural derivation replay support");
+    }
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    this.require(link);
+    const poles = this.source.poles(link);
+    if (!this.support.has(poles.start) || !this.support.has(poles.end)) {
+      throw new MemoryError("structural derivation replay support is not pole-closed");
+    }
+    return poles;
+  }
+
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    this.require(start);
+    this.require(end);
+    const found = this.source.find(start, end);
+    return found !== undefined && this.support.has(found) ? found : undefined;
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.require(start);
+    return Object.freeze(this.source.outgoing(start).filter((link) => this.support.has(link)));
+  }
+
+  incoming(end: LinkHandle): readonly LinkHandle[] {
+    this.require(end);
+    return Object.freeze(this.source.incoming(end).filter((link) => this.support.has(link)));
+  }
+
+  allLinks(): readonly LinkHandle[] {
+    return this.ordered;
+  }
+}
+
+function collectReplaySupport(
+  memory: ReadMemory,
+  evidence: StructuralDerivationEvidence,
+): ReadonlySet<LinkHandle> {
+  const support = new Set<LinkHandle>();
+  const pending: LinkHandle[] = [];
+
+  const include = (link: LinkHandle): void => {
+    if (support.has(link)) return;
+    // Validate owner/existence before the Link can enter builder bookkeeping.
+    memory.poles(link);
+    support.add(link);
+    pending.push(link);
+  };
+
+  const closePoles = (): void => {
+    while (pending.length > 0) {
+      const link = pending.pop();
+      if (link === undefined) continue;
+      const poles = memory.poles(link);
+      include(poles.start);
+      include(poles.end);
+    }
+  };
+
+  include(memory.root);
+  for (const link of explicitEvidenceHandles(evidence)) include(link);
+  closePoles();
+
+  // Base derivation replay globally enumerates exactly these namespaces through
+  // readExactActBindings(memory, act, ...). Preserve the complete outgoing set:
+  // unexpected/duplicate attachments are negative evidence and must not vanish.
+  const acts = new Set(evidence.nodes.map((node) => node.judgment.application.act));
+  for (const act of acts) {
+    include(act);
+    for (const attachment of memory.outgoing(act)) include(attachment);
+  }
+  closePoles();
+
+  return support;
+}
+
+/**
+ * Canonicalizes only the graph surface observed by base StructuralDerivation
+ * replay. This is transport-support construction, not proof validation or truth.
+ */
+export function exportStructuralDerivationSupportTopology(
+  memory: ReadMemory,
+  evidence: StructuralDerivationEvidence,
+): StructuralDerivationSupportTopologyExport {
+  const before = memory.linkCount;
+  try {
+    const support = collectReplaySupport(memory, evidence);
+    const view = new ReplaySupportView(memory, support);
+    const canonical = exportCanonicalTopology(view);
+    const links = Object.freeze(
+      [...canonical.coordinates.entries()]
+        .sort((left, right) => left[1] - right[1])
+        .map(([link]) => link),
+    );
+
+    if (links.length !== support.size || canonical.coordinates.size !== support.size) {
+      throw new StructuralDerivationSupportTopologyError("support topology cardinality mismatch");
+    }
+    if (memory.linkCount !== before) {
+      throw new StructuralDerivationSupportTopologyError("support topology export mutated Memory");
+    }
+
+    return Object.freeze({
+      topology: canonical.topology,
+      coordinates: canonical.coordinates,
+      links,
+    });
+  } catch (error) {
+    if (error instanceof StructuralDerivationSupportTopologyError) throw error;
+    if (error instanceof MemoryError || error instanceof CanonicalTopologyError) {
+      throw new StructuralDerivationSupportTopologyError("invalid structural derivation replay support");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) {
+      throw new StructuralDerivationSupportTopologyError("support topology export mutated Memory");
+    }
+  }
+}

--- a/ts/test/proof-support-topology.test.ts
+++ b/ts/test/proof-support-topology.test.ts
@@ -1,0 +1,299 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  MemoryError,
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  StructuralDerivationSupportTopologyError,
+  exportStructuralDerivationSupportTopology,
+} from "../src/proof-support-topology.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralDerivationReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  replayStructuralDerivation,
+  type StructuralDerivationEvidence,
+  type StructuralDerivationNodeEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: values differ`);
+}
+
+class RestrictedSupportMemory implements ReadMemory {
+  readonly root: LinkHandle;
+  private readonly support: ReadonlySet<LinkHandle>;
+
+  constructor(
+    private readonly source: ReadMemory,
+    links: readonly LinkHandle[],
+  ) {
+    this.root = source.root;
+    this.support = new Set(links);
+  }
+
+  get linkCount(): number {
+    return this.support.size;
+  }
+
+  private require(link: LinkHandle): void {
+    if (!this.support.has(link)) throw new MemoryError("Link is outside test replay support");
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    this.require(link);
+    const poles = this.source.poles(link);
+    if (!this.support.has(poles.start) || !this.support.has(poles.end)) {
+      throw new MemoryError("test replay support is not pole-closed");
+    }
+    return poles;
+  }
+
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    this.require(start);
+    this.require(end);
+    const found = this.source.find(start, end);
+    return found !== undefined && this.support.has(found) ? found : undefined;
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.require(start);
+    return this.source.outgoing(start).filter((link) => this.support.has(link));
+  }
+
+  incoming(end: LinkHandle): readonly LinkHandle[] {
+    this.require(end);
+    return this.source.incoming(end).filter((link) => this.support.has(link));
+  }
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationEvidence;
+  readonly role: LinkHandle;
+  readonly value: LinkHandle;
+  readonly targetAct: LinkHandle;
+  readonly attachments: readonly LinkHandle[];
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const role = fresh();
+  const value = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const rule = defineStructuralRule(memory, roleDictionary, role);
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+
+  const makeNode = (
+    context: LinkHandle,
+    premiseTemplates: readonly LinkHandle[],
+    premiseOccurrences: readonly LinkHandle[],
+  ): { readonly node: StructuralDerivationNodeEvidence; readonly attachment: LinkHandle } => {
+    const act = defineActHeader(memory, interpreter, roleDictionary, context);
+    const attachment = defineActField(memory, act, role, value);
+    const judgment: StructuralJudgmentEvidence = {
+      application: {
+        act,
+        rule,
+        ruleAdmission,
+        claimedBody: value,
+        expectedInterpreter,
+        expectedAfterContext: context,
+      },
+      judgment: { theory, context, claim: value },
+    };
+    const occurrence = defineStructuralProofOccurrence(memory, act, value);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    return {
+      attachment,
+      node: {
+        occurrence,
+        judgment,
+        derivationRule,
+        derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule),
+        premiseOccurrenceSequence: materializeExactSequence(memory, premiseOccurrences),
+      },
+    };
+  };
+
+  const leafContext = defineContext(memory, fresh(), fresh());
+  const targetContext = defineContext(memory, fresh(), fresh());
+  const leaf = makeNode(leafContext, [], []);
+  const target = makeNode(targetContext, [role], [leaf.node.occurrence]);
+
+  return {
+    memory,
+    role,
+    value,
+    targetAct: target.node.judgment.application.act,
+    attachments: Object.freeze([leaf.attachment, target.attachment]),
+    evidence: {
+      theory,
+      targetOccurrence: target.node.occurrence,
+      nodes: [target.node, leaf.node],
+    },
+  };
+}
+
+function explicitHandles(evidence: StructuralDerivationEvidence): readonly LinkHandle[] {
+  const result: LinkHandle[] = [evidence.theory, evidence.targetOccurrence];
+  for (const node of evidence.nodes) {
+    const application = node.judgment.application;
+    result.push(
+      node.occurrence,
+      application.act,
+      application.rule,
+      application.ruleAdmission,
+      application.claimedBody,
+      application.expectedInterpreter.dictionary,
+      application.expectedInterpreter.grammar,
+      application.expectedInterpreter.theory,
+      application.expectedAfterContext,
+      node.judgment.judgment.theory,
+      node.judgment.judgment.context,
+      node.judgment.judgment.claim,
+      node.derivationRule,
+      node.derivationRuleAdmission,
+      node.premiseOccurrenceSequence,
+    );
+  }
+  return result;
+}
+
+function replayReject(memory: ReadMemory, evidence: StructuralDerivationEvidence): string {
+  try {
+    replayStructuralDerivation(memory, evidence);
+  } catch (error) {
+    assert(error instanceof StructuralDerivationReplayError, "expected derivation replay rejection");
+    return error.code;
+  }
+  throw new Error("expected derivation replay rejection");
+}
+
+// Valid proof: canonical support is complete, read-only, host-node-order neutral,
+// and stable under unrelated ambient Memory growth.
+{
+  const fx = fixture();
+  const full = replayStructuralDerivation(fx.memory, fx.evidence);
+  same(full.occurrenceCount, 2, "full replay must verify both dependency nodes");
+
+  const beforeSupport = fx.memory.linkCount;
+  const supportA = exportStructuralDerivationSupportTopology(fx.memory, fx.evidence);
+  same(fx.memory.linkCount, beforeSupport, "support export must be read-only");
+  assert(supportA.links.length < fx.memory.linkCount, "support must exclude existing unrelated topology");
+
+  for (const link of explicitHandles(fx.evidence)) {
+    assert(supportA.coordinates.has(link), "every explicit evidence handle must be mapped");
+  }
+  for (const attachment of fx.attachments) {
+    assert(supportA.coordinates.has(attachment), "every normal Act attachment must be support");
+  }
+  supportA.links.forEach((link, coordinate) => {
+    same(supportA.coordinates.get(link), coordinate, "support links must be canonical-coordinate ordered");
+  });
+
+  const reordered = exportStructuralDerivationSupportTopology(fx.memory, {
+    ...fx.evidence,
+    nodes: [...fx.evidence.nodes].reverse(),
+  });
+  same(
+    JSON.stringify(reordered.topology),
+    JSON.stringify(supportA.topology),
+    "host nodes[] order must not affect support topology",
+  );
+
+  const restrictedA = new RestrictedSupportMemory(fx.memory, supportA.links);
+  const restrictedReplay = replayStructuralDerivation(restrictedA, fx.evidence);
+  same(restrictedReplay.theory, full.theory, "restricted replay Theory");
+  same(restrictedReplay.targetOccurrence, full.targetOccurrence, "restricted replay target");
+  same(restrictedReplay.occurrenceCount, full.occurrenceCount, "restricted replay dependency count");
+
+  const countBeforeJunk = fx.memory.linkCount;
+  const junkA = fx.memory.ensure(fx.value, fx.evidence.theory);
+  const junkB = fx.memory.ensure(junkA, fx.value);
+  assert(fx.memory.linkCount > countBeforeJunk, "ambient witness must add semantic topology");
+  const supportB = exportStructuralDerivationSupportTopology(fx.memory, fx.evidence);
+  same(
+    JSON.stringify(supportB.topology),
+    JSON.stringify(supportA.topology),
+    "unrelated ambient growth must not affect support topology",
+  );
+  assert(!supportB.coordinates.has(junkA), "first ambient Link must stay outside proof support");
+  assert(!supportB.coordinates.has(junkB), "second ambient Link must stay outside proof support");
+  same(replayStructuralDerivation(fx.memory, fx.evidence).occurrenceCount, 2, "ambient growth preserves proof");
+}
+
+// Security boundary: support minimization must preserve hostile outgoing evidence,
+// otherwise a full-Memory reject could be turned into a restricted-view accept.
+{
+  const fx = fixture();
+  const validSupport = exportStructuralDerivationSupportTopology(fx.memory, fx.evidence);
+  const undeclaredRole = fx.memory.ensure(fx.value, fx.value);
+  assert(undeclaredRole !== fx.role, "hostile role must be undeclared");
+  const hostileField = fx.memory.ensure(undeclaredRole, fx.value);
+  const hostileAttachment = fx.memory.ensure(fx.targetAct, hostileField);
+
+  const fullCode = replayReject(fx.memory, fx.evidence);
+  const hostileSupport = exportStructuralDerivationSupportTopology(fx.memory, fx.evidence);
+  assert(hostileSupport.coordinates.has(hostileAttachment), "hostile outgoing attachment must be support");
+  assert(hostileSupport.coordinates.has(hostileField), "hostile field must be pole-closed support");
+  assert(hostileSupport.coordinates.has(undeclaredRole), "hostile role must be pole-closed support");
+  assert(
+    JSON.stringify(hostileSupport.topology) !== JSON.stringify(validSupport.topology),
+    "hostile outgoing evidence must change support topology",
+  );
+
+  const restricted = new RestrictedSupportMemory(fx.memory, hostileSupport.links);
+  const restrictedCode = replayReject(restricted, fx.evidence);
+  same(restrictedCode, fullCode, "restricted support must preserve full-replay rejection");
+}
+
+// Foreign owner handles fail closed during support construction.
+{
+  const fx = fixture();
+  const foreign = new Memory();
+  try {
+    exportStructuralDerivationSupportTopology(fx.memory, {
+      ...fx.evidence,
+      theory: foreign.root,
+    });
+  } catch (error) {
+    assert(
+      error instanceof StructuralDerivationSupportTopologyError,
+      "foreign evidence handle must fail as support-topology error",
+    );
+    // Executable P6f classification:
+    // CANONICAL_REPLAY_SUPPORT_TOPOLOGY_SUPPORTED
+    void error;
+    return;
+  }
+  throw new Error("foreign evidence handle must reject support construction");
+}

--- a/ts/test/proof-support-topology.test.ts
+++ b/ts/test/proof-support-topology.test.ts
@@ -280,6 +280,7 @@ function replayReject(memory: ReadMemory, evidence: StructuralDerivationEvidence
 {
   const fx = fixture();
   const foreign = new Memory();
+  let rejected = false;
   try {
     exportStructuralDerivationSupportTopology(fx.memory, {
       ...fx.evidence,
@@ -290,10 +291,10 @@ function replayReject(memory: ReadMemory, evidence: StructuralDerivationEvidence
       error instanceof StructuralDerivationSupportTopologyError,
       "foreign evidence handle must fail as support-topology error",
     );
-    // Executable P6f classification:
-    // CANONICAL_REPLAY_SUPPORT_TOPOLOGY_SUPPORTED
-    void error;
-    return;
+    rejected = true;
   }
-  throw new Error("foreign evidence handle must reject support construction");
+  assert(rejected, "foreign evidence handle must reject support construction");
 }
+
+// Executable P6f classification:
+// CANONICAL_REPLAY_SUPPORT_TOPOLOGY_SUPPORTED


### PR DESCRIPTION
Closes #843

## Scope

P6f implements the first canonical **replay-support topology** for base `StructuralDerivationEvidence`.

```text
base = 898be3a997e19c3d2e63a02d8fe69d182b65edba
head = 5c2033e0171e840ed1c218fb4463235ef9b3b883
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

This PR does **not** change `portable-derivation.ts`, portable schema, public API, digest/provenance, derivation replay semantics, canonical-topology implementation, contracts, policy or docs.

## Why this slice exists

P6e proved two executable boundaries:

```text
FULL_MEMORY_PORTABLE_ARTIFACT_NOT_STABLE_PROOF_IDENTITY
NAIVE_POLE_CLOSURE_NOT_REPLAY_COMPLETE
```

Full selected Memory contains unrelated ambient topology, while explicit evidence handles + pole descendants miss replay-significant Act attachments discovered through `memory.outgoing(act)`.

## Support algorithm

`exportStructuralDerivationSupportTopology(memory,evidence)` now constructs support as:

```text
ROOT
+ every explicit LinkHandle carried by StructuralDerivationEvidence
+ recursive pole closure
+ complete memory.outgoing(act) for every evidence Act
+ recursive pole closure of every attachment/field/value
-> restricted EnumerableReadMemory view
-> existing P6b exportCanonicalTopology
```

No outgoing namespace is recursively added for arbitrary included Links because current base P2 replay globally enumerates only evidence Acts.

The complete outgoing namespace is security-significant: unexpected or duplicate fields must remain present so minimization cannot turn a full-Memory reject into an accept.

## Canonicalization / authority

P6f reuses the existing P6b canonicalizer. It does not introduce another coordinate authority.

The returned builder-side `links[]` is ordered strictly by canonical coordinate, not by evidence order, Set insertion order or Memory allocation order.

Support export is read-only and fail-closed on foreign/invalid handles.

## Executable corpus

A two-node branching derivation verifies:

- full replay succeeds with exact dependency count;
- support export is source-Memory read-only;
- all explicit evidence handles are mapped;
- all normal Act attachments are included;
- `links[]` follows canonical-coordinate order;
- reversing host `evidence.nodes[]` leaves canonical support topology unchanged;
- replay through a test-only restricted support `ReadMemory` gives the same Theory, target and occurrence count;
- unrelated ambient semantic growth is excluded and leaves support topology bytes unchanged.

Security corpus injects an undeclared outgoing field under the target Act and requires:

```text
full Memory replay rejects
hostile attachment + field + undeclared role are in support
support topology changes relative to the valid proof
restricted-support replay rejects with the same error code
```

Foreign-owner evidence handles fail closed as `StructuralDerivationSupportTopologyError`.

## Isolation / budget

```text
ts/src/proof-support-topology.ts       NEW +192
ts/test/proof-support-topology.test.ts NEW +300
------------------------------------------------
net additions                          492 / 520
new files                              2 / 2
behind_by                              0 at pre-PR comparison
```

## Expected classification

```text
CANONICAL_REPLAY_SUPPORT_TOPOLOGY_SUPPORTED
```

only if full CI and blocking repo-guard are green on the exact PR head.

This classification does not make support bytes proof truth or theorem identity. It establishes only a canonical replay-equivalent substrate suitable for a later versioned portable transport slice.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on the merge SHA