### PR TITLE
[Visual/V2b] Add pure blueprint interaction state

### DIFF
--- a/packages/visual/src/blueprint-interaction.ts
+++ b/packages/visual/src/blueprint-interaction.ts
@@ -1,0 +1,211 @@
+import type { VisualKey } from "./index.js";
+import type { BlueprintPosition, Point2D } from "./blueprint-geometry.js";
+import type { BlueprintSvgBounds } from "./blueprint-svg.js";
+
+export interface BlueprintViewport {
+  readonly scale: number;
+  readonly panX: number;
+  readonly panY: number;
+}
+
+export interface BlueprintScaleLimits {
+  readonly minScale?: number;
+  readonly maxScale?: number;
+}
+
+export interface BlueprintFitOptions extends BlueprintScaleLimits {
+  readonly padding?: number;
+}
+
+export type BlueprintInteractionErrorCode =
+  | "invalid-viewport"
+  | "invalid-screen-size"
+  | "invalid-padding"
+  | "invalid-scale-limit"
+  | "invalid-zoom-factor"
+  | "non-finite-point"
+  | "non-finite-pan"
+  | "missing-position"
+  | "duplicate-position";
+
+export class BlueprintInteractionError extends Error {
+  readonly code: BlueprintInteractionErrorCode;
+  readonly key?: VisualKey;
+
+  constructor(code: BlueprintInteractionErrorCode, key?: VisualKey) {
+    super(key === undefined ? code : `${code}: ${key}`);
+    this.name = "BlueprintInteractionError";
+    this.code = code;
+    if (key !== undefined) this.key = key;
+  }
+}
+
+const DEFAULT_MIN_SCALE = 0.1;
+const DEFAULT_MAX_SCALE = 20;
+
+export function createBlueprintViewport(
+  scale = 1,
+  panX = 0,
+  panY = 0,
+): BlueprintViewport {
+  return freezeViewport(validateViewport({ scale, panX, panY }));
+}
+
+export function fitBlueprintViewport(
+  bounds: BlueprintSvgBounds,
+  width: number,
+  height: number,
+  options: BlueprintFitOptions = {},
+): BlueprintViewport {
+  validateBounds(bounds);
+  validatePositiveFinite(width, "invalid-screen-size");
+  validatePositiveFinite(height, "invalid-screen-size");
+  const padding = options.padding ?? 0;
+  if (!Number.isFinite(padding) || padding < 0 || padding * 2 >= width || padding * 2 >= height) {
+    throw new BlueprintInteractionError("invalid-padding");
+  }
+  const limits = resolveScaleLimits(options);
+  const availableWidth = width - padding * 2;
+  const availableHeight = height - padding * 2;
+  const scale = clamp(
+    Math.min(availableWidth / bounds.width, availableHeight / bounds.height),
+    limits.minScale,
+    limits.maxScale,
+  );
+  const centerX = (bounds.minX + bounds.maxX) / 2;
+  const centerY = (bounds.minY + bounds.maxY) / 2;
+  return freezeViewport({
+    scale,
+    panX: width / 2 - centerX * scale,
+    panY: height / 2 - centerY * scale,
+  });
+}
+
+export function panBlueprintViewport(
+  viewport: BlueprintViewport,
+  dx: number,
+  dy: number,
+): BlueprintViewport {
+  const current = validateViewport(viewport);
+  if (!Number.isFinite(dx) || !Number.isFinite(dy)) {
+    throw new BlueprintInteractionError("non-finite-pan");
+  }
+  return freezeViewport({
+    scale: current.scale,
+    panX: current.panX + dx,
+    panY: current.panY + dy,
+  });
+}
+
+export function zoomBlueprintViewport(
+  viewport: BlueprintViewport,
+  factor: number,
+  screenAnchor: Point2D,
+  limits: BlueprintScaleLimits = {},
+): BlueprintViewport {
+  const current = validateViewport(viewport);
+  const anchor = validatePoint(screenAnchor);
+  if (!Number.isFinite(factor) || factor <= 0) {
+    throw new BlueprintInteractionError("invalid-zoom-factor");
+  }
+  const resolvedLimits = resolveScaleLimits(limits);
+  const worldAnchor = blueprintScreenToWorld(current, anchor);
+  const scale = clamp(current.scale * factor, resolvedLimits.minScale, resolvedLimits.maxScale);
+  return freezeViewport({
+    scale,
+    panX: anchor.x - worldAnchor.x * scale,
+    panY: anchor.y - worldAnchor.y * scale,
+  });
+}
+
+export function blueprintWorldToScreen(viewport: BlueprintViewport, point: Point2D): Point2D {
+  const current = validateViewport(viewport);
+  const world = validatePoint(point);
+  return freezePoint({
+    x: world.x * current.scale + current.panX,
+    y: world.y * current.scale + current.panY,
+  });
+}
+
+export function blueprintScreenToWorld(viewport: BlueprintViewport, point: Point2D): Point2D {
+  const current = validateViewport(viewport);
+  const screen = validatePoint(point);
+  return freezePoint({
+    x: (screen.x - current.panX) / current.scale,
+    y: (screen.y - current.panY) / current.scale,
+  });
+}
+
+export function moveBlueprintPosition(
+  positions: readonly BlueprintPosition[],
+  key: VisualKey,
+  worldPoint: Point2D,
+): readonly BlueprintPosition[] {
+  const nextPoint = validatePoint(worldPoint);
+  const seen = new Set<VisualKey>();
+  let found = false;
+  const next = positions.map((position) => {
+    if (seen.has(position.key)) throw new BlueprintInteractionError("duplicate-position", position.key);
+    seen.add(position.key);
+    validatePoint(position.point);
+    const point = position.key === key ? nextPoint : position.point;
+    if (position.key === key) found = true;
+    return freezePosition(position.key, point);
+  });
+  if (!found) throw new BlueprintInteractionError("missing-position", key);
+  return Object.freeze(next);
+}
+
+function validateViewport(viewport: BlueprintViewport): BlueprintViewport {
+  if (!Number.isFinite(viewport.scale) || viewport.scale <= 0
+    || !Number.isFinite(viewport.panX) || !Number.isFinite(viewport.panY)) {
+    throw new BlueprintInteractionError("invalid-viewport");
+  }
+  return viewport;
+}
+
+function validateBounds(bounds: BlueprintSvgBounds): void {
+  if (![bounds.minX, bounds.minY, bounds.maxX, bounds.maxY, bounds.width, bounds.height]
+    .every(Number.isFinite)
+    || bounds.width <= 0 || bounds.height <= 0
+    || bounds.maxX < bounds.minX || bounds.maxY < bounds.minY) {
+    throw new BlueprintInteractionError("invalid-screen-size");
+  }
+}
+
+function resolveScaleLimits(limits: BlueprintScaleLimits): { minScale: number; maxScale: number } {
+  const minScale = limits.minScale ?? DEFAULT_MIN_SCALE;
+  const maxScale = limits.maxScale ?? DEFAULT_MAX_SCALE;
+  if (!Number.isFinite(minScale) || !Number.isFinite(maxScale)
+    || minScale <= 0 || maxScale <= 0 || minScale > maxScale) {
+    throw new BlueprintInteractionError("invalid-scale-limit");
+  }
+  return { minScale, maxScale };
+}
+
+function validatePositiveFinite(value: number, code: BlueprintInteractionErrorCode): void {
+  if (!Number.isFinite(value) || value <= 0) throw new BlueprintInteractionError(code);
+}
+
+function validatePoint(point: Point2D): Point2D {
+  if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+    throw new BlueprintInteractionError("non-finite-point");
+  }
+  return point;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function freezeViewport(viewport: BlueprintViewport): BlueprintViewport {
+  return Object.freeze({ scale: viewport.scale, panX: viewport.panX, panY: viewport.panY });
+}
+
+function freezePoint(point: Point2D): Point2D {
+  return Object.freeze({ x: point.x, y: point.y });
+}
+
+function freezePosition(key: VisualKey, point: Point2D): BlueprintPosition {
+  return Object.freeze({ key, point: freezePoint(point) });
+}

