### PR TITLE
feat(proof): bind portable proof provenance claims

### DIFF
--- a/ts/src/portable-derivation-provenance.ts
+++ b/ts/src/portable-derivation-provenance.ts
@@ -1,0 +1,169 @@
+import {
+  PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+  computePortableStructuralDerivationContentDigest,
+  type PortableStructuralDerivationContentDigest,
+} from "./portable-derivation-digest.js";
+
+export const PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA =
+  "mts-portable-structural-derivation-provenance/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME =
+  "mts-portable-structural-derivation-provenance/sha-256/v0.1" as const;
+
+export interface PortableStructuralDerivationSourceProvenance {
+  readonly locator: string;
+  readonly revision: string;
+  readonly subject: string;
+}
+
+export interface PortableStructuralDerivationProducerProvenance {
+  readonly id: string;
+  readonly version: string;
+}
+
+export interface PortableStructuralDerivationProvenanceClaim {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA;
+  readonly contentDigest: PortableStructuralDerivationContentDigest;
+  readonly source: PortableStructuralDerivationSourceProvenance;
+  readonly producer: PortableStructuralDerivationProducerProvenance;
+}
+
+export interface PortableStructuralDerivationProvenanceDigest {
+  readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME;
+  readonly value: string;
+}
+
+export type PortableStructuralDerivationProvenanceErrorCode =
+  | "invalid-envelope"
+  | "unsupported-schema"
+  | "invalid-content-digest"
+  | "invalid-provenance-string"
+  | "content-digest-mismatch";
+
+export class PortableStructuralDerivationProvenanceError extends Error {
+  override readonly name = "PortableStructuralDerivationProvenanceError";
+
+  constructor(readonly code: PortableStructuralDerivationProvenanceErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: PortableStructuralDerivationProvenanceErrorCode): never {
+  throw new PortableStructuralDerivationProvenanceError(code);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail("invalid-envelope");
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactRecord(value: unknown, keys: readonly string[]): Record<string, unknown> {
+  const candidate = record(value);
+  const actual = Object.keys(candidate).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    fail("invalid-envelope");
+  }
+  return candidate;
+}
+
+function exactText(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail("invalid-provenance-string");
+  }
+  return value;
+}
+
+function parseContentDigest(value: unknown): PortableStructuralDerivationContentDigest {
+  const digest = exactRecord(value, ["scheme", "value"]);
+  if (digest.scheme !== PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME) {
+    fail("invalid-content-digest");
+  }
+  if (typeof digest.value !== "string" || !/^[0-9a-f]{64}$/.test(digest.value)) {
+    fail("invalid-content-digest");
+  }
+  return Object.freeze({
+    scheme: PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+    value: digest.value,
+  });
+}
+
+function parseSource(value: unknown): PortableStructuralDerivationSourceProvenance {
+  const source = exactRecord(value, ["locator", "revision", "subject"]);
+  return Object.freeze({
+    locator: exactText(source.locator),
+    revision: exactText(source.revision),
+    subject: exactText(source.subject),
+  });
+}
+
+function parseProducer(value: unknown): PortableStructuralDerivationProducerProvenance {
+  const producer = exactRecord(value, ["id", "version"]);
+  return Object.freeze({
+    id: exactText(producer.id),
+    version: exactText(producer.version),
+  });
+}
+
+function parseClaim(value: unknown): PortableStructuralDerivationProvenanceClaim {
+  const claim = exactRecord(value, ["schema", "contentDigest", "source", "producer"]);
+  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA) {
+    fail("unsupported-schema");
+  }
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+    contentDigest: parseContentDigest(claim.contentDigest),
+    source: parseSource(claim.source),
+    producer: parseProducer(claim.producer),
+  });
+}
+
+export function canonicalPortableStructuralDerivationProvenanceClaimJson(
+  input: unknown,
+): string {
+  return JSON.stringify(parseClaim(input));
+}
+
+export async function createPortableStructuralDerivationProvenanceClaim(
+  artifact: unknown,
+  source: PortableStructuralDerivationSourceProvenance,
+  producer: PortableStructuralDerivationProducerProvenance,
+): Promise<PortableStructuralDerivationProvenanceClaim> {
+  const contentDigest = await computePortableStructuralDerivationContentDigest(artifact);
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+    contentDigest,
+    source: parseSource(source),
+    producer: parseProducer(producer),
+  });
+}
+
+function lowercaseHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function computePortableStructuralDerivationProvenanceDigest(
+  input: unknown,
+): Promise<PortableStructuralDerivationProvenanceDigest> {
+  const canonicalJson = canonicalPortableStructuralDerivationProvenanceClaimJson(input);
+  const preimage = `${PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME}\n${canonicalJson}`;
+  const raw = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(preimage));
+  return Object.freeze({
+    scheme: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
+    value: lowercaseHex(new Uint8Array(raw)),
+  });
+}
+
+export async function verifyPortableStructuralDerivationProvenanceClaim(
+  artifact: unknown,
+  input: unknown,
+): Promise<PortableStructuralDerivationProvenanceClaim> {
+  const claim = parseClaim(input);
+  const actual = await computePortableStructuralDerivationContentDigest(artifact);
+  if (actual.value !== claim.contentDigest.value) fail("content-digest-mismatch");
+  return claim;
+}

