### PR TITLE
feat(proof): canonicalize declared-assumption replay support

### DIFF
--- a/ts/src/proof-support-topology.ts
+++ b/ts/src/proof-support-topology.ts
@@ -2,7 +2,11 @@ import {
   CanonicalTopologyError,
   exportCanonicalTopology,
 } from "./canonical-topology.js";
-import type { StructuralDerivationEvidence } from "./derivation.js";
+import { ExactSequenceError, readExactSequence } from "./exact-sequence.js";
+import type {
+  StructuralDerivationEvidence,
+  StructuralDerivationWithAssumptionsEvidence,
+} from "./derivation.js";
 import {
   MemoryError,
   type EnumerableReadMemory,
@@ -105,59 +109,71 @@ class ReplaySupportView implements EnumerableReadMemory {
   }
 }
 
+function includePoleClosure(
+  memory: ReadMemory,
+  support: Set<LinkHandle>,
+  roots: readonly LinkHandle[],
+): void {
+  const pending = [...roots];
+  while (pending.length > 0) {
+    const link = pending.pop();
+    if (link === undefined || support.has(link)) continue;
+    // Validate owner/existence before the Link can enter builder bookkeeping.
+    const poles = memory.poles(link);
+    support.add(link);
+    pending.push(poles.start, poles.end);
+  }
+}
+
 function collectReplaySupport(
   memory: ReadMemory,
   evidence: StructuralDerivationEvidence,
 ): ReadonlySet<LinkHandle> {
   const support = new Set<LinkHandle>();
-  const pending: LinkHandle[] = [];
-
-  const include = (link: LinkHandle): void => {
-    if (support.has(link)) return;
-    // Validate owner/existence before the Link can enter builder bookkeeping.
-    memory.poles(link);
-    support.add(link);
-    pending.push(link);
-  };
-
-  const closePoles = (): void => {
-    while (pending.length > 0) {
-      const link = pending.pop();
-      if (link === undefined) continue;
-      const poles = memory.poles(link);
-      include(poles.start);
-      include(poles.end);
-    }
-  };
-
-  include(memory.root);
-  for (const link of explicitEvidenceHandles(evidence)) include(link);
-  closePoles();
+  includePoleClosure(memory, support, [memory.root, ...explicitEvidenceHandles(evidence)]);
 
   // Base derivation replay globally enumerates exactly these namespaces through
   // readExactActBindings(memory, act, ...). Preserve the complete outgoing set:
   // unexpected/duplicate attachments are negative evidence and must not vanish.
   const acts = new Set(evidence.nodes.map((node) => node.judgment.application.act));
   for (const act of acts) {
-    include(act);
-    for (const attachment of memory.outgoing(act)) include(attachment);
+    includePoleClosure(memory, support, [act, ...memory.outgoing(act)]);
   }
-  closePoles();
 
   return support;
 }
 
-/**
- * Canonicalizes only the graph surface observed by base StructuralDerivation
- * replay. This is transport-support construction, not proof validation or truth.
- */
-export function exportStructuralDerivationSupportTopology(
+function collectReplaySupportWithAssumptions(
   memory: ReadMemory,
-  evidence: StructuralDerivationEvidence,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+): ReadonlySet<LinkHandle> {
+  const support = new Set(collectReplaySupport(memory, evidence.derivation));
+
+  // Conditional replay reads the declaration sequence and then performs an exact
+  // lookup Pair(assumptionContext, claim) for every declaration, including unused
+  // assumptions. Those lookup witnesses are replay evidence, not expendable junk.
+  includePoleClosure(memory, support, [evidence.assumptionContext]);
+  const declarations = readExactSequence(memory, evidence.assumptionContext).values;
+  for (const claim of declarations) {
+    const occurrence = memory.find(evidence.assumptionContext, claim);
+    if (occurrence === undefined) {
+      throw new StructuralDerivationSupportTopologyError(
+        "declared assumption occurrence is missing from Memory",
+      );
+    }
+    includePoleClosure(memory, support, [occurrence]);
+  }
+
+  return support;
+}
+
+function exportSupportTopology(
+  memory: ReadMemory,
+  collect: () => ReadonlySet<LinkHandle>,
 ): StructuralDerivationSupportTopologyExport {
   const before = memory.linkCount;
   try {
-    const support = collectReplaySupport(memory, evidence);
+    const support = collect();
     const view = new ReplaySupportView(memory, support);
     const canonical = exportCanonicalTopology(view);
     const links = Object.freeze(
@@ -180,7 +196,11 @@ export function exportStructuralDerivationSupportTopology(
     });
   } catch (error) {
     if (error instanceof StructuralDerivationSupportTopologyError) throw error;
-    if (error instanceof MemoryError || error instanceof CanonicalTopologyError) {
+    if (
+      error instanceof MemoryError ||
+      error instanceof CanonicalTopologyError ||
+      error instanceof ExactSequenceError
+    ) {
       throw new StructuralDerivationSupportTopologyError("invalid structural derivation replay support");
     }
     throw error;
@@ -189,4 +209,27 @@ export function exportStructuralDerivationSupportTopology(
       throw new StructuralDerivationSupportTopologyError("support topology export mutated Memory");
     }
   }
+}
+
+/**
+ * Canonicalizes only the graph surface observed by base StructuralDerivation
+ * replay. This is transport-support construction, not proof validation or truth.
+ */
+export function exportStructuralDerivationSupportTopology(
+  memory: ReadMemory,
+  evidence: StructuralDerivationEvidence,
+): StructuralDerivationSupportTopologyExport {
+  return exportSupportTopology(memory, () => collectReplaySupport(memory, evidence));
+}
+
+/**
+ * Extends base replay support with the exact declaration/lookup surface observed
+ * by StructuralDerivationWithAssumptions replay. It validates support existence;
+ * it does not validate theorem truth or materialize missing assumption evidence.
+ */
+export function exportStructuralDerivationWithAssumptionsSupportTopology(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+): StructuralDerivationSupportTopologyExport {
+  return exportSupportTopology(memory, () => collectReplaySupportWithAssumptions(memory, evidence));
 }

--- a/ts/src/proof-support-topology.ts
+++ b/ts/src/proof-support-topology.ts
@@ -149,12 +149,15 @@ function collectReplaySupportWithAssumptions(
 ): ReadonlySet<LinkHandle> {
   const support = new Set(collectReplaySupport(memory, evidence.derivation));
 
-  // Conditional replay reads the declaration sequence and then performs an exact
-  // lookup Pair(assumptionContext, claim) for every declaration, including unused
+  // Conditional replay reads [Theory, ...Claims], then performs the exact lookup
+  // Pair(assumptionContext, claim) for every declared claim, including unused
   // assumptions. Those lookup witnesses are replay evidence, not expendable junk.
   includePoleClosure(memory, support, [evidence.assumptionContext]);
-  const declarations = readExactSequence(memory, evidence.assumptionContext).values;
-  for (const claim of declarations) {
+  const values = readExactSequence(memory, evidence.assumptionContext).values;
+  if (values[0] === undefined) {
+    throw new StructuralDerivationSupportTopologyError("assumption context has no theory");
+  }
+  for (const claim of values.slice(1)) {
     const occurrence = memory.find(evidence.assumptionContext, claim);
     if (occurrence === undefined) {
       throw new StructuralDerivationSupportTopologyError(

--- a/ts/test/assumption-support-topology.test.ts
+++ b/ts/test/assumption-support-topology.test.ts
@@ -1,0 +1,278 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  MemoryError,
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  StructuralDerivationSupportTopologyError,
+  exportStructuralDerivationSupportTopology,
+  exportStructuralDerivationWithAssumptionsSupportTopology,
+} from "../src/proof-support-topology.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralAssumptionReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralAssumptionContext,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  replayStructuralDerivationWithAssumptions,
+  type StructuralDerivationNodeEvidence,
+  type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: values differ`);
+}
+
+class RestrictedSupportMemory implements ReadMemory {
+  readonly root: LinkHandle;
+  private readonly support: ReadonlySet<LinkHandle>;
+
+  constructor(
+    private readonly source: ReadMemory,
+    links: readonly LinkHandle[],
+  ) {
+    this.root = source.root;
+    this.support = new Set(links);
+  }
+
+  get linkCount(): number {
+    return this.support.size;
+  }
+
+  private require(link: LinkHandle): void {
+    if (!this.support.has(link)) throw new MemoryError("Link is outside test replay support");
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    this.require(link);
+    const poles = this.source.poles(link);
+    if (!this.support.has(poles.start) || !this.support.has(poles.end)) {
+      throw new MemoryError("test replay support is not pole-closed");
+    }
+    return poles;
+  }
+
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    this.require(start);
+    this.require(end);
+    const found = this.source.find(start, end);
+    return found !== undefined && this.support.has(found) ? found : undefined;
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.require(start);
+    return this.source.outgoing(start).filter((link) => this.support.has(link));
+  }
+
+  incoming(end: LinkHandle): readonly LinkHandle[] {
+    this.require(end);
+    return this.source.incoming(end).filter((link) => this.support.has(link));
+  }
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationWithAssumptionsEvidence;
+  readonly theory: LinkHandle;
+  readonly usedOccurrence: LinkHandle;
+  readonly unusedOccurrence: LinkHandle;
+  readonly targetAct: LinkHandle;
+  readonly fresh: () => LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const role = fresh();
+  const usedClaim = fresh();
+  const unusedClaim = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const rule = defineStructuralRule(memory, roleDictionary, role);
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+  const assumptionContext = defineStructuralAssumptionContext(
+    memory,
+    theory,
+    [usedClaim, unusedClaim],
+  );
+  const usedOccurrence = memory.find(assumptionContext, usedClaim);
+  const unusedOccurrence = memory.find(assumptionContext, unusedClaim);
+  assert(usedOccurrence !== undefined, "used assumption occurrence must exist");
+  assert(unusedOccurrence !== undefined, "unused assumption occurrence must exist");
+
+  const makeNode = (
+    premiseTemplates: readonly LinkHandle[],
+    premiseOccurrences: readonly LinkHandle[],
+  ): StructuralDerivationNodeEvidence => {
+    const context = defineContext(memory, fresh(), fresh());
+    const act = defineActHeader(memory, interpreter, roleDictionary, context);
+    defineActField(memory, act, role, usedClaim);
+    const judgment: StructuralJudgmentEvidence = {
+      application: {
+        act,
+        rule,
+        ruleAdmission,
+        claimedBody: usedClaim,
+        expectedInterpreter,
+        expectedAfterContext: context,
+      },
+      judgment: { theory, context, claim: usedClaim },
+    };
+    const occurrence = defineStructuralProofOccurrence(memory, act, usedClaim);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    return {
+      occurrence,
+      judgment,
+      derivationRule,
+      derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule),
+      premiseOccurrenceSequence: materializeExactSequence(memory, premiseOccurrences),
+    };
+  };
+
+  const helper = makeNode([], []);
+  const target = makeNode([role, role], [usedOccurrence, helper.occurrence]);
+
+  return {
+    memory,
+    theory,
+    usedOccurrence,
+    unusedOccurrence,
+    targetAct: target.judgment.application.act,
+    fresh,
+    evidence: {
+      derivation: {
+        theory,
+        targetOccurrence: target.occurrence,
+        nodes: [target, helper],
+      },
+      assumptionContext,
+    },
+  };
+}
+
+function supportReject(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+): void {
+  const before = memory.linkCount;
+  let rejected = false;
+  try {
+    exportStructuralDerivationWithAssumptionsSupportTopology(memory, evidence);
+  } catch (error) {
+    assert(error instanceof StructuralDerivationSupportTopologyError, "expected support rejection");
+    rejected = true;
+  }
+  assert(rejected, "support export must fail closed");
+  same(memory.linkCount, before, "failed support export must be read-only");
+}
+
+function replayReject(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+): string {
+  try {
+    replayStructuralDerivationWithAssumptions(memory, evidence);
+  } catch (error) {
+    assert(error instanceof StructuralAssumptionReplayError, "expected conditional replay rejection");
+    return error.code;
+  }
+  throw new Error("expected conditional replay rejection");
+}
+
+// Positive corpus: declared-but-unused assumptions remain transport evidence.
+{
+  const fx = fixture();
+  const full = replayStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  same(full.derivation.occurrenceCount, 2, "full replay must verify both proof nodes");
+  same(full.declaredAssumptionOccurrences.length, 2, "both assumptions must remain declared");
+  same(full.usedAssumptionOccurrences.length, 1, "exactly one assumption must be used");
+  same(full.usedAssumptionOccurrences[0], fx.usedOccurrence, "used assumption must be exact");
+
+  const base = exportStructuralDerivationSupportTopology(fx.memory, fx.evidence.derivation);
+  assert(!base.coordinates.has(fx.unusedOccurrence), "base support must preserve the P6l gap");
+
+  const before = fx.memory.linkCount;
+  const supportA = exportStructuralDerivationWithAssumptionsSupportTopology(fx.memory, fx.evidence);
+  same(fx.memory.linkCount, before, "assumption support export must be read-only");
+  assert(supportA.coordinates.has(fx.usedOccurrence), "used assumption occurrence must be support");
+  assert(supportA.coordinates.has(fx.unusedOccurrence), "unused declared occurrence must be support");
+  assert(supportA.links.length < fx.memory.linkCount, "support must exclude unrelated topology");
+
+  const restricted = replayStructuralDerivationWithAssumptions(
+    new RestrictedSupportMemory(fx.memory, supportA.links),
+    fx.evidence,
+  );
+  same(restricted.derivation.targetOccurrence, full.derivation.targetOccurrence, "target must match");
+  same(restricted.derivation.occurrenceCount, full.derivation.occurrenceCount, "node count must match");
+  same(restricted.usedAssumptionOccurrences[0], fx.usedOccurrence, "restricted use must match");
+
+  const reordered: StructuralDerivationWithAssumptionsEvidence = {
+    ...fx.evidence,
+    derivation: { ...fx.evidence.derivation, nodes: [...fx.evidence.derivation.nodes].reverse() },
+  };
+  const supportReordered = exportStructuralDerivationWithAssumptionsSupportTopology(fx.memory, reordered);
+  same(JSON.stringify(supportReordered.topology), JSON.stringify(supportA.topology), "host node order must be neutral");
+
+  const junkA = fx.fresh();
+  const junkB = fx.fresh();
+  fx.memory.ensure(junkA, junkB);
+  const supportB = exportStructuralDerivationWithAssumptionsSupportTopology(fx.memory, fx.evidence);
+  same(JSON.stringify(supportB.topology), JSON.stringify(supportA.topology), "ambient junk must be neutral");
+}
+
+// Missing lookup witness, malformed sequence and foreign owner all fail closed.
+{
+  const fx = fixture();
+  const missingClaim = fx.fresh();
+  const missingContext = materializeExactSequence(fx.memory, [fx.theory, missingClaim]);
+  supportReject(fx.memory, { ...fx.evidence, assumptionContext: missingContext });
+  supportReject(fx.memory, { ...fx.evidence, assumptionContext: fx.fresh() });
+
+  const foreign = new Memory();
+  const foreignContext = materializeExactSequence(foreign, [foreign.root]);
+  supportReject(fx.memory, { ...fx.evidence, assumptionContext: foreignContext });
+}
+
+// Complete outgoing(Act) remains security evidence: restriction cannot sanitize it.
+{
+  const fx = fixture();
+  const hostileRole = fx.fresh();
+  const hostileValue = fx.fresh();
+  const hostileAttachment = defineActField(fx.memory, fx.targetAct, hostileRole, hostileValue);
+  const fullCode = replayReject(fx.memory, fx.evidence);
+  const support = exportStructuralDerivationWithAssumptionsSupportTopology(fx.memory, fx.evidence);
+  assert(support.coordinates.has(hostileAttachment), "hostile Act attachment must remain support");
+  const restrictedCode = replayReject(
+    new RestrictedSupportMemory(fx.memory, support.links),
+    fx.evidence,
+  );
+  same(restrictedCode, fullCode, "restricted rejection must equal full-Memory rejection");
+}
+
+// Executable P6m classification:
+// CANONICAL_DECLARED_ASSUMPTION_REPLAY_SUPPORT_SUPPORTED


### PR DESCRIPTION
Closes #860

## Scope

P6m closes the replay-support gap proven by P6l #858/#859 without changing proof semantics, portable schemas, digest/provenance, package API, accepted MTS v0.11, or starting v0.12.

```text
base/main = e1fb397b6c0d3054d98bdbd63de57f6f2e8da0e7
head = bbefaa40338dd1536ab8aa66e0202845d2843995
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/proof-support-topology.ts            +81 -35
ts/test/assumption-support-topology.test.ts +278
-------------------------------------------------
net additions                               324 / 390
new files                                     1 / 1
```

## Implementation

The existing P6f support path remains the base:

- all explicit `StructuralDerivationEvidence` handles;
- recursive pole closure;
- complete `memory.outgoing(act)` for every proof Act, preserving unexpected attachments as negative evidence;
- existing P6b `exportCanonicalTopology` only.

P6m adds only the read surface actually observed by conditional replay:

```text
assumptionContext = ExactSequence([Theory, ...Claims])
for each Claim:
  existing occurrence = find(assumptionContext, Claim)
```

The new exporter includes/pole-closes the assumption context and every existing declared-assumption occurrence. Missing lookup witnesses, malformed ExactSequence data, and foreign-owner handles fail closed. No `ensure` or materialization occurs during support export.

A common pole-closure helper and common canonical export helper avoid introducing a second coordinate/canonicalization algorithm.

## Executable corpus

The new two-node fixture proves:

- full conditional replay accepts with one used and one unused declared assumption;
- assumption-aware support includes both declared occurrences;
- restricted replay over exactly exported support reproduces target, proof-node count and used-assumption result;
- host `nodes[]` reorder does not change canonical support topology;
- unrelated ambient Memory growth does not change topology;
- ordinary P6f base support still exhibits the P6l omission for the unused occurrence, so base behavior was not silently broadened;
- missing occurrence / malformed context / foreign owner fail closed and read-only;
- hostile unexpected Act attachment remains in support and restricted replay rejects with the same conditional replay error as full Memory.

## Classification

If exact-head full CI and blocking repo-guard are green:

```text
CANONICAL_DECLARED_ASSUMPTION_REPLAY_SUPPORT_SUPPORTED
```

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA