### PR TITLE
feat(proof): add generic scoped assumption discharge

### DIFF
--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -170,6 +170,16 @@ export type {
 } from "./derivation.js";
 
 export {
+  StructuralScopedDerivationReplayError,
+  replayStructuralScopedDerivation,
+} from "./scoped-derivation.js";
+export type {
+  StructuralScopedDerivationEvidence,
+  StructuralScopedDerivationReplayErrorCode,
+  StructuralScopedDerivationReplayResult,
+} from "./scoped-derivation.js";
+
+export {
   PORTABLE_MTS_SEMANTIC_BASE,
   PORTABLE_STRUCTURAL_DERIVATION_SCHEMA,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA,

--- a/ts/src/scoped-derivation.ts
+++ b/ts/src/scoped-derivation.ts
@@ -1,0 +1,315 @@
+import {
+  ExactSequenceError,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+} from "./memory.js";
+import {
+  StructuralAssumptionReplayError,
+  StructuralDerivationReplayError,
+  StructuralJudgmentReplayError,
+  readStructuralDerivationRule,
+  replayStructuralDerivationWithAssumptions,
+  replayStructuralJudgment,
+  type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralDerivationWithAssumptionsReplayResult,
+  type StructuralJudgmentEvidence,
+  type StructuralJudgmentReplayResult,
+} from "./derivation.js";
+import {
+  StructuralRuleError,
+  matchStructuralTemplate,
+} from "./structural-rule.js";
+
+export interface StructuralScopedDerivationEvidence {
+  /** Inner proof replayed under the larger explicit assumption scope Γ,Δ. */
+  readonly inner: StructuralDerivationWithAssumptionsEvidence;
+  /** Explicit outer scope Γ retained after the local suffix Δ is discharged. */
+  readonly outerAssumptionContext: LinkHandle;
+  /** Ordinary admitted StructuralRule judgment producing the outer claim C. */
+  readonly conclusion: StructuralJudgmentEvidence;
+  /** Existing StructuralDerivationRule with premises [Δ..., innerTarget]. */
+  readonly derivationRule: LinkHandle;
+  readonly derivationRuleAdmission: LinkHandle;
+}
+
+export interface StructuralScopedDerivationReplayResult {
+  readonly theory: LinkHandle;
+  readonly outerAssumptionContext: LinkHandle;
+  readonly outerAssumptionClaims: readonly LinkHandle[];
+  readonly outerAssumptionOccurrences: readonly LinkHandle[];
+  readonly localAssumptionClaims: readonly LinkHandle[];
+  readonly localAssumptionOccurrences: readonly LinkHandle[];
+  readonly dischargedLocalAssumptionOccurrences: readonly LinkHandle[];
+  readonly usedOuterAssumptionOccurrences: readonly LinkHandle[];
+  readonly inner: StructuralDerivationWithAssumptionsReplayResult;
+  readonly conclusion: StructuralJudgmentReplayResult;
+}
+
+export type StructuralScopedDerivationReplayErrorCode =
+  | "invalid-scoped-evidence"
+  | "invalid-outer-assumption-context"
+  | "scope-theory-mismatch"
+  | "outer-scope-not-prefix"
+  | "invalid-inner-derivation"
+  | "invalid-conclusion"
+  | "scoped-rule-mismatch"
+  | "scoped-rule-not-admitted"
+  | "scoped-premise-count-mismatch"
+  | "scoped-premise-mismatch"
+  | "scoped-replay-wrote";
+
+export class StructuralScopedDerivationReplayError extends Error {
+  override readonly name = "StructuralScopedDerivationReplayError";
+
+  constructor(readonly code: StructuralScopedDerivationReplayErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: StructuralScopedDerivationReplayErrorCode): never {
+  throw new StructuralScopedDerivationReplayError(code);
+}
+
+interface AssumptionScope {
+  readonly theory: LinkHandle;
+  readonly claims: readonly LinkHandle[];
+  readonly occurrences: readonly LinkHandle[];
+}
+
+/**
+ * Read one P3b assumption context without widening the existing derivation
+ * kernel. ExactSequence order is semantic evidence; every listed claim must
+ * also have its explicit context->claim occurrence, exactly as P3b requires.
+ */
+function readAssumptionScope(
+  memory: ReadMemory,
+  context: LinkHandle,
+): AssumptionScope {
+  let values: readonly LinkHandle[];
+  try {
+    values = readExactSequence(memory, context).values;
+  } catch (error) {
+    if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+      fail("invalid-outer-assumption-context");
+    }
+    throw error;
+  }
+
+  const theory = values[0];
+  if (theory === undefined) fail("invalid-outer-assumption-context");
+
+  const claims = values.slice(1);
+  const unique = new Set<LinkHandle>();
+  const occurrences: LinkHandle[] = [];
+  for (const claim of claims) {
+    if (unique.has(claim)) fail("invalid-outer-assumption-context");
+    unique.add(claim);
+
+    try {
+      memory.poles(claim);
+      const occurrence = memory.find(context, claim);
+      if (occurrence === undefined) fail("invalid-outer-assumption-context");
+      occurrences.push(occurrence);
+    } catch (error) {
+      if (error instanceof StructuralScopedDerivationReplayError) throw error;
+      if (error instanceof MemoryError) fail("invalid-outer-assumption-context");
+      throw error;
+    }
+  }
+
+  return Object.freeze({
+    theory,
+    claims: Object.freeze([...claims]),
+    occurrences: Object.freeze([...occurrences]),
+  });
+}
+
+function verifyDerivationRuleAdmission(
+  memory: ReadMemory,
+  theory: LinkHandle,
+  derivationRule: LinkHandle,
+  admission: LinkHandle,
+): void {
+  try {
+    const poles = memory.poles(admission);
+    if (poles.start !== theory || poles.end !== derivationRule) {
+      fail("scoped-rule-not-admitted");
+    }
+  } catch (error) {
+    if (error instanceof StructuralScopedDerivationReplayError) throw error;
+    if (error instanceof MemoryError) fail("scoped-rule-not-admitted");
+    throw error;
+  }
+}
+
+/**
+ * Generic scoped-premise discharge.
+ *
+ * The trusted code knows only structural scopes, an existing admitted
+ * StructuralDerivationRule, and ordinary template matching. It has no logical
+ * connective/opcode semantics. Locality is proven by the exact prefix law:
+ *
+ *   innerClaims = outerClaims ++ localClaims
+ *
+ * and only that exact local suffix may disappear at this boundary.
+ */
+export function replayStructuralScopedDerivation(
+  memory: ReadMemory,
+  evidence: StructuralScopedDerivationEvidence,
+): StructuralScopedDerivationReplayResult {
+  const beforeCount = memory.linkCount;
+  try {
+    let inner: StructuralDerivationWithAssumptionsReplayResult;
+    try {
+      inner = replayStructuralDerivationWithAssumptions(memory, evidence.inner);
+    } catch (error) {
+      if (
+        error instanceof StructuralAssumptionReplayError ||
+        error instanceof StructuralDerivationReplayError ||
+        error instanceof MemoryError
+      ) {
+        fail("invalid-inner-derivation");
+      }
+      throw error;
+    }
+
+    const outer = readAssumptionScope(memory, evidence.outerAssumptionContext);
+    const theory = inner.derivation.theory;
+    if (
+      outer.theory !== theory ||
+      evidence.conclusion.judgment.theory !== theory
+    ) {
+      fail("scope-theory-mismatch");
+    }
+
+    const innerClaims = inner.declaredAssumptionClaims;
+    const innerOccurrences = inner.declaredAssumptionOccurrences;
+    if (outer.claims.length > innerClaims.length) {
+      fail("outer-scope-not-prefix");
+    }
+    for (let index = 0; index < outer.claims.length; index += 1) {
+      if (outer.claims[index] !== innerClaims[index]) {
+        fail("outer-scope-not-prefix");
+      }
+    }
+
+    const localClaims = Object.freeze(innerClaims.slice(outer.claims.length));
+    const localOccurrences = Object.freeze(innerOccurrences.slice(outer.claims.length));
+
+    let conclusion: StructuralJudgmentReplayResult;
+    try {
+      conclusion = replayStructuralJudgment(memory, evidence.conclusion);
+    } catch (error) {
+      if (
+        error instanceof StructuralJudgmentReplayError ||
+        error instanceof StructuralRuleError ||
+        error instanceof MemoryError
+      ) {
+        fail("invalid-conclusion");
+      }
+      throw error;
+    }
+
+    let derivationRule: ReturnType<typeof readStructuralDerivationRule>;
+    try {
+      derivationRule = readStructuralDerivationRule(memory, evidence.derivationRule);
+    } catch (error) {
+      if (
+        error instanceof StructuralDerivationReplayError ||
+        error instanceof ExactSequenceError ||
+        error instanceof MemoryError
+      ) {
+        fail("invalid-scoped-evidence");
+      }
+      throw error;
+    }
+
+    if (derivationRule.structuralRule !== evidence.conclusion.application.rule) {
+      fail("scoped-rule-mismatch");
+    }
+    verifyDerivationRuleAdmission(
+      memory,
+      theory,
+      evidence.derivationRule,
+      evidence.derivationRuleAdmission,
+    );
+
+    const premiseClaims = Object.freeze([
+      ...localClaims,
+      inner.derivation.target.judgment.claim,
+    ]);
+    if (derivationRule.premiseTemplates.length !== premiseClaims.length) {
+      fail("scoped-premise-count-mismatch");
+    }
+
+    for (let index = 0; index < premiseClaims.length; index += 1) {
+      const template = derivationRule.premiseTemplates[index];
+      const claim = premiseClaims[index];
+      if (template === undefined || claim === undefined) {
+        fail("scoped-premise-count-mismatch");
+      }
+      try {
+        matchStructuralTemplate(
+          memory,
+          template,
+          claim,
+          conclusion.application.bindings,
+        );
+      } catch (error) {
+        if (error instanceof StructuralRuleError || error instanceof MemoryError) {
+          fail("scoped-premise-mismatch");
+        }
+        throw error;
+      }
+    }
+
+    const usedInner = new Set(inner.usedAssumptionOccurrences);
+    const usedOuterAssumptionOccurrences: LinkHandle[] = [];
+    for (let index = 0; index < outer.occurrences.length; index += 1) {
+      const innerOccurrence = innerOccurrences[index];
+      const outerOccurrence = outer.occurrences[index];
+      if (innerOccurrence === undefined || outerOccurrence === undefined) {
+        fail("invalid-scoped-evidence");
+      }
+      if (usedInner.has(innerOccurrence)) {
+        usedOuterAssumptionOccurrences.push(outerOccurrence);
+      }
+    }
+
+    const dischargedLocalAssumptionOccurrences = localOccurrences.filter(
+      (occurrence) => usedInner.has(occurrence),
+    );
+
+    if (memory.linkCount !== beforeCount) fail("scoped-replay-wrote");
+    return Object.freeze({
+      theory,
+      outerAssumptionContext: evidence.outerAssumptionContext,
+      outerAssumptionClaims: outer.claims,
+      outerAssumptionOccurrences: outer.occurrences,
+      localAssumptionClaims: localClaims,
+      localAssumptionOccurrences: localOccurrences,
+      dischargedLocalAssumptionOccurrences: Object.freeze([
+        ...dischargedLocalAssumptionOccurrences,
+      ]),
+      usedOuterAssumptionOccurrences: Object.freeze([
+        ...usedOuterAssumptionOccurrences,
+      ]),
+      inner,
+      conclusion,
+    });
+  } catch (error) {
+    if (error instanceof StructuralScopedDerivationReplayError) throw error;
+    if (error instanceof MemoryError || error instanceof ExactSequenceError) {
+      throw new StructuralScopedDerivationReplayError("invalid-scoped-evidence");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== beforeCount) {
+      throw new StructuralScopedDerivationReplayError("scoped-replay-wrote");
+    }
+  }
+}

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -35,6 +35,8 @@ import type {
   StructuralDerivationWithAssumptionsReplayResult,
   StructuralDerivationWithTheoremsEvidence,
   StructuralJudgmentEvidence,
+  StructuralScopedDerivationEvidence,
+  StructuralScopedDerivationReplayResult,
   StructuralTheoremEvidence,
   WriteMemory,
 } from "../src/public.js";
@@ -95,6 +97,7 @@ const expectedRuntimeExports = [
   "StructuralAssumptionReplayError",
   "StructuralDerivationReplayError",
   "StructuralJudgmentReplayError",
+  "StructuralScopedDerivationReplayError",
   "StructuralTheoremReplayError",
   "StructuralTheoremReuseReplayError",
   "ValueBundleReplayError",
@@ -139,6 +142,7 @@ const expectedRuntimeExports = [
   "replayStructuralDerivationWithAssumptions",
   "replayStructuralDerivationWithTheorems",
   "replayStructuralJudgment",
+  "replayStructuralScopedDerivation",
   "replayStructuralTheorem",
   "resolveFlatBundle",
   "symbolicStackAlgebra",
@@ -147,7 +151,7 @@ const expectedRuntimeExports = [
   "verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim",
 ].sort();
 
-assert(expectedRuntimeExports.length === 79, "P7b runtime export budget must be exactly 79");
+assert(expectedRuntimeExports.length === 81, "P9a1 runtime export budget must be exactly 81");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,
@@ -221,6 +225,8 @@ const derivation: StructuralDerivationEvidence | undefined = undefined;
 const derivationWithAssumptions: StructuralDerivationWithAssumptionsEvidence | undefined = undefined;
 const derivationWithAssumptionsResult: StructuralDerivationWithAssumptionsReplayResult | undefined = undefined;
 const derivationWithTheorems: StructuralDerivationWithTheoremsEvidence | undefined = undefined;
+const scopedDerivation: StructuralScopedDerivationEvidence | undefined = undefined;
+const scopedDerivationResult: StructuralScopedDerivationReplayResult | undefined = undefined;
 const theorem: StructuralTheoremEvidence | undefined = undefined;
 const judgment: StructuralJudgmentEvidence | undefined = undefined;
 const proof: DecomposeEqualityEvidence | undefined = undefined;
@@ -272,6 +278,8 @@ void [
   derivationWithAssumptions,
   derivationWithAssumptionsResult,
   derivationWithTheorems,
+  scopedDerivation,
+  scopedDerivationResult,
   theorem,
   judgment,
   proof,

--- a/ts/test/structural-assumption-discharge.test.ts
+++ b/ts/test/structural-assumption-discharge.test.ts
@@ -1,0 +1,498 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  StructuralScopedDerivationReplayError,
+  ensureRootBasis,
+  replayStructuralScopedDerivation,
+  type LinkHandle,
+  type ReadMemory,
+  type StructuralScopedDerivationEvidence,
+} from "../src/public.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  admitStructuralDerivationRule,
+  defineStructuralAssumptionContext,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  type StructuralDerivationNodeEvidence,
+  type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`P9a1 discharge: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectError(
+  code: InstanceType<typeof StructuralScopedDerivationReplayError>["code"],
+  effect: () => unknown,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralScopedDerivationReplayError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`P9a1 discharge: ${code}: expected rejection`);
+}
+
+interface Environment {
+  readonly interpreter: LinkHandle;
+  readonly expectedInterpreter: StructuralInterpreter;
+}
+
+interface RuleFixture {
+  readonly roleDictionary: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly ruleAdmission: LinkHandle;
+  readonly derivationRule: LinkHandle;
+  readonly derivationAdmission: LinkHandle;
+}
+
+interface BuiltNode {
+  readonly occurrence: LinkHandle;
+  readonly node: StructuralDerivationNodeEvidence;
+}
+
+const memory = new Memory();
+const { R, U } = ensureRootBasis(memory);
+let cursor = U;
+const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+
+const dictionary = fresh();
+const grammar = fresh();
+const theory = fresh();
+const weakTheory = fresh();
+const pRole = fresh();
+const qRole = fresh();
+const gRole = fresh();
+const aRole = fresh();
+const bRole = fresh();
+
+const p = fresh();
+const q = fresh();
+const g = fresh();
+const a = fresh();
+const b = fresh();
+const x = fresh();
+const r = fresh();
+
+const rawPair = (left: LinkHandle, right: LinkHandle): LinkHandle =>
+  memory.ensure(left, right);
+
+function environment(selectedTheory: LinkHandle): Environment {
+  const expectedInterpreter: StructuralInterpreter = {
+    dictionary,
+    grammar,
+    theory: selectedTheory,
+  };
+  return Object.freeze({
+    expectedInterpreter,
+    interpreter: defineStructuralInterpreter(memory, dictionary, grammar, selectedTheory),
+  });
+}
+
+const main = environment(theory);
+const weak = environment(weakTheory);
+
+function defineRule(
+  selectedTheory: LinkHandle,
+  roles: readonly LinkHandle[],
+  conclusionTemplate: LinkHandle,
+  premiseTemplates: readonly LinkHandle[],
+): RuleFixture {
+  const roleDictionary = defineStructuralRoleDictionary(memory, roles);
+  const rule = defineStructuralRule(memory, roleDictionary, conclusionTemplate);
+  const ruleAdmission = admitStructuralRule(memory, selectedTheory, rule);
+  const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+  const derivationAdmission = admitStructuralDerivationRule(memory, selectedTheory, derivationRule);
+  return Object.freeze({
+    roleDictionary,
+    rule,
+    ruleAdmission,
+    derivationRule,
+    derivationAdmission,
+  });
+}
+
+function judgment(
+  selectedTheory: LinkHandle,
+  env: Environment,
+  rf: RuleFixture,
+  bindings: readonly (readonly [LinkHandle, LinkHandle])[],
+  claim: LinkHandle,
+  ruleAdmission = rf.ruleAdmission,
+): StructuralJudgmentEvidence {
+  const context = defineContext(memory, fresh(), fresh());
+  const act = defineActHeader(memory, env.interpreter, rf.roleDictionary, context);
+  for (const [role, value] of bindings) defineActField(memory, act, role, value);
+  return Object.freeze({
+    application: Object.freeze({
+      act,
+      rule: rf.rule,
+      ruleAdmission,
+      claimedBody: claim,
+      expectedInterpreter: env.expectedInterpreter,
+      expectedAfterContext: context,
+    }),
+    judgment: Object.freeze({ theory: selectedTheory, context, claim }),
+  });
+}
+
+function node(
+  selectedTheory: LinkHandle,
+  env: Environment,
+  rf: RuleFixture,
+  bindings: readonly (readonly [LinkHandle, LinkHandle])[],
+  claim: LinkHandle,
+  premises: readonly LinkHandle[],
+): BuiltNode {
+  const selected = judgment(selectedTheory, env, rf, bindings, claim);
+  const occurrence = defineStructuralProofOccurrence(memory, selected.application.act, claim);
+  return Object.freeze({
+    occurrence,
+    node: Object.freeze({
+      occurrence,
+      judgment: selected,
+      derivationRule: rf.derivationRule,
+      derivationRuleAdmission: rf.derivationAdmission,
+      premiseOccurrenceSequence: materializeExactSequence(memory, premises),
+    }),
+  });
+}
+
+function assumptions(selectedTheory: LinkHandle, ...claims: LinkHandle[]) {
+  const context = defineStructuralAssumptionContext(memory, selectedTheory, claims);
+  const occurrences = claims.map((claim) => memory.find(context, claim));
+  assert(occurrences.every((value) => value !== undefined), "missing assumption occurrence");
+  return Object.freeze({ context, occurrences: occurrences as LinkHandle[] });
+}
+
+const deriveQFromP = defineRule(theory, [pRole, qRole], qRole, [pRole]);
+const scopedIntro = defineRule(
+  theory,
+  [pRole, qRole],
+  rawPair(pRole, qRole),
+  [pRole, qRole],
+);
+
+function simpleInner(
+  selectedP: LinkHandle,
+  selectedQ: LinkHandle,
+  extraClaims: readonly LinkHandle[] = [],
+): StructuralDerivationWithAssumptionsEvidence {
+  const scope = assumptions(theory, ...extraClaims, selectedP);
+  const pOccurrence = scope.occurrences[scope.occurrences.length - 1]!;
+  const target = node(
+    theory,
+    main,
+    deriveQFromP,
+    [[pRole, selectedP], [qRole, selectedQ]],
+    selectedQ,
+    [pOccurrence],
+  );
+  return Object.freeze({
+    derivation: Object.freeze({
+      theory,
+      targetOccurrence: target.occurrence,
+      nodes: Object.freeze([target.node]),
+    }),
+    assumptionContext: scope.context,
+  });
+}
+
+function scopedEvidence(
+  inner: StructuralDerivationWithAssumptionsEvidence,
+  outerAssumptionContext: LinkHandle,
+  selectedP: LinkHandle,
+  selectedQ: LinkHandle,
+  rf = scopedIntro,
+): StructuralScopedDerivationEvidence {
+  return Object.freeze({
+    inner,
+    outerAssumptionContext,
+    conclusion: judgment(
+      theory,
+      main,
+      rf,
+      [[pRole, selectedP], [qRole, selectedQ]],
+      rawPair(selectedP, selectedQ),
+    ),
+    derivationRule: rf.derivationRule,
+    derivationRuleAdmission: rf.derivationAdmission,
+  });
+}
+
+// Γ=[]; Δ=[P]. P is a local dependency and is discharged structurally.
+const emptyOuter = assumptions(theory);
+const basic = scopedEvidence(simpleInner(p, q), emptyOuter.context, p, q);
+{
+  const before = memory.linkCount;
+  const result = replayStructuralScopedDerivation(memory, basic);
+  same(result.conclusion.judgment.claim, rawPair(p, q), "basic discharged conclusion");
+  same(result.outerAssumptionClaims.length, 0, "basic outer assumptions");
+  same(result.localAssumptionClaims.length, 1, "basic local assumption count");
+  same(result.localAssumptionClaims[0], p, "basic local P");
+  same(result.dischargedLocalAssumptionOccurrences.length, 1, "P was used and discharged");
+  same(result.usedOuterAssumptionOccurrences.length, 0, "basic result assumption-free");
+  same(memory.linkCount, before, "basic replay read-only");
+}
+
+// The same generic scoped rule works for another P/Q substitution instance.
+{
+  const p2 = fresh();
+  const q2 = fresh();
+  const result = replayStructuralScopedDerivation(
+    memory,
+    scopedEvidence(simpleInner(p2, q2), emptyOuter.context, p2, q2),
+  );
+  same(result.conclusion.judgment.claim, rawPair(p2, q2), "second substitution conclusion");
+}
+
+// Γ=[G], Δ=[P]. A branching inner proof uses both G and P; only G survives.
+const fromG = defineRule(theory, [gRole, aRole], aRole, [gRole]);
+const fromP = defineRule(theory, [pRole, bRole], bRole, [pRole]);
+const combine = defineRule(theory, [aRole, bRole, qRole], qRole, [aRole, bRole]);
+const outerG = assumptions(theory, g);
+const innerGP = assumptions(theory, g, p);
+const aNode = node(theory, main, fromG, [[gRole, g], [aRole, a]], a, [innerGP.occurrences[0]!]);
+const bNode = node(theory, main, fromP, [[pRole, p], [bRole, b]], b, [innerGP.occurrences[1]!]);
+const qNode = node(
+  theory,
+  main,
+  combine,
+  [[aRole, a], [bRole, b], [qRole, q]],
+  q,
+  [aNode.occurrence, bNode.occurrence],
+);
+const branchingInner = (nodes: readonly StructuralDerivationNodeEvidence[]) => Object.freeze({
+  derivation: Object.freeze({ theory, targetOccurrence: qNode.occurrence, nodes }),
+  assumptionContext: innerGP.context,
+});
+{
+  const first = replayStructuralScopedDerivation(
+    memory,
+    scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), outerG.context, p, q),
+  );
+  const reordered = replayStructuralScopedDerivation(
+    memory,
+    scopedEvidence(branchingInner([bNode.node, qNode.node, aNode.node]), outerG.context, p, q),
+  );
+  same(first.usedOuterAssumptionOccurrences.length, 1, "G remains an outer dependency");
+  same(first.usedOuterAssumptionOccurrences[0], outerG.occurrences[0], "outer G occurrence mapped");
+  same(first.localAssumptionClaims[0], p, "only P is local");
+  same(reordered.conclusion.judgment.claim, first.conclusion.judgment.claim, "host node order irrelevant");
+}
+
+// Wrong Theory and a non-prefix outer scope reject.
+{
+  const weakOuter = assumptions(weakTheory);
+  expectError("scope-theory-mismatch", () =>
+    replayStructuralScopedDerivation(memory, { ...basic, outerAssumptionContext: weakOuter.context }),
+  );
+
+  const wrongOuter = assumptions(theory, p);
+  const preserveG = scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), wrongOuter.context, p, q);
+  expectError("outer-scope-not-prefix", () => replayStructuralScopedDerivation(memory, preserveG));
+}
+
+// A rule cannot silently discharge a claim that belongs to Γ, nor ignore extra local suffix claims.
+{
+  const overwide = defineRule(
+    theory,
+    [gRole, pRole, qRole],
+    rawPair(pRole, qRole),
+    [gRole, pRole, qRole],
+  );
+  const attemptOuterDischarge: StructuralScopedDerivationEvidence = {
+    inner: branchingInner([qNode.node, aNode.node, bNode.node]),
+    outerAssumptionContext: outerG.context,
+    conclusion: judgment(
+      theory,
+      main,
+      overwide,
+      [[gRole, g], [pRole, p], [qRole, q]],
+      rawPair(p, q),
+    ),
+    derivationRule: overwide.derivationRule,
+    derivationRuleAdmission: overwide.derivationAdmission,
+  };
+  expectError("scoped-premise-count-mismatch", () =>
+    replayStructuralScopedDerivation(memory, attemptOuterDischarge),
+  );
+
+  const innerWithExtra = simpleInner(p, q, [g, x]);
+  expectError("scoped-premise-count-mismatch", () =>
+    replayStructuralScopedDerivation(
+      memory,
+      scopedEvidence(innerWithExtra, outerG.context, p, q),
+    ),
+  );
+}
+
+// Wrong target template, forged conclusion, wrong binding and missing inner dependency fail closed.
+{
+  const wrongTargetRule = defineRule(
+    theory,
+    [pRole, qRole],
+    rawPair(pRole, qRole),
+    [pRole, pRole],
+  );
+  expectError("scoped-premise-mismatch", () =>
+    replayStructuralScopedDerivation(
+      memory,
+      scopedEvidence(simpleInner(p, q), emptyOuter.context, p, q, wrongTargetRule),
+    ),
+  );
+
+  const forgedConclusion = {
+    ...basic,
+    conclusion: judgment(
+      theory,
+      main,
+      scopedIntro,
+      [[pRole, p], [qRole, q]],
+      rawPair(p, r),
+    ),
+  };
+  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, forgedConclusion));
+
+  const wrongBinding = {
+    ...basic,
+    conclusion: judgment(
+      theory,
+      main,
+      scopedIntro,
+      [[pRole, p], [qRole, r]],
+      rawPair(p, q),
+    ),
+  };
+  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, wrongBinding));
+
+  const scope = assumptions(theory, p);
+  const missing = defineStructuralProofOccurrence(memory, fresh(), p);
+  const broken = node(
+    theory,
+    main,
+    deriveQFromP,
+    [[pRole, p], [qRole, q]],
+    q,
+    [missing],
+  );
+  const brokenInner: StructuralDerivationWithAssumptionsEvidence = {
+    derivation: { theory, targetOccurrence: broken.occurrence, nodes: [broken.node] },
+    assumptionContext: scope.context,
+  };
+  expectError("invalid-inner-derivation", () =>
+    replayStructuralScopedDerivation(
+      memory,
+      scopedEvidence(brokenInner, emptyOuter.context, p, q),
+    ),
+  );
+}
+
+// Structural rule authority and derivation admission cannot be forged by host metadata.
+{
+  const fakeAdmission = memory.ensure(fresh(), scopedIntro.derivationRule);
+  const hostLabelled = {
+    ...basic,
+    derivationRuleAdmission: fakeAdmission,
+    discharge: "implicationIntroduction",
+  };
+  expectError("scoped-rule-not-admitted", () =>
+    replayStructuralScopedDerivation(memory, hostLabelled),
+  );
+
+  const other = defineRule(theory, [pRole, qRole], qRole, [pRole, qRole]);
+  expectError("scoped-rule-mismatch", () =>
+    replayStructuralScopedDerivation(memory, {
+      ...basic,
+      derivationRule: other.derivationRule,
+      derivationRuleAdmission: other.derivationAdmission,
+    }),
+  );
+
+  const unadmittedDictionary = defineStructuralRoleDictionary(memory, [pRole, qRole]);
+  const unadmittedRule = defineStructuralRule(memory, unadmittedDictionary, rawPair(pRole, qRole));
+  const fakeRuleAdmission = memory.ensure(fresh(), unadmittedRule);
+  const unadmittedDerivation = defineStructuralDerivationRule(memory, unadmittedRule, [pRole, qRole]);
+  const unadmittedDerivationAdmission = admitStructuralDerivationRule(memory, theory, unadmittedDerivation);
+  const unadmittedConclusion: StructuralJudgmentEvidence = (() => {
+    const context = defineContext(memory, fresh(), fresh());
+    const act = defineActHeader(memory, main.interpreter, unadmittedDictionary, context);
+    defineActField(memory, act, pRole, p);
+    defineActField(memory, act, qRole, q);
+    return {
+      application: {
+        act,
+        rule: unadmittedRule,
+        ruleAdmission: fakeRuleAdmission,
+        claimedBody: rawPair(p, q),
+        expectedInterpreter: main.expectedInterpreter,
+        expectedAfterContext: context,
+      },
+      judgment: { theory, context, claim: rawPair(p, q) },
+    };
+  })();
+  expectError("invalid-conclusion", () =>
+    replayStructuralScopedDerivation(memory, {
+      ...basic,
+      conclusion: unadmittedConclusion,
+      derivationRule: unadmittedDerivation,
+      derivationRuleAdmission: unadmittedDerivationAdmission,
+    }),
+  );
+}
+
+// An outer dependency cannot disappear merely by claiming an assumption-free result.
+{
+  expectError("scoped-premise-count-mismatch", () =>
+    replayStructuralScopedDerivation(
+      memory,
+      scopedEvidence(
+        branchingInner([qNode.node, aNode.node, bNode.node]),
+        emptyOuter.context,
+        p,
+        q,
+      ),
+    ),
+  );
+}
+
+// Read-only replay detects write injection anywhere in the composed boundary.
+{
+  let injected = false;
+  const malicious: ReadMemory = {
+    get root() { return memory.root; },
+    get linkCount() { return memory.linkCount; },
+    poles(link) { return memory.poles(link); },
+    find(start, end) {
+      if (!injected) {
+        injected = true;
+        memory.ensure(fresh(), fresh());
+      }
+      return memory.find(start, end);
+    },
+    outgoing(start) { return memory.outgoing(start); },
+    incoming(end) { return memory.incoming(end); },
+  };
+  expectError("scoped-replay-wrote", () => replayStructuralScopedDerivation(malicious, basic));
+}
+
+const GENERIC_SCOPED_ASSUMPTION_DISCHARGE_SUPPORTED = true;
+const IMPLICATION_SPECIFIC_TRUSTED_CODE_REQUIRED = false;
+assert(GENERIC_SCOPED_ASSUMPTION_DISCHARGE_SUPPORTED, "P9a1 classification");
+assert(!IMPLICATION_SPECIFIC_TRUSTED_CODE_REQUIRED, "P9a1 trusted-code boundary");

--- a/ts/test/structural-assumption-discharge.test.ts
+++ b/ts/test/structural-assumption-discharge.test.ts
@@ -1,139 +1,70 @@
 import { materializeExactSequence } from "../src/exact-sequence.js";
 import {
-  Memory,
-  StructuralScopedDerivationReplayError,
-  ensureRootBasis,
-  replayStructuralScopedDerivation,
-  type LinkHandle,
-  type ReadMemory,
+  Memory, StructuralScopedDerivationReplayError, ensureRootBasis,
+  replayStructuralScopedDerivation, type LinkHandle, type ReadMemory,
   type StructuralScopedDerivationEvidence,
 } from "../src/public.js";
 import { defineContext } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
 import {
-  admitStructuralRule,
-  defineStructuralInterpreter,
-  defineStructuralRoleDictionary,
-  defineStructuralRule,
-  type StructuralInterpreter,
+  admitStructuralRule, defineStructuralInterpreter, defineStructuralRoleDictionary,
+  defineStructuralRule, type StructuralInterpreter,
 } from "../src/structural-rule.js";
 import {
-  admitStructuralDerivationRule,
-  defineStructuralAssumptionContext,
-  defineStructuralDerivationRule,
-  defineStructuralProofOccurrence,
-  type StructuralDerivationNodeEvidence,
-  type StructuralDerivationWithAssumptionsEvidence,
+  admitStructuralDerivationRule, defineStructuralAssumptionContext,
+  defineStructuralDerivationRule, defineStructuralProofOccurrence,
+  type StructuralDerivationNodeEvidence, type StructuralDerivationWithAssumptionsEvidence,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`P9a1 discharge: ${message}`);
 }
-
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
 }
-
-function expectError(
-  code: InstanceType<typeof StructuralScopedDerivationReplayError>["code"],
-  effect: () => unknown,
-): void {
-  try {
-    effect();
-  } catch (error) {
+function expectError(code: InstanceType<typeof StructuralScopedDerivationReplayError>["code"], effect: () => unknown): void {
+  try { effect(); } catch (error) {
     assert(error instanceof StructuralScopedDerivationReplayError, `${code}: wrong error type`);
-    same(error.code, code, `${code}: wrong error code`);
-    return;
+    same(error.code, code, `${code}: wrong error code`); return;
   }
   throw new Error(`P9a1 discharge: ${code}: expected rejection`);
 }
 
-interface Environment {
-  readonly interpreter: LinkHandle;
-  readonly expectedInterpreter: StructuralInterpreter;
-}
-
+interface Environment { readonly interpreter: LinkHandle; readonly expectedInterpreter: StructuralInterpreter; }
 interface RuleFixture {
-  readonly roleDictionary: LinkHandle;
-  readonly rule: LinkHandle;
-  readonly ruleAdmission: LinkHandle;
-  readonly derivationRule: LinkHandle;
-  readonly derivationAdmission: LinkHandle;
+  readonly roleDictionary: LinkHandle; readonly rule: LinkHandle; readonly ruleAdmission: LinkHandle;
+  readonly derivationRule: LinkHandle; readonly derivationAdmission: LinkHandle;
 }
-
-interface BuiltNode {
-  readonly occurrence: LinkHandle;
-  readonly node: StructuralDerivationNodeEvidence;
-}
+interface BuiltNode { readonly occurrence: LinkHandle; readonly node: StructuralDerivationNodeEvidence; }
 
 const memory = new Memory();
 const { R, U } = ensureRootBasis(memory);
 let cursor = U;
 const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
-
-const dictionary = fresh();
-const grammar = fresh();
-const theory = fresh();
-const weakTheory = fresh();
-const pRole = fresh();
-const qRole = fresh();
-const gRole = fresh();
-const aRole = fresh();
-const bRole = fresh();
-
-const p = fresh();
-const q = fresh();
-const g = fresh();
-const a = fresh();
-const b = fresh();
-const x = fresh();
-const r = fresh();
-
-const rawPair = (left: LinkHandle, right: LinkHandle): LinkHandle =>
-  memory.ensure(left, right);
+const dictionary = fresh(), grammar = fresh(), theory = fresh(), weakTheory = fresh();
+const pRole = fresh(), qRole = fresh(), gRole = fresh(), aRole = fresh(), bRole = fresh();
+const p = fresh(), q = fresh(), g = fresh(), a = fresh(), b = fresh(), x = fresh(), r = fresh();
+const rawPair = (left: LinkHandle, right: LinkHandle): LinkHandle => memory.ensure(left, right);
 
 function environment(selectedTheory: LinkHandle): Environment {
-  const expectedInterpreter: StructuralInterpreter = {
-    dictionary,
-    grammar,
-    theory: selectedTheory,
-  };
-  return Object.freeze({
-    expectedInterpreter,
-    interpreter: defineStructuralInterpreter(memory, dictionary, grammar, selectedTheory),
-  });
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory: selectedTheory };
+  return Object.freeze({ expectedInterpreter, interpreter: defineStructuralInterpreter(memory, dictionary, grammar, selectedTheory) });
 }
-
 const main = environment(theory);
-const weak = environment(weakTheory);
 
-function defineRule(
-  selectedTheory: LinkHandle,
-  roles: readonly LinkHandle[],
-  conclusionTemplate: LinkHandle,
-  premiseTemplates: readonly LinkHandle[],
-): RuleFixture {
+function defineRule(selectedTheory: LinkHandle, roles: readonly LinkHandle[], conclusion: LinkHandle, premises: readonly LinkHandle[]): RuleFixture {
   const roleDictionary = defineStructuralRoleDictionary(memory, roles);
-  const rule = defineStructuralRule(memory, roleDictionary, conclusionTemplate);
+  const rule = defineStructuralRule(memory, roleDictionary, conclusion);
   const ruleAdmission = admitStructuralRule(memory, selectedTheory, rule);
-  const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+  const derivationRule = defineStructuralDerivationRule(memory, rule, premises);
   const derivationAdmission = admitStructuralDerivationRule(memory, selectedTheory, derivationRule);
-  return Object.freeze({
-    roleDictionary,
-    rule,
-    ruleAdmission,
-    derivationRule,
-    derivationAdmission,
-  });
+  return Object.freeze({ roleDictionary, rule, ruleAdmission, derivationRule, derivationAdmission });
 }
 
 function judgment(
-  selectedTheory: LinkHandle,
-  env: Environment,
-  rf: RuleFixture,
-  bindings: readonly (readonly [LinkHandle, LinkHandle])[],
-  claim: LinkHandle,
+  selectedTheory: LinkHandle, env: Environment, rf: RuleFixture,
+  bindings: readonly (readonly [LinkHandle, LinkHandle])[], claim: LinkHandle,
   ruleAdmission = rf.ruleAdmission,
 ): StructuralJudgmentEvidence {
   const context = defineContext(memory, fresh(), fresh());
@@ -141,37 +72,24 @@ function judgment(
   for (const [role, value] of bindings) defineActField(memory, act, role, value);
   return Object.freeze({
     application: Object.freeze({
-      act,
-      rule: rf.rule,
-      ruleAdmission,
-      claimedBody: claim,
-      expectedInterpreter: env.expectedInterpreter,
-      expectedAfterContext: context,
+      act, rule: rf.rule, ruleAdmission, claimedBody: claim,
+      expectedInterpreter: env.expectedInterpreter, expectedAfterContext: context,
     }),
     judgment: Object.freeze({ theory: selectedTheory, context, claim }),
   });
 }
 
 function node(
-  selectedTheory: LinkHandle,
-  env: Environment,
-  rf: RuleFixture,
-  bindings: readonly (readonly [LinkHandle, LinkHandle])[],
-  claim: LinkHandle,
-  premises: readonly LinkHandle[],
+  rf: RuleFixture, bindings: readonly (readonly [LinkHandle, LinkHandle])[],
+  claim: LinkHandle, premises: readonly LinkHandle[],
 ): BuiltNode {
-  const selected = judgment(selectedTheory, env, rf, bindings, claim);
+  const selected = judgment(theory, main, rf, bindings, claim);
   const occurrence = defineStructuralProofOccurrence(memory, selected.application.act, claim);
-  return Object.freeze({
-    occurrence,
-    node: Object.freeze({
-      occurrence,
-      judgment: selected,
-      derivationRule: rf.derivationRule,
-      derivationRuleAdmission: rf.derivationAdmission,
-      premiseOccurrenceSequence: materializeExactSequence(memory, premises),
-    }),
-  });
+  return Object.freeze({ occurrence, node: Object.freeze({
+    occurrence, judgment: selected, derivationRule: rf.derivationRule,
+    derivationRuleAdmission: rf.derivationAdmission,
+    premiseOccurrenceSequence: materializeExactSequence(memory, premises),
+  }) });
 }
 
 function assumptions(selectedTheory: LinkHandle, ...claims: LinkHandle[]) {
@@ -182,312 +100,152 @@ function assumptions(selectedTheory: LinkHandle, ...claims: LinkHandle[]) {
 }
 
 const deriveQFromP = defineRule(theory, [pRole, qRole], qRole, [pRole]);
-const scopedIntro = defineRule(
-  theory,
-  [pRole, qRole],
-  rawPair(pRole, qRole),
-  [pRole, qRole],
-);
+const scopedIntro = defineRule(theory, [pRole, qRole], rawPair(pRole, qRole), [pRole, qRole]);
 
-function simpleInner(
-  selectedP: LinkHandle,
-  selectedQ: LinkHandle,
-  extraClaims: readonly LinkHandle[] = [],
-): StructuralDerivationWithAssumptionsEvidence {
-  const scope = assumptions(theory, ...extraClaims, selectedP);
-  const pOccurrence = scope.occurrences[scope.occurrences.length - 1]!;
-  const target = node(
-    theory,
-    main,
-    deriveQFromP,
-    [[pRole, selectedP], [qRole, selectedQ]],
-    selectedQ,
-    [pOccurrence],
-  );
+function simpleInner(selectedP: LinkHandle, selectedQ: LinkHandle, extra: readonly LinkHandle[] = []): StructuralDerivationWithAssumptionsEvidence {
+  const scope = assumptions(theory, ...extra, selectedP);
+  const target = node(deriveQFromP, [[pRole, selectedP], [qRole, selectedQ]], selectedQ, [scope.occurrences.at(-1)!]);
   return Object.freeze({
-    derivation: Object.freeze({
-      theory,
-      targetOccurrence: target.occurrence,
-      nodes: Object.freeze([target.node]),
-    }),
+    derivation: Object.freeze({ theory, targetOccurrence: target.occurrence, nodes: Object.freeze([target.node]) }),
     assumptionContext: scope.context,
   });
 }
 
 function scopedEvidence(
-  inner: StructuralDerivationWithAssumptionsEvidence,
-  outerAssumptionContext: LinkHandle,
-  selectedP: LinkHandle,
-  selectedQ: LinkHandle,
-  rf = scopedIntro,
+  inner: StructuralDerivationWithAssumptionsEvidence, outerAssumptionContext: LinkHandle,
+  selectedP: LinkHandle, selectedQ: LinkHandle, rf = scopedIntro,
 ): StructuralScopedDerivationEvidence {
   return Object.freeze({
-    inner,
-    outerAssumptionContext,
-    conclusion: judgment(
-      theory,
-      main,
-      rf,
-      [[pRole, selectedP], [qRole, selectedQ]],
-      rawPair(selectedP, selectedQ),
-    ),
-    derivationRule: rf.derivationRule,
-    derivationRuleAdmission: rf.derivationAdmission,
+    inner, outerAssumptionContext,
+    conclusion: judgment(theory, main, rf, [[pRole, selectedP], [qRole, selectedQ]], rawPair(selectedP, selectedQ)),
+    derivationRule: rf.derivationRule, derivationRuleAdmission: rf.derivationAdmission,
   });
 }
 
-// Γ=[]; Δ=[P]. P is a local dependency and is discharged structurally.
 const emptyOuter = assumptions(theory);
 const basic = scopedEvidence(simpleInner(p, q), emptyOuter.context, p, q);
 {
   const before = memory.linkCount;
   const result = replayStructuralScopedDerivation(memory, basic);
-  same(result.conclusion.judgment.claim, rawPair(p, q), "basic discharged conclusion");
-  same(result.outerAssumptionClaims.length, 0, "basic outer assumptions");
-  same(result.localAssumptionClaims.length, 1, "basic local assumption count");
-  same(result.localAssumptionClaims[0], p, "basic local P");
-  same(result.dischargedLocalAssumptionOccurrences.length, 1, "P was used and discharged");
+  same(result.conclusion.judgment.claim, rawPair(p, q), "basic conclusion");
+  same(result.outerAssumptionClaims.length, 0, "basic outer scope");
+  same(result.localAssumptionClaims[0], p, "local P");
+  same(result.dischargedLocalAssumptionOccurrences.length, 1, "used P discharged");
   same(result.usedOuterAssumptionOccurrences.length, 0, "basic result assumption-free");
   same(memory.linkCount, before, "basic replay read-only");
 }
-
-// The same generic scoped rule works for another P/Q substitution instance.
 {
-  const p2 = fresh();
-  const q2 = fresh();
-  const result = replayStructuralScopedDerivation(
-    memory,
-    scopedEvidence(simpleInner(p2, q2), emptyOuter.context, p2, q2),
+  const p2 = fresh(), q2 = fresh();
+  same(
+    replayStructuralScopedDerivation(memory, scopedEvidence(simpleInner(p2, q2), emptyOuter.context, p2, q2)).conclusion.judgment.claim,
+    rawPair(p2, q2), "same generic rule substitutes",
   );
-  same(result.conclusion.judgment.claim, rawPair(p2, q2), "second substitution conclusion");
 }
 
-// Γ=[G], Δ=[P]. A branching inner proof uses both G and P; only G survives.
+// Γ=[G], Δ=[P]; branching proof uses both, only G survives. Host node order is transport only.
 const fromG = defineRule(theory, [gRole, aRole], aRole, [gRole]);
 const fromP = defineRule(theory, [pRole, bRole], bRole, [pRole]);
 const combine = defineRule(theory, [aRole, bRole, qRole], qRole, [aRole, bRole]);
-const outerG = assumptions(theory, g);
-const innerGP = assumptions(theory, g, p);
-const aNode = node(theory, main, fromG, [[gRole, g], [aRole, a]], a, [innerGP.occurrences[0]!]);
-const bNode = node(theory, main, fromP, [[pRole, p], [bRole, b]], b, [innerGP.occurrences[1]!]);
-const qNode = node(
-  theory,
-  main,
-  combine,
-  [[aRole, a], [bRole, b], [qRole, q]],
-  q,
-  [aNode.occurrence, bNode.occurrence],
-);
+const outerG = assumptions(theory, g), innerGP = assumptions(theory, g, p);
+const aNode = node(fromG, [[gRole, g], [aRole, a]], a, [innerGP.occurrences[0]!]);
+const bNode = node(fromP, [[pRole, p], [bRole, b]], b, [innerGP.occurrences[1]!]);
+const qNode = node(combine, [[aRole, a], [bRole, b], [qRole, q]], q, [aNode.occurrence, bNode.occurrence]);
 const branchingInner = (nodes: readonly StructuralDerivationNodeEvidence[]) => Object.freeze({
-  derivation: Object.freeze({ theory, targetOccurrence: qNode.occurrence, nodes }),
-  assumptionContext: innerGP.context,
+  derivation: Object.freeze({ theory, targetOccurrence: qNode.occurrence, nodes }), assumptionContext: innerGP.context,
 });
 {
-  const first = replayStructuralScopedDerivation(
-    memory,
-    scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), outerG.context, p, q),
-  );
-  const reordered = replayStructuralScopedDerivation(
-    memory,
-    scopedEvidence(branchingInner([bNode.node, qNode.node, aNode.node]), outerG.context, p, q),
-  );
-  same(first.usedOuterAssumptionOccurrences.length, 1, "G remains an outer dependency");
-  same(first.usedOuterAssumptionOccurrences[0], outerG.occurrences[0], "outer G occurrence mapped");
-  same(first.localAssumptionClaims[0], p, "only P is local");
-  same(reordered.conclusion.judgment.claim, first.conclusion.judgment.claim, "host node order irrelevant");
+  const first = replayStructuralScopedDerivation(memory, scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), outerG.context, p, q));
+  const reordered = replayStructuralScopedDerivation(memory, scopedEvidence(branchingInner([bNode.node, qNode.node, aNode.node]), outerG.context, p, q));
+  same(first.usedOuterAssumptionOccurrences[0], outerG.occurrences[0], "G remains dependency");
+  same(first.localAssumptionClaims[0], p, "only P local");
+  same(reordered.conclusion.judgment.claim, first.conclusion.judgment.claim, "host order irrelevant");
 }
 
-// Wrong Theory and a non-prefix outer scope reject.
+// Wrong Theory / non-prefix scope.
 {
   const weakOuter = assumptions(weakTheory);
-  expectError("scope-theory-mismatch", () =>
-    replayStructuralScopedDerivation(memory, { ...basic, outerAssumptionContext: weakOuter.context }),
-  );
-
+  expectError("scope-theory-mismatch", () => replayStructuralScopedDerivation(memory, { ...basic, outerAssumptionContext: weakOuter.context }));
   const wrongOuter = assumptions(theory, p);
-  const preserveG = scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), wrongOuter.context, p, q);
-  expectError("outer-scope-not-prefix", () => replayStructuralScopedDerivation(memory, preserveG));
+  expectError("outer-scope-not-prefix", () => replayStructuralScopedDerivation(
+    memory, scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), wrongOuter.context, p, q),
+  ));
 }
 
-// A rule cannot silently discharge a claim that belongs to Γ, nor ignore extra local suffix claims.
+// Γ cannot be silently discharged, and undeclared extra suffix claims cannot vanish.
 {
-  const overwide = defineRule(
-    theory,
-    [gRole, pRole, qRole],
-    rawPair(pRole, qRole),
-    [gRole, pRole, qRole],
-  );
-  const attemptOuterDischarge: StructuralScopedDerivationEvidence = {
-    inner: branchingInner([qNode.node, aNode.node, bNode.node]),
-    outerAssumptionContext: outerG.context,
-    conclusion: judgment(
-      theory,
-      main,
-      overwide,
-      [[gRole, g], [pRole, p], [qRole, q]],
-      rawPair(p, q),
-    ),
-    derivationRule: overwide.derivationRule,
-    derivationRuleAdmission: overwide.derivationAdmission,
-  };
-  expectError("scoped-premise-count-mismatch", () =>
-    replayStructuralScopedDerivation(memory, attemptOuterDischarge),
-  );
-
-  const innerWithExtra = simpleInner(p, q, [g, x]);
-  expectError("scoped-premise-count-mismatch", () =>
-    replayStructuralScopedDerivation(
-      memory,
-      scopedEvidence(innerWithExtra, outerG.context, p, q),
-    ),
-  );
+  const overwide = defineRule(theory, [gRole, pRole, qRole], rawPair(pRole, qRole), [gRole, pRole, qRole]);
+  expectError("scoped-premise-count-mismatch", () => replayStructuralScopedDerivation(memory, {
+    inner: branchingInner([qNode.node, aNode.node, bNode.node]), outerAssumptionContext: outerG.context,
+    conclusion: judgment(theory, main, overwide, [[gRole, g], [pRole, p], [qRole, q]], rawPair(p, q)),
+    derivationRule: overwide.derivationRule, derivationRuleAdmission: overwide.derivationAdmission,
+  }));
+  expectError("scoped-premise-count-mismatch", () => replayStructuralScopedDerivation(
+    memory, scopedEvidence(simpleInner(p, q, [g, x]), outerG.context, p, q),
+  ));
 }
 
-// Wrong target template, forged conclusion, wrong binding and missing inner dependency fail closed.
+// Wrong target template / forged conclusion / wrong role binding.
 {
-  const wrongTargetRule = defineRule(
-    theory,
-    [pRole, qRole],
-    rawPair(pRole, qRole),
-    [pRole, pRole],
-  );
-  expectError("scoped-premise-mismatch", () =>
-    replayStructuralScopedDerivation(
-      memory,
-      scopedEvidence(simpleInner(p, q), emptyOuter.context, p, q, wrongTargetRule),
-    ),
-  );
+  const wrongTarget = defineRule(theory, [pRole, qRole], rawPair(pRole, qRole), [pRole, pRole]);
+  expectError("scoped-premise-mismatch", () => replayStructuralScopedDerivation(
+    memory, scopedEvidence(simpleInner(p, q), emptyOuter.context, p, q, wrongTarget),
+  ));
+  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, {
+    ...basic, conclusion: judgment(theory, main, scopedIntro, [[pRole, p], [qRole, q]], rawPair(p, r)),
+  }));
+  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, {
+    ...basic, conclusion: judgment(theory, main, scopedIntro, [[pRole, p], [qRole, r]], rawPair(p, q)),
+  }));
+}
 
-  const forgedConclusion = {
-    ...basic,
-    conclusion: judgment(
-      theory,
-      main,
-      scopedIntro,
-      [[pRole, p], [qRole, q]],
-      rawPair(p, r),
-    ),
-  };
-  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, forgedConclusion));
-
-  const wrongBinding = {
-    ...basic,
-    conclusion: judgment(
-      theory,
-      main,
-      scopedIntro,
-      [[pRole, p], [qRole, r]],
-      rawPair(p, q),
-    ),
-  };
-  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, wrongBinding));
-
+// Missing dependency in the inner DAG.
+{
   const scope = assumptions(theory, p);
   const missing = defineStructuralProofOccurrence(memory, fresh(), p);
-  const broken = node(
-    theory,
-    main,
-    deriveQFromP,
-    [[pRole, p], [qRole, q]],
-    q,
-    [missing],
-  );
+  const broken = node(deriveQFromP, [[pRole, p], [qRole, q]], q, [missing]);
   const brokenInner: StructuralDerivationWithAssumptionsEvidence = {
-    derivation: { theory, targetOccurrence: broken.occurrence, nodes: [broken.node] },
-    assumptionContext: scope.context,
+    derivation: { theory, targetOccurrence: broken.occurrence, nodes: [broken.node] }, assumptionContext: scope.context,
   };
-  expectError("invalid-inner-derivation", () =>
-    replayStructuralScopedDerivation(
-      memory,
-      scopedEvidence(brokenInner, emptyOuter.context, p, q),
-    ),
-  );
+  expectError("invalid-inner-derivation", () => replayStructuralScopedDerivation(
+    memory, scopedEvidence(brokenInner, emptyOuter.context, p, q),
+  ));
 }
 
-// Structural rule authority and derivation admission cannot be forged by host metadata.
+// Rule/admission authority is structural; host labels grant nothing.
 {
-  const fakeAdmission = memory.ensure(fresh(), scopedIntro.derivationRule);
-  const hostLabelled = {
-    ...basic,
-    derivationRuleAdmission: fakeAdmission,
-    discharge: "implicationIntroduction",
-  };
-  expectError("scoped-rule-not-admitted", () =>
-    replayStructuralScopedDerivation(memory, hostLabelled),
-  );
+  const fakeDerivationAdmission = memory.ensure(fresh(), scopedIntro.derivationRule);
+  expectError("scoped-rule-not-admitted", () => replayStructuralScopedDerivation(memory, {
+    ...basic, derivationRuleAdmission: fakeDerivationAdmission, discharge: "implicationIntroduction",
+  } as StructuralScopedDerivationEvidence & { readonly discharge: string }));
 
   const other = defineRule(theory, [pRole, qRole], qRole, [pRole, qRole]);
-  expectError("scoped-rule-mismatch", () =>
-    replayStructuralScopedDerivation(memory, {
-      ...basic,
-      derivationRule: other.derivationRule,
-      derivationRuleAdmission: other.derivationAdmission,
-    }),
-  );
+  expectError("scoped-rule-mismatch", () => replayStructuralScopedDerivation(memory, {
+    ...basic, derivationRule: other.derivationRule, derivationRuleAdmission: other.derivationAdmission,
+  }));
 
-  const unadmittedDictionary = defineStructuralRoleDictionary(memory, [pRole, qRole]);
-  const unadmittedRule = defineStructuralRule(memory, unadmittedDictionary, rawPair(pRole, qRole));
-  const fakeRuleAdmission = memory.ensure(fresh(), unadmittedRule);
-  const unadmittedDerivation = defineStructuralDerivationRule(memory, unadmittedRule, [pRole, qRole]);
-  const unadmittedDerivationAdmission = admitStructuralDerivationRule(memory, theory, unadmittedDerivation);
-  const unadmittedConclusion: StructuralJudgmentEvidence = (() => {
-    const context = defineContext(memory, fresh(), fresh());
-    const act = defineActHeader(memory, main.interpreter, unadmittedDictionary, context);
-    defineActField(memory, act, pRole, p);
-    defineActField(memory, act, qRole, q);
-    return {
-      application: {
-        act,
-        rule: unadmittedRule,
-        ruleAdmission: fakeRuleAdmission,
-        claimedBody: rawPair(p, q),
-        expectedInterpreter: main.expectedInterpreter,
-        expectedAfterContext: context,
-      },
-      judgment: { theory, context, claim: rawPair(p, q) },
-    };
-  })();
-  expectError("invalid-conclusion", () =>
-    replayStructuralScopedDerivation(memory, {
-      ...basic,
-      conclusion: unadmittedConclusion,
-      derivationRule: unadmittedDerivation,
-      derivationRuleAdmission: unadmittedDerivationAdmission,
-    }),
-  );
+  const fakeRuleAdmission = memory.ensure(fresh(), scopedIntro.rule);
+  expectError("invalid-conclusion", () => replayStructuralScopedDerivation(memory, {
+    ...basic,
+    conclusion: { ...basic.conclusion, application: { ...basic.conclusion.application, ruleAdmission: fakeRuleAdmission } },
+  }));
 }
 
-// An outer dependency cannot disappear merely by claiming an assumption-free result.
-{
-  expectError("scoped-premise-count-mismatch", () =>
-    replayStructuralScopedDerivation(
-      memory,
-      scopedEvidence(
-        branchingInner([qNode.node, aNode.node, bNode.node]),
-        emptyOuter.context,
-        p,
-        q,
-      ),
-    ),
-  );
-}
+// Claiming assumption-free while G remains requires a rule that explicitly accounts for G; this one does not.
+expectError("scoped-premise-count-mismatch", () => replayStructuralScopedDerivation(
+  memory, scopedEvidence(branchingInner([qNode.node, aNode.node, bNode.node]), emptyOuter.context, p, q),
+));
 
-// Read-only replay detects write injection anywhere in the composed boundary.
+// Zero-write composition detects injection.
 {
   let injected = false;
   const malicious: ReadMemory = {
-    get root() { return memory.root; },
-    get linkCount() { return memory.linkCount; },
+    get root() { return memory.root; }, get linkCount() { return memory.linkCount; },
     poles(link) { return memory.poles(link); },
     find(start, end) {
-      if (!injected) {
-        injected = true;
-        memory.ensure(fresh(), fresh());
-      }
+      if (!injected) { injected = true; memory.ensure(fresh(), fresh()); }
       return memory.find(start, end);
     },
-    outgoing(start) { return memory.outgoing(start); },
-    incoming(end) { return memory.incoming(end); },
+    outgoing(start) { return memory.outgoing(start); }, incoming(end) { return memory.incoming(end); },
   };
   expectError("scoped-replay-wrote", () => replayStructuralScopedDerivation(malicious, basic));
 }


### PR DESCRIPTION
Closes #891
Parent: #886 / #779
Trigger: #889 / PR #890

## ChangeIntent

```repo-guard-yaml
change_type: implementation
scope:
  - ts/src/scoped-derivation.ts
  - ts/src/public.ts
  - ts/test/structural-assumption-discharge.test.ts
  - ts/test/public-api.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 750
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/scoped-derivation.ts
  - ts/test/structural-assumption-discharge.test.ts
  - ts/test/public-api.test.ts
must_not_touch:
  - ts/src/derivation.ts
  - contracts/**
  - repo-policy.json
  - .github/workflows/**
expected_effects:
  - add generic proof evidence for one scoped subderivation whose structurally local assumption suffix is discharged at an outer proof boundary
  - reuse existing StructuralDerivationRule and P2/P3b replay rather than introducing a second rule language
  - preserve ordinary StructuralRule data as authority for the outer conclusion shape
  - synchronize the exact package-root export contract for the new public scoped replay boundary
  - keep replay read-only and fail closed on forged scope/dependency evidence
  - no implication-specific trusted opcode and no accepted MTS semantic delta
```

## Exact branch state at PR creation

```text
base main = 48d797d51e2d224171cee6882da3ec7fdfe98a96
initial head = fbf7888d55ff79ce4d4955f86932cbdf99c30d0f
behind_by = 0
initial changed files = 3
new files = 2
initial net added lines = 581 <= 750
accepted semantic base = MTS v0.11
active semantic candidate = NONE
exact workflows on base main = NONE
```

## Implementation

Adds a higher-order, logic-neutral replay boundary without modifying `derivation.ts`:

```text
outer assumptions Γ
inner assumptions Γ,Δ
inner replay proves Q under Γ,Δ
ordinary admitted StructuralDerivationRule matches [Δ...,Q]
ordinary admitted StructuralRule produces C
----------------------------------------------
scoped result proves C under retained Γ dependencies
```

Locality is not inferred by a host filter. The verifier reconstructs both P3b assumption contexts and requires the exact prefix law:

```text
innerClaims = outerClaims ++ localClaims
```

Only the exact structural suffix is discharged. Used assumptions from the Γ prefix are remapped to the corresponding outer structural occurrences and remain explicit dependencies.

## Trusted boundary

The new replay composes existing generic primitives only:

- `replayStructuralDerivationWithAssumptions` for the complete inner P2/P3b proof;
- `replayStructuralJudgment` for the outer ordinary rule application;
- the existing `StructuralDerivationRule` format and Theory admission;
- existing `matchStructuralTemplate` with the already-verified outer role bindings;
- exact `ExactSequence` scope evidence.

There is no trusted `implicationIntroduction`, `AND`, `OR`, callback, host switch, rule kind, or theorem-specific path.

## Executable corpus

Positive coverage includes:

- Γ=[] / Δ=[P] discharge to a Pair-shaped derived claim;
- Γ=[G] / Δ=[P] with G retained as an outer dependency;
- a second P/Q substitution using the same generic machinery;
- multi-step branching inner proof;
- host node-order independence;
- read-only replay.

Negative coverage includes wrong Theory, non-prefix scopes, attempted disappearance of Γ, extra local suffix claims, wrong target templates, forged conclusion/bindings, missing inner dependencies, forged rule/admission evidence, host-only discharge labels, and write injection.

## CI-discovered required API cochange

CI #3473 passed typecheck, build and package-check, then `public-api.test.ts` correctly rejected the newly exported runtime names because the exact package-root export set was still pinned to the pre-P9a1 surface. The existing exact API-contract test is therefore added to scope and will be synchronized with the two intentional runtime exports plus compile-time smoke for the new public evidence/result types. This does not widen production semantics.

Expected classification if the updated exact-head CI and blocking repo-guard are green:

```text
GENERIC_SCOPED_ASSUMPTION_DISCHARGE_SUPPORTED
implication-specific trusted code = NONE
P3b core mutation = NONE
accepted MTS semantic delta = NONE
v0.12 = NOT REQUIRED
```
