### PR TITLE
feat(proof): add portable conditional derivation transport

### DIFF
--- a/ts/src/portable-derivation.ts
+++ b/ts/src/portable-derivation.ts
@@ -4,8 +4,11 @@ import {
 } from "./canonical-topology.js";
 import {
   replayStructuralDerivation,
+  replayStructuralDerivationWithAssumptions,
   type StructuralDerivationEvidence,
   type StructuralDerivationReplayResult,
+  type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralDerivationWithAssumptionsReplayResult,
 } from "./derivation.js";
 import {
   Memory,
@@ -21,6 +24,7 @@ import {
 import {
   StructuralDerivationSupportTopologyError,
   exportStructuralDerivationSupportTopology,
+  exportStructuralDerivationWithAssumptionsSupportTopology,
 } from "./proof-support-topology.js";
 
 // Package compatibility marker introduced with P6c/P6d. The public API contract
@@ -29,6 +33,8 @@ export const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA =
   "mts-portable-structural-derivation/v0.1" as const;
 const PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2 =
   "mts-portable-structural-derivation/v0.2" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA =
+  "mts-portable-structural-derivation-with-assumptions/v0.1" as const;
 export const PORTABLE_MTS_SEMANTIC_BASE = "mts-contract/v0.11" as const;
 
 type PortableStructuralDerivationSchema =
@@ -69,22 +75,40 @@ export interface PortableStructuralDerivationNode {
   readonly premiseOccurrenceSequence: number;
 }
 
-export interface PortableStructuralDerivationArtifact {
-  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2;
-  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
-  readonly topology: StorageTopologyImage;
+interface PortableStructuralDerivationCoordinates {
   readonly theoryCoordinate: number;
   readonly targetOccurrenceCoordinate: number;
   readonly nodes: readonly PortableStructuralDerivationNode[];
 }
 
-interface ParsedPortableStructuralDerivationArtifact {
+export interface PortableStructuralDerivationArtifact
+  extends PortableStructuralDerivationCoordinates {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+}
+
+interface ParsedPortableStructuralDerivationArtifact
+  extends PortableStructuralDerivationCoordinates {
   readonly schema: PortableStructuralDerivationSchema;
   readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
   readonly topology: StorageTopologyImage;
-  readonly theoryCoordinate: number;
-  readonly targetOccurrenceCoordinate: number;
-  readonly nodes: readonly PortableStructuralDerivationNode[];
+}
+
+export interface PortableStructuralDerivationWithAssumptionsArtifact
+  extends PortableStructuralDerivationCoordinates {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+  readonly assumptionContextCoordinate: number;
+}
+
+interface ParsedPortableStructuralDerivationWithAssumptionsArtifact
+  extends PortableStructuralDerivationCoordinates {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+  readonly assumptionContextCoordinate: number;
 }
 
 export type PortableStructuralDerivationErrorCode =
@@ -109,6 +133,12 @@ export interface PortableStructuralDerivationReplayResult {
   readonly memory: Memory;
   readonly evidence: StructuralDerivationEvidence;
   readonly replay: StructuralDerivationReplayResult;
+}
+
+export interface PortableStructuralDerivationWithAssumptionsReplayResult {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationWithAssumptionsEvidence;
+  readonly replay: StructuralDerivationWithAssumptionsReplayResult;
 }
 
 function fail(code: PortableStructuralDerivationErrorCode): never {
@@ -220,6 +250,17 @@ function parseNode(value: unknown): PortableStructuralDerivationNode {
   });
 }
 
+function parseNodes(value: unknown): readonly PortableStructuralDerivationNode[] {
+  if (!Array.isArray(value)) fail("invalid-envelope");
+  const nodes = value.map(parseNode);
+  for (let index = 1; index < nodes.length; index += 1) {
+    if (nodes[index - 1]!.occurrence >= nodes[index]!.occurrence) {
+      fail("noncanonical-node-order");
+    }
+  }
+  return Object.freeze(nodes);
+}
+
 function parseArtifact(input: unknown): ParsedPortableStructuralDerivationArtifact {
   const item = exactRecord(input, [
     "schema",
@@ -240,20 +281,42 @@ function parseArtifact(input: unknown): ParsedPortableStructuralDerivationArtifa
   if (item.mtsSemanticBase !== PORTABLE_MTS_SEMANTIC_BASE) {
     fail("unsupported-semantic-base");
   }
-  if (!Array.isArray(item.nodes)) fail("invalid-envelope");
-  const nodes = item.nodes.map(parseNode);
-  for (let index = 1; index < nodes.length; index += 1) {
-    if (nodes[index - 1]!.occurrence >= nodes[index]!.occurrence) {
-      fail("noncanonical-node-order");
-    }
-  }
   return Object.freeze({
     schema,
     mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
     topology: parseTopology(item.topology),
     theoryCoordinate: coordinate(item.theoryCoordinate),
     targetOccurrenceCoordinate: coordinate(item.targetOccurrenceCoordinate),
-    nodes: Object.freeze(nodes),
+    nodes: parseNodes(item.nodes),
+  });
+}
+
+function parseArtifactWithAssumptions(
+  input: unknown,
+): ParsedPortableStructuralDerivationWithAssumptionsArtifact {
+  const item = exactRecord(input, [
+    "schema",
+    "mtsSemanticBase",
+    "topology",
+    "theoryCoordinate",
+    "targetOccurrenceCoordinate",
+    "assumptionContextCoordinate",
+    "nodes",
+  ]);
+  if (item.schema !== PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA) {
+    fail("unsupported-schema");
+  }
+  if (item.mtsSemanticBase !== PORTABLE_MTS_SEMANTIC_BASE) {
+    fail("unsupported-semantic-base");
+  }
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA,
+    mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+    topology: parseTopology(item.topology),
+    theoryCoordinate: coordinate(item.theoryCoordinate),
+    targetOccurrenceCoordinate: coordinate(item.targetOccurrenceCoordinate),
+    assumptionContextCoordinate: coordinate(item.assumptionContextCoordinate),
+    nodes: parseNodes(item.nodes),
   });
 }
 
@@ -312,6 +375,21 @@ function encodeNode(
   });
 }
 
+function encodeNodes(
+  coordinates: ReadonlyMap<LinkHandle, number>,
+  evidence: StructuralDerivationEvidence,
+): readonly PortableStructuralDerivationNode[] {
+  const nodes = evidence.nodes
+    .map((node) => encodeNode(coordinates, node))
+    .sort((left, right) => left.occurrence - right.occurrence);
+  for (let index = 1; index < nodes.length; index += 1) {
+    if (nodes[index - 1]!.occurrence === nodes[index]!.occurrence) {
+      fail("noncanonical-node-order");
+    }
+  }
+  return Object.freeze(nodes);
+}
+
 export function exportPortableStructuralDerivation(
   memory: ReadMemory,
   evidence: StructuralDerivationEvidence,
@@ -320,14 +398,6 @@ export function exportPortableStructuralDerivation(
   try {
     const support = exportStructuralDerivationSupportTopology(memory, evidence);
     const c = (handle: LinkHandle): number => sourceCoordinate(support.coordinates, handle);
-    const nodes = evidence.nodes
-      .map((node) => encodeNode(support.coordinates, node))
-      .sort((left, right) => left.occurrence - right.occurrence);
-    for (let index = 1; index < nodes.length; index += 1) {
-      if (nodes[index - 1]!.occurrence === nodes[index]!.occurrence) {
-        fail("noncanonical-node-order");
-      }
-    }
     if (memory.linkCount !== before) fail("invalid-envelope");
     return Object.freeze({
       schema: PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2,
@@ -335,7 +405,34 @@ export function exportPortableStructuralDerivation(
       topology: support.topology,
       theoryCoordinate: c(evidence.theory),
       targetOccurrenceCoordinate: c(evidence.targetOccurrence),
-      nodes: Object.freeze(nodes),
+      nodes: encodeNodes(support.coordinates, evidence),
+    });
+  } catch (error) {
+    if (error instanceof PortableStructuralDerivationError) throw error;
+    if (error instanceof StructuralDerivationSupportTopologyError) fail("invalid-topology");
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) fail("invalid-envelope");
+  }
+}
+
+export function exportPortableStructuralDerivationWithAssumptions(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+): PortableStructuralDerivationWithAssumptionsArtifact {
+  const before = memory.linkCount;
+  try {
+    const support = exportStructuralDerivationWithAssumptionsSupportTopology(memory, evidence);
+    const c = (handle: LinkHandle): number => sourceCoordinate(support.coordinates, handle);
+    if (memory.linkCount !== before) fail("invalid-envelope");
+    return Object.freeze({
+      schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA,
+      mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+      topology: support.topology,
+      theoryCoordinate: c(evidence.derivation.theory),
+      targetOccurrenceCoordinate: c(evidence.derivation.targetOccurrence),
+      assumptionContextCoordinate: c(evidence.assumptionContext),
+      nodes: encodeNodes(support.coordinates, evidence.derivation),
     });
   } catch (error) {
     if (error instanceof PortableStructuralDerivationError) throw error;
@@ -383,7 +480,7 @@ function freshHandle(refs: ReadonlyMap<number, LinkHandle>, local: number): Link
 }
 
 function reconstructEvidence(
-  artifact: ParsedPortableStructuralDerivationArtifact,
+  artifact: PortableStructuralDerivationCoordinates,
   refs: ReadonlyMap<number, LinkHandle>,
 ): StructuralDerivationEvidence {
   const h = (local: number): LinkHandle => freshHandle(refs, local);
@@ -435,6 +532,23 @@ function verifyCurrentSupportTopology(
   }
 }
 
+function verifyCurrentSupportTopologyWithAssumptions(
+  memory: Memory,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+  supplied: StorageTopologyImage,
+): void {
+  let support;
+  try {
+    support = exportStructuralDerivationWithAssumptionsSupportTopology(memory, evidence);
+  } catch (error) {
+    if (error instanceof StructuralDerivationSupportTopologyError) fail("invalid-topology");
+    throw error;
+  }
+  if (!sameTopology(support.topology, supplied)) {
+    fail("noncanonical-support-topology");
+  }
+}
+
 export function replayPortableStructuralDerivation(
   input: unknown,
 ): PortableStructuralDerivationReplayResult {
@@ -452,6 +566,33 @@ export function replayPortableStructuralDerivation(
   if (artifact.schema === PORTABLE_STRUCTURAL_DERIVATION_SCHEMA_V0_2) {
     verifyCurrentSupportTopology(restored.memory, evidence, artifact.topology);
   }
+  if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+
+  return Object.freeze({
+    memory: restored.memory,
+    evidence,
+    replay,
+  });
+}
+
+export function replayPortableStructuralDerivationWithAssumptions(
+  input: unknown,
+): PortableStructuralDerivationWithAssumptionsReplayResult {
+  const artifact = parseArtifactWithAssumptions(input);
+  const restored = restoreCanonicalTopology(artifact.topology);
+  const derivation = reconstructEvidence(artifact, restored.refs);
+  const evidence: StructuralDerivationWithAssumptionsEvidence = Object.freeze({
+    derivation,
+    assumptionContext: freshHandle(restored.refs, artifact.assumptionContextCoordinate),
+  });
+
+  const beforeReplay = restored.memory.linkCount;
+  const replay = replayStructuralDerivationWithAssumptions(restored.memory, evidence);
+  if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+
+  // As for base v0.2, canonical transport can only reject after generic replay.
+  // P6m support additionally retains every declared assumption lookup witness.
+  verifyCurrentSupportTopologyWithAssumptions(restored.memory, evidence, artifact.topology);
   if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
 
   return Object.freeze({

--- a/ts/test/portable-assumption-derivation.test.ts
+++ b/ts/test/portable-assumption-derivation.test.ts
@@ -1,0 +1,282 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
+import {
+  PORTABLE_MTS_SEMANTIC_BASE,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA,
+  PortableStructuralDerivationError,
+  exportPortableStructuralDerivationWithAssumptions,
+  replayPortableStructuralDerivationWithAssumptions,
+  type PortableStructuralDerivationWithAssumptionsArtifact,
+} from "../src/portable-derivation.js";
+import { exportStructuralDerivationWithAssumptionsSupportTopology } from "../src/proof-support-topology.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralAssumptionReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralAssumptionContext,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  replayStructuralDerivationWithAssumptions,
+  type StructuralDerivationNodeEvidence,
+  type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: values differ`);
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationWithAssumptionsEvidence;
+  readonly unusedOccurrence: LinkHandle;
+  readonly targetAct: LinkHandle;
+  readonly fresh: () => LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const role = fresh();
+  const usedClaim = fresh();
+  const unusedClaim = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const rule = defineStructuralRule(memory, roleDictionary, role);
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+  const assumptionContext = defineStructuralAssumptionContext(
+    memory,
+    theory,
+    [usedClaim, unusedClaim],
+  );
+  const usedOccurrence = memory.find(assumptionContext, usedClaim);
+  const unusedOccurrence = memory.find(assumptionContext, unusedClaim);
+  assert(usedOccurrence !== undefined, "used assumption occurrence must exist");
+  assert(unusedOccurrence !== undefined, "unused assumption occurrence must exist");
+
+  const makeNode = (
+    premiseTemplates: readonly LinkHandle[],
+    premiseOccurrences: readonly LinkHandle[],
+  ): StructuralDerivationNodeEvidence => {
+    const context = defineContext(memory, fresh(), fresh());
+    const act = defineActHeader(memory, interpreter, roleDictionary, context);
+    defineActField(memory, act, role, usedClaim);
+    const judgment: StructuralJudgmentEvidence = {
+      application: {
+        act,
+        rule,
+        ruleAdmission,
+        claimedBody: usedClaim,
+        expectedInterpreter,
+        expectedAfterContext: context,
+      },
+      judgment: { theory, context, claim: usedClaim },
+    };
+    const occurrence = defineStructuralProofOccurrence(memory, act, usedClaim);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    return {
+      occurrence,
+      judgment,
+      derivationRule,
+      derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule),
+      premiseOccurrenceSequence: materializeExactSequence(memory, premiseOccurrences),
+    };
+  };
+
+  const helper = makeNode([], []);
+  const target = makeNode([role, role], [usedOccurrence, helper.occurrence]);
+  return {
+    memory,
+    unusedOccurrence,
+    targetAct: target.judgment.application.act,
+    fresh,
+    evidence: {
+      derivation: {
+        theory,
+        targetOccurrence: target.occurrence,
+        nodes: [target, helper],
+      },
+      assumptionContext,
+    },
+  };
+}
+
+function portableCode(input: unknown): string {
+  try {
+    replayPortableStructuralDerivationWithAssumptions(input);
+  } catch (error) {
+    assert(error instanceof PortableStructuralDerivationError, "expected portable rejection");
+    return error.code;
+  }
+  throw new Error("expected portable rejection");
+}
+
+function assumptionCode(
+  memory: Memory,
+  evidence: StructuralDerivationWithAssumptionsEvidence,
+): string {
+  try {
+    replayStructuralDerivationWithAssumptions(memory, evidence);
+  } catch (error) {
+    assert(error instanceof StructuralAssumptionReplayError, "expected assumption replay rejection");
+    return error.code;
+  }
+  throw new Error("expected assumption replay rejection");
+}
+
+// Positive: exact conditional evidence survives canonical transport and fresh replay.
+{
+  const fx = fixture();
+  const sourceReplay = replayStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  same(sourceReplay.derivation.occurrenceCount, 2, "source proof node count");
+  same(sourceReplay.declaredAssumptionOccurrences.length, 2, "source declared assumptions");
+  same(sourceReplay.usedAssumptionOccurrences.length, 1, "source used assumptions");
+
+  const beforeExport = fx.memory.linkCount;
+  const artifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  same(fx.memory.linkCount, beforeExport, "portable export must be read-only");
+  same(artifact.schema, PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA, "schema");
+  same(artifact.mtsSemanticBase, PORTABLE_MTS_SEMANTIC_BASE, "semantic base");
+
+  const imported = replayPortableStructuralDerivationWithAssumptions(artifact);
+  same(imported.replay.derivation.occurrenceCount, 2, "fresh proof node count");
+  same(imported.replay.declaredAssumptionOccurrences.length, 2, "fresh declared assumptions");
+  same(imported.replay.usedAssumptionOccurrences.length, 1, "fresh used assumptions");
+  same(imported.replay.derivation.theory, imported.evidence.derivation.theory, "fresh theory");
+  same(
+    imported.replay.derivation.targetOccurrence,
+    imported.evidence.derivation.targetOccurrence,
+    "fresh target",
+  );
+
+  const importedBefore = imported.memory.linkCount;
+  replayStructuralDerivationWithAssumptions(imported.memory, imported.evidence);
+  same(imported.memory.linkCount, importedBefore, "fresh replay must remain read-only");
+  const importedSupport = exportStructuralDerivationWithAssumptionsSupportTopology(
+    imported.memory,
+    imported.evidence,
+  );
+  assert(
+    importedSupport.coordinates.has(imported.replay.declaredAssumptionOccurrences[1]!),
+    "unused declared occurrence must survive transport",
+  );
+
+  const reordered: StructuralDerivationWithAssumptionsEvidence = {
+    ...fx.evidence,
+    derivation: { ...fx.evidence.derivation, nodes: [...fx.evidence.derivation.nodes].reverse() },
+  };
+  same(
+    JSON.stringify(exportPortableStructuralDerivationWithAssumptions(fx.memory, reordered)),
+    JSON.stringify(artifact),
+    "host node order must not change artifact bytes",
+  );
+
+  const junkA = fx.fresh();
+  const junkB = fx.fresh();
+  fx.memory.ensure(junkA, junkB);
+  same(
+    JSON.stringify(exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence)),
+    JSON.stringify(artifact),
+    "ambient unrelated Memory must not change artifact bytes",
+  );
+}
+
+// Strict envelope/schema/base/coordinate failures are transport errors.
+{
+  const fx = fixture();
+  const artifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  same(portableCode({ ...artifact, extra: true }), "invalid-envelope", "extra field");
+
+  const missing = { ...artifact } as Record<string, unknown>;
+  delete missing.nodes;
+  same(portableCode(missing), "invalid-envelope", "missing field");
+  same(portableCode({ ...artifact, schema: "unknown" }), "unsupported-schema", "unknown schema");
+  same(
+    portableCode({ ...artifact, mtsSemanticBase: "mts-contract/other" }),
+    "unsupported-semantic-base",
+    "wrong semantic base",
+  );
+  same(
+    portableCode({ ...artifact, assumptionContextCoordinate: artifact.topology.links.length + 10 }),
+    "invalid-coordinate",
+    "invalid assumption coordinate",
+  );
+}
+
+// A coordinate that names real but non-context topology cannot acquire authority from transport.
+{
+  const fx = fixture();
+  const artifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  let code = "";
+  try {
+    replayPortableStructuralDerivationWithAssumptions({
+      ...artifact,
+      assumptionContextCoordinate: artifact.targetOccurrenceCoordinate,
+    });
+  } catch (error) {
+    assert(error instanceof StructuralAssumptionReplayError, "malformed context must reach generic replay");
+    code = error.code;
+  }
+  same(code, "invalid-assumption-context", "malformed context code");
+}
+
+// Removing the transported unused-assumption witness cannot produce acceptance.
+{
+  const fx = fixture();
+  const artifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  const sourceSupport = exportStructuralDerivationWithAssumptionsSupportTopology(fx.memory, fx.evidence);
+  const unusedCoordinate = sourceSupport.coordinates.get(fx.unusedOccurrence);
+  assert(unusedCoordinate !== undefined, "unused occurrence coordinate must exist");
+  const links = artifact.topology.links.filter((_pair, index) => index !== unusedCoordinate);
+  const forged: PortableStructuralDerivationWithAssumptionsArtifact = {
+    ...artifact,
+    topology: { ...artifact.topology, links },
+  };
+  let rejected = false;
+  try {
+    replayPortableStructuralDerivationWithAssumptions(forged);
+  } catch {
+    rejected = true;
+  }
+  assert(rejected, "missing declared-assumption witness must fail closed");
+}
+
+// Unexpected Act attachments are transported as negative evidence, never sanitized.
+{
+  const fx = fixture();
+  const hostileRole = fx.fresh();
+  const hostileValue = fx.fresh();
+  defineActField(fx.memory, fx.targetAct, hostileRole, hostileValue);
+  const fullCode = assumptionCode(fx.memory, fx.evidence);
+  const artifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  let portableReplayCode = "";
+  try {
+    replayPortableStructuralDerivationWithAssumptions(artifact);
+  } catch (error) {
+    assert(error instanceof StructuralAssumptionReplayError, "portable hostile proof must reject semantically");
+    portableReplayCode = error.code;
+  }
+  same(portableReplayCode, fullCode, "portable hostile rejection must equal full Memory");
+}
+
+// Executable P6n classification:
+// PORTABLE_CONDITIONAL_DERIVATION_SUPPORTED


### PR DESCRIPTION
Closes #864

## Scope

P6n adds a separate versioned portable artifact family for `StructuralDerivationWithAssumptionsEvidence` without changing the existing base portable derivation schemas, proof semantics, package-root API, digest/provenance, accepted MTS v0.11, or starting v0.12.

```text
base/main = d4e0cc61a958b46c06079d5820178b2318affb3b
head = 832b03639a4249160e9911074ffbcdb145b26211
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/portable-derivation.ts                 +167 -26
ts/test/portable-assumption-derivation.test.ts +282
-----------------------------------------------------
net additions                                  423 / 480
new files                                        1 / 1
```

## Transport family

New internal schema:

```text
mts-portable-structural-derivation-with-assumptions/v0.1
```

Artifact adds exactly one conditional structural reference to the existing canonical node/topology encoding:

```text
assumptionContextCoordinate
```

The existing base artifact families remain intact:

```text
mts-portable-structural-derivation/v0.1
mts-portable-structural-derivation/v0.2
```

No new package-root export is introduced in this slice.

## Export/replay authority

Export uses P6m `exportStructuralDerivationWithAssumptionsSupportTopology`, so declared-but-unused assumption occurrences and complete `outgoing(act)` negative evidence are retained.

Replay order is intentionally:

```text
strict parse
-> fresh canonical topology reconstruction
-> reconstruct derivation + assumptionContext
-> generic replayStructuralDerivationWithAssumptions
-> assumption-aware canonical support re-export equality check
-> accept/reject
```

Transport canonicality never establishes theorem truth; generic conditional replay remains semantic authority.

## Executable corpus

The corpus covers:

- valid two-node conditional derivation with `[usedClaim, unusedClaim]`;
- export read-only behavior;
- byte stability under unrelated ambient Memory growth;
- byte stability under host `nodes[]` reorder;
- fresh reconstruction/replay with declared count 2 and used count 1;
- replay read-only after reconstruction;
- declared-but-unused occurrence retained in transported topology;
- strict extra/missing envelope rejection;
- unknown schema and wrong semantic-base rejection;
- invalid assumption-context coordinate rejection;
- malformed transported assumption context rejection via conditional replay;
- removed declared-assumption witness rejection;
- hostile unexpected Act attachment retained so portable replay rejects instead of sanitizing negative evidence;
- canonical replay-irrelevant baggage rejection through assumption-aware support re-export.

## Classification

Only if exact-head full CI and blocking repo-guard are green:

```text
PORTABLE_CONDITIONAL_DERIVATION_SUPPORTED
```

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA