### PR TITLE
feat(proof): bind conditional proof provenance

### DIFF
--- a/ts/src/portable-derivation-provenance.ts
+++ b/ts/src/portable-derivation-provenance.ts
@@ -1,13 +1,20 @@
 import {
   PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
   computePortableStructuralDerivationContentDigest,
+  computePortableStructuralDerivationWithAssumptionsContentDigest,
   type PortableStructuralDerivationContentDigest,
+  type PortableStructuralDerivationWithAssumptionsContentDigest,
 } from "./portable-derivation-digest.js";
 
 export const PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA =
   "mts-portable-structural-derivation-provenance/v0.1" as const;
 export const PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME =
   "mts-portable-structural-derivation-provenance/sha-256/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA =
+  "mts-portable-structural-derivation-with-assumptions-provenance/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME =
+  "mts-portable-structural-derivation-with-assumptions-provenance/sha-256/v0.1" as const;
 
 export interface PortableStructuralDerivationSourceProvenance {
   readonly locator: string;
@@ -29,6 +36,18 @@ export interface PortableStructuralDerivationProvenanceClaim {
 
 export interface PortableStructuralDerivationProvenanceDigest {
   readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME;
+  readonly value: string;
+}
+
+export interface PortableStructuralDerivationWithAssumptionsProvenanceClaim {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA;
+  readonly contentDigest: PortableStructuralDerivationWithAssumptionsContentDigest;
+  readonly source: PortableStructuralDerivationSourceProvenance;
+  readonly producer: PortableStructuralDerivationProducerProvenance;
+}
+
+export interface PortableStructuralDerivationWithAssumptionsProvenanceDigest {
+  readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME;
   readonly value: string;
 }
 
@@ -92,6 +111,22 @@ function parseContentDigest(value: unknown): PortableStructuralDerivationContent
   });
 }
 
+function parseContentDigestWithAssumptions(
+  value: unknown,
+): PortableStructuralDerivationWithAssumptionsContentDigest {
+  const digest = exactRecord(value, ["scheme", "value"]);
+  if (digest.scheme !== PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME) {
+    fail("invalid-content-digest");
+  }
+  if (typeof digest.value !== "string" || !/^[0-9a-f]{64}$/.test(digest.value)) {
+    fail("invalid-content-digest");
+  }
+  return Object.freeze({
+    scheme: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
+    value: digest.value,
+  });
+}
+
 function parseSource(value: unknown): PortableStructuralDerivationSourceProvenance {
   const source = exactRecord(value, ["locator", "revision", "subject"]);
   return Object.freeze({
@@ -122,10 +157,31 @@ function parseClaim(value: unknown): PortableStructuralDerivationProvenanceClaim
   });
 }
 
+function parseClaimWithAssumptions(
+  value: unknown,
+): PortableStructuralDerivationWithAssumptionsProvenanceClaim {
+  const claim = exactRecord(value, ["schema", "contentDigest", "source", "producer"]);
+  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA) {
+    fail("unsupported-schema");
+  }
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
+    contentDigest: parseContentDigestWithAssumptions(claim.contentDigest),
+    source: parseSource(claim.source),
+    producer: parseProducer(claim.producer),
+  });
+}
+
 export function canonicalPortableStructuralDerivationProvenanceClaimJson(
   input: unknown,
 ): string {
   return JSON.stringify(parseClaim(input));
+}
+
+export function canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson(
+  input: unknown,
+): string {
+  return JSON.stringify(parseClaimWithAssumptions(input));
 }
 
 export async function createPortableStructuralDerivationProvenanceClaim(
@@ -136,6 +192,20 @@ export async function createPortableStructuralDerivationProvenanceClaim(
   const contentDigest = await computePortableStructuralDerivationContentDigest(artifact);
   return Object.freeze({
     schema: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+    contentDigest,
+    source: parseSource(source),
+    producer: parseProducer(producer),
+  });
+}
+
+export async function createPortableStructuralDerivationWithAssumptionsProvenanceClaim(
+  artifact: unknown,
+  source: PortableStructuralDerivationSourceProvenance,
+  producer: PortableStructuralDerivationProducerProvenance,
+): Promise<PortableStructuralDerivationWithAssumptionsProvenanceClaim> {
+  const contentDigest = await computePortableStructuralDerivationWithAssumptionsContentDigest(artifact);
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
     contentDigest,
     source: parseSource(source),
     producer: parseProducer(producer),
@@ -158,12 +228,34 @@ export async function computePortableStructuralDerivationProvenanceDigest(
   });
 }
 
