### PR TITLE
feat(proof): expose conditional digest package API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -189,10 +189,13 @@ export type {
 
 export {
   PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
   computePortableStructuralDerivationContentDigest,
+  computePortableStructuralDerivationWithAssumptionsContentDigest,
 } from "./portable-derivation-digest.js";
 export type {
   PortableStructuralDerivationContentDigest,
+  PortableStructuralDerivationWithAssumptionsContentDigest,
 } from "./portable-derivation-digest.js";
 
 export {

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -19,6 +19,7 @@ import type {
   PortableStructuralDerivationReplayResult,
   PortableStructuralDerivationSourceProvenance,
   PortableStructuralDerivationWithAssumptionsArtifact,
+  PortableStructuralDerivationWithAssumptionsContentDigest,
   PortableStructuralDerivationWithAssumptionsReplayResult,
   ReadMemory,
   RelationReplayEvidence,
@@ -48,6 +49,8 @@ import type { RelationRoles } from "../src/public.js";
 import type { PortableStructuralDerivationNode } from "../src/public.js";
 // @ts-expect-error P6i keeps portable canonical JSON normalization internal.
 type InternalCanonicalPortableStructuralDerivationV02Json = typeof import("../src/public.js").canonicalPortableStructuralDerivationV02Json;
+// @ts-expect-error P6q keeps conditional portable canonical JSON normalization internal.
+type InternalCanonicalPortableStructuralDerivationWithAssumptionsV01Json = typeof import("../src/public.js").canonicalPortableStructuralDerivationWithAssumptionsV01Json;
 // @ts-expect-error P6k keeps provenance canonical JSON normalization internal.
 type InternalCanonicalPortableStructuralDerivationProvenanceClaimJson = typeof import("../src/public.js").canonicalPortableStructuralDerivationProvenanceClaimJson;
 // @ts-expect-error P3b keeps assumption construction internal; consumers submit materialized evidence.
@@ -71,6 +74,7 @@ const expectedRuntimeExports = [
   "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME",
   "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_SCHEMA",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
@@ -91,6 +95,7 @@ const expectedRuntimeExports = [
   "bundleRoleAt",
   "computePortableStructuralDerivationContentDigest",
   "computePortableStructuralDerivationProvenanceDigest",
+  "computePortableStructuralDerivationWithAssumptionsContentDigest",
   "createPortableStructuralDerivationProvenanceClaim",
   "deserializeAnum",
   "deserializeStream",
@@ -131,7 +136,7 @@ const expectedRuntimeExports = [
   "verifyPortableStructuralDerivationProvenanceClaim",
 ].sort();
 
-assert(expectedRuntimeExports.length === 71, "P6o runtime export budget must be exactly 71");
+assert(expectedRuntimeExports.length === 73, "P6q runtime export budget must be exactly 73");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -157,6 +162,11 @@ assert(
   publicApi.PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME ===
     "mts-portable-structural-derivation-content/sha-256/v0.1",
   "portable derivation content digest scheme must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME ===
+    "mts-portable-structural-derivation-with-assumptions-content/sha-256/v0.1",
+  "portable conditional derivation content digest scheme must stay pinned",
 );
 assert(
   publicApi.PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA ===
@@ -197,6 +207,7 @@ const integrated: IntegratedProofEvidence | undefined = undefined;
 const portableArtifact: PortableStructuralDerivationArtifact | undefined = undefined;
 const portableConditionalArtifact: PortableStructuralDerivationWithAssumptionsArtifact | undefined = undefined;
 const portableDigest: PortableStructuralDerivationContentDigest | undefined = undefined;
+const portableConditionalDigest: PortableStructuralDerivationWithAssumptionsContentDigest | undefined = undefined;
 const portableErrorCode: PortableStructuralDerivationErrorCode | undefined = undefined;
 const portableReplay: PortableStructuralDerivationReplayResult | undefined = undefined;
 const portableConditionalReplay: PortableStructuralDerivationWithAssumptionsReplayResult | undefined = undefined;
@@ -204,6 +215,8 @@ const exportPortableConditional: (memory: ReadMemory, evidence: StructuralDeriva
 const replayPortableConditional: (input: unknown) => PortableStructuralDerivationWithAssumptionsReplayResult = publicApi.replayPortableStructuralDerivationWithAssumptions;
 const portableDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationContentDigest> =
   publicApi.computePortableStructuralDerivationContentDigest;
+const portableConditionalDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationWithAssumptionsContentDigest> =
+  publicApi.computePortableStructuralDerivationWithAssumptionsContentDigest;
 const provenanceSource: PortableStructuralDerivationSourceProvenance | undefined = undefined;
 const provenanceProducer: PortableStructuralDerivationProducerProvenance | undefined = undefined;
 const provenanceClaim: PortableStructuralDerivationProvenanceClaim | undefined = undefined;
@@ -238,12 +251,14 @@ void [
   portableArtifact,
   portableConditionalArtifact,
   portableDigest,
+  portableConditionalDigest,
   portableErrorCode,
   portableReplay,
   portableConditionalReplay,
   exportPortableConditional,
   replayPortableConditional,
   portableDigestFunction,
+  portableConditionalDigestFunction,
   provenanceSource,
   provenanceProducer,
   provenanceClaim,


### PR DESCRIPTION
Closes #870

## Scope

P6q exposes the already-proven conditional portable derivation content digest through the exact `@mts/core` package root. It does not change digest semantics, transport/replay semantics, provenance, accepted MTS v0.11, or start v0.12.

```text
base/main = cd4b482e3879bd3329e5adbc4656f1cbcbb52d8e
head = 336177e68b2983108cfc813d30753663468630e3
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/public.ts          +3
 ts/test/public-api.test.ts +16 -1
--------------------------------
net additions              18 / 40
new files                   0 / 0
```

## Exact package delta

Adds exactly two runtime exports:

```text
PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME
computePortableStructuralDerivationWithAssumptionsContentDigest
```

Adds exactly one public type:

```text
PortableStructuralDerivationWithAssumptionsContentDigest
```

Runtime allowlist is pinned from 71 to exactly 73 names.

The conditional digest scheme remains pinned to:

```text
mts-portable-structural-derivation-with-assumptions-content/sha-256/v0.1
```

The package contract also proves that:

```text
canonicalPortableStructuralDerivationWithAssumptionsV01Json
```

remains internal via `@ts-expect-error`.

## Critical non-conflations

```text
package API widening != MTS semantic release
digest API != proof acceptance
digest equality != theorem truth
conditional digest != base digest
conditional digest != provenance digest
public digest function != public canonical JSON normalizer
```

## Classification

Only if exact-head full CI and blocking repo-guard are green:

```text
PORTABLE_CONDITIONAL_CONTENT_DIGEST_PACKAGE_API_SUPPORTED
```

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA