### PR TITLE
[Visual/V0] Establish renderer-neutral @mts/visual boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Typecheck, test and browser-check current MTS core
         run: npm --prefix ts run check
 
+      - name: Check renderer-neutral MTS visual package
+        run: |
+          ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
+          node packages/visual/dist/test/model.test.js
+
   no-python:
     runs-on: ubuntu-latest
     steps:

--- a/packages/visual/package.json
+++ b/packages/visual/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mts/visual",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "files": [
+    "dist/src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build --silent && node dist/test/model.test.js",
+    "check": "npm test"
+  }
+}

--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -1,0 +1,101 @@
+export type VisualKey = string;
+
+/**
+ * Renderer-neutral presentation of one MTS Link.
+ *
+ * The keys are presentation references only. They are not semantic Link identity,
+ * runtime handles, proof identity, or a third "center node" ontology.
+ */
+export interface VisualLink {
+  readonly key: VisualKey;
+  readonly startKey: VisualKey;
+  readonly endKey: VisualKey;
+  readonly label?: string;
+  readonly tags?: readonly string[];
+}
+
+export interface VisualLinkNetwork {
+  readonly links: readonly VisualLink[];
+}
+
+export type VisualNetworkErrorCode =
+  | "empty-key"
+  | "duplicate-key"
+  | "empty-start"
+  | "empty-end"
+  | "missing-start"
+  | "missing-end";
+
+export class VisualNetworkError extends Error {
+  readonly code: VisualNetworkErrorCode;
+  readonly key: VisualKey;
+  readonly reference?: VisualKey;
+
+  constructor(code: VisualNetworkErrorCode, key: VisualKey, reference?: VisualKey) {
+    const suffix = reference === undefined ? "" : `: ${reference}`;
+    super(`${code} for ${key}${suffix}`);
+    this.name = "VisualNetworkError";
+    this.code = code;
+    this.key = key;
+    if (reference !== undefined) this.reference = reference;
+  }
+}
+
+function isBlank(key: VisualKey): boolean {
+  return key.trim().length === 0;
+}
+
+/**
+ * Validate only presentation topology.
+ *
+ * Cycles and self-links are intentionally legal. In particular this function must
+ * not impose an ordinary acyclic graph model on recursive MTS Link structure.
+ */
+export function validateVisualLinkNetwork(network: VisualLinkNetwork): void {
+  const keys = new Set<VisualKey>();
+
+  for (const link of network.links) {
+    if (isBlank(link.key)) throw new VisualNetworkError("empty-key", link.key);
+    if (keys.has(link.key)) throw new VisualNetworkError("duplicate-key", link.key);
+    keys.add(link.key);
+  }
+
+  for (const link of network.links) {
+    if (isBlank(link.startKey)) {
+      throw new VisualNetworkError("empty-start", link.key, link.startKey);
+    }
+    if (isBlank(link.endKey)) {
+      throw new VisualNetworkError("empty-end", link.key, link.endKey);
+    }
+    if (!keys.has(link.startKey)) {
+      throw new VisualNetworkError("missing-start", link.key, link.startKey);
+    }
+    if (!keys.has(link.endKey)) {
+      throw new VisualNetworkError("missing-end", link.key, link.endKey);
+    }
+  }
+}
+
+function cloneVisualLink(link: VisualLink): VisualLink {
+  return Object.freeze({
+    key: link.key,
+    startKey: link.startKey,
+    endKey: link.endKey,
+    ...(link.label === undefined ? {} : { label: link.label }),
+    ...(link.tags === undefined ? {} : { tags: Object.freeze([...link.tags]) }),
+  });
+}
+
+/**
+ * Produce a deterministic immutable presentation snapshot.
+ *
+ * Sorting by VisualKey is only presentation normalization. It is deliberately not
+ * named or treated as semantic canonicalization of MTS Links.
+ */
+export function normalizeVisualLinkNetwork(network: VisualLinkNetwork): VisualLinkNetwork {
+  validateVisualLinkNetwork(network);
+  const links = [...network.links]
+    .sort((left, right) => (left.key < right.key ? -1 : left.key > right.key ? 1 : 0))
+    .map(cloneVisualLink);
+  return Object.freeze({ links: Object.freeze(links) });
+}

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -1,0 +1,112 @@
+import {
+  VisualNetworkError,
+  normalizeVisualLinkNetwork,
+  validateVisualLinkNetwork,
+  type VisualLink,
+  type VisualLinkNetwork,
+  type VisualNetworkErrorCode,
+} from "../src/index.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V0: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectCode(effect: () => unknown, code: VisualNetworkErrorCode, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof VisualNetworkError, `${message}: wrong error type`);
+    same(error.code, code, `${message}: wrong error code`);
+    return;
+  }
+  throw new Error(`@mts/visual V0: ${message}: expected rejection`);
+}
+
+function basisLinks(): VisualLink[] {
+  return [
+    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+    { key: "O", startKey: "O", endKey: "R" },
+    { key: "C", startKey: "R", endKey: "C" },
+    { key: "L", startKey: "O", endKey: "C" },
+    { key: "U", startKey: "C", endKey: "O" },
+    { key: "X", startKey: "L", endKey: "U", tags: ["link-of-links"] },
+  ];
+}
+
+const basis: VisualLinkNetwork = { links: basisLinks() };
+validateVisualLinkNetwork(basis);
+
+const normalized = normalizeVisualLinkNetwork(basis);
+same(normalized.links.length, 6, "all links preserved");
+same(normalized.links.map((link) => link.key).join(","), "C,L,O,R,U,X", "stable key order");
+
+const root = normalized.links.find((link) => link.key === "R");
+assert(root !== undefined, "root presentation retained");
+same(root.startKey, "R", "self-link start retained");
+same(root.endKey, "R", "self-link end retained");
+same(root.label, "∞", "presentation label retained");
+same(root.tags?.join(","), "root", "presentation tags retained");
+
+const linkOfLinks = normalized.links.find((link) => link.key === "X");
+assert(linkOfLinks !== undefined, "link-of-links retained");
+same(linkOfLinks.startKey, "L", "link-of-links start retained");
+same(linkOfLinks.endKey, "U", "link-of-links end retained");
+
+const reordered: VisualLinkNetwork = { links: [...basisLinks()].reverse() };
+const normalizedReordered = normalizeVisualLinkNetwork(reordered);
+const topology = (network: VisualLinkNetwork): string =>
+  JSON.stringify(network.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
+same(topology(normalizedReordered), topology(normalized), "input order does not alter normalized topology");
+
+const relabeled: VisualLinkNetwork = {
+  links: basisLinks().map((link) =>
+    link.key === "X" ? { ...link, label: "display only", tags: ["selected", "debug"] } : link,
+  ),
+};
+same(topology(normalizeVisualLinkNetwork(relabeled)), topology(normalized), "metadata does not alter topology");
+
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "R", startKey: "R", endKey: "R" }] }),
+  "duplicate-key",
+  "duplicate visual key",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [{ key: "   ", startKey: "   ", endKey: "   " }] }),
+  "empty-key",
+  "blank visual key",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "missing", endKey: "R" }] }),
+  "missing-start",
+  "missing start reference",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "R", endKey: "missing" }] }),
+  "missing-end",
+  "missing end reference",
+);
+expectCode(
+  () =>
+    validateVisualLinkNetwork({
+      links: [...basisLinks(), { key: "Y", startKey: "missing", endKey: "R", label: "missing", tags: ["missing"] }],
+    }),
+  "missing-start",
+  "metadata cannot repair invalid topology",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: " ", endKey: "R" }] }),
+  "empty-start",
+  "blank start reference",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "R", endKey: "\t" }] }),
+  "empty-end",
+  "blank end reference",
+);
+
+assert(Object.isFrozen(normalized), "normalized network is immutable presentation snapshot");
+assert(Object.isFrozen(normalized.links), "normalized link list is immutable presentation snapshot");

--- a/packages/visual/tsconfig.json
+++ b/packages/visual/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Closes #903
Parent: #902

## Summary

Establish the first non-semantic `@mts/visual` boundary:

- independent `packages/visual` package with zero runtime dependencies;
- renderer-neutral `VisualLinkNetwork` / `VisualLink` DTO;
- presentation-only keys, never semantic/proof identity;
- topology validation for self-links and link-of-links;
- deterministic presentation normalization without claiming MTS semantic canonicalization;
- blocking CI step using the existing TypeScript toolchain.

## Architectural invariant

```text
@mts/core -X-> @mts/visual

semantic/trusted != presentation/untrusted
```

No `@mts/core` import exists in the visual package. No renderer, parser/prover adapter, contract mutation, or semantic release is introduced.

## Exact pre-PR evidence

```text
base main = d954d188bc0537cfe18d4e30de379b10aeabd5f8
head = b75881908aaa49e921474cd1025ed5bdc62c5919
compare status = ahead
behind_by = 0
new files = 4
contracts/cutover/ts/src/ts/test = untouched
```

CI/repo-guard must provide final acceptance evidence before merge.