--- a/ts/test/portable-derivation-provenance.test.ts
+++ b/ts/test/portable-derivation-provenance.test.ts
@@ -1,0 +1,246 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+} from "../src/memory.js";
+import { computePortableStructuralDerivationContentDigest } from "../src/portable-derivation-digest.js";
+import {
+  PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+  PortableStructuralDerivationProvenanceError,
+  canonicalPortableStructuralDerivationProvenanceClaimJson,
+  computePortableStructuralDerivationProvenanceDigest,
+  createPortableStructuralDerivationProvenanceClaim,
+  verifyPortableStructuralDerivationProvenanceClaim,
+  type PortableStructuralDerivationProducerProvenance,
+  type PortableStructuralDerivationSourceProvenance,
+} from "../src/portable-derivation-provenance.js";
+import {
+  exportPortableStructuralDerivation,
+  replayPortableStructuralDerivation,
+} from "../src/portable-derivation.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralDerivationReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  type StructuralDerivationEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+async function expectProvenance(
+  code: PortableStructuralDerivationProvenanceError["code"],
+  effect: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await effect();
+  } catch (error) {
+    assert(error instanceof PortableStructuralDerivationProvenanceError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected provenance rejection`);
+}
+
+function expectReplayReject(effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralDerivationReplayError, "expected generic derivation rejection");
+    return;
+  }
+  throw new Error("expected generic derivation rejection");
+}
+
+function fixture(): {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationEvidence;
+} {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const context = defineContext(memory, fresh(), fresh());
+  const role = fresh();
+  const value = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const rule = defineStructuralRule(memory, roleDictionary, role);
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+  const act = defineActHeader(memory, interpreter, roleDictionary, context);
+  defineActField(memory, act, role, value);
+  const judgment: StructuralJudgmentEvidence = {
+    application: {
+      act,
+      rule,
+      ruleAdmission,
+      claimedBody: value,
+      expectedInterpreter,
+      expectedAfterContext: context,
+    },
+    judgment: { theory, context, claim: value },
+  };
+  const occurrence = defineStructuralProofOccurrence(memory, act, value);
+  const derivationRule = defineStructuralDerivationRule(memory, rule, []);
+  return {
+    memory,
+    evidence: {
+      theory,
+      targetOccurrence: occurrence,
+      nodes: [{
+        occurrence,
+        judgment,
+        derivationRule,
+        derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule),
+        premiseOccurrenceSequence: materializeExactSequence(memory, []),
+      }],
+    },
+  };
+}
+
+function reverseObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(reverseObjectKeys);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .reverse()
+      .map(([key, nested]) => [key, reverseObjectKeys(nested)]),
+  );
+}
+
+async function main(): Promise<void> {
+  const fx = fixture();
+  const artifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  const source: PortableStructuralDerivationSourceProvenance = {
+    locator: "https://github.com/leanprover-community/mathlib4",
+    revision: "0123456789abcdef0123456789abcdef01234567",
+    subject: "Mathlib.Example.theorem",
+  };
+  const producer: PortableStructuralDerivationProducerProvenance = {
+    id: "mts-proof-importer",
+    version: "0.1.0",
+  };
+  const before = fx.memory.linkCount;
+  const directContent = await computePortableStructuralDerivationContentDigest(artifact);
+  const claim = await createPortableStructuralDerivationProvenanceClaim(artifact, source, producer);
+  same(claim.schema, PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA, "claim schema is pinned");
+  same(claim.contentDigest.value, directContent.value, "claim binds recomputed content digest");
+  same(fx.memory.linkCount, before, "claim creation remains source read-only");
+
+  const digest = await computePortableStructuralDerivationProvenanceDigest(claim);
+  same(digest.scheme, PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME, "provenance digest scheme is pinned");
+  assert(/^[0-9a-f]{64}$/.test(digest.value), "provenance digest must be lowercase 64-hex");
+  const repeated = await computePortableStructuralDerivationProvenanceDigest(claim);
+  same(repeated.value, digest.value, "repeated provenance digest is stable");
+
+  const reordered = reverseObjectKeys(claim);
+  same(
+    canonicalPortableStructuralDerivationProvenanceClaimJson(reordered),
+    canonicalPortableStructuralDerivationProvenanceClaimJson(claim),
+    "object key order has no provenance authority",
+  );
+  const reorderedDigest = await computePortableStructuralDerivationProvenanceDigest(reordered);
+  same(reorderedDigest.value, digest.value, "object key order leaves provenance digest stable");
+
+  for (const [label, changedSource, changedProducer] of [
+    ["locator", { ...source, locator: `${source.locator}/` }, producer],
+    ["revision", { ...source, revision: `${source.revision}x` }, producer],
+    ["subject", { ...source, subject: `${source.subject}.changed` }, producer],
+    ["producer-id", source, { ...producer, id: `${producer.id}.changed` }],
+    ["producer-version", source, { ...producer, version: `${producer.version}+changed` }],
+  ] as const) {
+    const changedClaim = await createPortableStructuralDerivationProvenanceClaim(
+      artifact,
+      changedSource,
+      changedProducer,
+    );
+    const changedDigest = await computePortableStructuralDerivationProvenanceDigest(changedClaim);
+    assert(changedDigest.value !== digest.value, `${label} must change provenance digest`);
+  }
+
+  const valid = await verifyPortableStructuralDerivationProvenanceClaim(artifact, claim);
+  same(valid.contentDigest.value, claim.contentDigest.value, "valid claim verifies against artifact");
+  same(fx.memory.linkCount, before, "digest and verification remain source read-only");
+
+  const junkA = fx.memory.ensure(fx.evidence.theory, fx.evidence.theory);
+  fx.memory.ensure(junkA, fx.evidence.theory);
+  const ambientArtifact = exportPortableStructuralDerivation(fx.memory, fx.evidence);
+  same(JSON.stringify(ambientArtifact), JSON.stringify(artifact), "ambient growth leaves v0.2 artifact stable");
+  const ambientClaim = await createPortableStructuralDerivationProvenanceClaim(ambientArtifact, source, producer);
+  const ambientDigest = await computePortableStructuralDerivationProvenanceDigest(ambientClaim);
+  same(ambientDigest.value, digest.value, "ambient growth leaves provenance digest stable");
+
+  await expectProvenance("unsupported-schema", () => computePortableStructuralDerivationProvenanceDigest({
+    ...claim,
+    schema: "mts-portable-structural-derivation-provenance/v999",
+  }));
+  await expectProvenance("invalid-content-digest", () => computePortableStructuralDerivationProvenanceDigest({
+    ...claim,
+    contentDigest: { ...claim.contentDigest, scheme: "sha256" },
+  }));
+  await expectProvenance("invalid-content-digest", () => computePortableStructuralDerivationProvenanceDigest({
+    ...claim,
+    contentDigest: { ...claim.contentDigest, value: claim.contentDigest.value.toUpperCase() },
+  }));
+  await expectProvenance("invalid-provenance-string", () => computePortableStructuralDerivationProvenanceDigest({
+    ...claim,
+    source: { ...claim.source, revision: "   " },
+  }));
+  await expectProvenance("invalid-envelope", () => computePortableStructuralDerivationProvenanceDigest({
+    ...claim,
+    trusted: true,
+  }));
+  await expectProvenance("invalid-envelope", () => computePortableStructuralDerivationProvenanceDigest({
+    ...claim,
+    source: { ...claim.source, signature: "not-authority" },
+  }));
+
+  const forgedClaim = {
+    ...claim,
+    contentDigest: { ...claim.contentDigest, value: "0".repeat(64) },
+  };
+  const forgedClaimDigest = await computePortableStructuralDerivationProvenanceDigest(forgedClaim);
+  assert(forgedClaimDigest.value !== digest.value, "structurally valid forged claim has distinct identity");
+  await expectProvenance(
+    "content-digest-mismatch",
+    () => verifyPortableStructuralDerivationProvenanceClaim(artifact, forgedClaim),
+  );
+
+  assert(artifact.theoryCoordinate !== 0, "fixture theory coordinate must make proof forgery observable");
+  const forgedArtifact = { ...artifact, theoryCoordinate: 0 };
+  const forgedProofClaim = await createPortableStructuralDerivationProvenanceClaim(
+    forgedArtifact,
+    source,
+    producer,
+  );
+  const forgedProofDigest = await computePortableStructuralDerivationProvenanceDigest(forgedProofClaim);
+  assert(forgedProofDigest.value !== digest.value, "proof mutation changes bound provenance identity");
+  expectReplayReject(() => replayPortableStructuralDerivation(forgedArtifact));
+
+  // Executable P6j classification:
+  // PORTABLE_V02_EXTERNAL_PROVENANCE_CLAIM_SUPPORTED
+}
+
+await main();


### PR DESCRIPTION
Closes #854

## Scope

P6j adds an internal/core canonical external-provenance claim bound to the already-proven portable v0.2 content digest, plus a separate domain-separated provenance SHA-256.

```text
base/main = 7f61fa6ec16205d56f2fc847a7b82cd48d01cb38
head = 9b8fc4d75a65ef6f97c3966fbbe610b0de249c24
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

Exact diff:

```text
ts/src/portable-derivation-provenance.ts       NEW +169
ts/test/portable-derivation-provenance.test.ts NEW +246
-----------------------------------------------------
net additions                                      415 / 420
new files                                            2 / 2
```

No package-root API, existing portable/digest semantics, contracts, policy, docs or release lifecycle files change.

## Provenance contract

```text
claim schema  = mts-portable-structural-derivation-provenance/v0.1
digest scheme = mts-portable-structural-derivation-provenance/sha-256/v0.1
```

The claim binds:

```text
exact P6h v0.2 content digest
+ source locator
+ exact source revision
+ source subject
+ producer id/version
```

Claim creation recomputes the P6h content digest from the supplied artifact; callers do not supply proof identity themselves.

## Canonicalization / hashing

The provenance parser requires exact envelope/nested keys, the exact P6h content-digest scheme, lowercase 64-hex content digest, and non-empty provenance strings. It reconstructs the claim in fixed field order before JSON serialization.

The provenance digest is WebCrypto SHA-256 over:

```text
mts-portable-structural-derivation-provenance/sha-256/v0.1\n
+ canonical provenance claim JSON
```

No `node:crypto`, custom SHA implementation, proof-topology canonicalizer, proof replay or network source lookup is introduced.

## Authority boundary

`verifyPortableStructuralDerivationProvenanceClaim` recomputes the artifact content digest and verifies only claim-to-artifact binding.

Executable falsification keeps these distinctions explicit:

```text
provenance claim != source authenticity
provenance digest != cryptographic signature
provenance digest != proof truth
producer identity != trusted authority
```

A structurally valid forged provenance claim can receive its own digest but fails artifact-binding verification. A structurally parseable forged proof artifact can receive content/provenance identity but remains rejected by generic proof replay.

## Stability / negative corpus

Tests cover exact scheme pinning, repeated stability, object-key-order neutrality, ambient Memory growth invariance, sensitivity to every source/producer field, valid binding verification, wrong schema/scheme/digest/text/extra-field rejection, forged claim mismatch, and proof-invalidity remaining independent of provenance metadata.

## Expected classification

```text
PORTABLE_V02_EXTERNAL_PROVENANCE_CLAIM_SUPPORTED
```

only if exact-head full CI and blocking repo-guard are green.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA