### PR TITLE
test(research): recover historical Coq self through context

### DIFF
--- a/ts/test/research-historical-coq-self-context.test.ts
+++ b/ts/test/research-historical-coq-self-context.test.ts
@@ -27,7 +27,11 @@ import {
   type SourceFrontEndEvidence,
 } from "../src/source.js";
 import { defineContext } from "../src/state.js";
-import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  defineActField,
+  defineActHeader,
+  readOptionalMany,
+} from "../src/structural-readers.js";
 import {
   defineStructuralInterpreter,
   defineStructuralRoleDictionary,
@@ -308,7 +312,10 @@ reject("wrong explicit context cannot resolve self to another current", () =>
 );
 same(memory.linkCount, afterWrongContextConstruction, "wrong-context rejection must be read-only");
 
-// Missing the explicit K binding is underdetermined and fails closed.
+// Missing the explicit K binding is underdetermined and fails closed. Use a
+// fresh header context so this malformed Act cannot canonicalize to an earlier
+// fully populated Act and accidentally inherit its attachments.
+const missingHeaderContext = defineContext(memory, O, U);
 const missingContextEvidence = contextualEvidence(
   memory,
   source,
@@ -316,8 +323,14 @@ const missingContextEvidence = contextualEvidence(
   dotRole,
   rootContext,
   R,
-  rootContext,
+  missingHeaderContext,
   true,
+);
+assert(missingContextEvidence.act !== rootEvidence.act, "malformed Act must be structurally fresh");
+same(
+  readOptionalMany(memory, missingContextEvidence.act, vocabulary.beforeContext).length,
+  0,
+  "malformed Act must truly omit beforeContext",
 );
 const afterMissingContextConstruction = memory.linkCount;
 reject("missing explicit context binding", () =>

--- a/ts/test/research-historical-coq-self-context.test.ts
+++ b/ts/test/research-historical-coq-self-context.test.ts
@@ -1,0 +1,326 @@
+import {
+  defineDictionaryEffect,
+  defineDictionaryScope,
+} from "../src/dictionary.js";
+import {
+  materializeExactSequence,
+  readExactSequence,
+} from "../src/exact-sequence.js";
+import {
+  InterpreterReplayError,
+  replayContextualReading,
+  type ContextualReadingEvidence,
+  type ContextualReadingRoles,
+} from "../src/interpreter.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  buildSelectedSourceEvidence,
+  defineSourceForm,
+  materializeSourceContent,
+  type SelectedSegmentSpec,
+  type SourceFrontEndEvidence,
+} from "../src/source.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+} from "../src/structural-rule.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`historical Coq self/context: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function sameJson(actual: unknown, expected: unknown, message: string): void {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${message}: ${JSON.stringify(actual)} !== ${JSON.stringify(expected)}`,
+  );
+}
+
+function reject(message: string, effect: () => unknown): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof InterpreterReplayError, `${message}: expected InterpreterReplayError`);
+    same(error.code, "invalid-flat-evidence", `${message}: error code`);
+    return;
+  }
+  throw new Error(`historical Coq self/context: ${message}: expected rejection`);
+}
+
+class Probe implements ReadMemory {
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined {
+    throw new Error("historical self replay must not use find/ambient lookup");
+  }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    return this.source.outgoing(start);
+  }
+  incoming(): readonly LinkHandle[] {
+    throw new Error("historical self replay must not scan incoming");
+  }
+}
+
+function anchors(memory: Memory, count: number): readonly LinkHandle[] {
+  const result: LinkHandle[] = [];
+  const seed = memory.ensureEndSelfClosed(memory.root);
+  let tag = memory.ensureStartSelfClosed(memory.root);
+  for (let index = 0; index < count; index += 1) {
+    tag = memory.ensureStartSelfClosed(tag);
+    result.push(memory.ensure(seed, tag));
+  }
+  return Object.freeze(result);
+}
+
+interface DictionaryFixture {
+  readonly dictionary: LinkHandle;
+  readonly occurrence: LinkHandle;
+}
+
+function oneEntryDictionary(
+  memory: Memory,
+  sourceContent: LinkHandle,
+  form: LinkHandle,
+): DictionaryFixture {
+  const before = defineDictionaryScope(memory, memory.root, memory.root);
+  const effect = defineDictionaryEffect(
+    memory,
+    before,
+    memory.root,
+    memory.root,
+    sourceContent,
+    form,
+  );
+  return Object.freeze({ dictionary: effect.afterScope, occurrence: effect.occurrence });
+}
+
+function dotSourceEvidence(
+  memory: Memory,
+  form: LinkHandle,
+  dictionary: DictionaryFixture,
+  grammar: LinkHandle,
+  theory: LinkHandle,
+): SourceFrontEndEvidence {
+  const bytes = new Uint8Array([0x2e]);
+  const content = materializeSourceContent(memory, bytes);
+  const source = defineSourceForm(memory, content);
+  const specs: readonly SelectedSegmentSpec[] = Object.freeze([
+    Object.freeze({
+      start: 0,
+      end: 1,
+      form,
+      dictionaryOccurrence: dictionary.occurrence,
+    }),
+  ]);
+  return buildSelectedSourceEvidence(
+    memory,
+    source,
+    specs,
+    { dictionary: dictionary.dictionary, grammar, theory },
+  );
+}
+
+function contextualRoles(memory: Memory): ContextualReadingRoles {
+  const values = anchors(memory, 24).slice(14);
+  assert(values.length === 10, "role vocabulary must contain ten roles");
+  return Object.freeze({
+    source: values[0]!,
+    sourceSelection: values[1]!,
+    formSequence: values[2]!,
+    dictionary: values[3]!,
+    grammar: values[4]!,
+    theory: values[5]!,
+    beforeContext: values[6]!,
+    contextualRole: values[7]!,
+    result: values[8]!,
+    afterContext: values[9]!,
+  });
+}
+
+function roleList(value: ContextualReadingRoles): readonly LinkHandle[] {
+  return Object.freeze([
+    value.source,
+    value.sourceSelection,
+    value.formSequence,
+    value.dictionary,
+    value.grammar,
+    value.theory,
+    value.beforeContext,
+    value.contextualRole,
+    value.result,
+    value.afterContext,
+  ]);
+}
+
+function contextualEvidence(
+  memory: Memory,
+  source: SourceFrontEndEvidence,
+  vocabulary: ContextualReadingRoles,
+  contextualRole: LinkHandle,
+  beforeContext: LinkHandle,
+  result: LinkHandle,
+  afterContext: LinkHandle,
+  omitBeforeContext = false,
+): ContextualReadingEvidence {
+  const interpreter = defineStructuralInterpreter(
+    memory,
+    source.dictionary,
+    source.grammar,
+    source.theory,
+  );
+  const roleDictionary = defineStructuralRoleDictionary(memory, roleList(vocabulary));
+  const act = defineActHeader(memory, interpreter, roleDictionary, afterContext);
+  const fields: readonly [LinkHandle, LinkHandle][] = [
+    [vocabulary.source, source.source],
+    [vocabulary.sourceSelection, source.selectionSequence],
+    [vocabulary.formSequence, source.formSequence],
+    [vocabulary.dictionary, source.dictionary],
+    [vocabulary.grammar, source.grammar],
+    [vocabulary.theory, source.theory],
+    [vocabulary.contextualRole, contextualRole],
+    [vocabulary.result, result],
+    [vocabulary.afterContext, afterContext],
+  ];
+  for (const [role, value] of fields) defineActField(memory, act, role, value);
+  if (!omitBeforeContext) defineActField(memory, act, vocabulary.beforeContext, beforeContext);
+  return Object.freeze({
+    sourceEvidence: source,
+    act,
+    roles: vocabulary,
+    interpreter,
+    roleDictionary,
+  });
+}
+
+const memory = new Memory();
+const basis = ensureRootBasis(memory);
+const { R, O, C, L, U } = basis;
+const pool = anchors(memory, 8);
+const dotRole = pool[0];
+const otherForm = pool[1];
+const grammar = pool[2];
+const theory = pool[3];
+assert(dotRole && otherForm && grammar && theory, "fixture anchors must exist");
+
+// Historical Coq `self` is tested only as an occurrence role. It is not a new
+// semantic Self primitive and is not the accepted semantic DotMeaning Link.
+const dotMeaning = memory.ensure(L, R);
+assert(dotRole !== dotMeaning, "contextual self occurrence must differ from DotMeaning=L⟼R");
+assert(![R, O, C, L, U].includes(dotRole), "contextual self occurrence must not alias root basis");
+
+const dotContent = materializeSourceContent(memory, new Uint8Array([0x2e]));
+const dotDictionary = oneEntryDictionary(memory, dotContent, dotRole);
+const source = dotSourceEvidence(memory, dotRole, dotDictionary, grammar, theory);
+const vocabulary = contextualRoles(memory);
+
+const rootContext = defineContext(memory, R, R);
+const oContext = defineContext(memory, R, O);
+const cContext = defineContext(memory, R, C);
+assert(new Set([rootContext, oContext, cContext]).size === 3, "explicit contexts must remain distinct");
+
+const rootEvidence = contextualEvidence(memory, source, vocabulary, dotRole, rootContext, R, rootContext);
+const oEvidence = contextualEvidence(memory, source, vocabulary, dotRole, oContext, O, oContext);
+const cEvidence = contextualEvidence(memory, source, vocabulary, dotRole, cContext, C, cContext);
+const constructionCount = memory.linkCount;
+const probe = new Probe(memory);
+
+// One and the same occurrence role resolves deictically from the explicit K.
+same(replayContextualReading(probe, rootEvidence), R, "old self in old E resolves to current R");
+same(replayContextualReading(probe, oEvidence), O, "old self in old O resolves to current O");
+same(replayContextualReading(probe, cEvidence), C, "old self in old S resolves to current C");
+same(memory.linkCount, constructionCount, "contextual self replay must be read-only");
+
+// Two self occurrences are two structural positions even though both carry the
+// same role and resolve to the same selected current Link.
+const twoSelfOccurrences = materializeExactSequence(memory, [dotRole, dotRole]);
+const occurrences = readExactSequence(memory, twoSelfOccurrences);
+sameJson(occurrences.values, [dotRole, dotRole], "two historical self occurrences keep the same role value");
+same(occurrences.cells.length, 2, "two historical self occurrences keep two exact positions");
+assert(occurrences.cells[0] !== occurrences.cells[1], "the two occurrence positions must remain distinct");
+const afterOccurrenceConstruction = memory.linkCount;
+same(replayContextualReading(new Probe(memory), rootEvidence), R, "first root self occurrence resolves to R");
+same(replayContextualReading(new Probe(memory), rootEvidence), R, "second root self occurrence resolves to R");
+same(memory.linkCount, afterOccurrenceConstruction, "replaying both self occurrences performs zero writes");
+
+// The historical definitions then become the already accepted root equations.
+// No finite `self` leaf is substituted into the semantic structure.
+const rPoles = probe.poles(R);
+same(rPoles.start, R, "old E -> current R satisfies Pair(R,R)=R at START pole");
+same(rPoles.end, R, "old E -> current R satisfies Pair(R,R)=R at END pole");
+const oPoles = probe.poles(O);
+same(oPoles.start, O, "old O -> current O satisfies Pair(O,R)=O at START pole");
+same(oPoles.end, R, "old O -> current O satisfies Pair(O,R)=O at END pole");
+const cPoles = probe.poles(C);
+same(cPoles.start, R, "old S -> current C satisfies Pair(R,C)=C at START pole");
+same(cPoles.end, C, "old S -> current C satisfies Pair(R,C)=C at END pole");
+const lPoles = probe.poles(L);
+same(lPoles.start, O, "old R -> current L satisfies Pair(O,C)=L at START pole");
+same(lPoles.end, C, "old R -> current L satisfies Pair(O,C)=L at END pole");
+
+// Physical '.' is presentation only. If the admitted dictionary maps the same
+// byte to another form, it cannot impersonate the explicit contextual role.
+const glyphOnlyDictionary = oneEntryDictionary(memory, dotContent, otherForm);
+const glyphOnlySource = dotSourceEvidence(memory, otherForm, glyphOnlyDictionary, grammar, theory);
+const glyphOnlyEvidence = contextualEvidence(
+  memory,
+  glyphOnlySource,
+  vocabulary,
+  dotRole,
+  rootContext,
+  R,
+  rootContext,
+);
+const afterGlyphConstruction = memory.linkCount;
+reject("physical dot without admitted contextual role has no self authority", () =>
+  replayContextualReading(new Probe(memory), glyphOnlyEvidence)
+);
+same(memory.linkCount, afterGlyphConstruction, "glyph-only rejection must be read-only");
+
+// Explicit context is authority: using the wrong K cannot be repaired by host
+// lexical state, ambient current, or the requested result.
+const wrongContextEvidence = contextualEvidence(
+  memory,
+  source,
+  vocabulary,
+  dotRole,
+  oContext,
+  C,
+  cContext,
+);
+const afterWrongContextConstruction = memory.linkCount;
+reject("wrong explicit context cannot resolve self to another current", () =>
+  replayContextualReading(new Probe(memory), wrongContextEvidence)
+);
+same(memory.linkCount, afterWrongContextConstruction, "wrong-context rejection must be read-only");
+
+// Missing the explicit K binding is underdetermined and fails closed.
+const missingContextEvidence = contextualEvidence(
+  memory,
+  source,
+  vocabulary,
+  dotRole,
+  rootContext,
+  R,
+  rootContext,
+  true,
+);
+const afterMissingContextConstruction = memory.linkCount;
+reject("missing explicit context binding", () =>
+  replayContextualReading(new Probe(memory), missingContextEvidence)
+);
+same(memory.linkCount, afterMissingContextConstruction, "missing-context rejection must be read-only");