+export async function computePortableStructuralDerivationWithAssumptionsProvenanceDigest(
+  input: unknown,
+): Promise<PortableStructuralDerivationWithAssumptionsProvenanceDigest> {
+  const canonicalJson = canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson(input);
+  const preimage = `${PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME}\n${canonicalJson}`;
+  const raw = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(preimage));
+  return Object.freeze({
+    scheme: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
+    value: lowercaseHex(new Uint8Array(raw)),
+  });
+}
+
 export async function verifyPortableStructuralDerivationProvenanceClaim(
   artifact: unknown,
   input: unknown,
 ): Promise<PortableStructuralDerivationProvenanceClaim> {
   const claim = parseClaim(input);
   const actual = await computePortableStructuralDerivationContentDigest(artifact);
+  if (actual.value !== claim.contentDigest.value) fail("content-digest-mismatch");
+  return claim;
+}
+
+export async function verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim(
+  artifact: unknown,
+  input: unknown,
+): Promise<PortableStructuralDerivationWithAssumptionsProvenanceClaim> {
+  const claim = parseClaimWithAssumptions(input);
+  const actual = await computePortableStructuralDerivationWithAssumptionsContentDigest(artifact);
   if (actual.value !== claim.contentDigest.value) fail("content-digest-mismatch");
   return claim;
 }

