### PR TITLE
feat(proof): expose portable digest package API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -183,6 +183,14 @@ export type {
 } from "./portable-derivation.js";
 
 export {
+  PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+  computePortableStructuralDerivationContentDigest,
+} from "./portable-derivation-digest.js";
+export type {
+  PortableStructuralDerivationContentDigest,
+} from "./portable-derivation-digest.js";
+
+export {
   ProofRuleReplayError,
   replayDecomposeEqualRelations,
 } from "./proof.js";

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -10,6 +10,7 @@ import type {
   PersistentSequenceDescription,
   PersistentTopologyBackend,
   PortableStructuralDerivationArtifact,
+  PortableStructuralDerivationContentDigest,
   PortableStructuralDerivationErrorCode,
   PortableStructuralDerivationReplayResult,
   ReadMemory,
@@ -38,6 +39,8 @@ import type { EnumerableReadMemory } from "../src/public.js";
 import type { RelationRoles } from "../src/public.js";
 // @ts-expect-error P6d keeps nested portable transport coordinate plumbing internal.
 import type { PortableStructuralDerivationNode } from "../src/public.js";
+// @ts-expect-error P6i keeps portable canonical JSON normalization internal.
+type InternalCanonicalPortableStructuralDerivationV02Json = typeof import("../src/public.js").canonicalPortableStructuralDerivationV02Json;
 // @ts-expect-error P3b keeps assumption construction internal; consumers submit materialized evidence.
 type InternalAssumptionContextConstructor = typeof import("../src/public.js").defineStructuralAssumptionContext;
 
@@ -55,6 +58,7 @@ const expectedRuntimeExports = [
   "Memory",
   "MemoryError",
   "PORTABLE_MTS_SEMANTIC_BASE",
+  "PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME",
   "PORTABLE_STRUCTURAL_DERIVATION_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
@@ -72,6 +76,7 @@ const expectedRuntimeExports = [
   "ValueBundleReplayError",
   "analyzeDirectDeixisCarrier",
   "bundleRoleAt",
+  "computePortableStructuralDerivationContentDigest",
   "deserializeAnum",
   "deserializeStream",
   "elaborateBundleRoles",
@@ -108,6 +113,7 @@ const expectedRuntimeExports = [
   "valuesEqual",
 ].sort();
 
+assert(expectedRuntimeExports.length === 62, "P6i runtime export budget must be exactly 62");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -123,6 +129,11 @@ assert(
 assert(
   publicApi.PORTABLE_MTS_SEMANTIC_BASE === "mts-contract/v0.11",
   "portable derivation semantic base must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME ===
+    "mts-portable-structural-derivation-content/sha-256/v0.1",
+  "portable derivation content digest scheme must stay pinned",
 );
 
 // Compile-time smoke for the intended consumer concepts. The top-level evidence
@@ -151,8 +162,11 @@ const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
 const integrated: IntegratedProofEvidence | undefined = undefined;
 const portableArtifact: PortableStructuralDerivationArtifact | undefined = undefined;
+const portableDigest: PortableStructuralDerivationContentDigest | undefined = undefined;
 const portableErrorCode: PortableStructuralDerivationErrorCode | undefined = undefined;
 const portableReplay: PortableStructuralDerivationReplayResult | undefined = undefined;
+const portableDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationContentDigest> =
+  publicApi.computePortableStructuralDerivationContentDigest;
 void [
   read,
   write,
@@ -177,6 +191,8 @@ void [
   proof,
   integrated,
   portableArtifact,
+  portableDigest,
   portableErrorCode,
   portableReplay,
+  portableDigestFunction,
 ];


### PR DESCRIPTION
Closes #852

## Scope

P6i exposes only the already-proven P6h digest consumer surface through the exact `@mts/core` package-root contract.

```text
base/main = d63021ab631216b9baeb31259aa725d4a54cafb6
head = 9763813e903195663cc850317deec5e1adce252b
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

Exact diff:

```text
ts/src/public.ts          +8
ts/test/public-api.test.ts +16
--------------------------------
net additions             +24 / 40
new files                   0
```

No digest implementation, portable transport semantics, contracts, policy, docs or release lifecycle files change.

## Exact package widening

The runtime package allowlist grows deliberately from 60 to exactly 62 names:

```text
PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME
computePortableStructuralDerivationContentDigest
```

One top-level type is added:

```text
PortableStructuralDerivationContentDigest
```

The internal normalization helper remains excluded:

```text
canonicalPortableStructuralDerivationV02Json
```

`public-api.test.ts` contains an `@ts-expect-error` guard so accidental future leakage fails typecheck.

## Pinned contracts

The public test keeps the existing portable compatibility markers pinned:

```text
PORTABLE_STRUCTURAL_DERIVATION_SCHEMA = mts-portable-structural-derivation/v0.1
PORTABLE_MTS_SEMANTIC_BASE = mts-contract/v0.11
```

and newly pins:

```text
PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME
= mts-portable-structural-derivation-content/sha-256/v0.1
```

It also checks the package-root function shape:

```text
(input: unknown) => Promise<PortableStructuralDerivationContentDigest>
```

## Authority boundary

This PR adds package exposure only. It does not alter P6h semantics:

```text
public digest API != proof authority
content digest != theorem truth
content digest != theorem identity
content digest != external source provenance
package widening != MTS semantic release
```

## Expected classification

```text
PORTABLE_V02_CONTENT_DIGEST_PACKAGE_API_SUPPORTED
```

only if exact-head full CI and blocking repo-guard are green.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main SHA after merge
- claim post-merge CI only if workflows actually exist for the merge SHA