### PR TITLE
feat(proof): expose portable provenance package API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -191,6 +191,22 @@ export type {
 } from "./portable-derivation-digest.js";
 
 export {
+  PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+  PortableStructuralDerivationProvenanceError,
+  computePortableStructuralDerivationProvenanceDigest,
+  createPortableStructuralDerivationProvenanceClaim,
+  verifyPortableStructuralDerivationProvenanceClaim,
+} from "./portable-derivation-provenance.js";
+export type {
+  PortableStructuralDerivationProducerProvenance,
+  PortableStructuralDerivationProvenanceClaim,
+  PortableStructuralDerivationProvenanceDigest,
+  PortableStructuralDerivationProvenanceErrorCode,
+  PortableStructuralDerivationSourceProvenance,
+} from "./portable-derivation-provenance.js";
+
+export {
   ProofRuleReplayError,
   replayDecomposeEqualRelations,
 } from "./proof.js";

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -12,7 +12,12 @@ import type {
   PortableStructuralDerivationArtifact,
   PortableStructuralDerivationContentDigest,
   PortableStructuralDerivationErrorCode,
+  PortableStructuralDerivationProducerProvenance,
+  PortableStructuralDerivationProvenanceClaim,
+  PortableStructuralDerivationProvenanceDigest,
+  PortableStructuralDerivationProvenanceErrorCode,
   PortableStructuralDerivationReplayResult,
+  PortableStructuralDerivationSourceProvenance,
   ReadMemory,
   RelationReplayEvidence,
   RunEvidence,
@@ -41,6 +46,8 @@ import type { RelationRoles } from "../src/public.js";
 import type { PortableStructuralDerivationNode } from "../src/public.js";
 // @ts-expect-error P6i keeps portable canonical JSON normalization internal.
 type InternalCanonicalPortableStructuralDerivationV02Json = typeof import("../src/public.js").canonicalPortableStructuralDerivationV02Json;
+// @ts-expect-error P6k keeps provenance canonical JSON normalization internal.
+type InternalCanonicalPortableStructuralDerivationProvenanceClaimJson = typeof import("../src/public.js").canonicalPortableStructuralDerivationProvenanceClaimJson;
 // @ts-expect-error P3b keeps assumption construction internal; consumers submit materialized evidence.
 type InternalAssumptionContextConstructor = typeof import("../src/public.js").defineStructuralAssumptionContext;
 
@@ -59,10 +66,13 @@ const expectedRuntimeExports = [
   "MemoryError",
   "PORTABLE_MTS_SEMANTIC_BASE",
   "PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME",
+  "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME",
+  "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
   "PortableStructuralDerivationError",
+  "PortableStructuralDerivationProvenanceError",
   "ProofRuleReplayError",
   "QuaternaryDecodeError",
   "RunReplayError",
@@ -77,6 +87,8 @@ const expectedRuntimeExports = [
   "analyzeDirectDeixisCarrier",
   "bundleRoleAt",
   "computePortableStructuralDerivationContentDigest",
+  "computePortableStructuralDerivationProvenanceDigest",
+  "createPortableStructuralDerivationProvenanceClaim",
   "deserializeAnum",
   "deserializeStream",
   "elaborateBundleRoles",
@@ -111,9 +123,10 @@ const expectedRuntimeExports = [
   "resolveFlatBundle",
   "symbolicStackAlgebra",
   "valuesEqual",
+  "verifyPortableStructuralDerivationProvenanceClaim",
 ].sort();
 
-assert(expectedRuntimeExports.length === 62, "P6i runtime export budget must be exactly 62");
+assert(expectedRuntimeExports.length === 68, "P6k runtime export budget must be exactly 68");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -134,6 +147,16 @@ assert(
   publicApi.PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME ===
     "mts-portable-structural-derivation-content/sha-256/v0.1",
   "portable derivation content digest scheme must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA ===
+    "mts-portable-structural-derivation-provenance/v0.1",
+  "portable derivation provenance schema must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME ===
+    "mts-portable-structural-derivation-provenance/sha-256/v0.1",
+  "portable derivation provenance digest scheme must stay pinned",
 );
 
 // Compile-time smoke for the intended consumer concepts. The top-level evidence
@@ -167,6 +190,14 @@ const portableErrorCode: PortableStructuralDerivationErrorCode | undefined = und
 const portableReplay: PortableStructuralDerivationReplayResult | undefined = undefined;
 const portableDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationContentDigest> =
   publicApi.computePortableStructuralDerivationContentDigest;
+const provenanceSource: PortableStructuralDerivationSourceProvenance | undefined = undefined;
+const provenanceProducer: PortableStructuralDerivationProducerProvenance | undefined = undefined;
+const provenanceClaim: PortableStructuralDerivationProvenanceClaim | undefined = undefined;
+const provenanceDigest: PortableStructuralDerivationProvenanceDigest | undefined = undefined;
+const provenanceErrorCode: PortableStructuralDerivationProvenanceErrorCode | undefined = undefined;
+const createProvenance: (artifact: unknown, source: PortableStructuralDerivationSourceProvenance, producer: PortableStructuralDerivationProducerProvenance) => Promise<PortableStructuralDerivationProvenanceClaim> = publicApi.createPortableStructuralDerivationProvenanceClaim;
+const digestProvenance: (input: unknown) => Promise<PortableStructuralDerivationProvenanceDigest> = publicApi.computePortableStructuralDerivationProvenanceDigest;
+const verifyProvenance: (artifact: unknown, input: unknown) => Promise<PortableStructuralDerivationProvenanceClaim> = publicApi.verifyPortableStructuralDerivationProvenanceClaim;
 void [
   read,
   write,
@@ -195,4 +226,12 @@ void [
   portableErrorCode,
   portableReplay,
   portableDigestFunction,
+  provenanceSource,
+  provenanceProducer,
+  provenanceClaim,
+  provenanceDigest,
+  provenanceErrorCode,
+  createProvenance,
+  digestProvenance,
+  verifyProvenance,
 ];


### PR DESCRIPTION
Closes #856

## Scope

P6k exposes only the already-proven P6j provenance consumer surface through the exact `@mts/core` package-root contract.

```text
base/main = 2c976af7839a8b8c0dc41432be18f06603271a3f
head = ab1c7d6a1c0c6caf005f8dc2be1406090ccf6ca2
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
v0.12 = NOT OPENED
```

Exact diff:

```text
ts/src/public.ts           +16
ts/test/public-api.test.ts +40/-1
---------------------------------
net additions              +55 / 60
new files                    0
```

No provenance implementation, portable/content-digest semantics, contracts, policy, docs or release lifecycle files change.

## Exact package widening

Runtime package allowlist grows deliberately from 62 to exactly 68 names by adding:

```text
PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA
PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME
PortableStructuralDerivationProvenanceError
createPortableStructuralDerivationProvenanceClaim
computePortableStructuralDerivationProvenanceDigest
verifyPortableStructuralDerivationProvenanceClaim
```

Five top-level provenance consumer types are added:

```text
PortableStructuralDerivationSourceProvenance
PortableStructuralDerivationProducerProvenance
PortableStructuralDerivationProvenanceClaim
PortableStructuralDerivationProvenanceDigest
PortableStructuralDerivationProvenanceErrorCode
```

The internal normalization helper remains excluded:

```text
canonicalPortableStructuralDerivationProvenanceClaimJson
```

and `public-api.test.ts` has an `@ts-expect-error` guard against future leakage.

## Pinned package contracts

The existing portable and content-digest markers remain pinned, and P6k newly pins:

```text
PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA
= mts-portable-structural-derivation-provenance/v0.1

PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME
= mts-portable-structural-derivation-provenance/sha-256/v0.1
```

Compile-time smoke also pins async creation, provenance-digest and claim-to-artifact verification function shapes.

## Authority boundary

This PR only exposes P6j functionality; it does not change its semantics:

```text
public provenance API != source authenticity
public provenance API != proof authority
provenance digest != cryptographic signature
provenance digest != theorem truth
package widening != MTS semantic release
```

## Expected classification

```text
PORTABLE_V02_EXTERNAL_PROVENANCE_PACKAGE_API_SUPPORTED
```

only if exact-head full CI and blocking repo-guard are green.

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA