### PR TITLE
[Visual/V3a] Add repository-derived Contract Observatory index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
           ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
           node packages/visual/dist/test/model.test.js
 
+      - name: Check Contract Observatory index
+        run: |
+          ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
+          node web/contract-observatory/dist/test/contract-index.test.js
+
   no-python:
     runs-on: ubuntu-latest
     steps:

--- a/web/contract-observatory/src/contract-index.ts
+++ b/web/contract-observatory/src/contract-index.ts
@@ -1,0 +1,341 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface ContractVersionSummary {
+  readonly contractId: string;
+  readonly conformanceId: string;
+  readonly contractPath: string;
+  readonly conformancePath: string;
+  readonly status: string;
+  readonly accepted: boolean;
+  readonly acceptanceReady: boolean;
+  readonly semanticBase: string;
+  readonly observableSemanticDelta: boolean;
+  readonly issue?: number;
+  readonly candidateLifecycleIssue?: number;
+  readonly coverageState: string;
+  readonly requiredExecutableGateCount: number;
+  readonly requiredNegativeVectorCount: number;
+  readonly isCurrent: boolean;
+  readonly isPrevious: boolean;
+}
+
+export interface ContractObservatoryIndex {
+  readonly schema: "mts-contract-observatory-index/v0.1";
+  readonly acceptancePath: string;
+  readonly currentContractPath: string;
+  readonly currentConformancePath: string;
+  readonly previousContractPath: string;
+  readonly previousConformancePath: string;
+  readonly versions: readonly ContractVersionSummary[];
+}
+
+export type ContractIndexErrorCode =
+  | "malformed-json"
+  | "invalid-document"
+  | "invalid-schema-version"
+  | "duplicate-contract-id"
+  | "duplicate-conformance-id"
+  | "missing-conformance"
+  | "orphan-conformance"
+  | "pair-mismatch"
+  | "policy-path-missing"
+  | "acceptance-missing"
+  | "acceptance-mismatch";
+
+export class ContractIndexError extends Error {
+  readonly code: ContractIndexErrorCode;
+  readonly path?: string;
+
+  constructor(code: ContractIndexErrorCode, path?: string) {
+    super(path === undefined ? code : `${code}: ${path}`);
+    this.name = "ContractIndexError";
+    this.code = code;
+    if (path !== undefined) this.path = path;
+  }
+}
+
+type JsonRecord = Record<string, unknown>;
+
+interface ContractDocument {
+  readonly schema: string;
+  readonly conformanceCorpus: string;
+  readonly status: string;
+  readonly accepted: boolean;
+  readonly acceptanceReady: boolean;
+  readonly semanticBase: string;
+  readonly observableSemanticDelta: boolean;
+  readonly issue?: number;
+  readonly candidateLifecycleIssue?: number;
+}
+
+interface ConformanceDocument {
+  readonly schema: string;
+  readonly contract: string;
+  readonly status: string;
+  readonly accepted: boolean;
+  readonly coverageState: string;
+  readonly requiredExecutableGates: readonly string[];
+  readonly requiredNegativeVectors: readonly string[];
+}
+
+interface PolicyPointers {
+  readonly currentContractPath: string;
+  readonly currentConformancePath: string;
+  readonly previousContractPath: string;
+  readonly previousConformancePath: string;
+  readonly acceptancePath: string;
+}
+
+const CONTRACT_FILENAME = /^mts-contract-v.+\.json$/;
+const CONFORMANCE_FILENAME = /^mts-conformance-v.+\.json$/;
+const CONTRACT_SCHEMA = /^mts-contract\/v(\d+(?:\.\d+)*)$/;
+const CONFORMANCE_SCHEMA = /^mts-conformance\/v(\d+(?:\.\d+)*)$/;
+
+export function buildContractObservatoryIndex(repoRoot: string): ContractObservatoryIndex {
+  const policy = readJson(join(repoRoot, "repo-policy.json"), "policy-path-missing");
+  const pointers = readPolicyPointers(policy);
+  const contractsDirectory = join(repoRoot, "contracts");
+  const entries = readdirSync(contractsDirectory, { withFileTypes: true });
+  const contractPaths = entries
+    .filter((entry) => entry.isFile() && CONTRACT_FILENAME.test(entry.name))
+    .map((entry) => `contracts/${entry.name}`)
+    .sort();
+  const conformancePaths = entries
+    .filter((entry) => entry.isFile() && CONFORMANCE_FILENAME.test(entry.name))
+    .map((entry) => `contracts/${entry.name}`)
+    .sort();
+
+  const contracts = new Map<string, { path: string; document: ContractDocument }>();
+  for (const path of contractPaths) {
+    const document = readContract(readJson(join(repoRoot, path), "invalid-document"), path);
+    if (contracts.has(document.schema)) throw new ContractIndexError("duplicate-contract-id", path);
+    contracts.set(document.schema, { path, document });
+  }
+
+  const conformancesById = new Map<string, { path: string; document: ConformanceDocument }>();
+  const conformancesByPath = new Map<string, ConformanceDocument>();
+  for (const path of conformancePaths) {
+    const document = readConformance(readJson(join(repoRoot, path), "invalid-document"), path);
+    if (conformancesById.has(document.schema)) {
+      throw new ContractIndexError("duplicate-conformance-id", path);
+    }
+    conformancesById.set(document.schema, { path, document });
+    conformancesByPath.set(path, document);
+  }
+
+  const usedConformancePaths = new Set<string>();
+  const versions: ContractVersionSummary[] = [];
+  for (const { path: contractPath, document: contract } of contracts.values()) {
+    parseVersion(contract.schema, CONTRACT_SCHEMA, contractPath);
+    const conformance = conformancesByPath.get(contract.conformanceCorpus);
+    if (conformance === undefined) {
+      throw new ContractIndexError("missing-conformance", contract.conformanceCorpus);
+    }
+    if (usedConformancePaths.has(contract.conformanceCorpus)) {
+      throw new ContractIndexError("pair-mismatch", contract.conformanceCorpus);
+    }
+    usedConformancePaths.add(contract.conformanceCorpus);
+    parseVersion(conformance.schema, CONFORMANCE_SCHEMA, contract.conformanceCorpus);
+    const expectedConformanceId = contract.schema.replace("mts-contract/", "mts-conformance/");
+    if (conformance.contract !== contract.schema || conformance.schema !== expectedConformanceId) {
+      throw new ContractIndexError("pair-mismatch", contract.conformanceCorpus);
+    }
+
+    versions.push(freezeSummary({
+      contractId: contract.schema,
+      conformanceId: conformance.schema,
+      contractPath,
+      conformancePath: contract.conformanceCorpus,
+      status: contract.status,
+      accepted: contract.accepted,
+      acceptanceReady: contract.acceptanceReady,
+      semanticBase: contract.semanticBase,
+      observableSemanticDelta: contract.observableSemanticDelta,
+      ...(contract.issue === undefined ? {} : { issue: contract.issue }),
+      ...(contract.candidateLifecycleIssue === undefined
+        ? {}
+        : { candidateLifecycleIssue: contract.candidateLifecycleIssue }),
+      coverageState: conformance.coverageState,
+      requiredExecutableGateCount: conformance.requiredExecutableGates.length,
+      requiredNegativeVectorCount: conformance.requiredNegativeVectors.length,
+      isCurrent: contractPath === pointers.currentContractPath
+        && contract.conformanceCorpus === pointers.currentConformancePath,
+      isPrevious: contractPath === pointers.previousContractPath
+        && contract.conformanceCorpus === pointers.previousConformancePath,
+    }));
+  }
+
+  for (const { path } of conformancesById.values()) {
+    if (!usedConformancePaths.has(path)) throw new ContractIndexError("orphan-conformance", path);
+  }
+
+  requirePairPath(versions, pointers.currentContractPath, pointers.currentConformancePath);
+  requirePairPath(versions, pointers.previousContractPath, pointers.previousConformancePath);
+  verifyAcceptance(repoRoot, pointers);
+
+  versions.sort((left, right) => compareVersions(left.contractId, right.contractId));
+  return Object.freeze({
+    schema: "mts-contract-observatory-index/v0.1",
+    acceptancePath: pointers.acceptancePath,
+    currentContractPath: pointers.currentContractPath,
+    currentConformancePath: pointers.currentConformancePath,
+    previousContractPath: pointers.previousContractPath,
+    previousConformancePath: pointers.previousConformancePath,
+    versions: Object.freeze(versions),
+  });
+}
+
+export function serializeContractObservatoryIndex(index: ContractObservatoryIndex): string {
+  return `${JSON.stringify(index, null, 2)}\n`;
+}
+
+function readPolicyPointers(policy: JsonRecord): PolicyPointers {
+  const boundary = recordField(policy, "contract_conformance", "repo-policy.json");
+  const current = recordField(boundary, "current", "repo-policy.json");
+  const previous = recordField(boundary, "previous", "repo-policy.json");
+  const acceptance = recordField(boundary, "acceptance", "repo-policy.json");
+  return {
+    currentContractPath: documentPath(current, "contract"),
+    currentConformancePath: documentPath(current, "conformance"),
+    previousContractPath: documentPath(previous, "contract"),
+    previousConformancePath: documentPath(previous, "conformance"),
+    acceptancePath: documentPath(acceptance, "document"),
+  };
+}
+
+function verifyAcceptance(repoRoot: string, pointers: PolicyPointers): void {
+  const absolutePath = join(repoRoot, pointers.acceptancePath);
+  const acceptance = readJson(absolutePath, "acceptance-missing");
+  const current = recordField(acceptance, "current", pointers.acceptancePath);
+  if (stringField(current, "contract", pointers.acceptancePath) !== pointers.currentContractPath
+    || stringField(current, "conformance", pointers.acceptancePath) !== pointers.currentConformancePath) {
+    throw new ContractIndexError("acceptance-mismatch", pointers.acceptancePath);
+  }
+}
+
+function requirePairPath(
+  versions: readonly ContractVersionSummary[],
+  contractPath: string,
+  conformancePath: string,
+): void {
+  if (!versions.some((version) => version.contractPath === contractPath
+    && version.conformancePath === conformancePath)) {
+    throw new ContractIndexError("policy-path-missing", `${contractPath} | ${conformancePath}`);
+  }
+}
+
+function readContract(value: JsonRecord, path: string): ContractDocument {
+  const schema = stringField(value, "schema", path);
+  parseVersion(schema, CONTRACT_SCHEMA, path);
+  return {
+    schema,
+    conformanceCorpus: stringField(value, "conformanceCorpus", path),
+    status: stringField(value, "status", path),
+    accepted: booleanField(value, "accepted", path),
+    acceptanceReady: booleanField(value, "acceptanceReady", path),
+    semanticBase: stringField(value, "semanticBase", path),
+    observableSemanticDelta: booleanField(value, "observableSemanticDelta", path),
+    ...optionalNumberField(value, "issue", path),
+    ...optionalNumberField(value, "candidateLifecycleIssue", path),
+  };
+}
+
+function readConformance(value: JsonRecord, path: string): ConformanceDocument {
+  const schema = stringField(value, "schema", path);
+  parseVersion(schema, CONFORMANCE_SCHEMA, path);
+  return {
+    schema,
+    contract: stringField(value, "contract", path),
+    status: stringField(value, "status", path),
+    accepted: booleanField(value, "accepted", path),
+    coverageState: stringField(value, "coverageState", path),
+    requiredExecutableGates: stringArrayField(value, "requiredExecutableGates", path),
+    requiredNegativeVectors: stringArrayField(value, "requiredNegativeVectors", path),
+  };
+}
+
+function compareVersions(left: string, right: string): number {
+  const a = parseVersion(left, CONTRACT_SCHEMA, left);
+  const b = parseVersion(right, CONTRACT_SCHEMA, right);
+  const length = Math.max(a.length, b.length);
+  for (let index = 0; index < length; index += 1) {
+    const delta = (a[index] ?? 0) - (b[index] ?? 0);
+    if (delta !== 0) return delta;
+  }
+  return 0;
+}
+
+function parseVersion(value: string, pattern: RegExp, path: string): readonly number[] {
+  const match = pattern.exec(value);
+  if (match === null || match[1] === undefined) throw new ContractIndexError("invalid-schema-version", path);
+  const parts = match[1].split(".").map((part) => Number(part));
+  if (parts.some((part) => !Number.isSafeInteger(part) || part < 0)) {
+    throw new ContractIndexError("invalid-schema-version", path);
+  }
+  return parts;
+}
+
+function readJson(path: string, missingCode: ContractIndexErrorCode): JsonRecord {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    throw new ContractIndexError(missingCode, path);
+  }
+  try {
+    const value: unknown = JSON.parse(text);
+    return requireRecord(value, path);
+  } catch (error) {
+    if (error instanceof ContractIndexError) throw error;
+    throw new ContractIndexError("malformed-json", path);
+  }
+}
+
+function requireRecord(value: unknown, path: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ContractIndexError("invalid-document", path);
+  }
+  return value as JsonRecord;
+}
+
+function recordField(record: JsonRecord, field: string, path: string): JsonRecord {
+  return requireRecord(record[field], path);
+}
+
+function documentPath(record: JsonRecord, field: string): string {
+  return stringField(recordField(record, field, "repo-policy.json"), "path", "repo-policy.json");
+}
+
+function stringField(record: JsonRecord, field: string, path: string): string {
+  const value = record[field];
+  if (typeof value !== "string" || value.length === 0) throw new ContractIndexError("invalid-document", path);
+  return value;
+}
+
+function booleanField(record: JsonRecord, field: string, path: string): boolean {
+  const value = record[field];
+  if (typeof value !== "boolean") throw new ContractIndexError("invalid-document", path);
+  return value;
+}
+
+function optionalNumberField(record: JsonRecord, field: string, path: string): Record<string, number> {
+  const value = record[field];
+  if (value === undefined) return {};
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new ContractIndexError("invalid-document", path);
+  }
+  return { [field]: value };
+}
+
+function stringArrayField(record: JsonRecord, field: string, path: string): readonly string[] {
+  const value = record[field];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new ContractIndexError("invalid-document", path);
+  }
+  return value;
+}
+
+function freezeSummary(summary: ContractVersionSummary): ContractVersionSummary {
+  return Object.freeze({ ...summary });
+}