--- a/ts/test/portable-assumption-derivation-provenance.test.ts
+++ b/ts/test/portable-assumption-derivation-provenance.test.ts
@@ -1,0 +1,317 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import { Memory, ensureRootBasis, type LinkHandle } from "../src/memory.js";
+import {
+  PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+  computePortableStructuralDerivationWithAssumptionsContentDigest,
+} from "../src/portable-derivation-digest.js";
+import {
+  PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
+  PortableStructuralDerivationProvenanceError,
+  canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson,
+  computePortableStructuralDerivationProvenanceDigest,
+  computePortableStructuralDerivationWithAssumptionsProvenanceDigest,
+  createPortableStructuralDerivationWithAssumptionsProvenanceClaim,
+  verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim,
+  type PortableStructuralDerivationProducerProvenance,
+  type PortableStructuralDerivationSourceProvenance,
+} from "../src/portable-derivation-provenance.js";
+import {
+  exportPortableStructuralDerivationWithAssumptions,
+  replayPortableStructuralDerivationWithAssumptions,
+} from "../src/portable-derivation.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralAssumptionReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralAssumptionContext,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+async function expectProvenance(
+  code: PortableStructuralDerivationProvenanceError["code"],
+  effect: () => unknown | Promise<unknown>,
+): Promise<void> {
+  try {
+    await effect();
+  } catch (error) {
+    assert(error instanceof PortableStructuralDerivationProvenanceError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected provenance rejection`);
+}
+
+function reverseObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(reverseObjectKeys);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .reverse()
+      .map(([key, nested]) => [key, reverseObjectKeys(nested)]),
+  );
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationWithAssumptionsEvidence;
+  readonly fresh: () => LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const role = fresh();
+  const claim = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const rule = defineStructuralRule(memory, roleDictionary, role);
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+  const assumptionContext = defineStructuralAssumptionContext(memory, theory, [claim]);
+  const assumptionOccurrence = memory.find(assumptionContext, claim);
+  assert(assumptionOccurrence !== undefined, "assumption occurrence must exist");
+
+  const context = defineContext(memory, fresh(), fresh());
+  const act = defineActHeader(memory, interpreter, roleDictionary, context);
+  defineActField(memory, act, role, claim);
+  const judgment: StructuralJudgmentEvidence = {
+    application: {
+      act,
+      rule,
+      ruleAdmission,
+      claimedBody: claim,
+      expectedInterpreter,
+      expectedAfterContext: context,
+    },
+    judgment: { theory, context, claim },
+  };
+  const occurrence = defineStructuralProofOccurrence(memory, act, claim);
+  const derivationRule = defineStructuralDerivationRule(memory, rule, [role]);
+  const node = {
+    occurrence,
+    judgment,
+    derivationRule,
+    derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule),
+    premiseOccurrenceSequence: materializeExactSequence(memory, [assumptionOccurrence]),
+  };
+  return {
+    memory,
+    fresh,
+    evidence: {
+      derivation: { theory, targetOccurrence: occurrence, nodes: [node] },
+      assumptionContext,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  same(
+    PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+    "mts-portable-structural-derivation-provenance/v0.1",
+    "base provenance schema remains pinned",
+  );
+  same(
+    PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
+    "mts-portable-structural-derivation-provenance/sha-256/v0.1",
+    "base provenance digest remains pinned",
+  );
+  same(
+    PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
+    "mts-portable-structural-derivation-with-assumptions-provenance/v0.1",
+    "conditional provenance schema",
+  );
+  same(
+    PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
+    "mts-portable-structural-derivation-with-assumptions-provenance/sha-256/v0.1",
+    "conditional provenance digest scheme",
+  );
+
+  const source: PortableStructuralDerivationSourceProvenance = {
+    locator: "https://example.invalid/math-source",
+    revision: "0123456789abcdef0123456789abcdef01234567",
+    subject: "Example.conditionalTheorem",
+  };
+  const producer: PortableStructuralDerivationProducerProvenance = {
+    id: "mts-proof-importer",
+    version: "0.2.0",
+  };
+  const fx = fixture();
+  const artifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  const before = fx.memory.linkCount;
+  const directContent = await computePortableStructuralDerivationWithAssumptionsContentDigest(artifact);
+  const claim = await createPortableStructuralDerivationWithAssumptionsProvenanceClaim(
+    artifact,
+    source,
+    producer,
+  );
+  same(claim.contentDigest.value, directContent.value, "claim binds recomputed conditional content");
+  same(fx.memory.linkCount, before, "claim creation is source read-only");
+
+  const digest = await computePortableStructuralDerivationWithAssumptionsProvenanceDigest(claim);
+  same(digest.scheme, PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME, "digest scheme");
+  assert(/^[0-9a-f]{64}$/.test(digest.value), "conditional provenance digest must be lowercase 64-hex");
+  same(
+    (await computePortableStructuralDerivationWithAssumptionsProvenanceDigest(claim)).value,
+    digest.value,
+    "repeated digest",
+  );
+  same(
+    canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson(reverseObjectKeys(claim)),
+    canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson(claim),
+    "object key insertion order has no authority",
+  );
+
+  for (const [label, changedSource, changedProducer] of [
+    ["locator", { ...source, locator: `${source.locator}/changed` }, producer],
+    ["revision", { ...source, revision: `${source.revision}x` }, producer],
+    ["subject", { ...source, subject: `${source.subject}.changed` }, producer],
+    ["producer-id", source, { ...producer, id: `${producer.id}.changed` }],
+    ["producer-version", source, { ...producer, version: `${producer.version}+changed` }],
+  ] as const) {
+    const changed = await createPortableStructuralDerivationWithAssumptionsProvenanceClaim(
+      artifact,
+      changedSource,
+      changedProducer,
+    );
+    const changedDigest = await computePortableStructuralDerivationWithAssumptionsProvenanceDigest(changed);
+    assert(changedDigest.value !== digest.value, `${label} must change provenance identity`);
+  }
+
+  const verified = await verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim(artifact, claim);
+  same(verified.contentDigest.value, claim.contentDigest.value, "claim verifies against artifact");
+  same(fx.memory.linkCount, before, "digest and verification are source read-only");
+
+  const junkA = fx.fresh();
+  const junkB = fx.fresh();
+  fx.memory.ensure(junkA, junkB);
+  const ambientArtifact = exportPortableStructuralDerivationWithAssumptions(fx.memory, fx.evidence);
+  same(JSON.stringify(ambientArtifact), JSON.stringify(artifact), "ambient growth leaves artifact stable");
+  const ambientClaim = await createPortableStructuralDerivationWithAssumptionsProvenanceClaim(
+    ambientArtifact,
+    source,
+    producer,
+  );
+  same(
+    (await computePortableStructuralDerivationWithAssumptionsProvenanceDigest(ambientClaim)).value,
+    digest.value,
+    "ambient growth leaves provenance stable",
+  );
+
+  const baseClaim = {
+    schema: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+    contentDigest: {
+      scheme: PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
+      value: "0".repeat(64),
+    },
+    source,
+    producer,
+  };
+  assert(
+    /^[0-9a-f]{64}$/.test((await computePortableStructuralDerivationProvenanceDigest(baseClaim)).value),
+    "base provenance function remains operational",
+  );
+  await expectProvenance(
+    "unsupported-schema",
+    () => computePortableStructuralDerivationWithAssumptionsProvenanceDigest(baseClaim),
+  );
+  await expectProvenance(
+    "unsupported-schema",
+    () => computePortableStructuralDerivationProvenanceDigest(claim),
+  );
+  await expectProvenance("unsupported-schema", () =>
+    computePortableStructuralDerivationWithAssumptionsProvenanceDigest({ ...claim, schema: "unknown" }));
+  await expectProvenance("invalid-content-digest", () =>
+    computePortableStructuralDerivationWithAssumptionsProvenanceDigest({
+      ...claim,
+      contentDigest: { ...claim.contentDigest, scheme: PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME },
+    }));
+  await expectProvenance("invalid-content-digest", () =>
+    computePortableStructuralDerivationWithAssumptionsProvenanceDigest({
+      ...claim,
+      contentDigest: { ...claim.contentDigest, value: claim.contentDigest.value.toUpperCase() },
+    }));
+  await expectProvenance("invalid-provenance-string", () =>
+    computePortableStructuralDerivationWithAssumptionsProvenanceDigest({
+      ...claim,
+      source: { ...claim.source, revision: "   " },
+    }));
+  await expectProvenance("invalid-envelope", () =>
+    computePortableStructuralDerivationWithAssumptionsProvenanceDigest({ ...claim, trusted: true }));
+  await expectProvenance("invalid-envelope", () =>
+    computePortableStructuralDerivationWithAssumptionsProvenanceDigest({
+      ...claim,
+      producer: { ...claim.producer, signature: "not-authority" },
+    }));
+
+  const forgedClaim = {
+    ...claim,
+    contentDigest: { ...claim.contentDigest, value: "0".repeat(64) },
+  };
+  assert(
+    /^[0-9a-f]{64}$/.test(
+      (await computePortableStructuralDerivationWithAssumptionsProvenanceDigest(forgedClaim)).value,
+    ),
+    "structurally valid forged claim may have content identity",
+  );
+  await expectProvenance(
+    "content-digest-mismatch",
+    () => verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim(artifact, forgedClaim),
+  );
+
+  assert(
+    artifact.assumptionContextCoordinate !== artifact.targetOccurrenceCoordinate,
+    "fixture requires distinct context and target coordinates",
+  );
+  const forgedArtifact = {
+    ...artifact,
+    assumptionContextCoordinate: artifact.targetOccurrenceCoordinate,
+  };
+  const forgedProofClaim = await createPortableStructuralDerivationWithAssumptionsProvenanceClaim(
+    forgedArtifact,
+    source,
+    producer,
+  );
+  const forgedProofDigest = await computePortableStructuralDerivationWithAssumptionsProvenanceDigest(
+    forgedProofClaim,
+  );
+  assert(forgedProofDigest.value !== digest.value, "proof mutation changes provenance identity");
+  try {
+    replayPortableStructuralDerivationWithAssumptions(forgedArtifact);
+    throw new Error("invalid conditional proof must reject");
+  } catch (error) {
+    assert(error instanceof StructuralAssumptionReplayError, "generic conditional replay must reject forged proof");
+    same(error.code, "invalid-assumption-context", "forged proof rejection code");
+  }
+
+  // Executable P6r classification:
+  // PORTABLE_CONDITIONAL_EXTERNAL_PROVENANCE_CLAIM_SUPPORTED
+}
+
+await main();


### PR DESCRIPTION
Closes #872

## Scope

P6r adds a separate external provenance identity family for portable structural derivations with assumptions. Existing base P6j provenance v0.1 remains semantically unchanged and continues to bind only the base v0.2 content-digest family.

```text
base/main = 7a4a27b5e9cd4b143a4bd6e1d84472f34599758f
head = 7f67c258083cab893649d3cc904670f9ae7f3de9
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/portable-derivation-provenance.ts                  +92
ts/test/portable-assumption-derivation-provenance.test.ts +317
----------------------------------------------------------------
net additions                                              409 / 420
new files                                                    1 / 1
```

## Conditional provenance family

```text
schema = mts-portable-structural-derivation-with-assumptions-provenance/v0.1
digest = mts-portable-structural-derivation-with-assumptions-provenance/sha-256/v0.1
content = mts-portable-structural-derivation-with-assumptions-content/sha-256/v0.1
```

Adds module-level conditional claim/digest types plus canonicalization, create, digest and verify functions. It reuses the existing generic source/producer types and `PortableStructuralDerivationProvenanceError`; no second provenance authority is introduced.

Creation and verification recompute the accepted conditional content digest. Provenance digest uses domain-separated SHA-256 over the canonical conditional claim JSON. No network/source lookup is performed and no proof replay is performed by provenance functions.

Package-root exposure is deliberately deferred to a later API slice.

## Critical non-conflations

```text
conditional provenance claim != source authenticity
conditional provenance digest != signature
conditional provenance digest != theorem truth
claim-to-artifact verification != proof acceptance
producer id != trusted authority
base provenance v0.1 != conditional provenance v0.1
package surface unchanged
P6r != v0.12
```

## Executable corpus

Covers:
- base provenance schema/digest literals and base digest function remain operational;
- conditional creation binds recomputed conditional content digest;
- stable lowercase 64-hex domain-separated provenance digest;
- host object-property insertion order normalization;
- exact source/producer mutations change provenance identity;
- ambient unrelated Memory growth leaves conditional artifact/provenance identity stable;
- creation/digest/verification are proof-Memory read-only;
- base/conditional provenance family isolation;
- wrong schema/content scheme, malformed digest, blank strings and extra authority fail closed;
- structurally valid forged contentDigest can be hashed but binding verification rejects;
- structurally parseable invalid conditional proof can receive content/provenance identity while generic conditional replay rejects `invalid-assumption-context`.

## Classification

Only if exact-head full CI and blocking repo-guard are green:

```text
PORTABLE_CONDITIONAL_EXTERNAL_PROVENANCE_CLAIM_SUPPORTED
```

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA