### PR TITLE
[Visual/V2a] Add pure static SVG blueprint scene

### DIFF
--- a/packages/visual/src/blueprint-svg.ts
+++ b/packages/visual/src/blueprint-svg.ts
@@ -1,0 +1,303 @@
+import {
+  normalizeVisualLinkNetwork,
+  type VisualKey,
+  type VisualLinkNetwork,
+} from "./index.js";
+import {
+  blueprintGeometryIsFinite,
+  buildBlueprintGeometry,
+  type BlueprintGeometry,
+  type BlueprintOptions,
+  type BlueprintPosition,
+  type CubicBezierSegment,
+  type Point2D,
+} from "./blueprint-geometry.js";
+
+// Presentation-only marker/color language adapted from the current anum_parser
+// blueprint renderer. Historical visual inspiration remains:
+// repository: konard/links-visuals
+// commit: f377441533e4f10fa94aaa07138b684df88234b1
+// license: Unlicense
+
+export interface BlueprintSvgOptions {
+  readonly padding?: number;
+  readonly positions?: readonly BlueprintPosition[];
+  readonly geometryOptions?: BlueprintOptions;
+}
+
+export interface BlueprintSvgBounds {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface BlueprintSvgMarker {
+  readonly id: string;
+  readonly kind: "start" | "end";
+  readonly color: string;
+}
+
+export interface BlueprintSvgLink {
+  readonly key: VisualKey;
+  readonly startKey: VisualKey;
+  readonly endKey: VisualKey;
+  readonly pathId: string;
+  readonly d: string;
+  readonly color: string;
+  readonly startMarkerId: string;
+  readonly endMarkerId: string;
+  readonly center: Point2D;
+  readonly label?: string;
+}
+
+export interface BlueprintSvgScene {
+  readonly links: readonly BlueprintSvgLink[];
+  readonly markers: readonly BlueprintSvgMarker[];
+  readonly bounds: BlueprintSvgBounds;
+  readonly viewBox: string;
+  readonly padding: number;
+}
+
+export type BlueprintSvgErrorCode =
+  | "invalid-padding"
+  | "geometry-count-mismatch"
+  | "geometry-key-mismatch"
+  | "geometry-pole-mismatch"
+  | "non-finite-geometry"
+  | "empty-path";
+
+export class BlueprintSvgError extends Error {
+  readonly code: BlueprintSvgErrorCode;
+  readonly key?: VisualKey;
+
+  constructor(code: BlueprintSvgErrorCode, key?: VisualKey) {
+    super(key === undefined ? code : `${code}: ${key}`);
+    this.name = "BlueprintSvgError";
+    this.code = code;
+    if (key !== undefined) this.key = key;
+  }
+}
+
+export const BLUEPRINT_LINK_PALETTE = Object.freeze([
+  "#59aaf7",
+  "#ff9d4d",
+  "#ef6f6c",
+  "#65c4b0",
+  "#9bc75b",
+  "#f2cf5b",
+  "#b889d6",
+  "#f28eae",
+  "#c49a6c",
+  "#b9b9b9",
+  "#5bc0eb",
+  "#d982c3",
+] as const);
+
+export function blueprintLinkColor(index: number): string {
+  const safeIndex = Number.isInteger(index) && index >= 0 ? index : 0;
+  const paletteColor = BLUEPRINT_LINK_PALETTE[safeIndex];
+  if (paletteColor !== undefined) return paletteColor;
+  const hue = (210 + safeIndex * 137.50776405003785) % 360;
+  return `hsl(${Number(hue.toFixed(3))} 72% 62%)`;
+}
+
+export function buildBlueprintSvgScene(
+  network: VisualLinkNetwork,
+  geometry?: BlueprintGeometry,
+  options: BlueprintSvgOptions = {},
+): BlueprintSvgScene {
+  const normalized = normalizeVisualLinkNetwork(network);
+  const padding = resolvePadding(options.padding);
+  const resolvedGeometry = geometry ?? buildBlueprintGeometry(
+    normalized,
+    options.positions,
+    options.geometryOptions ?? {},
+  );
+  validateGeometry(normalized, resolvedGeometry);
+
+  const geometryByKey = new Map(resolvedGeometry.links.map((link) => [link.key, link] as const));
+  const links = normalized.links.map((link, index) => {
+    const current = geometryByKey.get(link.key);
+    if (current === undefined) throw new BlueprintSvgError("geometry-key-mismatch", link.key);
+    const baseId = `mts-blueprint-${index}-${encodeVisualKey(link.key)}`;
+    return freezeSvgLink({
+      key: link.key,
+      startKey: link.startKey,
+      endKey: link.endKey,
+      pathId: `${baseId}-path`,
+      d: cubicPathData(current.segments),
+      color: blueprintLinkColor(index),
+      startMarkerId: `${baseId}-start`,
+      endMarkerId: `${baseId}-end`,
+      center: current.center,
+      ...(link.label === undefined ? {} : { label: link.label }),
+    });
+  });
+
+  const markers = Object.freeze(links.flatMap((link) => [
+    freezeMarker({ id: link.startMarkerId, kind: "start", color: link.color }),
+    freezeMarker({ id: link.endMarkerId, kind: "end", color: link.color }),
+  ]));
+  const bounds = freezeBounds(computeBounds(resolvedGeometry, padding));
+  const viewBox = [bounds.minX, bounds.minY, bounds.width, bounds.height]
+    .map(canonicalNumber)
+    .join(" ");
+
+  return Object.freeze({
+    links: Object.freeze(links),
+    markers,
+    bounds,
+    viewBox,
+    padding,
+  });
+}
+
+export function serializeBlueprintSvg(scene: BlueprintSvgScene): string {
+  const markerMarkup = scene.markers.map((marker) => marker.kind === "start"
+    ? serializeStartMarker(marker)
+    : serializeEndMarker(marker)).join("");
+  const linkMarkup = scene.links.map((link) => {
+    const label = link.label === undefined
+      ? ""
+      : `<text data-role="blueprint-label" data-link-key="${escapeXml(link.key)}" x="${canonicalNumber(link.center.x + 11)}" y="${canonicalNumber(link.center.y - 11)}">${escapeXml(link.label)}</text>`;
+    return `<g data-role="blueprint-link" data-link-key="${escapeXml(link.key)}">`
+      + `<path id="${escapeXml(link.pathId)}" data-role="blueprint-link-path" d="${escapeXml(link.d)}" fill="none" stroke="${escapeXml(link.color)}" marker-start="url(#${escapeXml(link.startMarkerId)})" marker-end="url(#${escapeXml(link.endMarkerId)})"/>`
+      + `<circle data-role="blueprint-center" data-link-key="${escapeXml(link.key)}" cx="${canonicalNumber(link.center.x)}" cy="${canonicalNumber(link.center.y)}" r="6.5"/>`
+      + label
+      + `</g>`;
+  }).join("");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" role="img" viewBox="${escapeXml(scene.viewBox)}">`
+    + `<defs>${markerMarkup}</defs>`
+    + linkMarkup
+    + `</svg>`;
+}
+
+function validateGeometry(network: VisualLinkNetwork, geometry: BlueprintGeometry): void {
+  if (!blueprintGeometryIsFinite(geometry)) throw new BlueprintSvgError("non-finite-geometry");
+  if (geometry.links.length !== network.links.length) {
+    throw new BlueprintSvgError("geometry-count-mismatch");
+  }
+
+  const expected = new Map(network.links.map((link) => [link.key, link] as const));
+  const seen = new Set<VisualKey>();
+  for (const link of geometry.links) {
+    const declared = expected.get(link.key);
+    if (declared === undefined || seen.has(link.key)) {
+      throw new BlueprintSvgError("geometry-key-mismatch", link.key);
+    }
+    seen.add(link.key);
+    if (link.startKey !== declared.startKey || link.endKey !== declared.endKey) {
+      throw new BlueprintSvgError("geometry-pole-mismatch", link.key);
+    }
+    if (link.segments.length === 0) throw new BlueprintSvgError("empty-path", link.key);
+  }
+  for (const key of expected.keys()) {
+    if (!seen.has(key)) throw new BlueprintSvgError("geometry-key-mismatch", key);
+  }
+}
+
+function cubicPathData(segments: readonly CubicBezierSegment[]): string {
+  const first = segments[0];
+  if (first === undefined) throw new BlueprintSvgError("empty-path");
+  const commands = [`M ${pointText(first.p0)}`];
+  for (const segment of segments) {
+    commands.push(`C ${pointText(segment.p1)} ${pointText(segment.p2)} ${pointText(segment.p3)}`);
+  }
+  return commands.join(" ");
+}
+
+function computeBounds(geometry: BlueprintGeometry, padding: number): BlueprintSvgBounds {
+  const points = geometry.links.flatMap((link) => [
+    link.center,
+    link.startAnchor,
+    link.endAnchor,
+    ...link.segments.flatMap((segment) => [segment.p0, segment.p1, segment.p2, segment.p3]),
+  ]);
+
+  if (points.length === 0) {
+    const half = 0.5 + padding;
+    return {
+      minX: -half,
+      minY: -half,
+      maxX: half,
+      maxY: half,
+      width: half * 2,
+      height: half * 2,
+    };
+  }
+
+  let minX = Math.min(...points.map((point) => point.x));
+  let minY = Math.min(...points.map((point) => point.y));
+  let maxX = Math.max(...points.map((point) => point.x));
+  let maxY = Math.max(...points.map((point) => point.y));
+  if (maxX === minX) {
+    minX -= 0.5;
+    maxX += 0.5;
+  }
+  if (maxY === minY) {
+    minY -= 0.5;
+    maxY += 0.5;
+  }
+  minX -= padding;
+  minY -= padding;
+  maxX += padding;
+  maxY += padding;
+  return { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY };
+}
+
+function serializeStartMarker(marker: BlueprintSvgMarker): string {
+  return `<marker id="${escapeXml(marker.id)}" data-role="blueprint-start-marker" viewBox="0 0 100 100" markerWidth="10" markerHeight="10" refX="50" refY="50" orient="auto" markerUnits="strokeWidth">`
+    + `<line x1="50" y1="34" x2="50" y2="66" stroke="${escapeXml(marker.color)}" stroke-width="6" stroke-linecap="round"/>`
+    + `</marker>`;
+}
+
+function serializeEndMarker(marker: BlueprintSvgMarker): string {
+  return `<marker id="${escapeXml(marker.id)}" data-role="blueprint-end-marker" viewBox="-2 0 102 100" markerWidth="10" markerHeight="10" refX="10" refY="50" orient="auto" markerUnits="strokeWidth">`
+    + `<polyline points="0,40 10,50 0,60" fill="none" stroke="${escapeXml(marker.color)}" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>`
+    + `</marker>`;
+}
+
+function encodeVisualKey(key: VisualKey): string {
+  return [...key].map((character) => character.codePointAt(0)!.toString(16)).join("_");
+}
+
+function resolvePadding(value: number | undefined): number {
+  if (value === undefined) return 36;
+  if (!Number.isFinite(value) || value < 0) throw new BlueprintSvgError("invalid-padding");
+  return value;
+}
+
+function pointText(point: Point2D): string {
+  return `${canonicalNumber(point.x)} ${canonicalNumber(point.y)}`;
+}
+
+function canonicalNumber(value: number): string {
+  if (!Number.isFinite(value)) throw new BlueprintSvgError("non-finite-geometry");
+  if (Object.is(value, -0) || Math.abs(value) < 1e-12) return "0";
+  return Number(value.toFixed(9)).toString();
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function freezeSvgLink(link: BlueprintSvgLink): BlueprintSvgLink {
+  return Object.freeze({ ...link, center: Object.freeze({ x: link.center.x, y: link.center.y }) });
+}
+
+function freezeMarker(marker: BlueprintSvgMarker): BlueprintSvgMarker {
+  return Object.freeze({ ...marker });
+}
+
+function freezeBounds(bounds: BlueprintSvgBounds): BlueprintSvgBounds {
+  return Object.freeze({ ...bounds });
+}

--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -101,3 +101,4 @@ export function normalizeVisualLinkNetwork(network: VisualLinkNetwork): VisualLi
 }
 
 export * from "./blueprint-geometry.js";
+export * from "./blueprint-svg.js";

--- a/packages/visual/test/blueprint-svg.test.ts
+++ b/packages/visual/test/blueprint-svg.test.ts
@@ -1,0 +1,204 @@
+import {
+  BlueprintSvgError,
+  buildBlueprintGeometry,
+  buildBlueprintSvgScene,
+  serializeBlueprintSvg,
+  type BlueprintGeometry,
+  type BlueprintSvgErrorCode,
+  type VisualLink,
+  type VisualLinkNetwork,
+} from "../src/index.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2a: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectCode(effect: () => unknown, code: BlueprintSvgErrorCode, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof BlueprintSvgError, `${message}: wrong error type`);
+    same(error.code, code, `${message}: wrong error code`);
+    return;
+  }
+  throw new Error(`@mts/visual V2a: ${message}: expected rejection`);
+}
+
+function basisLinks(): VisualLink[] {
+  return [
+    { key: "R", startKey: "R", endKey: "R", label: "∞" },
+    { key: "O", startKey: "O", endKey: "R" },
+    { key: "C", startKey: "R", endKey: "C" },
+    { key: "L", startKey: "O", endKey: "C" },
+    { key: "U", startKey: "C", endKey: "O" },
+    { key: "X", startKey: "L", endKey: "U", label: "link of links" },
+  ];
+}
+
+function numberText(value: number): string {
+  if (Object.is(value, -0) || Math.abs(value) < 1e-12) return "0";
+  return Number(value.toFixed(9)).toString();
+}
+
+const basis: VisualLinkNetwork = { links: basisLinks() };
+const geometry = buildBlueprintGeometry(basis);
+const scene = buildBlueprintSvgScene(basis, geometry);
+same(scene.links.length, 6, "basis emits exactly one descriptor per Link");
+same(scene.markers.length, 12, "basis emits start and end marker per Link");
+
+const keys = scene.links.map((link) => link.key).join(",");
+same(keys, "C,L,O,R,U,X", "scene follows normalized visual order");
+
+const xGeometry = geometry.links.find((link) => link.key === "X");
+const xScene = scene.links.find((link) => link.key === "X");
+assert(xGeometry !== undefined && xScene !== undefined, "link-of-links scene exists");
+const firstX = xGeometry.segments[0];
+const lastX = xGeometry.segments.at(-1);
+assert(firstX !== undefined && lastX !== undefined, "link-of-links has cubic geometry");
+assert(
+  xScene.d.startsWith(`M ${numberText(firstX.p0.x)} ${numberText(firstX.p0.y)} `),
+  "path begins at V1 start anchor",
+);
+assert(
+  xScene.d.endsWith(`${numberText(lastX.p3.x)} ${numberText(lastX.p3.y)}`),
+  "path ends at V1 end anchor",
+);
+same(xScene.startKey, "L", "scene preserves start pole");
+same(xScene.endKey, "U", "scene preserves end pole");
+
+const root = scene.links.find((link) => link.key === "R");
+assert(root !== undefined, "root scene exists");
+same(root.d.split(" C ").length - 1, 2, "root self-link remains one two-segment cubic path");
+assert(root.startMarkerId !== root.endMarkerId, "start/end marker IDs are distinct");
+const rootStart = scene.markers.find((marker) => marker.id === root.startMarkerId);
+const rootEnd = scene.markers.find((marker) => marker.id === root.endMarkerId);
+assert(rootStart !== undefined && rootEnd !== undefined, "root endpoint markers exist");
+same(rootStart.kind, "start", "start marker role retained");
+same(rootEnd.kind, "end", "end marker role retained");
+same(rootStart.color, root.color, "start marker shares Link color");
+same(rootEnd.color, root.color, "end marker shares Link color");
+
+assert(Number.isFinite(scene.bounds.minX), "finite minX");
+assert(Number.isFinite(scene.bounds.minY), "finite minY");
+assert(Number.isFinite(scene.bounds.maxX), "finite maxX");
+assert(Number.isFinite(scene.bounds.maxY), "finite maxY");
+assert(scene.bounds.width > 0, "positive view width");
+assert(scene.bounds.height > 0, "positive view height");
+assert(scene.viewBox.split(" ").length === 4, "viewBox has four scalar components");
+
+const svg = serializeBlueprintSvg(scene);
+same((svg.match(/data-role="blueprint-link-path"/g) ?? []).length, 6, "static SVG has one path element per Link");
+same((svg.match(/data-role="blueprint-start-marker"/g) ?? []).length, 6, "static SVG has one start marker per Link");
+same((svg.match(/data-role="blueprint-end-marker"/g) ?? []).length, 6, "static SVG has one end marker per Link");
+assert(!/<script/i.test(svg), "static SVG has no script element");
+assert(!/\son[a-z]+=/i.test(svg), "static SVG has no event handler attributes");
+
+const reordered: VisualLinkNetwork = { links: [...basisLinks()].reverse() };
+same(
+  serializeBlueprintSvg(buildBlueprintSvgScene(reordered)),
+  serializeBlueprintSvg(buildBlueprintSvgScene(basis)),
+  "input order does not alter normalized static scene",
+);
+
+const hostileLabel = `<script>&"`;
+const hostileNetwork: VisualLinkNetwork = {
+  links: basisLinks().map((link) => link.key === "X" ? { ...link, label: hostileLabel } : link),
+};
+const hostileSvg = serializeBlueprintSvg(buildBlueprintSvgScene(hostileNetwork));
+assert(!hostileSvg.includes(hostileLabel), "hostile label is never injected raw");
+assert(hostileSvg.includes("&lt;script&gt;&amp;&quot;"), "hostile label is XML escaped");
+
+const unusualKeys: VisualLinkNetwork = {
+  links: [
+    { key: "R", startKey: "R", endKey: "R" },
+    { key: "a/b", startKey: "R", endKey: "R" },
+    { key: "a?b", startKey: "R", endKey: "R" },
+    { key: "<root>", startKey: "R", endKey: "R" },
+    { key: `"quoted"`, startKey: "R", endKey: "R" },
+    { key: "русский ключ", startKey: "R", endKey: "R" },
+  ],
+};
+const unusualScene = buildBlueprintSvgScene(unusualKeys);
+const allIds = unusualScene.links.flatMap((link) => [link.pathId, link.startMarkerId, link.endMarkerId]);
+same(new Set(allIds).size, allIds.length, "encoded SVG IDs remain unique for adversarial keys");
+assert(allIds.every((id) => /^[A-Za-z][A-Za-z0-9_-]*$/.test(id)), "encoded SVG IDs are XML/DOM-safe ASCII");
+assert(unusualScene.links.some((link) => link.key === "русский ключ"), "raw Unicode VisualKey remains separately preserved");
+
+expectCode(() => buildBlueprintSvgScene(basis, geometry, { padding: -1 }), "invalid-padding", "negative padding");
+expectCode(() => buildBlueprintSvgScene(basis, geometry, { padding: Number.NaN }), "invalid-padding", "NaN padding");
+expectCode(() => buildBlueprintSvgScene(basis, geometry, { padding: Number.POSITIVE_INFINITY }), "invalid-padding", "infinite padding");
+
+const missingGeometry: BlueprintGeometry = {
+  positions: geometry.positions,
+  links: geometry.links.slice(0, -1),
+};
+expectCode(
+  () => buildBlueprintSvgScene(basis, missingGeometry),
+  "geometry-count-mismatch",
+  "missing geometry Link",
+);
+
+const extraGeometry: BlueprintGeometry = {
+  positions: geometry.positions,
+  links: [...geometry.links, geometry.links[0]!],
+};
+expectCode(
+  () => buildBlueprintSvgScene(basis, extraGeometry),
+  "geometry-count-mismatch",
+  "extra geometry Link",
+);
+
+const keyMismatch: BlueprintGeometry = {
+  positions: geometry.positions,
+  links: geometry.links.map((link, index) => index === 0 ? { ...link, key: "not-declared" } : link),
+};
+expectCode(
+  () => buildBlueprintSvgScene(basis, keyMismatch),
+  "geometry-key-mismatch",
+  "geometry key mismatch",
+);
+
+const poleMismatch: BlueprintGeometry = {
+  positions: geometry.positions,
+  links: geometry.links.map((link) => link.key === "X" ? { ...link, endKey: "R" } : link),
+};
+expectCode(
+  () => buildBlueprintSvgScene(basis, poleMismatch),
+  "geometry-pole-mismatch",
+  "geometry pole mismatch",
+);
+
+const nonFiniteGeometry: BlueprintGeometry = {
+  positions: geometry.positions,
+  links: geometry.links.map((link) => link.key === "X"
+    ? { ...link, center: { x: Number.POSITIVE_INFINITY, y: link.center.y } }
+    : link),
+};
+expectCode(
+  () => buildBlueprintSvgScene(basis, nonFiniteGeometry),
+  "non-finite-geometry",
+  "non-finite supplied geometry",
+);
+
+const emptyPathGeometry: BlueprintGeometry = {
+  positions: geometry.positions,
+  links: geometry.links.map((link) => link.key === "X" ? { ...link, segments: [] } : link),
+};
+expectCode(
+  () => buildBlueprintSvgScene(basis, emptyPathGeometry),
+  "empty-path",
+  "empty supplied path",
+);
+
+const topologyBefore = JSON.stringify(basis.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
+buildBlueprintSvgScene(basis, undefined, { padding: 12 });
+const topologyAfter = JSON.stringify(basis.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
+same(topologyAfter, topologyBefore, "scene construction cannot mutate semantic topology");
+assert(Object.isFrozen(scene), "scene snapshot is frozen");
+assert(Object.isFrozen(scene.links), "scene Link descriptors are frozen");
+assert(Object.isFrozen(scene.markers), "scene marker descriptors are frozen");
+assert(Object.isFrozen(scene.bounds), "scene bounds are frozen");

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -1,4 +1,5 @@
 import "./blueprint-geometry.test.js";
+import "./blueprint-svg.test.js";
 
 import {
   VisualNetworkError,


### PR DESCRIPTION
Closes #907
Parent: #902
Predecessor: #905 / PR #906
Primary donor/migration peer: https://github.com/netkeep80/anum_parser/issues/101

## Summary

Add a framework-free static SVG scene layer over the V1 blueprint geometry:

- exactly one SVG path descriptor per represented MTS Link;
- distinct start/end endpoint markers;
- deterministic presentation-only Link colors;
- lossless safe SVG IDs from normalized ordinal + code-point encoding;
- finite conservative bounds and deterministic viewBox;
- XML-safe static SVG serialization with no scripts/event handlers;
- fail-closed network/geometry topology validation;
- adversarial tests for unsafe labels, unusual keys, non-finite geometry and mismatches.

## Boundary

```text
VisualLinkNetwork
      |
      v
BlueprintGeometry
      |
      v
BlueprintSvgScene
      |
      v
static SVG string
```

No DOM events, pan/zoom, dragging, fullscreen, Vue, Cytoscape, Three.js or @mts/core dependency are introduced.

The center remains only a presentation point on the same represented Link; it is not a semantic node.

## Donor provenance

Marker/color presentation ideas are adapted from the current `anum_parser/src/blueprint-renderer.js`. Historical geometry inspiration remains:

```text
konard/links-visuals
commit = f377441533e4f10fa94aaa07138b684df88234b1
license = Unlicense
```

## Exact pre-PR evidence

```text
base main = 89d1e2dd77f0218781a9cec09d0ed2841a8e6bba
head = c9a7a60059e15588676e302ee386fcd06589f6a4
compare status = ahead
ahead_by = 4
behind_by = 0
changed paths = 4
new files = 2
net added lines = 509
issue budget = 750
workflow/governance files = untouched
contracts/cutover/ts/src/ts/test = untouched
blocking repo policy = enabled
```

CI and blocking repo-guard are required before merge. No accepted MTS semantic change and no v0.12 lifecycle are implied.