### PR TITLE
feat(proof): expose conditional provenance package API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -201,10 +201,15 @@ export type {
 export {
   PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
   PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
   PortableStructuralDerivationProvenanceError,
   computePortableStructuralDerivationProvenanceDigest,
+  computePortableStructuralDerivationWithAssumptionsProvenanceDigest,
   createPortableStructuralDerivationProvenanceClaim,
+  createPortableStructuralDerivationWithAssumptionsProvenanceClaim,
   verifyPortableStructuralDerivationProvenanceClaim,
+  verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim,
 } from "./portable-derivation-provenance.js";
 export type {
   PortableStructuralDerivationProducerProvenance,
@@ -212,6 +217,8 @@ export type {
   PortableStructuralDerivationProvenanceDigest,
   PortableStructuralDerivationProvenanceErrorCode,
   PortableStructuralDerivationSourceProvenance,
+  PortableStructuralDerivationWithAssumptionsProvenanceClaim,
+  PortableStructuralDerivationWithAssumptionsProvenanceDigest,
 } from "./portable-derivation-provenance.js";
 
 export {

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -20,6 +20,8 @@ import type {
   PortableStructuralDerivationSourceProvenance,
   PortableStructuralDerivationWithAssumptionsArtifact,
   PortableStructuralDerivationWithAssumptionsContentDigest,
+  PortableStructuralDerivationWithAssumptionsProvenanceClaim,
+  PortableStructuralDerivationWithAssumptionsProvenanceDigest,
   PortableStructuralDerivationWithAssumptionsReplayResult,
   ReadMemory,
   RelationReplayEvidence,
@@ -53,6 +55,8 @@ type InternalCanonicalPortableStructuralDerivationV02Json = typeof import("../sr
 type InternalCanonicalPortableStructuralDerivationWithAssumptionsV01Json = typeof import("../src/public.js").canonicalPortableStructuralDerivationWithAssumptionsV01Json;
 // @ts-expect-error P6k keeps provenance canonical JSON normalization internal.
 type InternalCanonicalPortableStructuralDerivationProvenanceClaimJson = typeof import("../src/public.js").canonicalPortableStructuralDerivationProvenanceClaimJson;
+// @ts-expect-error P6s keeps conditional provenance canonical JSON normalization internal.
+type InternalCanonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson = typeof import("../src/public.js").canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson;
 // @ts-expect-error P3b keeps assumption construction internal; consumers submit materialized evidence.
 type InternalAssumptionContextConstructor = typeof import("../src/public.js").defineStructuralAssumptionContext;
 
@@ -75,6 +79,8 @@ const expectedRuntimeExports = [
   "PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
@@ -96,7 +102,9 @@ const expectedRuntimeExports = [
   "computePortableStructuralDerivationContentDigest",
   "computePortableStructuralDerivationProvenanceDigest",
   "computePortableStructuralDerivationWithAssumptionsContentDigest",
+  "computePortableStructuralDerivationWithAssumptionsProvenanceDigest",
   "createPortableStructuralDerivationProvenanceClaim",
+  "createPortableStructuralDerivationWithAssumptionsProvenanceClaim",
   "deserializeAnum",
   "deserializeStream",
   "elaborateBundleRoles",
@@ -134,9 +142,10 @@ const expectedRuntimeExports = [
   "symbolicStackAlgebra",
   "valuesEqual",
   "verifyPortableStructuralDerivationProvenanceClaim",
+  "verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim",
 ].sort();
 
-assert(expectedRuntimeExports.length === 73, "P6q runtime export budget must be exactly 73");
+assert(expectedRuntimeExports.length === 78, "P6s runtime export budget must be exactly 78");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -177,6 +186,16 @@ assert(
   publicApi.PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME ===
     "mts-portable-structural-derivation-provenance/sha-256/v0.1",
   "portable derivation provenance digest scheme must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA ===
+    "mts-portable-structural-derivation-with-assumptions-provenance/v0.1",
+  "portable conditional derivation provenance schema must stay pinned",
+);
+assert(
+  publicApi.PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME ===
+    "mts-portable-structural-derivation-with-assumptions-provenance/sha-256/v0.1",
+  "portable conditional derivation provenance digest scheme must stay pinned",
 );
 
 // Compile-time smoke for the intended consumer concepts. The top-level evidence
@@ -221,10 +240,15 @@ const provenanceSource: PortableStructuralDerivationSourceProvenance | undefined
 const provenanceProducer: PortableStructuralDerivationProducerProvenance | undefined = undefined;
 const provenanceClaim: PortableStructuralDerivationProvenanceClaim | undefined = undefined;
 const provenanceDigest: PortableStructuralDerivationProvenanceDigest | undefined = undefined;
+const provenanceConditionalClaim: PortableStructuralDerivationWithAssumptionsProvenanceClaim | undefined = undefined;
+const provenanceConditionalDigest: PortableStructuralDerivationWithAssumptionsProvenanceDigest | undefined = undefined;
 const provenanceErrorCode: PortableStructuralDerivationProvenanceErrorCode | undefined = undefined;
 const createProvenance: (artifact: unknown, source: PortableStructuralDerivationSourceProvenance, producer: PortableStructuralDerivationProducerProvenance) => Promise<PortableStructuralDerivationProvenanceClaim> = publicApi.createPortableStructuralDerivationProvenanceClaim;
 const digestProvenance: (input: unknown) => Promise<PortableStructuralDerivationProvenanceDigest> = publicApi.computePortableStructuralDerivationProvenanceDigest;
 const verifyProvenance: (artifact: unknown, input: unknown) => Promise<PortableStructuralDerivationProvenanceClaim> = publicApi.verifyPortableStructuralDerivationProvenanceClaim;
+const createConditionalProvenance: (artifact: unknown, source: PortableStructuralDerivationSourceProvenance, producer: PortableStructuralDerivationProducerProvenance) => Promise<PortableStructuralDerivationWithAssumptionsProvenanceClaim> = publicApi.createPortableStructuralDerivationWithAssumptionsProvenanceClaim;
+const digestConditionalProvenance: (input: unknown) => Promise<PortableStructuralDerivationWithAssumptionsProvenanceDigest> = publicApi.computePortableStructuralDerivationWithAssumptionsProvenanceDigest;
+const verifyConditionalProvenance: (artifact: unknown, input: unknown) => Promise<PortableStructuralDerivationWithAssumptionsProvenanceClaim> = publicApi.verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim;
 void [
   read,
   write,
@@ -263,8 +287,13 @@ void [
   provenanceProducer,
   provenanceClaim,
   provenanceDigest,
+  provenanceConditionalClaim,
+  provenanceConditionalDigest,
   provenanceErrorCode,
   createProvenance,
   digestProvenance,
   verifyProvenance,
+  createConditionalProvenance,
+  digestConditionalProvenance,
+  verifyConditionalProvenance,
 ];


### PR DESCRIPTION
Closes #874

## Scope

P6s exposes the already-proven conditional provenance family through the exact package root. This is package API only: provenance semantics, digest semantics, proof replay, contracts and accepted MTS semantics are unchanged.

```text
base/main = 567e8c500afd48ecd2487c69e5ed097feff215dc
head = 01079a5d9d78dc2d2b9f7999c03e059dd69f7cc3
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/public.ts           +7
ts/test/public-api.test.ts +30/-1
---------------------------------
net additions              36 / 50
new files                   0 / 0
```

## Exact package delta

Runtime allowlist:

```text
73 -> 78
```

Adds exactly five runtime exports:

```text
PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA
PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME
createPortableStructuralDerivationWithAssumptionsProvenanceClaim
computePortableStructuralDerivationWithAssumptionsProvenanceDigest
verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim
```

Adds exactly two package types:

```text
PortableStructuralDerivationWithAssumptionsProvenanceClaim
PortableStructuralDerivationWithAssumptionsProvenanceDigest
```

Shared source/producer/error vocabulary remains shared. `canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson` remains internal and is protected by a compile-time negative guard.

Exact public domains are pinned to:

```text
schema = mts-portable-structural-derivation-with-assumptions-provenance/v0.1
digest = mts-portable-structural-derivation-with-assumptions-provenance/sha-256/v0.1
```

## Non-conflations

```text
package export != semantic authority
package export != proof truth
conditional provenance != base provenance
provenance claim != source authenticity
provenance digest != signature
P6s != MTS v0.12
```

## Classification

Only if exact-head full CI and blocking repo-guard are green:

```text
PORTABLE_CONDITIONAL_EXTERNAL_PROVENANCE_PACKAGE_API_SUPPORTED
```

## Merge gates

- full CI green
- blocking repo-guard green
- behind_by=0
- mergeable=true
- draft=false
- stable exact head
- merge only with expected_head_sha
- confirm exact new main after merge
- claim post-merge CI only if workflows actually exist on merge SHA