--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -102,3 +102,4 @@ export function normalizeVisualLinkNetwork(network: VisualLinkNetwork): VisualLi
 
 export * from "./blueprint-geometry.js";
 export * from "./blueprint-svg.js";
+export * from "./blueprint-interaction.js";

--- a/packages/visual/test/blueprint-interaction.test.ts
+++ b/packages/visual/test/blueprint-interaction.test.ts
@@ -1,0 +1,169 @@
+import {
+  BlueprintInteractionError,
+  blueprintScreenToWorld,
+  blueprintWorldToScreen,
+  buildBlueprintGeometry,
+  buildBlueprintSvgScene,
+  createBlueprintInitialPositions,
+  createBlueprintViewport,
+  fitBlueprintViewport,
+  moveBlueprintPosition,
+  panBlueprintViewport,
+  zoomBlueprintViewport,
+  type BlueprintInteractionErrorCode,
+  type BlueprintPosition,
+  type VisualLink,
+  type VisualLinkNetwork,
+} from "../src/index.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2b: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function near(actual: number, expected: number, message: string, epsilon = 1e-9): void {
+  assert(Math.abs(actual - expected) <= epsilon, `${message}: ${actual} !~= ${expected}`);
+}
+
+function expectCode(effect: () => unknown, code: BlueprintInteractionErrorCode, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof BlueprintInteractionError, `${message}: wrong error type`);
+    same(error.code, code, `${message}: wrong error code`);
+    return;
+  }
+  throw new Error(`@mts/visual V2b: ${message}: expected rejection`);
+}
+
+function basisLinks(): VisualLink[] {
+  return [
+    { key: "R", startKey: "R", endKey: "R" },
+    { key: "O", startKey: "O", endKey: "R" },
+    { key: "C", startKey: "R", endKey: "C" },
+    { key: "L", startKey: "O", endKey: "C" },
+    { key: "U", startKey: "C", endKey: "O" },
+    { key: "X", startKey: "L", endKey: "U" },
+  ];
+}
+
+const identity = createBlueprintViewport();
+assert(Object.isFrozen(identity), "viewport snapshot is immutable");
+same(identity.scale, 1, "identity scale");
+same(identity.panX, 0, "identity panX");
+same(identity.panY, 0, "identity panY");
+const identityPoint = blueprintWorldToScreen(identity, { x: 12.5, y: -8.25 });
+near(identityPoint.x, 12.5, "identity world->screen x");
+near(identityPoint.y, -8.25, "identity world->screen y");
+
+const viewport = createBlueprintViewport(2.5, 17, -31);
+const world = { x: -12.25, y: 9.75 };
+const screen = blueprintWorldToScreen(viewport, world);
+const roundTrip = blueprintScreenToWorld(viewport, screen);
+near(roundTrip.x, world.x, "world->screen->world x");
+near(roundTrip.y, world.y, "world->screen->world y");
+assert(Object.isFrozen(screen) && Object.isFrozen(roundTrip), "converted points are immutable snapshots");
+
+const bounds = Object.freeze({ minX: -50, minY: -25, maxX: 50, maxY: 25, width: 100, height: 50 });
+const fitted = fitBlueprintViewport(bounds, 400, 200, { padding: 20, minScale: 0.1, maxScale: 20 });
+near(fitted.scale, 3.2, "fit uses limiting dimension");
+near(fitted.panX, 200, "fit centers x");
+near(fitted.panY, 100, "fit centers y");
+const fittedCenter = blueprintWorldToScreen(fitted, { x: 0, y: 0 });
+near(fittedCenter.x, 200, "bounds center maps to screen center x");
+near(fittedCenter.y, 100, "bounds center maps to screen center y");
+
+same(fitBlueprintViewport(bounds, 1000, 1000, { maxScale: 2 }).scale, 2, "fit maxScale clamp");
+same(fitBlueprintViewport(bounds, 20, 20, { minScale: 1 }).scale, 1, "fit minScale clamp");
+
+const panned = panBlueprintViewport(viewport, 5, -7);
+same(panned.scale, viewport.scale, "pan preserves scale exactly");
+same(panned.panX, 22, "pan changes panX");
+same(panned.panY, -38, "pan changes panY");
+
+const anchor = { x: 123, y: 77 };
+const beforeAnchor = blueprintScreenToWorld(viewport, anchor);
+const zoomed = zoomBlueprintViewport(viewport, 2, anchor);
+const afterAnchor = blueprintScreenToWorld(zoomed, anchor);
+near(afterAnchor.x, beforeAnchor.x, "zoom preserves anchor world x");
+near(afterAnchor.y, beforeAnchor.y, "zoom preserves anchor world y");
+near(zoomed.scale, 5, "zoom factor applied");
+
+const clampedZoom = zoomBlueprintViewport(viewport, 1000, anchor, { maxScale: 4 });
+same(clampedZoom.scale, 4, "zoom scale clamp applied");
+const afterClampedAnchor = blueprintScreenToWorld(clampedZoom, anchor);
+near(afterClampedAnchor.x, beforeAnchor.x, "clamped zoom preserves anchor world x");
+near(afterClampedAnchor.y, beforeAnchor.y, "clamped zoom preserves anchor world y");
+
+const zoomForward = zoomBlueprintViewport(viewport, 1.5, anchor);
+const zoomBack = zoomBlueprintViewport(zoomForward, 1 / 1.5, anchor);
+near(zoomBack.scale, viewport.scale, "inverse zoom restores scale");
+near(zoomBack.panX, viewport.panX, "inverse zoom restores panX");
+near(zoomBack.panY, viewport.panY, "inverse zoom restores panY");
+
+const basis: VisualLinkNetwork = { links: basisLinks() };
+const positions = createBlueprintInitialPositions(basis);
+const topologyBefore = JSON.stringify(basis.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
+const positionsBefore = JSON.stringify(positions);
+const moved = moveBlueprintPosition(positions, "X", { x: 777, y: -333 });
+assert(Object.isFrozen(moved), "moved position list is immutable");
+assert(moved.every(Object.isFrozen), "moved position rows are immutable");
+const movedX = moved.find((position) => position.key === "X");
+assert(movedX !== undefined, "moved X exists");
+same(movedX.point.x, 777, "X presentation x moved");
+same(movedX.point.y, -333, "X presentation y moved");
+for (const original of positions) {
+  if (original.key === "X") continue;
+  const current = moved.find((position) => position.key === original.key);
+  assert(current !== undefined, `unchanged ${original.key} exists`);
+  same(current.point.x, original.point.x, `${original.key} x unchanged`);
+  same(current.point.y, original.point.y, `${original.key} y unchanged`);
+}
+same(JSON.stringify(positions), positionsBefore, "move does not mutate source positions");
+
+const movedGeometry = buildBlueprintGeometry(basis, moved);
+const movedScene = buildBlueprintSvgScene(basis, movedGeometry);
+same(movedScene.links.length, 6, "moved positions rebuild V1/V2a stack");
+const topologyAfter = JSON.stringify(basis.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
+same(topologyAfter, topologyBefore, "interaction cannot mutate semantic topology");
+const xLink = basis.links.find((link) => link.key === "X");
+assert(xLink !== undefined, "semantic X remains present");
+same(xLink.startKey, "L", "X start pole unchanged after move");
+same(xLink.endKey, "U", "X end pole unchanged after move");
+
+expectCode(() => createBlueprintViewport(0, 0, 0), "invalid-viewport", "zero scale");
+expectCode(() => createBlueprintViewport(-1, 0, 0), "invalid-viewport", "negative scale");
+expectCode(() => createBlueprintViewport(Number.NaN, 0, 0), "invalid-viewport", "NaN scale");
+expectCode(() => createBlueprintViewport(1, Number.POSITIVE_INFINITY, 0), "invalid-viewport", "infinite pan");
+expectCode(() => fitBlueprintViewport(bounds, 0, 100), "invalid-screen-size", "zero screen width");
+expectCode(() => fitBlueprintViewport(bounds, 100, -1), "invalid-screen-size", "negative screen height");
+expectCode(() => fitBlueprintViewport(bounds, 100, Number.NaN), "invalid-screen-size", "NaN screen height");
+expectCode(() => fitBlueprintViewport(bounds, 100, 100, { padding: -1 }), "invalid-padding", "negative padding");
+expectCode(() => fitBlueprintViewport(bounds, 100, 100, { padding: 50 }), "invalid-padding", "padding consumes viewport");
+expectCode(() => fitBlueprintViewport(bounds, 100, 100, { minScale: 2, maxScale: 1 }), "invalid-scale-limit", "inverted scale limits");
+expectCode(() => zoomBlueprintViewport(viewport, 0, anchor), "invalid-zoom-factor", "zero zoom factor");
+expectCode(() => zoomBlueprintViewport(viewport, -2, anchor), "invalid-zoom-factor", "negative zoom factor");
+expectCode(() => zoomBlueprintViewport(viewport, Number.NaN, anchor), "invalid-zoom-factor", "NaN zoom factor");
+expectCode(() => panBlueprintViewport(viewport, Number.POSITIVE_INFINITY, 0), "non-finite-pan", "infinite pan delta");
+expectCode(() => blueprintWorldToScreen(viewport, { x: Number.NaN, y: 0 }), "non-finite-point", "NaN world point");
+expectCode(() => blueprintScreenToWorld(viewport, { x: 0, y: Number.NEGATIVE_INFINITY }), "non-finite-point", "infinite screen point");
+expectCode(() => moveBlueprintPosition(positions, "missing", { x: 0, y: 0 }), "missing-position", "missing position key");
+expectCode(
+  () => moveBlueprintPosition([...positions, positions[0]!], "X", { x: 0, y: 0 }),
+  "duplicate-position",
+  "duplicate position key",
+);
+expectCode(
+  () => moveBlueprintPosition(positions, "X", { x: Number.POSITIVE_INFINITY, y: 0 }),
+  "non-finite-point",
+  "non-finite moved point",
+);
+
+const explicitPositions: readonly BlueprintPosition[] = Object.freeze([
+  Object.freeze({ key: "R", point: Object.freeze({ x: 0, y: 0 }) }),
+]);
+const movedRoot = moveBlueprintPosition(explicitPositions, "R", { x: 10, y: 20 });
+same(movedRoot[0]!.point.x, 10, "generic interaction layer does not hard-code root pinning");

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -1,5 +1,6 @@
 import "./blueprint-geometry.test.js";
 import "./blueprint-svg.test.js";
+import "./blueprint-interaction.test.js";
 
 import {
   VisualNetworkError,


### PR DESCRIPTION
Closes #909
Parent: #902
Predecessor: #907 / PR #908
Primary donor/migration peer: https://github.com/netkeep80/anum_parser/issues/101

## Summary

Add framework-free pure interaction mathematics/state over the common blueprint stack:

- immutable validated viewport state;
- deterministic fit into explicit screen dimensions;
- pure pan;
- zoom around a screen anchor with explicit min/max scale clamping;
- exact world↔screen conversion helpers;
- presentation-only movement of one `BlueprintPosition`;
- executable integration proving moved positions rebuild V1 geometry and V2a SVG scene without changing Link topology.

## Boundary

```text
BlueprintSvgBounds / BlueprintPosition[]
        |
        v
pure interaction state
        |
        +-- fit
        +-- pan
        +-- zoom-at-anchor
        +-- world <-> screen
        `-- move presentation center
```

No DOM container, listeners, pointer capture, wheel/pinch interpretation, fullscreen API, root pinning policy, Vue, Cytoscape or Three.js are introduced.

The interaction API does not accept or mutate `startKey/endKey`; movement is layout state only.

## Exact pre-PR evidence

```text
base main = 028a629f32274954661e264ae25083d83f1b866b
head = f8f09941cb5755e9b00306d936f33fb085f81472
compare status = ahead
ahead_by = 4
behind_by = 0
changed paths = 4
new files = 2
net added lines = 382
issue budget = 700
workflow/governance files = untouched
contracts/cutover/ts/src/ts/test = untouched
blocking repo policy = enabled
```

CI and blocking repo-guard are required before merge. No accepted MTS semantic change and no v0.12 lifecycle are implied.