### PR DESCRIPTION
Closes #887
Parent: #886 / #779

## ChangeIntent

```repo-guard-yaml
change_type: test
scope:
  - ts/test/research-historical-coq-self-context.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 400
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/test/research-historical-coq-self-context.test.ts
must_not_touch:
  - ts/src/**
  - contracts/**
  - repo-policy.json
  - .github/workflows/**
expected_effects:
  - executable falsification of historical Coq self as an explicit contextual occurrence
  - no production, accepted-semantic, Q-alphabet, contract, or policy delta
```

## Scope

Test-only P9-0 falsification witness. No `ts/src/**`, contract, policy, Q-alphabet, or accepted semantic changes.

Exact base at PR creation:

```text
main = b9581cf14ecb00fec322a3ef8e1e604813630bad
initial head = 42404490e49079dc50384bd7ae78d7c6c2246afd
accepted semantic base = mts-contract/v0.11
active semantic candidate = NONE
exact workflows/statuses on main = NONE
```

Adds only:

```text
ts/test/research-historical-coq-self-context.test.ts
```

The witness tests the historical reinterpretation:

```text
old Coq self
  -> explicit contextual occurrence role
  -> selected K.current
  -> accepted root Link equations
```

Positive evidence:

- one contextual self occurrence resolves from explicit `K` read-only;
- the same occurrence role resolves differently under `R`, `O`, and `C` contexts;
- two self occurrences retain two ExactSequence positions while carrying the same role;
- historical `E/O/S/R` presentation maps to current `R/O/C/L` equations:
  - `R = Pair(R,R)`
  - `O = Pair(O,R)`
  - `C = Pair(R,C)`
  - `L = Pair(O,C)`;
- replay performs zero writes.

Negative evidence:

- contextual self occurrence != semantic `DotMeaning=L⟼R`;
- physical UTF-8 `.` alone has no contextual authority;
- wrong explicit context rejects;
- missing explicit context binding rejects;
- no Self semantic primitive is introduced.

CI discovered and the second commit corrected one fixture-specific pitfall: reusing the same structural Act header canonicalized to the already-populated Act, so simply omitting a later `defineActField` call did not remove an existing attachment. The corrected malformed witness uses a fresh header context and asserts the `beforeContext` attachment count is exactly zero before replay.

Expected classification if exact-head CI/repo-guard remain green:

```text
HISTORICAL_SELF_IS_CONTEXTUAL_OCCURRENCE_SUPPORTED
production delta = NONE
semantic delta = NONE
v0.12 = NOT REQUIRED
```

P9e may then reuse the existing contextual substitution boundary, but this PR does not implement IF or any new logical connective.