### PR TITLE
test(proof): derive explicit L/U from contextual equality evidence

### DIFF
--- a/ts/test/derived-equality-lu.test.ts
+++ b/ts/test/derived-equality-lu.test.ts
@@ -1,0 +1,690 @@
+import { materializeExactSequence, readExactSequence } from "../src/exact-sequence.js";
+import {
+  InterpreterReplayError,
+  replayEqualityEvaluation,
+  type EqualityReplayEvidence,
+  type EqualityRoles,
+} from "../src/interpreter.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  defineContext,
+  defineLocalRepresentativeBinding,
+} from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  StructuralDerivationReplayError,
+  admitStructuralDerivationRule,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  replayStructuralDerivation,
+  type StructuralDerivationEvidence,
+  type StructuralDerivationNodeEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`P9d Eq->L/U: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectEqualityReject(effect: () => unknown, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof InterpreterReplayError, `${message}: wrong error type`);
+    same(error.code, "invalid-equality-evidence", `${message}: wrong equality error`);
+    return;
+  }
+  throw new Error(`P9d Eq->L/U: ${message}: expected equality rejection`);
+}
+
+function expectDerivationReject(effect: () => unknown, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof StructuralDerivationReplayError, `${message}: wrong error type`);
+    return;
+  }
+  throw new Error(`P9d Eq->L/U: ${message}: expected derivation rejection`);
+}
+
+type Binding = readonly [LinkHandle, LinkHandle];
+
+interface RulePack {
+  readonly roleDictionary: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly ruleAdmission: LinkHandle;
+  readonly derivationRule: LinkHandle;
+  readonly derivationAdmission: LinkHandle;
+}
+
+interface BuiltNode {
+  readonly occurrence: LinkHandle;
+  readonly node: StructuralDerivationNodeEvidence;
+}
+
+interface ResolvedNode extends BuiltNode {
+  readonly equality: EqualityReplayEvidence;
+}
+
+interface ResolvedOptions {
+  readonly omitRightRepresentative?: boolean;
+  readonly headerContext?: LinkHandle;
+}
+
+function fixture() {
+  const memory = new Memory();
+  const basis = ensureRootBasis(memory);
+  const { R, O, C, L, U } = basis;
+  assert(O !== C, "closed representative domain requires distinct O/C");
+  assert(L !== U, "boolean carrier requires distinct L/U");
+
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+  const exact = (values: readonly LinkHandle[]): LinkHandle => materializeExactSequence(memory, values);
+
+  const dictionary = fresh();
+  const grammar = fresh();
+  const theory = fresh();
+  const foreignTheory = fresh();
+  const resolvedTag = fresh();
+  const distinctTag = fresh();
+  const eqValueTag = fresh();
+
+  const contextRole = fresh();
+  const leftRole = fresh();
+  const rightRole = fresh();
+  const leftRepresentativeRole = fresh();
+  const rightRepresentativeRole = fresh();
+  const equalityRoles: EqualityRoles = Object.freeze({
+    context: contextRole,
+    left: leftRole,
+    right: rightRole,
+    leftRepresentative: leftRepresentativeRole,
+    rightRepresentative: rightRepresentativeRole,
+  });
+
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+
+  const resolved = (
+    context: LinkHandle,
+    left: LinkHandle,
+    right: LinkHandle,
+    leftRepresentative: LinkHandle,
+    rightRepresentative: LinkHandle,
+  ): LinkHandle => exact([
+    resolvedTag,
+    context,
+    left,
+    right,
+    leftRepresentative,
+    rightRepresentative,
+  ]);
+
+  const distinct = (leftRepresentative: LinkHandle, rightRepresentative: LinkHandle): LinkHandle =>
+    exact([distinctTag, leftRepresentative, rightRepresentative]);
+
+  const eqValue = (
+    context: LinkHandle,
+    left: LinkHandle,
+    right: LinkHandle,
+    result: LinkHandle,
+  ): LinkHandle => exact([eqValueTag, context, left, right, result]);
+
+  function makePack(
+    roles: readonly LinkHandle[],
+    conclusionTemplate: LinkHandle,
+    premiseTemplates: readonly LinkHandle[],
+  ): RulePack {
+    const roleDictionary = defineStructuralRoleDictionary(memory, roles);
+    const rule = defineStructuralRule(memory, roleDictionary, conclusionTemplate);
+    const ruleAdmission = admitStructuralRule(memory, theory, rule);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    const derivationAdmission = admitStructuralDerivationRule(memory, theory, derivationRule);
+    return Object.freeze({
+      roleDictionary,
+      rule,
+      ruleAdmission,
+      derivationRule,
+      derivationAdmission,
+    });
+  }
+
+  const resolvedPack = makePack(
+    [contextRole, leftRole, rightRole, leftRepresentativeRole, rightRepresentativeRole],
+    resolved(
+      contextRole,
+      leftRole,
+      rightRole,
+      leftRepresentativeRole,
+      rightRepresentativeRole,
+    ),
+    [],
+  );
+
+  const lContextRole = fresh();
+  const lLeftRole = fresh();
+  const lRightRole = fresh();
+  const lRepresentativeRole = fresh();
+  const lPack = makePack(
+    [lContextRole, lLeftRole, lRightRole, lRepresentativeRole],
+    eqValue(lContextRole, lLeftRole, lRightRole, L),
+    [resolved(
+      lContextRole,
+      lLeftRole,
+      lRightRole,
+      lRepresentativeRole,
+      lRepresentativeRole,
+    )],
+  );
+
+  const uContextRole = fresh();
+  const uLeftRole = fresh();
+  const uRightRole = fresh();
+  const uLeftRepresentativeRole = fresh();
+  const uRightRepresentativeRole = fresh();
+  const uPack = makePack(
+    [uContextRole, uLeftRole, uRightRole, uLeftRepresentativeRole, uRightRepresentativeRole],
+    eqValue(uContextRole, uLeftRole, uRightRole, U),
+    [
+      resolved(
+        uContextRole,
+        uLeftRole,
+        uRightRole,
+        uLeftRepresentativeRole,
+        uRightRepresentativeRole,
+      ),
+      distinct(uLeftRepresentativeRole, uRightRepresentativeRole),
+    ],
+  );
+
+  // The two grounded rows are the explicit closed disequality fragment over {O,C}.
+  // Equality on the diagonal is handled constructively by lPack, so no negative
+  // host predicate or global closed-world assumption is needed.
+  const distinctOC = distinct(O, C);
+  const distinctCO = distinct(C, O);
+  const distinctOCPack = makePack([], distinctOC, []);
+  const distinctCOPack = makePack([], distinctCO, []);
+
+  function node(
+    pack: RulePack,
+    bindings: readonly Binding[],
+    claim: LinkHandle,
+    premises: readonly LinkHandle[],
+    context: LinkHandle,
+    headerContext: LinkHandle = context,
+    ruleAdmission: LinkHandle = pack.ruleAdmission,
+  ): BuiltNode {
+    const act = defineActHeader(memory, interpreter, pack.roleDictionary, headerContext);
+    for (const [role, value] of bindings) defineActField(memory, act, role, value);
+    const judgment: StructuralJudgmentEvidence = {
+      application: {
+        act,
+        rule: pack.rule,
+        ruleAdmission,
+        claimedBody: claim,
+        expectedInterpreter,
+        expectedAfterContext: context,
+      },
+      judgment: { theory, context, claim },
+    };
+    const occurrence = defineStructuralProofOccurrence(memory, act, claim);
+    return Object.freeze({
+      occurrence,
+      node: Object.freeze({
+        occurrence,
+        judgment,
+        derivationRule: pack.derivationRule,
+        derivationRuleAdmission: pack.derivationAdmission,
+        premiseOccurrenceSequence: exact(premises),
+      }),
+    });
+  }
+
+  function resolvedNode(
+    context: LinkHandle,
+    left: LinkHandle,
+    right: LinkHandle,
+    leftRepresentative: LinkHandle,
+    rightRepresentative: LinkHandle,
+    options: ResolvedOptions = {},
+  ): ResolvedNode {
+    const bindings: Binding[] = [
+      [contextRole, context],
+      [leftRole, left],
+      [rightRole, right],
+      [leftRepresentativeRole, leftRepresentative],
+    ];
+    if (!options.omitRightRepresentative) {
+      bindings.push([rightRepresentativeRole, rightRepresentative]);
+    }
+    const built = node(
+      resolvedPack,
+      bindings,
+      resolved(context, left, right, leftRepresentative, rightRepresentative),
+      [],
+      context,
+      options.headerContext ?? context,
+    );
+    return Object.freeze({
+      ...built,
+      equality: Object.freeze({
+        act: built.node.judgment.application.act,
+        roles: equalityRoles,
+        interpreter,
+        roleDictionary: resolvedPack.roleDictionary,
+      }),
+    });
+  }
+
+  function lNode(
+    context: LinkHandle,
+    left: LinkHandle,
+    right: LinkHandle,
+    representative: LinkHandle,
+    resolvedOccurrence: LinkHandle,
+    result: LinkHandle = L,
+  ): BuiltNode {
+    return node(
+      lPack,
+      [
+        [lContextRole, context],
+        [lLeftRole, left],
+        [lRightRole, right],
+        [lRepresentativeRole, representative],
+      ],
+      eqValue(context, left, right, result),
+      [resolvedOccurrence],
+      context,
+    );
+  }
+
+  function uNode(
+    context: LinkHandle,
+    left: LinkHandle,
+    right: LinkHandle,
+    leftRepresentative: LinkHandle,
+    rightRepresentative: LinkHandle,
+    resolvedOccurrence: LinkHandle,
+    distinctOccurrence: LinkHandle,
+    result: LinkHandle = U,
+  ): BuiltNode {
+    return node(
+      uPack,
+      [
+        [uContextRole, context],
+        [uLeftRole, left],
+        [uRightRole, right],
+        [uLeftRepresentativeRole, leftRepresentative],
+        [uRightRepresentativeRole, rightRepresentative],
+      ],
+      eqValue(context, left, right, result),
+      [resolvedOccurrence, distinctOccurrence],
+      context,
+    );
+  }
+
+  const distinctRoot = (
+    pack: RulePack,
+    claim: LinkHandle,
+    context: LinkHandle,
+  ): BuiltNode => node(pack, [], claim, [], context);
+
+  function derivation(target: BuiltNode, nodes: readonly BuiltNode[]): StructuralDerivationEvidence {
+    return Object.freeze({
+      theory,
+      targetOccurrence: target.occurrence,
+      nodes: Object.freeze(nodes.map((built) => built.node)),
+    });
+  }
+
+  function replayVerified(
+    resolvedEvidence: readonly EqualityReplayEvidence[],
+    proof: StructuralDerivationEvidence,
+    readMemory: ReadMemory = memory,
+  ) {
+    const before = readMemory.linkCount;
+    for (const equality of resolvedEvidence) {
+      // Existing Eq_K replay validates K and both claimed representatives.
+      // Its host boolean is deliberately discarded: it does not select L/U.
+      void replayEqualityEvaluation(readMemory, equality);
+    }
+    const checked = replayStructuralDerivation(readMemory, proof);
+    same(readMemory.linkCount, before, "composed equality/derivation replay must be read-only");
+    return checked;
+  }
+
+  function resultOf(claim: LinkHandle): LinkHandle {
+    const values = readExactSequence(memory, claim).values;
+    same(values[0], eqValueTag, "EqValue tag");
+    assert(values.length === 5, "EqValue arity");
+    const result = values[4];
+    assert(result !== undefined, "EqValue result missing");
+    return result;
+  }
+
+  return {
+    memory,
+    basis,
+    theory,
+    foreignTheory,
+    resolvedPack,
+    lPack,
+    uPack,
+    distinctOC,
+    distinctCO,
+    distinctOCPack,
+    distinctCOPack,
+    fresh,
+    resolvedNode,
+    lNode,
+    uNode,
+    distinctRoot,
+    derivation,
+    replayVerified,
+    resultOf,
+  };
+}
+
+// Canonical identity and an unbound member fallback both produce L through the
+// repeated representative role. No host boolean chooses the result.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const resolved = fx.resolvedNode(K, X, X, X, X);
+  const target = fx.lNode(K, X, X, X, resolved.occurrence);
+  const checked = fx.replayVerified([resolved.equality], fx.derivation(target, [target, resolved]));
+  same(fx.resultOf(checked.target.judgment.claim), basis.L, "same semantic Link -> L");
+}
+
+// Two distinct members may resolve to one contextual representative and derive L.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  defineLocalRepresentativeBinding(memory, K, X, basis.O);
+  defineLocalRepresentativeBinding(memory, K, Y, basis.O);
+  const resolved = fx.resolvedNode(K, X, Y, basis.O, basis.O);
+  const target = fx.lNode(K, X, Y, basis.O, resolved.occurrence);
+  const checked = fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, target]));
+  same(fx.resultOf(checked.target.judgment.claim), basis.L, "context-equal distinct members -> L");
+}
+
+// The same X/Y can be L in one explicit K and U in another. U additionally
+// requires an explicit Distinct(O,C) proof row from the selected Theory.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const outer = defineContext(memory, basis.R, basis.O);
+  const inner = defineContext(memory, outer, basis.C);
+  defineLocalRepresentativeBinding(memory, outer, X, basis.O);
+  defineLocalRepresentativeBinding(memory, outer, Y, basis.O);
+  defineLocalRepresentativeBinding(memory, inner, X, basis.O);
+  defineLocalRepresentativeBinding(memory, inner, Y, basis.C);
+
+  const outerResolved = fx.resolvedNode(outer, X, Y, basis.O, basis.O);
+  const outerTarget = fx.lNode(outer, X, Y, basis.O, outerResolved.occurrence);
+  const outerChecked = fx.replayVerified(
+    [outerResolved.equality],
+    fx.derivation(outerTarget, [outerResolved, outerTarget]),
+  );
+  same(fx.resultOf(outerChecked.target.judgment.claim), basis.L, "outer Eq_K -> L");
+
+  const innerResolved = fx.resolvedNode(inner, X, Y, basis.O, basis.C);
+  const distinct = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, inner);
+  const innerTarget = fx.uNode(
+    inner,
+    X,
+    Y,
+    basis.O,
+    basis.C,
+    innerResolved.occurrence,
+    distinct.occurrence,
+  );
+  const innerChecked = fx.replayVerified(
+    [innerResolved.equality],
+    fx.derivation(innerTarget, [innerTarget, distinct, innerResolved]),
+  );
+  same(fx.resultOf(innerChecked.target.judgment.claim), basis.U, "inner explicit disequality -> U");
+}
+
+// The second off-diagonal row closes the two-representative {O,C} decision table.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.C);
+  defineLocalRepresentativeBinding(memory, K, X, basis.C);
+  defineLocalRepresentativeBinding(memory, K, Y, basis.O);
+  const resolved = fx.resolvedNode(K, X, Y, basis.C, basis.O);
+  const distinct = fx.distinctRoot(fx.distinctCOPack, fx.distinctCO, K);
+  const target = fx.uNode(K, X, Y, basis.C, basis.O, resolved.occurrence, distinct.occurrence);
+  const checked = fx.replayVerified(
+    [resolved.equality],
+    fx.derivation(target, [distinct, target, resolved]),
+  );
+  same(fx.resultOf(checked.target.judgment.claim), basis.U, "reverse closed row -> U");
+}
+
+// A valid false host equality result outside the closed fragment is not U.
+// Distinct(X,Y) was never admitted, so the only available O/C row cannot satisfy the proof.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const resolved = fx.resolvedNode(K, X, Y, X, Y);
+  const distinct = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, K);
+  const target = fx.uNode(K, X, Y, X, Y, resolved.occurrence, distinct.occurrence);
+  expectDerivationReject(
+    () => fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, distinct, target])),
+    "uncovered distinct pair must stay unknown, not U",
+  );
+}
+
+// L cannot be proposed for distinct resolved representatives.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  defineLocalRepresentativeBinding(memory, K, X, basis.O);
+  defineLocalRepresentativeBinding(memory, K, Y, basis.C);
+  const resolved = fx.resolvedNode(K, X, Y, basis.O, basis.C);
+  const target = fx.lNode(K, X, Y, basis.O, resolved.occurrence);
+  expectDerivationReject(
+    () => fx.replayVerified([resolved.equality], fx.derivation(target, [target, resolved])),
+    "distinct representatives cannot satisfy L premise",
+  );
+}
+
+// U cannot be proposed for equal representatives because there is no admitted
+// Distinct(O,O) row; borrowing Distinct(O,C) fails structural premise matching.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  defineLocalRepresentativeBinding(memory, K, X, basis.O);
+  defineLocalRepresentativeBinding(memory, K, Y, basis.O);
+  const resolved = fx.resolvedNode(K, X, Y, basis.O, basis.O);
+  const distinct = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, K);
+  const target = fx.uNode(K, X, Y, basis.O, basis.O, resolved.occurrence, distinct.occurrence);
+  expectDerivationReject(
+    () => fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, target, distinct])),
+    "equal representatives cannot satisfy U premise",
+  );
+}
+
+// Forged/missing/conflicting representative evidence is rejected by Eq_K itself
+// before any Link-valued result is available; invalid evidence is never U.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const Y = fx.fresh();
+  const forged = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  defineLocalRepresentativeBinding(memory, K, X, basis.O);
+  defineLocalRepresentativeBinding(memory, K, Y, basis.C);
+  const forgedResolved = fx.resolvedNode(K, X, Y, forged, basis.C);
+  expectEqualityReject(
+    () => fx.replayVerified([forgedResolved.equality], fx.derivation(forgedResolved, [forgedResolved])),
+    "forged representative",
+  );
+
+  const missing = fx.resolvedNode(K, X, Y, basis.O, basis.C, { omitRightRepresentative: true });
+  expectEqualityReject(
+    () => fx.replayVerified([missing.equality], fx.derivation(missing, [missing])),
+    "missing representative field",
+  );
+
+  defineLocalRepresentativeBinding(memory, K, X, basis.C);
+  const conflict = fx.resolvedNode(K, X, Y, basis.O, basis.C);
+  expectEqualityReject(
+    () => fx.replayVerified([conflict.equality], fx.derivation(conflict, [conflict])),
+    "representative conflict",
+  );
+}
+
+// A foreign Act header context is invalid equality evidence, not false/U.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const foreignK = defineContext(memory, basis.R, basis.C);
+  const resolved = fx.resolvedNode(K, X, X, X, X, { headerContext: foreignK });
+  expectEqualityReject(
+    () => fx.replayVerified([resolved.equality], fx.derivation(resolved, [resolved])),
+    "foreign equality context",
+  );
+}
+
+// An alternate truth atom cannot impersonate L even when Eq_K is valid.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const alternate = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const resolved = fx.resolvedNode(K, X, X, X, X);
+  const target = fx.lNode(K, X, X, X, resolved.occurrence, alternate);
+  expectDerivationReject(
+    () => fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, target])),
+    "alternate boolean atom",
+  );
+}
+
+// Host metadata has no semantic authority. Even metadata claiming U/false cannot
+// alter an equality proof whose structural representatives derive L.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const resolved = fx.resolvedNode(K, X, X, X, X);
+  const noisyEquality = Object.freeze({ ...resolved.equality, equal: false, branch: "U" });
+  const target = fx.lNode(K, X, X, X, resolved.occurrence);
+  const checked = fx.replayVerified([noisyEquality], fx.derivation(target, [target, resolved]));
+  same(fx.resultOf(checked.target.judgment.claim), basis.L, "host metadata cannot select U");
+}
+
+// Wrong Theory admission cannot authorize the otherwise matching L rule.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const resolved = fx.resolvedNode(K, X, X, X, X);
+  const target = fx.lNode(K, X, X, X, resolved.occurrence);
+  const foreignAdmission = memory.ensure(fx.foreignTheory, fx.lPack.rule);
+  const forgedTarget: BuiltNode = Object.freeze({
+    occurrence: target.occurrence,
+    node: Object.freeze({
+      ...target.node,
+      judgment: Object.freeze({
+        ...target.node.judgment,
+        application: Object.freeze({
+          ...target.node.judgment.application,
+          ruleAdmission: foreignAdmission,
+        }),
+      }),
+    }),
+  });
+  expectDerivationReject(
+    () => fx.replayVerified(
+      [resolved.equality],
+      fx.derivation(forgedTarget, [resolved, forgedTarget]),
+    ),
+    "wrong Theory admission",
+  );
+}
+
+class WriteInjectingProbe implements ReadMemory {
+  private injected = false;
+
+  constructor(
+    private readonly source: Memory,
+    private readonly injectStart: LinkHandle,
+    private readonly injectEnd: LinkHandle,
+  ) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
+  find(): LinkHandle | undefined { throw new Error("P9d probe: find is forbidden"); }
+  incoming(): readonly LinkHandle[] { throw new Error("P9d probe: incoming is forbidden"); }
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    if (!this.injected) {
+      this.injected = true;
+      this.source.ensure(this.injectStart, this.injectEnd);
+    }
+    return this.source.outgoing(start);
+  }
+}
+
+// A hostile ReadMemory that mutates during replay is rejected instead of turning
+// an unstable lookup into either L or U.
+{
+  const fx = fixture();
+  const { memory, basis } = fx;
+  const X = fx.fresh();
+  const K = defineContext(memory, basis.R, basis.O);
+  const resolved = fx.resolvedNode(K, X, X, X, X);
+  const injectStart = fx.fresh();
+  const injectEnd = fx.fresh();
+  assert(memory.find(injectStart, injectEnd) === undefined, "write-injection pair must start absent");
+  const probe = new WriteInjectingProbe(memory, injectStart, injectEnd);
+  expectEqualityReject(
+    () => fx.replayVerified([resolved.equality], fx.derivation(resolved, [resolved]), probe),
+    "write injection",
+  );
+}

--- a/ts/test/derived-equality-lu.test.ts
+++ b/ts/test/derived-equality-lu.test.ts
@@ -1,63 +1,43 @@
 import { materializeExactSequence, readExactSequence } from "../src/exact-sequence.js";
 import {
-  InterpreterReplayError,
-  replayEqualityEvaluation,
-  type EqualityReplayEvidence,
-  type EqualityRoles,
+  InterpreterReplayError, replayEqualityEvaluation,
+  type EqualityReplayEvidence, type EqualityRoles,
 } from "../src/interpreter.js";
 import {
-  Memory,
-  ensureRootBasis,
-  type LinkHandle,
-  type LinkPoles,
-  type ReadMemory,
+  Memory, ensureRootBasis,
+  type LinkHandle, type LinkPoles, type ReadMemory,
 } from "../src/memory.js";
-import {
-  defineContext,
-  defineLocalRepresentativeBinding,
-} from "../src/state.js";
+import { defineContext, defineLocalRepresentativeBinding } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
 import {
-  admitStructuralRule,
-  defineStructuralInterpreter,
-  defineStructuralRoleDictionary,
-  defineStructuralRule,
+  admitStructuralRule, defineStructuralInterpreter,
+  defineStructuralRoleDictionary, defineStructuralRule,
   type StructuralInterpreter,
 } from "../src/structural-rule.js";
 import {
-  StructuralDerivationReplayError,
-  admitStructuralDerivationRule,
-  defineStructuralDerivationRule,
-  defineStructuralProofOccurrence,
+  StructuralDerivationReplayError, admitStructuralDerivationRule,
+  defineStructuralDerivationRule, defineStructuralProofOccurrence,
   replayStructuralDerivation,
-  type StructuralDerivationEvidence,
-  type StructuralDerivationNodeEvidence,
+  type StructuralDerivationEvidence, type StructuralDerivationNodeEvidence,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`P9d Eq->L/U: ${message}`);
 }
-
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
 }
-
-function expectEqualityReject(effect: () => unknown, message: string): void {
-  try {
-    effect();
-  } catch (error) {
+function equalityReject(effect: () => unknown, message: string): void {
+  try { effect(); } catch (error) {
     assert(error instanceof InterpreterReplayError, `${message}: wrong error type`);
     same(error.code, "invalid-equality-evidence", `${message}: wrong equality error`);
     return;
   }
   throw new Error(`P9d Eq->L/U: ${message}: expected equality rejection`);
 }
-
-function expectDerivationReject(effect: () => unknown, message: string): void {
-  try {
-    effect();
-  } catch (error) {
+function derivationReject(effect: () => unknown, message: string): void {
+  try { effect(); } catch (error) {
     assert(error instanceof StructuralDerivationReplayError, `${message}: wrong error type`);
     return;
   }
@@ -65,7 +45,6 @@ function expectDerivationReject(effect: () => unknown, message: string): void {
 }
 
 type Binding = readonly [LinkHandle, LinkHandle];
-
 interface RulePack {
   readonly roleDictionary: LinkHandle;
   readonly rule: LinkHandle;
@@ -73,618 +52,304 @@ interface RulePack {
   readonly derivationRule: LinkHandle;
   readonly derivationAdmission: LinkHandle;
 }
-
-interface BuiltNode {
-  readonly occurrence: LinkHandle;
-  readonly node: StructuralDerivationNodeEvidence;
-}
-
-interface ResolvedNode extends BuiltNode {
-  readonly equality: EqualityReplayEvidence;
-}
-
-interface ResolvedOptions {
-  readonly omitRightRepresentative?: boolean;
-  readonly headerContext?: LinkHandle;
-}
+interface BuiltNode { readonly occurrence: LinkHandle; readonly node: StructuralDerivationNodeEvidence; }
+interface ResolvedNode extends BuiltNode { readonly equality: EqualityReplayEvidence; }
+interface ResolvedOptions { readonly omitRightRepresentative?: boolean; readonly headerContext?: LinkHandle; }
 
 function fixture() {
   const memory = new Memory();
   const basis = ensureRootBasis(memory);
   const { R, O, C, L, U } = basis;
-  assert(O !== C, "closed representative domain requires distinct O/C");
-  assert(L !== U, "boolean carrier requires distinct L/U");
-
+  assert(O !== C && L !== U, "closed O/C and L/U carriers must be distinct");
   let cursor = U;
   const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
-  const exact = (values: readonly LinkHandle[]): LinkHandle => materializeExactSequence(memory, values);
+  const exact = (values: readonly LinkHandle[]) => materializeExactSequence(memory, values);
 
-  const dictionary = fresh();
-  const grammar = fresh();
-  const theory = fresh();
-  const foreignTheory = fresh();
-  const resolvedTag = fresh();
-  const distinctTag = fresh();
-  const eqValueTag = fresh();
-
-  const contextRole = fresh();
-  const leftRole = fresh();
-  const rightRole = fresh();
-  const leftRepresentativeRole = fresh();
-  const rightRepresentativeRole = fresh();
+  const dictionary = fresh(), grammar = fresh(), theory = fresh(), foreignTheory = fresh();
+  const resolvedTag = fresh(), distinctTag = fresh(), eqValueTag = fresh();
+  const contextRole = fresh(), leftRole = fresh(), rightRole = fresh();
+  const leftRepresentativeRole = fresh(), rightRepresentativeRole = fresh();
   const equalityRoles: EqualityRoles = Object.freeze({
-    context: contextRole,
-    left: leftRole,
-    right: rightRole,
-    leftRepresentative: leftRepresentativeRole,
-    rightRepresentative: rightRepresentativeRole,
+    context: contextRole, left: leftRole, right: rightRole,
+    leftRepresentative: leftRepresentativeRole, rightRepresentative: rightRepresentativeRole,
   });
-
   const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
   const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
 
-  const resolved = (
-    context: LinkHandle,
-    left: LinkHandle,
-    right: LinkHandle,
-    leftRepresentative: LinkHandle,
-    rightRepresentative: LinkHandle,
-  ): LinkHandle => exact([
-    resolvedTag,
-    context,
-    left,
-    right,
-    leftRepresentative,
-    rightRepresentative,
-  ]);
+  const resolved = (K: LinkHandle, A: LinkHandle, B: LinkHandle, RA: LinkHandle, RB: LinkHandle) =>
+    exact([resolvedTag, K, A, B, RA, RB]);
+  const distinct = (RA: LinkHandle, RB: LinkHandle) => exact([distinctTag, RA, RB]);
+  const eqValue = (K: LinkHandle, A: LinkHandle, B: LinkHandle, result: LinkHandle) =>
+    exact([eqValueTag, K, A, B, result]);
 
-  const distinct = (leftRepresentative: LinkHandle, rightRepresentative: LinkHandle): LinkHandle =>
-    exact([distinctTag, leftRepresentative, rightRepresentative]);
-
-  const eqValue = (
-    context: LinkHandle,
-    left: LinkHandle,
-    right: LinkHandle,
-    result: LinkHandle,
-  ): LinkHandle => exact([eqValueTag, context, left, right, result]);
-
-  function makePack(
-    roles: readonly LinkHandle[],
-    conclusionTemplate: LinkHandle,
-    premiseTemplates: readonly LinkHandle[],
-  ): RulePack {
+  function pack(roles: readonly LinkHandle[], conclusion: LinkHandle, premises: readonly LinkHandle[]): RulePack {
     const roleDictionary = defineStructuralRoleDictionary(memory, roles);
-    const rule = defineStructuralRule(memory, roleDictionary, conclusionTemplate);
+    const rule = defineStructuralRule(memory, roleDictionary, conclusion);
     const ruleAdmission = admitStructuralRule(memory, theory, rule);
-    const derivationRule = defineStructuralDerivationRule(memory, rule, premiseTemplates);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, premises);
     const derivationAdmission = admitStructuralDerivationRule(memory, theory, derivationRule);
-    return Object.freeze({
-      roleDictionary,
-      rule,
-      ruleAdmission,
-      derivationRule,
-      derivationAdmission,
-    });
+    return Object.freeze({ roleDictionary, rule, ruleAdmission, derivationRule, derivationAdmission });
   }
 
-  const resolvedPack = makePack(
+  const resolvedPack = pack(
     [contextRole, leftRole, rightRole, leftRepresentativeRole, rightRepresentativeRole],
-    resolved(
-      contextRole,
-      leftRole,
-      rightRole,
-      leftRepresentativeRole,
-      rightRepresentativeRole,
-    ),
-    [],
+    resolved(contextRole, leftRole, rightRole, leftRepresentativeRole, rightRepresentativeRole), [],
   );
-
-  const lContextRole = fresh();
-  const lLeftRole = fresh();
-  const lRightRole = fresh();
-  const lRepresentativeRole = fresh();
-  const lPack = makePack(
-    [lContextRole, lLeftRole, lRightRole, lRepresentativeRole],
-    eqValue(lContextRole, lLeftRole, lRightRole, L),
-    [resolved(
-      lContextRole,
-      lLeftRole,
-      lRightRole,
-      lRepresentativeRole,
-      lRepresentativeRole,
-    )],
+  const lK = fresh(), lA = fresh(), lB = fresh(), lR = fresh();
+  const lPack = pack(
+    [lK, lA, lB, lR], eqValue(lK, lA, lB, L), [resolved(lK, lA, lB, lR, lR)],
   );
-
-  const uContextRole = fresh();
-  const uLeftRole = fresh();
-  const uRightRole = fresh();
-  const uLeftRepresentativeRole = fresh();
-  const uRightRepresentativeRole = fresh();
-  const uPack = makePack(
-    [uContextRole, uLeftRole, uRightRole, uLeftRepresentativeRole, uRightRepresentativeRole],
-    eqValue(uContextRole, uLeftRole, uRightRole, U),
-    [
-      resolved(
-        uContextRole,
-        uLeftRole,
-        uRightRole,
-        uLeftRepresentativeRole,
-        uRightRepresentativeRole,
-      ),
-      distinct(uLeftRepresentativeRole, uRightRepresentativeRole),
-    ],
+  const uK = fresh(), uA = fresh(), uB = fresh(), uRA = fresh(), uRB = fresh();
+  const uPack = pack(
+    [uK, uA, uB, uRA, uRB], eqValue(uK, uA, uB, U),
+    [resolved(uK, uA, uB, uRA, uRB), distinct(uRA, uRB)],
   );
-
-  // The two grounded rows are the explicit closed disequality fragment over {O,C}.
-  // Equality on the diagonal is handled constructively by lPack, so no negative
-  // host predicate or global closed-world assumption is needed.
-  const distinctOC = distinct(O, C);
-  const distinctCO = distinct(C, O);
-  const distinctOCPack = makePack([], distinctOC, []);
-  const distinctCOPack = makePack([], distinctCO, []);
+  const distinctOC = distinct(O, C), distinctCO = distinct(C, O);
+  const distinctOCPack = pack([], distinctOC, []), distinctCOPack = pack([], distinctCO, []);
 
   function node(
-    pack: RulePack,
-    bindings: readonly Binding[],
-    claim: LinkHandle,
-    premises: readonly LinkHandle[],
-    context: LinkHandle,
-    headerContext: LinkHandle = context,
-    ruleAdmission: LinkHandle = pack.ruleAdmission,
+    p: RulePack, bindings: readonly Binding[], claim: LinkHandle,
+    premises: readonly LinkHandle[], context: LinkHandle,
+    headerContext: LinkHandle = context, ruleAdmission: LinkHandle = p.ruleAdmission,
   ): BuiltNode {
-    const act = defineActHeader(memory, interpreter, pack.roleDictionary, headerContext);
+    const act = defineActHeader(memory, interpreter, p.roleDictionary, headerContext);
     for (const [role, value] of bindings) defineActField(memory, act, role, value);
     const judgment: StructuralJudgmentEvidence = {
       application: {
-        act,
-        rule: pack.rule,
-        ruleAdmission,
-        claimedBody: claim,
-        expectedInterpreter,
-        expectedAfterContext: context,
+        act, rule: p.rule, ruleAdmission, claimedBody: claim,
+        expectedInterpreter, expectedAfterContext: context,
       },
       judgment: { theory, context, claim },
     };
     const occurrence = defineStructuralProofOccurrence(memory, act, claim);
-    return Object.freeze({
-      occurrence,
-      node: Object.freeze({
-        occurrence,
-        judgment,
-        derivationRule: pack.derivationRule,
-        derivationRuleAdmission: pack.derivationAdmission,
-        premiseOccurrenceSequence: exact(premises),
-      }),
-    });
+    return Object.freeze({ occurrence, node: Object.freeze({
+      occurrence, judgment, derivationRule: p.derivationRule,
+      derivationRuleAdmission: p.derivationAdmission,
+      premiseOccurrenceSequence: exact(premises),
+    }) });
   }
 
   function resolvedNode(
-    context: LinkHandle,
-    left: LinkHandle,
-    right: LinkHandle,
-    leftRepresentative: LinkHandle,
-    rightRepresentative: LinkHandle,
+    K: LinkHandle, A: LinkHandle, B: LinkHandle, RA: LinkHandle, RB: LinkHandle,
     options: ResolvedOptions = {},
   ): ResolvedNode {
     const bindings: Binding[] = [
-      [contextRole, context],
-      [leftRole, left],
-      [rightRole, right],
-      [leftRepresentativeRole, leftRepresentative],
+      [contextRole, K], [leftRole, A], [rightRole, B], [leftRepresentativeRole, RA],
     ];
-    if (!options.omitRightRepresentative) {
-      bindings.push([rightRepresentativeRole, rightRepresentative]);
-    }
+    if (!options.omitRightRepresentative) bindings.push([rightRepresentativeRole, RB]);
     const built = node(
-      resolvedPack,
-      bindings,
-      resolved(context, left, right, leftRepresentative, rightRepresentative),
-      [],
-      context,
-      options.headerContext ?? context,
+      resolvedPack, bindings, resolved(K, A, B, RA, RB), [], K, options.headerContext ?? K,
     );
-    return Object.freeze({
-      ...built,
-      equality: Object.freeze({
-        act: built.node.judgment.application.act,
-        roles: equalityRoles,
-        interpreter,
-        roleDictionary: resolvedPack.roleDictionary,
-      }),
-    });
+    return Object.freeze({ ...built, equality: Object.freeze({
+      act: built.node.judgment.application.act, roles: equalityRoles,
+      interpreter, roleDictionary: resolvedPack.roleDictionary,
+    }) });
   }
 
-  function lNode(
-    context: LinkHandle,
-    left: LinkHandle,
-    right: LinkHandle,
-    representative: LinkHandle,
-    resolvedOccurrence: LinkHandle,
-    result: LinkHandle = L,
-  ): BuiltNode {
-    return node(
-      lPack,
-      [
-        [lContextRole, context],
-        [lLeftRole, left],
-        [lRightRole, right],
-        [lRepresentativeRole, representative],
-      ],
-      eqValue(context, left, right, result),
-      [resolvedOccurrence],
-      context,
-    );
-  }
+  const lNode = (
+    K: LinkHandle, A: LinkHandle, B: LinkHandle, R0: LinkHandle,
+    premise: LinkHandle, result: LinkHandle = L,
+  ) => node(lPack, [[lK, K], [lA, A], [lB, B], [lR, R0]], eqValue(K, A, B, result), [premise], K);
 
-  function uNode(
-    context: LinkHandle,
-    left: LinkHandle,
-    right: LinkHandle,
-    leftRepresentative: LinkHandle,
-    rightRepresentative: LinkHandle,
-    resolvedOccurrence: LinkHandle,
-    distinctOccurrence: LinkHandle,
-    result: LinkHandle = U,
-  ): BuiltNode {
-    return node(
-      uPack,
-      [
-        [uContextRole, context],
-        [uLeftRole, left],
-        [uRightRole, right],
-        [uLeftRepresentativeRole, leftRepresentative],
-        [uRightRepresentativeRole, rightRepresentative],
-      ],
-      eqValue(context, left, right, result),
-      [resolvedOccurrence, distinctOccurrence],
-      context,
-    );
-  }
-
-  const distinctRoot = (
-    pack: RulePack,
-    claim: LinkHandle,
-    context: LinkHandle,
-  ): BuiltNode => node(pack, [], claim, [], context);
-
-  function derivation(target: BuiltNode, nodes: readonly BuiltNode[]): StructuralDerivationEvidence {
-    return Object.freeze({
-      theory,
-      targetOccurrence: target.occurrence,
-      nodes: Object.freeze(nodes.map((built) => built.node)),
-    });
-  }
+  const uNode = (
+    K: LinkHandle, A: LinkHandle, B: LinkHandle, RA: LinkHandle, RB: LinkHandle,
+    resolvedOccurrence: LinkHandle, distinctOccurrence: LinkHandle, result: LinkHandle = U,
+  ) => node(
+    uPack, [[uK, K], [uA, A], [uB, B], [uRA, RA], [uRB, RB]],
+    eqValue(K, A, B, result), [resolvedOccurrence, distinctOccurrence], K,
+  );
+  const distinctRoot = (p: RulePack, claim: LinkHandle, K: LinkHandle) => node(p, [], claim, [], K);
+  const derivation = (target: BuiltNode, nodes: readonly BuiltNode[]): StructuralDerivationEvidence =>
+    Object.freeze({ theory, targetOccurrence: target.occurrence, nodes: Object.freeze(nodes.map((x) => x.node)) });
 
   function replayVerified(
-    resolvedEvidence: readonly EqualityReplayEvidence[],
-    proof: StructuralDerivationEvidence,
+    equalities: readonly EqualityReplayEvidence[], proof: StructuralDerivationEvidence,
     readMemory: ReadMemory = memory,
   ) {
     const before = readMemory.linkCount;
-    for (const equality of resolvedEvidence) {
-      // Existing Eq_K replay validates K and both claimed representatives.
-      // Its host boolean is deliberately discarded: it does not select L/U.
-      void replayEqualityEvaluation(readMemory, equality);
-    }
+    for (const equality of equalities) void replayEqualityEvaluation(readMemory, equality);
     const checked = replayStructuralDerivation(readMemory, proof);
-    same(readMemory.linkCount, before, "composed equality/derivation replay must be read-only");
+    same(readMemory.linkCount, before, "composed replay must be read-only");
     return checked;
   }
-
   function resultOf(claim: LinkHandle): LinkHandle {
     const values = readExactSequence(memory, claim).values;
     same(values[0], eqValueTag, "EqValue tag");
-    assert(values.length === 5, "EqValue arity");
-    const result = values[4];
-    assert(result !== undefined, "EqValue result missing");
-    return result;
+    assert(values.length === 5 && values[4] !== undefined, "EqValue shape");
+    return values[4]!;
   }
-
   return {
-    memory,
-    basis,
-    theory,
-    foreignTheory,
-    resolvedPack,
-    lPack,
-    uPack,
-    distinctOC,
-    distinctCO,
-    distinctOCPack,
-    distinctCOPack,
-    fresh,
-    resolvedNode,
-    lNode,
-    uNode,
-    distinctRoot,
-    derivation,
-    replayVerified,
-    resultOf,
+    memory, basis, theory, foreignTheory, lPack,
+    distinctOC, distinctCO, distinctOCPack, distinctCOPack,
+    fresh, resolvedNode, lNode, uNode, distinctRoot, derivation, replayVerified, resultOf,
   };
 }
 
-// Canonical identity and an unbound member fallback both produce L through the
-// repeated representative role. No host boolean chooses the result.
+// Unbound canonical fallback Rep_K(X)=X is valid resolved evidence and derives L.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const resolved = fx.resolvedNode(K, X, X, X, X);
-  const target = fx.lNode(K, X, X, X, resolved.occurrence);
-  const checked = fx.replayVerified([resolved.equality], fx.derivation(target, [target, resolved]));
-  same(fx.resultOf(checked.target.judgment.claim), basis.L, "same semantic Link -> L");
+  const fx = fixture(), X = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  const r = fx.resolvedNode(K, X, X, X, X), t = fx.lNode(K, X, X, X, r.occurrence);
+  const checked = fx.replayVerified([r.equality], fx.derivation(t, [t, r]));
+  same(fx.resultOf(checked.target.judgment.claim), fx.basis.L, "same semantic Link -> L");
 }
 
-// Two distinct members may resolve to one contextual representative and derive L.
+// Distinct members resolving to one representative derive L.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  defineLocalRepresentativeBinding(memory, K, X, basis.O);
-  defineLocalRepresentativeBinding(memory, K, Y, basis.O);
-  const resolved = fx.resolvedNode(K, X, Y, basis.O, basis.O);
-  const target = fx.lNode(K, X, Y, basis.O, resolved.occurrence);
-  const checked = fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, target]));
-  same(fx.resultOf(checked.target.judgment.claim), basis.L, "context-equal distinct members -> L");
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, X, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, Y, fx.basis.O);
+  const r = fx.resolvedNode(K, X, Y, fx.basis.O, fx.basis.O);
+  const t = fx.lNode(K, X, Y, fx.basis.O, r.occurrence);
+  const checked = fx.replayVerified([r.equality], fx.derivation(t, [r, t]));
+  same(fx.resultOf(checked.target.judgment.claim), fx.basis.L, "context-equal members -> L");
 }
 
-// The same X/Y can be L in one explicit K and U in another. U additionally
-// requires an explicit Distinct(O,C) proof row from the selected Theory.
+// Same X/Y: outer K is L; inner K is U only with explicit Distinct(O,C) evidence.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const outer = defineContext(memory, basis.R, basis.O);
-  const inner = defineContext(memory, outer, basis.C);
-  defineLocalRepresentativeBinding(memory, outer, X, basis.O);
-  defineLocalRepresentativeBinding(memory, outer, Y, basis.O);
-  defineLocalRepresentativeBinding(memory, inner, X, basis.O);
-  defineLocalRepresentativeBinding(memory, inner, Y, basis.C);
-
-  const outerResolved = fx.resolvedNode(outer, X, Y, basis.O, basis.O);
-  const outerTarget = fx.lNode(outer, X, Y, basis.O, outerResolved.occurrence);
-  const outerChecked = fx.replayVerified(
-    [outerResolved.equality],
-    fx.derivation(outerTarget, [outerResolved, outerTarget]),
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh();
+  const outer = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  const inner = defineContext(fx.memory, outer, fx.basis.C);
+  defineLocalRepresentativeBinding(fx.memory, outer, X, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, outer, Y, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, inner, X, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, inner, Y, fx.basis.C);
+  const ro = fx.resolvedNode(outer, X, Y, fx.basis.O, fx.basis.O);
+  const to = fx.lNode(outer, X, Y, fx.basis.O, ro.occurrence);
+  same(
+    fx.resultOf(fx.replayVerified([ro.equality], fx.derivation(to, [ro, to])).target.judgment.claim),
+    fx.basis.L, "outer Eq_K -> L",
   );
-  same(fx.resultOf(outerChecked.target.judgment.claim), basis.L, "outer Eq_K -> L");
-
-  const innerResolved = fx.resolvedNode(inner, X, Y, basis.O, basis.C);
-  const distinct = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, inner);
-  const innerTarget = fx.uNode(
-    inner,
-    X,
-    Y,
-    basis.O,
-    basis.C,
-    innerResolved.occurrence,
-    distinct.occurrence,
-  );
-  const innerChecked = fx.replayVerified(
-    [innerResolved.equality],
-    fx.derivation(innerTarget, [innerTarget, distinct, innerResolved]),
-  );
-  same(fx.resultOf(innerChecked.target.judgment.claim), basis.U, "inner explicit disequality -> U");
-}
-
-// The second off-diagonal row closes the two-representative {O,C} decision table.
-{
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.C);
-  defineLocalRepresentativeBinding(memory, K, X, basis.C);
-  defineLocalRepresentativeBinding(memory, K, Y, basis.O);
-  const resolved = fx.resolvedNode(K, X, Y, basis.C, basis.O);
-  const distinct = fx.distinctRoot(fx.distinctCOPack, fx.distinctCO, K);
-  const target = fx.uNode(K, X, Y, basis.C, basis.O, resolved.occurrence, distinct.occurrence);
-  const checked = fx.replayVerified(
-    [resolved.equality],
-    fx.derivation(target, [distinct, target, resolved]),
-  );
-  same(fx.resultOf(checked.target.judgment.claim), basis.U, "reverse closed row -> U");
-}
-
-// A valid false host equality result outside the closed fragment is not U.
-// Distinct(X,Y) was never admitted, so the only available O/C row cannot satisfy the proof.
-{
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const resolved = fx.resolvedNode(K, X, Y, X, Y);
-  const distinct = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, K);
-  const target = fx.uNode(K, X, Y, X, Y, resolved.occurrence, distinct.occurrence);
-  expectDerivationReject(
-    () => fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, distinct, target])),
-    "uncovered distinct pair must stay unknown, not U",
+  const ri = fx.resolvedNode(inner, X, Y, fx.basis.O, fx.basis.C);
+  const d = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, inner);
+  const ti = fx.uNode(inner, X, Y, fx.basis.O, fx.basis.C, ri.occurrence, d.occurrence);
+  same(
+    fx.resultOf(fx.replayVerified([ri.equality], fx.derivation(ti, [ti, d, ri])).target.judgment.claim),
+    fx.basis.U, "inner explicit disequality -> U",
   );
 }
 
-// L cannot be proposed for distinct resolved representatives.
+// Reverse off-diagonal row closes the explicit {O,C} decision fragment.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  defineLocalRepresentativeBinding(memory, K, X, basis.O);
-  defineLocalRepresentativeBinding(memory, K, Y, basis.C);
-  const resolved = fx.resolvedNode(K, X, Y, basis.O, basis.C);
-  const target = fx.lNode(K, X, Y, basis.O, resolved.occurrence);
-  expectDerivationReject(
-    () => fx.replayVerified([resolved.equality], fx.derivation(target, [target, resolved])),
-    "distinct representatives cannot satisfy L premise",
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.C);
+  defineLocalRepresentativeBinding(fx.memory, K, X, fx.basis.C);
+  defineLocalRepresentativeBinding(fx.memory, K, Y, fx.basis.O);
+  const r = fx.resolvedNode(K, X, Y, fx.basis.C, fx.basis.O);
+  const d = fx.distinctRoot(fx.distinctCOPack, fx.distinctCO, K);
+  const t = fx.uNode(K, X, Y, fx.basis.C, fx.basis.O, r.occurrence, d.occurrence);
+  same(
+    fx.resultOf(fx.replayVerified([r.equality], fx.derivation(t, [d, t, r])).target.judgment.claim),
+    fx.basis.U, "reverse closed row -> U",
   );
 }
 
-// U cannot be proposed for equal representatives because there is no admitted
-// Distinct(O,O) row; borrowing Distinct(O,C) fails structural premise matching.
+// Valid host false outside the explicit table remains unknown, not U.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  defineLocalRepresentativeBinding(memory, K, X, basis.O);
-  defineLocalRepresentativeBinding(memory, K, Y, basis.O);
-  const resolved = fx.resolvedNode(K, X, Y, basis.O, basis.O);
-  const distinct = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, K);
-  const target = fx.uNode(K, X, Y, basis.O, basis.O, resolved.occurrence, distinct.occurrence);
-  expectDerivationReject(
-    () => fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, target, distinct])),
-    "equal representatives cannot satisfy U premise",
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  const r = fx.resolvedNode(K, X, Y, X, Y);
+  const d = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, K);
+  const t = fx.uNode(K, X, Y, X, Y, r.occurrence, d.occurrence);
+  derivationReject(
+    () => fx.replayVerified([r.equality], fx.derivation(t, [r, d, t])),
+    "uncovered distinct pair must stay unknown",
   );
 }
 
-// Forged/missing/conflicting representative evidence is rejected by Eq_K itself
-// before any Link-valued result is available; invalid evidence is never U.
+// Structural matching rejects the wrong branch in both directions.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const Y = fx.fresh();
-  const forged = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  defineLocalRepresentativeBinding(memory, K, X, basis.O);
-  defineLocalRepresentativeBinding(memory, K, Y, basis.C);
-  const forgedResolved = fx.resolvedNode(K, X, Y, forged, basis.C);
-  expectEqualityReject(
-    () => fx.replayVerified([forgedResolved.equality], fx.derivation(forgedResolved, [forgedResolved])),
-    "forged representative",
-  );
-
-  const missing = fx.resolvedNode(K, X, Y, basis.O, basis.C, { omitRightRepresentative: true });
-  expectEqualityReject(
-    () => fx.replayVerified([missing.equality], fx.derivation(missing, [missing])),
-    "missing representative field",
-  );
-
-  defineLocalRepresentativeBinding(memory, K, X, basis.C);
-  const conflict = fx.resolvedNode(K, X, Y, basis.O, basis.C);
-  expectEqualityReject(
-    () => fx.replayVerified([conflict.equality], fx.derivation(conflict, [conflict])),
-    "representative conflict",
-  );
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, X, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, Y, fx.basis.C);
+  const r = fx.resolvedNode(K, X, Y, fx.basis.O, fx.basis.C);
+  const l = fx.lNode(K, X, Y, fx.basis.O, r.occurrence);
+  derivationReject(() => fx.replayVerified([r.equality], fx.derivation(l, [l, r])), "distinct -> L");
+}
+{
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, X, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, Y, fx.basis.O);
+  const r = fx.resolvedNode(K, X, Y, fx.basis.O, fx.basis.O);
+  const d = fx.distinctRoot(fx.distinctOCPack, fx.distinctOC, K);
+  const u = fx.uNode(K, X, Y, fx.basis.O, fx.basis.O, r.occurrence, d.occurrence);
+  derivationReject(() => fx.replayVerified([r.equality], fx.derivation(u, [r, u, d])), "equal -> U");
 }
 
-// A foreign Act header context is invalid equality evidence, not false/U.
+// Forged/missing/conflicting representative evidence is invalid, never U.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const foreignK = defineContext(memory, basis.R, basis.C);
-  const resolved = fx.resolvedNode(K, X, X, X, X, { headerContext: foreignK });
-  expectEqualityReject(
-    () => fx.replayVerified([resolved.equality], fx.derivation(resolved, [resolved])),
-    "foreign equality context",
+  const fx = fixture(), X = fx.fresh(), Y = fx.fresh(), forged = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, X, fx.basis.O);
+  defineLocalRepresentativeBinding(fx.memory, K, Y, fx.basis.C);
+  const bad = fx.resolvedNode(K, X, Y, forged, fx.basis.C);
+  equalityReject(() => fx.replayVerified([bad.equality], fx.derivation(bad, [bad])), "forged representative");
+  const missing = fx.resolvedNode(K, X, Y, fx.basis.O, fx.basis.C, { omitRightRepresentative: true });
+  equalityReject(() => fx.replayVerified([missing.equality], fx.derivation(missing, [missing])), "missing field");
+  defineLocalRepresentativeBinding(fx.memory, K, X, fx.basis.C);
+  const conflict = fx.resolvedNode(K, X, Y, fx.basis.O, fx.basis.C);
+  equalityReject(() => fx.replayVerified([conflict.equality], fx.derivation(conflict, [conflict])), "representative conflict");
+}
+
+// Foreign K, alternate boolean atom, host metadata and wrong Theory have no authority.
+{
+  const fx = fixture(), X = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  const foreignK = defineContext(fx.memory, fx.basis.R, fx.basis.C);
+  const badK = fx.resolvedNode(K, X, X, X, X, { headerContext: foreignK });
+  equalityReject(() => fx.replayVerified([badK.equality], fx.derivation(badK, [badK])), "foreign context");
+
+  const r = fx.resolvedNode(K, X, X, X, X), alternate = fx.fresh();
+  const alt = fx.lNode(K, X, X, X, r.occurrence, alternate);
+  derivationReject(() => fx.replayVerified([r.equality], fx.derivation(alt, [r, alt])), "alternate boolean atom");
+
+  const noisy = Object.freeze({ ...r.equality, equal: false, branch: "U" });
+  const t = fx.lNode(K, X, X, X, r.occurrence);
+  same(
+    fx.resultOf(fx.replayVerified([noisy], fx.derivation(t, [t, r])).target.judgment.claim),
+    fx.basis.L, "host metadata cannot select U",
   );
-}
 
-// An alternate truth atom cannot impersonate L even when Eq_K is valid.
-{
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const alternate = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const resolved = fx.resolvedNode(K, X, X, X, X);
-  const target = fx.lNode(K, X, X, X, resolved.occurrence, alternate);
-  expectDerivationReject(
-    () => fx.replayVerified([resolved.equality], fx.derivation(target, [resolved, target])),
-    "alternate boolean atom",
-  );
-}
-
-// Host metadata has no semantic authority. Even metadata claiming U/false cannot
-// alter an equality proof whose structural representatives derive L.
-{
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const resolved = fx.resolvedNode(K, X, X, X, X);
-  const noisyEquality = Object.freeze({ ...resolved.equality, equal: false, branch: "U" });
-  const target = fx.lNode(K, X, X, X, resolved.occurrence);
-  const checked = fx.replayVerified([noisyEquality], fx.derivation(target, [target, resolved]));
-  same(fx.resultOf(checked.target.judgment.claim), basis.L, "host metadata cannot select U");
-}
-
-// Wrong Theory admission cannot authorize the otherwise matching L rule.
-{
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const resolved = fx.resolvedNode(K, X, X, X, X);
-  const target = fx.lNode(K, X, X, X, resolved.occurrence);
-  const foreignAdmission = memory.ensure(fx.foreignTheory, fx.lPack.rule);
-  const forgedTarget: BuiltNode = Object.freeze({
-    occurrence: target.occurrence,
-    node: Object.freeze({
-      ...target.node,
-      judgment: Object.freeze({
-        ...target.node.judgment,
-        application: Object.freeze({
-          ...target.node.judgment.application,
-          ruleAdmission: foreignAdmission,
-        }),
-      }),
-    }),
-  });
-  expectDerivationReject(
-    () => fx.replayVerified(
-      [resolved.equality],
-      fx.derivation(forgedTarget, [resolved, forgedTarget]),
-    ),
+  const foreignAdmission = fx.memory.ensure(fx.foreignTheory, fx.lPack.rule);
+  const forgedTarget: BuiltNode = Object.freeze({ occurrence: t.occurrence, node: Object.freeze({
+    ...t.node,
+    judgment: Object.freeze({ ...t.node.judgment, application: Object.freeze({
+      ...t.node.judgment.application, ruleAdmission: foreignAdmission,
+    }) }),
+  }) });
+  derivationReject(
+    () => fx.replayVerified([r.equality], fx.derivation(forgedTarget, [r, forgedTarget])),
     "wrong Theory admission",
   );
 }
 
 class WriteInjectingProbe implements ReadMemory {
   private injected = false;
-
   constructor(
     private readonly source: Memory,
     private readonly injectStart: LinkHandle,
     private readonly injectEnd: LinkHandle,
   ) {}
-
   get root(): LinkHandle { return this.source.root; }
   get linkCount(): number { return this.source.linkCount; }
   poles(link: LinkHandle): LinkPoles { return this.source.poles(link); }
-  find(): LinkHandle | undefined { throw new Error("P9d probe: find is forbidden"); }
-  incoming(): readonly LinkHandle[] { throw new Error("P9d probe: incoming is forbidden"); }
+  find(): LinkHandle | undefined { throw new Error("P9d probe: find forbidden"); }
+  incoming(): readonly LinkHandle[] { throw new Error("P9d probe: incoming forbidden"); }
   outgoing(start: LinkHandle): readonly LinkHandle[] {
-    if (!this.injected) {
-      this.injected = true;
-      this.source.ensure(this.injectStart, this.injectEnd);
-    }
+    if (!this.injected) { this.injected = true; this.source.ensure(this.injectStart, this.injectEnd); }
     return this.source.outgoing(start);
   }
 }
 
-// A hostile ReadMemory that mutates during replay is rejected instead of turning
-// an unstable lookup into either L or U.
+// Replay detects a hostile read adapter that mutates memory; no L/U is produced.
 {
-  const fx = fixture();
-  const { memory, basis } = fx;
-  const X = fx.fresh();
-  const K = defineContext(memory, basis.R, basis.O);
-  const resolved = fx.resolvedNode(K, X, X, X, X);
-  const injectStart = fx.fresh();
-  const injectEnd = fx.fresh();
-  assert(memory.find(injectStart, injectEnd) === undefined, "write-injection pair must start absent");
-  const probe = new WriteInjectingProbe(memory, injectStart, injectEnd);
-  expectEqualityReject(
-    () => fx.replayVerified([resolved.equality], fx.derivation(resolved, [resolved]), probe),
-    "write injection",
-  );
+  const fx = fixture(), X = fx.fresh();
+  const K = defineContext(fx.memory, fx.basis.R, fx.basis.O);
+  const r = fx.resolvedNode(K, X, X, X, X), a = fx.fresh(), b = fx.fresh();
+  assert(fx.memory.find(a, b) === undefined, "injection pair must start absent");
+  const probe = new WriteInjectingProbe(fx.memory, a, b);
+  equalityReject(() => fx.replayVerified([r.equality], fx.derivation(r, [r]), probe), "write injection");
 }


### PR DESCRIPTION
```repo-guard-yaml
change_type: test
scope:
  - ts/test/derived-equality-lu.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 600
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/test/derived-equality-lu.test.ts
must_not_touch:
  - ts/src/**
  - contracts/**
  - repo-policy.json
  - .github/workflows/**
expected_effects:
  - contextual Eq_K evidence is validated without using its host boolean to choose L/U
  - L is derived by repeated structural representative role
  - U requires explicit Distinct evidence from a closed Theory fragment
  - invalid or uncovered equality evidence never collapses to U
  - no production, accepted-semantic, contract, policy, or workflow delta
```

Closes #897.

## P9d result under test

This is a test-only falsification slice over accepted MTS v0.11.

The witness composes existing contextual equality verification with the generic structural derivation layer without making the host boolean semantically authoritative:

```text
replayEqualityEvaluation(Eq_K evidence)
  -> validates explicit K and exact Rep_K(A)/Rep_K(B)
  -> returned host boolean is discarded

Resolved(K,A,B,R,R)
  -> L

Resolved(K,A,B,RA,RB) + Distinct(RA,RB)
  -> U
```

`L` is selected by ordinary repeated-role structural matching. `U` additionally requires proof of `Distinct(RA,RB)` from an explicitly closed Theory fragment. The witness closes the concrete `{O,C}` representative fragment with grounded rows `Distinct(O,C)` and `Distinct(C,O)`; diagonal equality is handled by the `L` rule.

A valid contextual equality replay whose distinct representatives are outside this explicit table does **not** become `U`; the derivation remains unclassified/rejects. Malformed, missing, conflicting, or foreign-context equality evidence rejects before any L/U result.

Adversarial vectors also cover wrong branch proposals, alternate boolean atom, host `{equal:false, branch:"U"}` metadata, wrong Theory admission, and replay-time write injection.

Diff against opening main is one new test file, 355 additions; no production/contracts/policy/workflow changes.

Expected classification after both gates are green:

```text
CONTEXTUAL_EQUALITY_LU_CLOSED_DECIDABLE_SUPPORTED
host boolean semantic authority = NONE
production delta = NONE
accepted semantic delta = NONE
v0.12 = NOT REQUIRED
```