### PR TITLE
feat(proof): expose single portable replay package API

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -188,6 +188,13 @@ export type {
 } from "./portable-derivation.js";
 
 export {
+  replayPortableStructuralProof,
+} from "./portable-proof-replay.js";
+export type {
+  PortableStructuralProofReplayResult,
+} from "./portable-proof-replay.js";
+
+export {
   PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
   computePortableStructuralDerivationContentDigest,

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -23,6 +23,7 @@ import type {
   PortableStructuralDerivationWithAssumptionsProvenanceClaim,
   PortableStructuralDerivationWithAssumptionsProvenanceDigest,
   PortableStructuralDerivationWithAssumptionsReplayResult,
+  PortableStructuralProofReplayResult,
   ReadMemory,
   RelationReplayEvidence,
   RunEvidence,
@@ -127,6 +128,7 @@ const expectedRuntimeExports = [
   "replayPersistentSequenceMaterialization",
   "replayPortableStructuralDerivation",
   "replayPortableStructuralDerivationWithAssumptions",
+  "replayPortableStructuralProof",
   "replayRelationStep",
   "replayRelationSubselectionStep",
   "replayResolvedSequenceGrouping",
@@ -145,7 +147,7 @@ const expectedRuntimeExports = [
   "verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim",
 ].sort();
 
-assert(expectedRuntimeExports.length === 78, "P6s runtime export budget must be exactly 78");
+assert(expectedRuntimeExports.length === 79, "P7b runtime export budget must be exactly 79");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -230,8 +232,10 @@ const portableConditionalDigest: PortableStructuralDerivationWithAssumptionsCont
 const portableErrorCode: PortableStructuralDerivationErrorCode | undefined = undefined;
 const portableReplay: PortableStructuralDerivationReplayResult | undefined = undefined;
 const portableConditionalReplay: PortableStructuralDerivationWithAssumptionsReplayResult | undefined = undefined;
+const portableUnifiedReplay: PortableStructuralProofReplayResult | undefined = undefined;
 const exportPortableConditional: (memory: ReadMemory, evidence: StructuralDerivationWithAssumptionsEvidence) => PortableStructuralDerivationWithAssumptionsArtifact = publicApi.exportPortableStructuralDerivationWithAssumptions;
 const replayPortableConditional: (input: unknown) => PortableStructuralDerivationWithAssumptionsReplayResult = publicApi.replayPortableStructuralDerivationWithAssumptions;
+const replayPortableUnified: (input: unknown) => PortableStructuralProofReplayResult = publicApi.replayPortableStructuralProof;
 const portableDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationContentDigest> =
   publicApi.computePortableStructuralDerivationContentDigest;
 const portableConditionalDigestFunction: (input: unknown) => Promise<PortableStructuralDerivationWithAssumptionsContentDigest> =
@@ -279,8 +283,10 @@ void [
   portableErrorCode,
   portableReplay,
   portableConditionalReplay,
+  portableUnifiedReplay,
   exportPortableConditional,
   replayPortableConditional,
+  replayPortableUnified,
   portableDigestFunction,
   portableConditionalDigestFunction,
   provenanceSource,


### PR DESCRIPTION
Closes #878

## Scope

P7b exposes the already-proven P7a single fail-closed portable replay boundary through the package root. This is API-only: no replay routing implementation, proof kernel, structural Rule semantics, contracts, digest or provenance semantics change.

```text
base/main = 13944dc45c9a7976622a187ea64e593ecc98a035
head = 8a8d9a06c6e3c3ceeec11c0e6f743bb2922db6e4
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
```

Exact diff:

```text
ts/src/public.ts             +7/-0
ts/test/public-api.test.ts   +8/-2
---------------------------------
net additions               13 / 30
new files                    0 / 0
```

Package-root additions only:

```text
replayPortableStructuralProof
PortableStructuralProofReplayResult
```

Runtime allowlist is pinned from 78 to 79. Existing family-specific base/conditional portable replay exports remain for backward compatibility.

Compile-time package contract pins:

```text
(input: unknown) => PortableStructuralProofReplayResult
```

P7a implementation `ts/src/portable-proof-replay.ts` and all existing replay/kernel files are untouched.

Non-conflations:

```text
package export != semantic authority
single entrypoint != theorem truth
compatibility API != second proof semantics
portable replay != provenance authenticity
external replay != internal Gödel proof predicate
P7b != MTS v0.12
```

Classification only if exact-head full CI and blocking repo-guard are green:

```text
SINGLE_PORTABLE_TRUSTED_REPLAY_PACKAGE_API_SUPPORTED
```

Merge gates: full CI green; blocking repo-guard green; behind_by=0; mergeable=true; draft=false; stable exact head; merge only with expected_head_sha; confirm exact new main SHA; claim post-merge CI only if workflows actually exist on merge SHA.