### PR TITLE
feat(proof): expose portable conditional derivation API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -172,14 +172,19 @@ export type {
 export {
   PORTABLE_MTS_SEMANTIC_BASE,
   PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA,
   PortableStructuralDerivationError,
   exportPortableStructuralDerivation,
+  exportPortableStructuralDerivationWithAssumptions,
   replayPortableStructuralDerivation,
+  replayPortableStructuralDerivationWithAssumptions,
 } from "./portable-derivation.js";
 export type {
   PortableStructuralDerivationArtifact,
   PortableStructuralDerivationErrorCode,
   PortableStructuralDerivationReplayResult,
+  PortableStructuralDerivationWithAssumptionsArtifact,
+  PortableStructuralDerivationWithAssumptionsReplayResult,
 } from "./portable-derivation.js";
 
 export {

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -18,6 +18,8 @@ import type {
   PortableStructuralDerivationProvenanceErrorCode,
   PortableStructuralDerivationReplayResult,
   PortableStructuralDerivationSourceProvenance,
+  PortableStructuralDerivationWithAssumptionsArtifact,
+  PortableStructuralDerivationWithAssumptionsReplayResult,
   ReadMemory,
   RelationReplayEvidence,
   RunEvidence,
@@ -69,6 +71,7 @@ const expectedRuntimeExports = [
   "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME",
   "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_SCHEMA",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
   "PortableStructuralDerivationError",
@@ -95,6 +98,7 @@ const expectedRuntimeExports = [
   "ensureRootBasis",
   "executeAbits",
   "exportPortableStructuralDerivation",
+  "exportPortableStructuralDerivationWithAssumptions",
   "materializePersistentSequence",
   "materializeSequence",
   "normalizeRawForm",
@@ -109,6 +113,7 @@ const expectedRuntimeExports = [
   "replayIntegratedProof",
   "replayPersistentSequenceMaterialization",
   "replayPortableStructuralDerivation",
+  "replayPortableStructuralDerivationWithAssumptions",
   "replayRelationStep",
   "replayRelationSubselectionStep",
   "replayResolvedSequenceGrouping",
@@ -126,7 +131,7 @@ const expectedRuntimeExports = [
   "verifyPortableStructuralDerivationProvenanceClaim",
 ].sort();
 
-assert(expectedRuntimeExports.length === 68, "P6k runtime export budget must be exactly 68");
+assert(expectedRuntimeExports.length === 71, "P6o runtime export budget must be exactly 71");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -138,6 +143,11 @@ assert(
 assert(
   publicApi.PORTABLE_STRUCTURAL_DERIVATION_SCHEMA === "mts-portable-structural-derivation/v0.1",
   "portable derivation schema must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA ===
+    "mts-portable-structural-derivation-with-assumptions/v0.1",
+  "portable conditional derivation schema must stay pinned",
 );
 assert(
   publicApi.PORTABLE_MTS_SEMANTIC_BASE === "mts-contract/v0.11",
@@ -185,9 +195,13 @@ const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
 const integrated: IntegratedProofEvidence | undefined = undefined;
 const portableArtifact: PortableStructuralDerivationArtifact | undefined = undefined;
+const portableConditionalArtifact: PortableStructuralDerivationWithAssumptionsArtifact | undefined = undefined;
 const portableDigest: PortableStructuralDerivationContentDigest | undefined = undefined;
 const portableErrorCode: PortableStructuralDerivationErrorCode | undefined = undefined;
 const portableReplay: PortableStructuralDerivationReplayResult | undefined = undefined;
+const portableConditionalReplay: PortableStructuralDerivationWithAssumptionsReplayResult | undefined = undefined;
+const exportPortableConditional: (memory: ReadMemory, evidence: StructuralDerivationWithAssumptionsEvidence) => PortableStructuralDerivationWithAssumptionsArtifact = publicApi.exportPortableStructuralDerivationWithAssumptions;
+const replayPortableConditional: (input: unknown) => PortableStructuralDerivationWithAssumptionsReplayResult = publicApi.replayPortableStructuralDerivationWithAssumptions;
 const portableDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationContentDigest> =
   publicApi.computePortableStructuralDerivationContentDigest;
 const provenanceSource: PortableStructuralDerivationSourceProvenance | undefined = undefined;
@@ -222,9 +236,13 @@ void [
   proof,
   integrated,
   portableArtifact,
+  portableConditionalArtifact,
   portableDigest,
   portableErrorCode,
   portableReplay,
+  portableConditionalReplay,
+  exportPortableConditional,
+  replayPortableConditional,
   portableDigestFunction,
   provenanceSource,
   provenanceProducer,


### PR DESCRIPTION
Closes #866

## Scope

P6o exposes the already-green P6n portable conditional derivation transport through the package root without changing transport/replay semantics, digest/provenance, accepted MTS v0.11, or starting v0.12.

```text
base/main = ca72ddb7af31e8a868df39612c3ec4ba66e13bce
head = 4515831936d44b1fdaaff5cedd8d44d3fa232b5b
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/public.ts          +5
ts/test/public-api.test.ts +19 -1
--------------------------------
net additions             23 / 45
new files                  0 / 0
```

## Public runtime delta

Exactly three runtime names are added:

```text
PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA
exportPortableStructuralDerivationWithAssumptions
replayPortableStructuralDerivationWithAssumptions
```

Exactly two public types are added:

```text
PortableStructuralDerivationWithAssumptionsArtifact
PortableStructuralDerivationWithAssumptionsReplayResult
```

The exact runtime allowlist therefore changes from 68 to 71 exports.

Compatibility boundaries remain pinned:

- base `PORTABLE_STRUCTURAL_DERIVATION_SCHEMA` remains `mts-portable-structural-derivation/v0.1`;
- conditional schema is exactly `mts-portable-structural-derivation-with-assumptions/v0.1`;
- shared `PortableStructuralDerivationError` remains the error boundary;
- nested portable coordinate/node plumbing remains internal;
- canonical JSON helpers remain internal;
- no conditional digest or provenance surface is added.

## Executable API corpus

`public-api.test.ts` now pins:

- exact runtime allowlist/count = 71;
- exact conditional schema literal;
- compile-time import of both conditional portable types;
- package-consumer signatures for export/replay over public `ReadMemory` and `StructuralDerivationWithAssumptionsEvidence`;
- existing base portable/digest/provenance literals unchanged.

## Classification

Only if exact-head full CI and blocking repo-guard are green:

```text
PORTABLE_CONDITIONAL_DERIVATION_PACKAGE_API_SUPPORTED
```

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA