### PR TITLE
feat(proof): adopt replay-support portable schema v0.2

### DIFF
--- a/ts/src/portable-derivation.ts
+++ b/ts/src/portable-derivation.ts
@@ -9,8 +9,8 @@ import {
 } from "./derivation.js";
 import {
   Memory,
-  type EnumerableReadMemory,
   type LinkHandle,
+  type ReadMemory,
 } from "./memory.js";
 import {
   PersistenceTopologyError,
@@ -18,10 +18,20 @@ import {
   restoreTopology,
   type StorageTopologyImage,
 } from "./persistence-topology.js";
+import {
+  StructuralDerivationSupportTopologyError,
+  exportStructuralDerivationSupportTopology,
+} from "./proof-support-topology.js";
 
-export const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA =
+const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1 =
   "mts-portable-structural-derivation/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA =
+  "mts-portable-structural-derivation/v0.2" as const;
 export const PORTABLE_MTS_SEMANTIC_BASE = "mts-contract/v0.11" as const;
+
+type PortableStructuralDerivationSchema =
+  | typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1
+  | typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA;
 
 export interface PortableStructuralInterpreterCoordinates {
   readonly dictionary: number;
@@ -66,12 +76,22 @@ export interface PortableStructuralDerivationArtifact {
   readonly nodes: readonly PortableStructuralDerivationNode[];
 }
 
+interface ParsedPortableStructuralDerivationArtifact {
+  readonly schema: PortableStructuralDerivationSchema;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+  readonly theoryCoordinate: number;
+  readonly targetOccurrenceCoordinate: number;
+  readonly nodes: readonly PortableStructuralDerivationNode[];
+}
+
 export type PortableStructuralDerivationErrorCode =
   | "invalid-envelope"
   | "unsupported-schema"
   | "unsupported-semantic-base"
   | "invalid-topology"
   | "noncanonical-topology"
+  | "noncanonical-support-topology"
   | "invalid-coordinate"
   | "noncanonical-node-order";
 
@@ -198,7 +218,7 @@ function parseNode(value: unknown): PortableStructuralDerivationNode {
   });
 }
 
-function parseArtifact(input: unknown): PortableStructuralDerivationArtifact {
+function parseArtifact(input: unknown): ParsedPortableStructuralDerivationArtifact {
   const item = exactRecord(input, [
     "schema",
     "mtsSemanticBase",
@@ -207,7 +227,12 @@ function parseArtifact(input: unknown): PortableStructuralDerivationArtifact {
     "targetOccurrenceCoordinate",
     "nodes",
   ]);
-  if (item.schema !== PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+  let schema: PortableStructuralDerivationSchema;
+  if (item.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1) {
+    schema = PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1;
+  } else if (item.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+    schema = PORTABLE_STRUCTURAL_DERIVATION_SCHEMA;
+  } else {
     fail("unsupported-schema");
   }
   if (item.mtsSemanticBase !== PORTABLE_MTS_SEMANTIC_BASE) {
@@ -221,7 +246,7 @@ function parseArtifact(input: unknown): PortableStructuralDerivationArtifact {
     }
   }
   return Object.freeze({
-    schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+    schema,
     mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
     topology: parseTopology(item.topology),
     theoryCoordinate: coordinate(item.theoryCoordinate),
@@ -286,15 +311,15 @@ function encodeNode(
 }
 
 export function exportPortableStructuralDerivation(
-  memory: EnumerableReadMemory,
+  memory: ReadMemory,
   evidence: StructuralDerivationEvidence,
 ): PortableStructuralDerivationArtifact {
   const before = memory.linkCount;
   try {
-    const canonical = exportCanonicalTopology(memory);
-    const c = (handle: LinkHandle): number => sourceCoordinate(canonical.coordinates, handle);
+    const support = exportStructuralDerivationSupportTopology(memory, evidence);
+    const c = (handle: LinkHandle): number => sourceCoordinate(support.coordinates, handle);
     const nodes = evidence.nodes
-      .map((node) => encodeNode(canonical.coordinates, node))
+      .map((node) => encodeNode(support.coordinates, node))
       .sort((left, right) => left.occurrence - right.occurrence);
     for (let index = 1; index < nodes.length; index += 1) {
       if (nodes[index - 1]!.occurrence === nodes[index]!.occurrence) {
@@ -305,14 +330,14 @@ export function exportPortableStructuralDerivation(
     return Object.freeze({
       schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
       mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
-      topology: canonical.topology,
+      topology: support.topology,
       theoryCoordinate: c(evidence.theory),
       targetOccurrenceCoordinate: c(evidence.targetOccurrence),
       nodes: Object.freeze(nodes),
     });
   } catch (error) {
     if (error instanceof PortableStructuralDerivationError) throw error;
-    if (error instanceof CanonicalTopologyError) fail("invalid-topology");
+    if (error instanceof StructuralDerivationSupportTopologyError) fail("invalid-topology");
     throw error;
   } finally {
     if (memory.linkCount !== before) fail("invalid-envelope");
@@ -355,13 +380,12 @@ function freshHandle(refs: ReadonlyMap<number, LinkHandle>, local: number): Link
   return handle;
 }
 
-export function replayPortableStructuralDerivation(
-  input: unknown,
-): PortableStructuralDerivationReplayResult {
-  const artifact = parseArtifact(input);
-  const restored = restoreCanonicalTopology(artifact.topology);
-  const h = (local: number): LinkHandle => freshHandle(restored.refs, local);
-  const evidence: StructuralDerivationEvidence = Object.freeze({
+function reconstructEvidence(
+  artifact: ParsedPortableStructuralDerivationArtifact,
+  refs: ReadonlyMap<number, LinkHandle>,
+): StructuralDerivationEvidence {
+  const h = (local: number): LinkHandle => freshHandle(refs, local);
+  return Object.freeze({
     theory: h(artifact.theoryCoordinate),
     targetOccurrence: h(artifact.targetOccurrenceCoordinate),
     nodes: Object.freeze(artifact.nodes.map((node) => Object.freeze({
@@ -390,6 +414,27 @@ export function replayPortableStructuralDerivation(
       premiseOccurrenceSequence: h(node.premiseOccurrenceSequence),
     }))),
   });
+}
+
+export function replayPortableStructuralDerivation(
+  input: unknown,
+): PortableStructuralDerivationReplayResult {
+  const artifact = parseArtifact(input);
+  const restored = restoreCanonicalTopology(artifact.topology);
+  const evidence = reconstructEvidence(artifact, restored.refs);
+
+  if (artifact.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+    let support;
+    try {
+      support = exportStructuralDerivationSupportTopology(restored.memory, evidence);
+    } catch (error) {
+      if (error instanceof StructuralDerivationSupportTopologyError) fail("invalid-topology");
+      throw error;
+    }
+    if (!sameTopology(support.topology, artifact.topology)) {
+      fail("noncanonical-support-topology");
+    }
+  }
 
   const beforeReplay = restored.memory.linkCount;
   const replay = replayStructuralDerivation(restored.memory, evidence);

--- a/ts/src/portable-derivation.ts
+++ b/ts/src/portable-derivation.ts
@@ -23,15 +23,17 @@ import {
   exportStructuralDerivationSupportTopology,
 } from "./proof-support-topology.js";
 
-const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1 =
-  "mts-portable-structural-derivation/v0.1" as const;
+// Package compatibility marker introduced with P6c/P6d. The public API contract
+// pins this literal to v0.1; current artifacts carry their own v0.2 schema value.
 export const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA =
+  "mts-portable-structural-derivation/v0.1" as const;
+const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2 =
   "mts-portable-structural-derivation/v0.2" as const;
 export const PORTABLE_MTS_SEMANTIC_BASE = "mts-contract/v0.11" as const;
 
 type PortableStructuralDerivationSchema =
-  | typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1
-  | typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA;
+  | typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA
+  | typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2;
 
 export interface PortableStructuralInterpreterCoordinates {
   readonly dictionary: number;
@@ -68,7 +70,7 @@ export interface PortableStructuralDerivationNode {
 }
 
 export interface PortableStructuralDerivationArtifact {
-  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA;
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2;
   readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
   readonly topology: StorageTopologyImage;
   readonly theoryCoordinate: number;
@@ -228,10 +230,10 @@ function parseArtifact(input: unknown): ParsedPortableStructuralDerivationArtifa
     "nodes",
   ]);
   let schema: PortableStructuralDerivationSchema;
-  if (item.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1) {
-    schema = PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_1;
-  } else if (item.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+  if (item.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
     schema = PORTABLE_STRUCTURAL_DERIVATION_SCHEMA;
+  } else if (item.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2) {
+    schema = PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2;
   } else {
     fail("unsupported-schema");
   }
@@ -328,7 +330,7 @@ export function exportPortableStructuralDerivation(
     }
     if (memory.linkCount !== before) fail("invalid-envelope");
     return Object.freeze({
-      schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+      schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2,
       mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
       topology: support.topology,
       theoryCoordinate: c(evidence.theory),
@@ -447,7 +449,7 @@ export function replayPortableStructuralDerivation(
   // Transport canonicality never establishes proof truth. Generic replay runs
   // first; this v0.2-only gate can only reject an otherwise valid proof whose
   // canonical topology contains replay-irrelevant ambient baggage.
-  if (artifact.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+  if (artifact.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2) {
     verifyCurrentSupportTopology(restored.memory, evidence, artifact.topology);
   }
   if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");

--- a/ts/src/portable-derivation.ts
+++ b/ts/src/portable-derivation.ts
@@ -416,6 +416,23 @@ function reconstructEvidence(
   });
 }
 
+function verifyCurrentSupportTopology(
+  memory: Memory,
+  evidence: StructuralDerivationEvidence,
+  supplied: StorageTopologyImage,
+): void {
+  let support;
+  try {
+    support = exportStructuralDerivationSupportTopology(memory, evidence);
+  } catch (error) {
+    if (error instanceof StructuralDerivationSupportTopologyError) fail("invalid-topology");
+    throw error;
+  }
+  if (!sameTopology(support.topology, supplied)) {
+    fail("noncanonical-support-topology");
+  }
+}
+
 export function replayPortableStructuralDerivation(
   input: unknown,
 ): PortableStructuralDerivationReplayResult {
@@ -423,22 +440,18 @@ export function replayPortableStructuralDerivation(
   const restored = restoreCanonicalTopology(artifact.topology);
   const evidence = reconstructEvidence(artifact, restored.refs);
 
-  if (artifact.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
-    let support;
-    try {
-      support = exportStructuralDerivationSupportTopology(restored.memory, evidence);
-    } catch (error) {
-      if (error instanceof StructuralDerivationSupportTopologyError) fail("invalid-topology");
-      throw error;
-    }
-    if (!sameTopology(support.topology, artifact.topology)) {
-      fail("noncanonical-support-topology");
-    }
-  }
-
   const beforeReplay = restored.memory.linkCount;
   const replay = replayStructuralDerivation(restored.memory, evidence);
   if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+
+  // Transport canonicality never establishes proof truth. Generic replay runs
+  // first; this v0.2-only gate can only reject an otherwise valid proof whose
+  // canonical topology contains replay-irrelevant ambient baggage.
+  if (artifact.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA) {
+    verifyCurrentSupportTopology(restored.memory, evidence, artifact.topology);
+  }
+  if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+
   return Object.freeze({
     memory: restored.memory,
     evidence,

--- a/ts/test/portable-derivation.test.ts
+++ b/ts/test/portable-derivation.test.ts
@@ -162,13 +162,17 @@ function siblingFixture(reverse: boolean): Memory {
   return memory;
 }
 
-// Current output is v0.2 replay-support topology. A real three-node branching
-// proof crosses the owner boundary, reconstructs fresh and replays read-only.
+// The package marker remains pinned to v0.1 for compatibility, while current
+// artifact output is the versioned v0.2 replay-support transport.
 {
   const fx = branchFixture();
   const beforeExport = fx.memory.linkCount;
   const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
-  same(artifact.schema, PORTABLE_STRUCTURAL_DERIVATION_SCHEMA, "current portable schema constant");
+  same(
+    PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+    "mts-portable-structural-derivation/v0.1",
+    "public package compatibility marker remains pinned",
+  );
   same(artifact.schema, "mts-portable-structural-derivation/v0.2", "current output must be v0.2");
   same(fx.memory.linkCount, beforeExport, "portable export is source read-only");
   same(artifact.nodes.length, 3, "complete branching node closure transported");

--- a/ts/test/portable-derivation.test.ts
+++ b/ts/test/portable-derivation.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/memory.js";
 import { exportTopology } from "../src/persistence-topology.js";
 import {
+  PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
   PortableStructuralDerivationError,
   exportPortableStructuralDerivation,
   replayPortableStructuralDerivation,
@@ -29,6 +30,8 @@ import {
   type StructuralDerivationEvidence,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
+
+const LEGACY_SCHEMA = "mts-portable-structural-derivation/v0.1" as const;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -159,12 +162,14 @@ function siblingFixture(reverse: boolean): Memory {
   return memory;
 }
 
-// A real three-node branching P2 proof crosses the owner boundary through
-// canonical coordinates, reconstructs in a fresh Memory and replays read-only.
+// Current output is v0.2 replay-support topology. A real three-node branching
+// proof crosses the owner boundary, reconstructs fresh and replays read-only.
 {
   const fx = branchFixture();
   const beforeExport = fx.memory.linkCount;
   const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  same(artifact.schema, PORTABLE_STRUCTURAL_DERIVATION_SCHEMA, "current portable schema constant");
+  same(artifact.schema, "mts-portable-structural-derivation/v0.2", "current output must be v0.2");
   same(fx.memory.linkCount, beforeExport, "portable export is source read-only");
   same(artifact.nodes.length, 3, "complete branching node closure transported");
   assert(
@@ -186,10 +191,10 @@ function siblingFixture(reverse: boolean): Memory {
   assert(foreignRejected, "portable replay must not reuse source owner handles");
 
   const reexported = exportPortableStructuralDerivation(imported.memory, imported.evidence);
-  same(JSON.stringify(reexported), JSON.stringify(artifact), "portable import/re-export is stable");
+  same(JSON.stringify(reexported), JSON.stringify(artifact), "v0.2 import/re-export is byte-stable");
 }
 
-// P2 host nodes[] order is transport-only: opposite source order emits the same artifact.
+// P2 host nodes[] order remains transport-only.
 {
   const fx = branchFixture();
   const a = exportPortableStructuralDerivation(fx.memory, fx.evidence);
@@ -198,6 +203,63 @@ function siblingFixture(reverse: boolean): Memory {
     nodes: [...fx.evidence.nodes].reverse(),
   });
   same(JSON.stringify(a), JSON.stringify(b), "source node order has no portable authority");
+}
+
+// P6f adoption removes unrelated selected-Memory topology from current bytes.
+{
+  const fx = branchFixture();
+  const before = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  const countBeforeJunk = fx.memory.linkCount;
+  const junkA = fx.memory.ensure(fx.evidence.theory, fx.evidence.theory);
+  const junkB = fx.memory.ensure(junkA, fx.evidence.theory);
+  assert(fx.memory.linkCount > countBeforeJunk, "ambient witness must grow selected Memory");
+
+  const after = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  same(JSON.stringify(after), JSON.stringify(before), "unrelated ambient growth must not change v0.2 bytes");
+  const full = exportCanonicalTopology(fx.memory).topology;
+  assert(
+    after.topology.links.length < full.links.length,
+    "v0.2 support topology must be smaller than ambient full-Memory topology",
+  );
+  void junkB;
+}
+
+// v0.1 remains a real compatibility contract. Add one canonical START-self Link
+// over the old final coordinate: it is a new later round and not outgoing(any Act).
+// Legacy v0.1 accepts this canonical baggage; current v0.2 rejects it, and a
+// current re-export from the legacy reconstruction strips it deterministically.
+{
+  const fx = branchFixture();
+  const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  const next = artifact.topology.links.length;
+  const last = next - 1;
+  assert(last >= 0, "portable topology must be non-empty");
+  const expandedTopology = Object.freeze({
+    ...artifact.topology,
+    links: Object.freeze([
+      ...artifact.topology.links,
+      Object.freeze([next, last] as const),
+    ]),
+  });
+
+  const legacy = {
+    ...artifact,
+    schema: LEGACY_SCHEMA,
+    topology: expandedTopology,
+  };
+  const legacyImported = replayPortableStructuralDerivation(legacy);
+  same(legacyImported.replay.occurrenceCount, 3, "legacy v0.1 canonical baggage remains accepted");
+
+  expectPortable("noncanonical-support-topology", () => replayPortableStructuralDerivation({
+    ...artifact,
+    topology: expandedTopology,
+  }));
+
+  const normalized = exportPortableStructuralDerivation(legacyImported.memory, legacyImported.evidence);
+  same(JSON.stringify(normalized), JSON.stringify(artifact), "legacy baggage normalizes to exact current v0.2");
+
+  const minimalLegacy = replayPortableStructuralDerivation({ ...artifact, schema: LEGACY_SCHEMA });
+  same(minimalLegacy.replay.occurrenceCount, 3, "support-minimal v0.1 input also remains accepted");
 }
 
 // Strict envelope validation is fail-closed before structural replay.
@@ -258,8 +320,27 @@ function siblingFixture(reverse: boolean): Memory {
   }));
 }
 
-// Once transport is structurally valid, forged coordinates do not gain authority:
-// the existing generic derivation kernel rejects the reconstructed proof.
+// Hostile outgoing evidence remains inside v0.2 support. Export does not decide
+// truth; reconstructed generic replay still rejects the undeclared binding.
+{
+  const fx = branchFixture();
+  const valid = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  const targetAct = fx.evidence.nodes[0]!.judgment.application.act;
+  const badRole = fx.memory.ensure(fx.evidence.theory, fx.evidence.theory);
+  const badField = fx.memory.ensure(badRole, fx.evidence.theory);
+  const hostileAttachment = fx.memory.ensure(targetAct, badField);
+  assert(fx.memory.outgoing(targetAct).includes(hostileAttachment), "hostile attachment must be outgoing(target Act)");
+
+  const hostile = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  assert(
+    hostile.topology.links.length > valid.topology.links.length,
+    "hostile outgoing evidence must enlarge exact replay support",
+  );
+  expectReplayReject(() => replayPortableStructuralDerivation(hostile));
+}
+
+// Once transport is structurally valid, forged proof coordinates do not gain
+// authority: the existing generic derivation kernel rejects first.
 {
   const fx = branchFixture();
   const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
@@ -284,4 +365,7 @@ function siblingFixture(reverse: boolean): Memory {
     ...artifact,
     nodes: forgedNodes,
   }));
+
+  // Executable P6g classification:
+  // PORTABLE_REPLAY_SUPPORT_V02_SUPPORTED
 }


### PR DESCRIPTION
Closes #845

## Scope

P6g advances the current portable base-derivation output from `mts-portable-structural-derivation/v0.1` to `.../v0.2` and adopts the P6f canonical replay-support topology without changing accepted MTS semantics.

```text
base = 7cd12b255b76884e4bb16359afc8d172eade06ee
head = 4412b524fbf4dd2472f8b93519b7f5e3c4a8bac9
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

Only these existing files change:

```text
ts/src/portable-derivation.ts       +76 / -18
ts/test/portable-derivation.test.ts +90 / -6
------------------------------------------------
additions                           166
net additions                       142 / 420
new files                           0
```

No public key is added; `public.ts` and `public-api.test.ts` are untouched. The existing public `PORTABLE_STRUCTURAL_DERIVATION_SCHEMA` symbol now denotes the current v0.2 output string.

## v0.2 current output

`exportPortableStructuralDerivation` now accepts ordinary `ReadMemory` and reuses P6f `exportStructuralDerivationSupportTopology` instead of canonicalizing the whole selected Memory.

Consequences:

- all evidence coordinates come from the canonical replay-support map;
- complete `outgoing(act)` namespaces for evidence Acts remain in transport, including hostile negative evidence;
- unrelated ambient Memory topology is excluded;
- current artifact bytes are invariant under unrelated source-Memory growth;
- canonical node ordering remains by occurrence coordinate;
- export remains read-only.

## v0.1 backward compatibility

The importer accepts both:

```text
mts-portable-structural-derivation/v0.1
mts-portable-structural-derivation/v0.2
```

v0.1 keeps its historical contract: canonical topology may contain ambient/full selected-Memory baggage. It is not silently reinterpreted as support-minimal.

The executable witness appends a new canonical START-self Link `[newCoordinate,lastCoordinate]` over the previous final canonical coordinate. This is guaranteed to form a new later canonical round and is not `outgoing(any evidence Act)`.

```text
same valid proof + canonical baggage as v0.1 -> replay accepts
same valid proof + canonical baggage as v0.2 -> noncanonical-support-topology
legacy reconstruction -> current re-export -> exact minimal v0.2 bytes
```

## Authority ordering

Transport canonicality does not decide proof truth.

Replay order is deliberately:

```text
strict parse
-> canonical topology reconstruction
-> fresh evidence reconstruction
-> existing generic replayStructuralDerivation
-> v0.2 exact-support canonicality gate
-> accept
```

Therefore forged proof coordinates continue to be rejected first by the existing generic derivation kernel. The v0.2 support gate can only reject an otherwise semantically valid reconstructed proof whose topology contains replay-irrelevant canonical baggage.

## Executable corpus

P6g adds/retains witnesses for:

- exact current v0.2 schema;
- source export read-only;
- fresh owner reconstruction and read-only replay;
- v0.2 import/re-export byte stability;
- host `nodes[]` reorder neutrality;
- complete artifact invariance under unrelated ambient Memory growth;
- support topology smaller than full canonical selected Memory with ambient witness;
- valid minimal v0.1 acceptance;
- valid v0.1 canonical-baggage acceptance;
- same baggage rejected as v0.2;
- legacy reconstruction normalized to exact v0.2;
- unknown schema / wrong semantic base / extra envelope authority rejection;
- noncanonical raw topology rejection;
- hostile outgoing Act attachment retained and generic replay rejection preserved;
- semantic forgeries remain generic derivation rejections.

## Non-conflations

```text
v0.2 canonical support bytes != theorem truth
transport schema version != MTS semantic release
legacy v0.1 acceptance != current v0.1 export
support minimization != deleting negative evidence
proof artifact identity != theorem identity
digest/hash != truth
P6g != digest/provenance
P6g != theorem/assumption portable families
P6g != v0.12
```

## Expected classification

```text
PORTABLE_REPLAY_SUPPORT_V02_SUPPORTED
```

only if exact-head full CI and blocking repo-guard are green.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on the merge SHA