--- a/web/contract-observatory/test/contract-index.test.ts
+++ b/web/contract-observatory/test/contract-index.test.ts
@@ -1,0 +1,232 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ContractIndexError,
+  buildContractObservatoryIndex,
+  serializeContractObservatoryIndex,
+  type ContractIndexErrorCode,
+} from "../src/contract-index.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Contract Observatory V3a: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectCode(effect: () => unknown, code: ContractIndexErrorCode, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof ContractIndexError, `${message}: wrong error type`);
+    same(error.code, code, `${message}: wrong error code`);
+    return;
+  }
+  throw new Error(`Contract Observatory V3a: ${message}: expected rejection`);
+}
+
+const repositoryRoot = process.cwd();
+const realIndex = buildContractObservatoryIndex(repositoryRoot);
+same(realIndex.schema, "mts-contract-observatory-index/v0.1", "index schema");
+same(realIndex.versions.length, 2, "current repository has two live pairs");
+same(
+  realIndex.versions.map((version) => version.contractId).join(","),
+  "mts-contract/v0.10,mts-contract/v0.11",
+  "real repository uses natural version order",
+);
+same(realIndex.currentContractPath, "contracts/mts-contract-v0.11.json", "policy current contract");
+same(realIndex.currentConformancePath, "contracts/mts-conformance-v0.11.json", "policy current conformance");
+same(realIndex.previousContractPath, "contracts/mts-contract-v0.10.json", "policy previous contract");
+same(realIndex.previousConformancePath, "contracts/mts-conformance-v0.10.json", "policy previous conformance");
+same(realIndex.acceptancePath, "cutover/typescript-c1-acceptance-v0.4.json", "acceptance path comes from policy");
+
+const current = realIndex.versions.find((version) => version.isCurrent);
+const previous = realIndex.versions.find((version) => version.isPrevious);
+assert(current !== undefined && previous !== undefined, "current and previous summaries exist");
+same(current.contractId, "mts-contract/v0.11", "current classification comes from evidence");
+same(previous.contractId, "mts-contract/v0.10", "previous classification comes from evidence");
+same(current.status, "accepted", "current status projected");
+same(current.accepted, true, "current accepted flag projected");
+same(current.acceptanceReady, true, "current readiness projected");
+same(current.coverageState, "complete", "current coverage projected");
+same(current.requiredExecutableGateCount, 5, "current executable gate count projected");
+assert(current.requiredNegativeVectorCount > 0, "current negative-vector coverage projected");
+
+const serialized = serializeContractObservatoryIndex(realIndex);
+same(serialized, serializeContractObservatoryIndex(buildContractObservatoryIndex(repositoryRoot)), "serialization is deterministic");
+assert(!serialized.includes("rootBasisTarget"), "index does not copy raw contract bodies");
+assert(!serialized.includes("TopBind(R,S)"), "index does not copy semantic equations");
+const livePaths = new Set(realIndex.versions.flatMap((version) => [version.contractPath, version.conformancePath]));
+same(livePaths.size, 4, "all four live evidence files accounted for exactly once");
+
+interface Fixture {
+  readonly root: string;
+  readonly acceptancePath: string;
+}
+
+function createFixture(versions = ["0.9", "0.10", "1.2", "1.10"]): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "mts-contract-index-"));
+  mkdirSync(join(root, "contracts"));
+  mkdirSync(join(root, "cutover"));
+  for (const version of versions) {
+    writeJson(root, `contracts/mts-contract-v${version}.json`, {
+      schema: `mts-contract/v${version}`,
+      status: "accepted",
+      accepted: true,
+      acceptanceReady: true,
+      semanticBase: "mts-contract/v0.1",
+      observableSemanticDelta: true,
+      conformanceCorpus: `contracts/mts-conformance-v${version}.json`,
+      issue: 1,
+      candidateLifecycleIssue: 2,
+    });
+    writeJson(root, `contracts/mts-conformance-v${version}.json`, {
+      schema: `mts-conformance/v${version}`,
+      status: "accepted",
+      accepted: true,
+      contract: `mts-contract/v${version}`,
+      coverageState: "complete",
+      requiredExecutableGates: [`test-${version}`],
+      requiredNegativeVectors: [`negative-${version}`],
+    });
+  }
+  const current = versions.at(-1)!;
+  const previous = versions.at(-2)!;
+  const acceptancePath = "cutover/acceptance.json";
+  writeJson(root, "repo-policy.json", {
+    contract_conformance: {
+      current: {
+        contract: { path: `contracts/mts-contract-v${current}.json` },
+        conformance: { path: `contracts/mts-conformance-v${current}.json` },
+      },
+      previous: {
+        contract: { path: `contracts/mts-contract-v${previous}.json` },
+        conformance: { path: `contracts/mts-conformance-v${previous}.json` },
+      },
+      acceptance: { document: { path: acceptancePath } },
+    },
+  });
+  writeJson(root, acceptancePath, {
+    current: {
+      contract: `contracts/mts-contract-v${current}.json`,
+      conformance: `contracts/mts-conformance-v${current}.json`,
+    },
+  });
+  return { root, acceptancePath };
+}
+
+function writeJson(root: string, path: string, value: unknown): void {
+  writeFileSync(join(root, path), `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function overwrite(root: string, path: string, value: unknown): void {
+  writeJson(root, path, value);
+}
+
+function fixtureCase(effect: (fixture: Fixture) => void): void {
+  const fixture = createFixture();
+  try {
+    effect(fixture);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+const natural = createFixture();
+try {
+  same(
+    buildContractObservatoryIndex(natural.root).versions.map((version) => version.contractId).join(","),
+    "mts-contract/v0.9,mts-contract/v0.10,mts-contract/v1.2,mts-contract/v1.10",
+    "numeric version ordering is not lexical ordering",
+  );
+} finally {
+  rmSync(natural.root, { recursive: true, force: true });
+}
+
+fixtureCase(({ root }) => {
+  writeFileSync(join(root, "contracts/mts-contract-v0.9.json"), "{broken", "utf8");
+  expectCode(() => buildContractObservatoryIndex(root), "malformed-json", "malformed contract JSON");
+});
+fixtureCase(({ root }) => {
+  overwrite(root, "contracts/mts-contract-v0.9.json", {
+    status: "accepted", accepted: true, acceptanceReady: true,
+    semanticBase: "mts-contract/v0.1", observableSemanticDelta: true,
+    conformanceCorpus: "contracts/mts-conformance-v0.9.json",
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "invalid-document", "missing contract schema");
+});
+fixtureCase(({ root }) => {
+  overwrite(root, "contracts/mts-contract-v0.9.json", {
+    schema: "mts-contract/v0.9", status: "accepted", accepted: true, acceptanceReady: true,
+    semanticBase: "mts-contract/v0.1", observableSemanticDelta: true,
+    conformanceCorpus: "contracts/not-present.json",
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "missing-conformance", "missing declared conformance");
+});
+fixtureCase(({ root }) => {
+  writeJson(root, "contracts/mts-conformance-v9.9.json", {
+    schema: "mts-conformance/v9.9", status: "accepted", accepted: true,
+    contract: "mts-contract/v9.9", coverageState: "complete",
+    requiredExecutableGates: [], requiredNegativeVectors: [],
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "orphan-conformance", "orphan conformance");
+});
+fixtureCase(({ root }) => {
+  writeJson(root, "contracts/mts-contract-v9.9.json", {
+    schema: "mts-contract/v0.9", status: "accepted", accepted: true, acceptanceReady: true,
+    semanticBase: "mts-contract/v0.1", observableSemanticDelta: true,
+    conformanceCorpus: "contracts/mts-conformance-v0.9.json",
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "duplicate-contract-id", "duplicate contract ID");
+});
+fixtureCase(({ root }) => {
+  writeJson(root, "contracts/mts-conformance-v9.9.json", {
+    schema: "mts-conformance/v0.9", status: "accepted", accepted: true,
+    contract: "mts-contract/v0.9", coverageState: "complete",
+    requiredExecutableGates: [], requiredNegativeVectors: [],
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "duplicate-conformance-id", "duplicate conformance ID");
+});
+fixtureCase(({ root }) => {
+  overwrite(root, "contracts/mts-conformance-v0.9.json", {
+    schema: "mts-conformance/v0.9", status: "accepted", accepted: true,
+    contract: "mts-contract/v0.10", coverageState: "complete",
+    requiredExecutableGates: [], requiredNegativeVectors: [],
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "pair-mismatch", "declared pair mismatch");
+});
+fixtureCase(({ root }) => {
+  overwrite(root, "repo-policy.json", {
+    contract_conformance: {
+      current: { contract: { path: "contracts/missing.json" }, conformance: { path: "contracts/mts-conformance-v1.10.json" } },
+      previous: { contract: { path: "contracts/mts-contract-v1.2.json" }, conformance: { path: "contracts/mts-conformance-v1.2.json" } },
+      acceptance: { document: { path: "cutover/acceptance.json" } },
+    },
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "policy-path-missing", "policy points outside discovered pairs");
+});
+fixtureCase(({ root, acceptancePath }) => {
+  rmSync(join(root, acceptancePath));
+  expectCode(() => buildContractObservatoryIndex(root), "acceptance-missing", "missing acceptance manifest");
+});
+fixtureCase(({ root, acceptancePath }) => {
+  overwrite(root, acceptancePath, {
+    current: { contract: "contracts/mts-contract-v1.2.json", conformance: "contracts/mts-conformance-v1.2.json" },
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "acceptance-mismatch", "acceptance disagrees with policy");
+});
+fixtureCase(({ root }) => {
+  writeJson(root, "contracts/mts-contract-v1.x.json", {
+    schema: "mts-contract/v1.x", status: "accepted", accepted: true, acceptanceReady: true,
+    semanticBase: "mts-contract/v0.1", observableSemanticDelta: true,
+    conformanceCorpus: "contracts/mts-conformance-v1.x.json",
+  });
+  writeJson(root, "contracts/mts-conformance-v1.x.json", {
+    schema: "mts-conformance/v1.x", status: "accepted", accepted: true,
+    contract: "mts-contract/v1.x", coverageState: "complete",
+    requiredExecutableGates: [], requiredNegativeVectors: [],
+  });
+  expectCode(() => buildContractObservatoryIndex(root), "invalid-schema-version", "ambiguous schema version");
+});

--- a/web/contract-observatory/tsconfig.json
+++ b/web/contract-observatory/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "typeRoots": ["../../ts/node_modules/@types"],
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Closes #911
Parent: #902
Predecessor: #909 / PR #910

## Summary

Add the first repository-specific Contract Observatory data layer:

- auto-discover live `contracts/mts-contract-v*.json` and `mts-conformance-v*.json` files;
- validate declared contract↔conformance pairing and reject orphan/duplicate/mismatch evidence;
- resolve current/previous and acceptance manifest paths dynamically from `repo-policy.json`;
- verify acceptance current pointers agree with repository policy;
- derive compact deterministic version summaries without copying raw semantic documents;
- sort schema versions by numeric components rather than filesystem/lexical order;
- exercise the real repository plus runtime-generated adversarial fixtures;
- add one blocking CI step using the existing Node 24 / TypeScript toolchain.

## Boundary

```text
repo-policy.json + contracts/*.json + declared acceptance manifest
                         |
                         v
              ContractObservatoryIndex
```

The index is read-only derived navigation/presentation metadata. It is not semantic authority. Repository parsing stays under `web/contract-observatory/**`; neither `@mts/core` nor `@mts/visual` is changed.

## Governance

#911 contains an explicit narrow GovernanceGrant authorizing only the additive `.github/workflows/ci.yml` Contract Observatory check, with no policy relaxation.

## Exact pre-PR evidence

```text
base main = 573394ba3db656523bd858fc66c6b37309a3e2ac
head = 31083f0418e20797e6b91446b33005948267efa2
compare status = ahead
ahead_by = 4
behind_by = 0
changed paths = 4
new files = 3
net added lines = 596
issue budget = 800
contracts/cutover/ts/src/ts/test/packages/visual = untouched
repo-policy/repo-guard workflow = untouched
ci.yml delta = additive blocking step only
blocking repository policy = enabled
```

Production index code contains no hard-coded version list. The real-repository test records the current two-pair baseline as executable evidence only.

CI and blocking repo-guard are required before merge. No accepted MTS semantic change and no v0.12 lifecycle are implied.