### PR TITLE
[Visual/V3b] Add static Contract Observatory Timeline and Version Overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
           node web/contract-observatory/dist/test/contract-index.test.js
+          node web/contract-observatory/dist/test/site.test.js
 
   no-python:
     runs-on: ubuntu-latest

--- a/web/contract-observatory/src/site.ts
+++ b/web/contract-observatory/src/site.ts
@@ -1,0 +1,195 @@
+import type { ContractObservatoryIndex, ContractVersionSummary } from "./contract-index.js";
+
+export function renderContractObservatoryHtml(index: ContractObservatoryIndex): string {
+  const timeline = index.versions
+    .map((version, ordinal) => renderTimelineItem(version, ordinal))
+    .join("\n");
+  const versions = index.versions
+    .map((version, ordinal) => renderVersionSection(version, ordinal))
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MTS Contract Observatory</title>
+  <style>
+    :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: Canvas; color: CanvasText; }
+    a { color: LinkText; }
+    a:focus-visible, summary:focus-visible { outline: 3px solid Highlight; outline-offset: 3px; }
+    .shell { width: min(1120px, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0 4rem; }
+    .hero { display: grid; gap: .8rem; margin-bottom: 2rem; }
+    .eyebrow { margin: 0; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; opacity: .7; }
+    h1 { margin: 0; font-size: clamp(2rem, 6vw, 4.5rem); line-height: .95; max-width: 12ch; }
+    .lede { margin: 0; max-width: 72ch; line-height: 1.6; opacity: .82; }
+    .provenance { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .75rem; margin: 1.5rem 0 2rem; }
+    .provenance div, .version-card { border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 1rem; background: color-mix(in srgb, Canvas 94%, CanvasText 6%); }
+    .provenance div { padding: .9rem 1rem; min-width: 0; }
+    dt { font-size: .72rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; opacity: .65; }
+    dd { margin: .35rem 0 0; overflow-wrap: anywhere; }
+    .timeline { margin: 0 0 2.5rem; }
+    .timeline h2, .versions h2 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .timeline ol { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: .8rem; padding: 0; margin: 0; list-style: none; }
+    .timeline a { display: grid; gap: .5rem; min-height: 8rem; padding: 1rem; border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 1rem; color: inherit; text-decoration: none; background: color-mix(in srgb, Canvas 96%, CanvasText 4%); }
+    .timeline a:hover { border-color: color-mix(in srgb, CanvasText 45%, transparent); }
+    .timeline .current { border-width: 2px; }
+    .timeline-id { font-weight: 800; overflow-wrap: anywhere; }
+    .badges { display: flex; flex-wrap: wrap; gap: .35rem; align-items: center; }
+    .badge { display: inline-flex; align-items: center; min-height: 1.7rem; padding: .2rem .55rem; border: 1px solid currentColor; border-radius: 999px; font-size: .72rem; font-weight: 800; letter-spacing: .04em; }
+    .badge-muted { opacity: .65; }
+    .version-list { display: grid; gap: 1rem; }
+    .version-card { overflow: hidden; }
+    .version-card.current { border-width: 2px; }
+    .version-card summary { cursor: pointer; display: flex; flex-wrap: wrap; gap: .7rem; justify-content: space-between; align-items: center; padding: 1rem 1.2rem; font-weight: 800; }
+    .version-body { padding: 0 1.2rem 1.2rem; }
+    .metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: .7rem; margin: .4rem 0 1rem; }
+    .metric { padding: .8rem; border-radius: .8rem; background: color-mix(in srgb, Canvas 90%, CanvasText 10%); }
+    .metric strong { display: block; margin-top: .25rem; font-size: 1.15rem; overflow-wrap: anywhere; }
+    table { width: 100%; border-collapse: collapse; font-size: .92rem; }
+    th, td { padding: .65rem .4rem; border-top: 1px solid color-mix(in srgb, CanvasText 15%, transparent); text-align: left; vertical-align: top; }
+    th { width: 13rem; font-weight: 700; }
+    td { overflow-wrap: anywhere; }
+    .footer { margin-top: 2.5rem; font-size: .85rem; opacity: .7; }
+    @media (max-width: 680px) {
+      .shell { width: min(100% - 1rem, 1120px); padding-top: 1rem; }
+      .provenance { grid-template-columns: 1fr; }
+      th, td { display: block; width: 100%; padding-left: 0; padding-right: 0; }
+      th { border-bottom: 0; padding-bottom: .2rem; }
+      td { border-top: 0; padding-top: 0; }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header class="hero">
+      <p class="eyebrow">MTS · derived evidence</p>
+      <h1>Contract Observatory</h1>
+      <p class="lede">Статическое представление contract/conformance evidence. Эта страница является производной навигацией и не является источником семантики МТС.</p>
+    </header>
+
+    <dl class="provenance" aria-label="Provenance">
+      ${renderDefinition("Index schema", index.schema)}
+      ${renderDefinition("Acceptance", index.acceptancePath)}
+      ${renderDefinition("Current contract", index.currentContractPath)}
+      ${renderDefinition("Previous contract", index.previousContractPath)}
+    </dl>
+
+    <nav class="timeline" aria-labelledby="timeline-title">
+      <h2 id="timeline-title">Timeline</h2>
+      <ol>
+${timeline}
+      </ol>
+    </nav>
+
+    <main class="versions" aria-labelledby="versions-title">
+      <h2 id="versions-title">Version Overview</h2>
+      <div class="version-list">
+${versions}
+      </div>
+    </main>
+
+    <footer class="footer">Generated deterministically from ContractObservatoryIndex. Presentation is non-normative.</footer>
+  </div>
+</body>
+</html>
+`;
+}
+
+function renderTimelineItem(version: ContractVersionSummary, ordinal: number): string {
+  const anchor = anchorId(ordinal);
+  const classification = classify(version);
+  const semanticDelta = version.observableSemanticDelta ? "SEMANTIC DELTA" : "NO SEMANTIC DELTA";
+  return `        <li>
+          <a href="#${anchor}" class="${version.isCurrent ? "current" : ""}"${version.isCurrent ? " aria-current=\"page\"" : ""}>
+            <span class="timeline-id">${escapeHtml(version.contractId)}</span>
+            <span class="badges">
+              ${badge(classification, false)}
+              ${badge(version.status.toUpperCase(), true)}
+              ${badge(version.accepted ? "ACCEPTED" : "NOT ACCEPTED", true)}
+              ${badge(semanticDelta, true)}
+            </span>
+          </a>
+        </li>`;
+}
+
+function renderVersionSection(version: ContractVersionSummary, ordinal: number): string {
+  const anchor = anchorId(ordinal);
+  const issueRows = [
+    version.issue === undefined ? "" : renderRow("Issue", `#${version.issue}`),
+    version.candidateLifecycleIssue === undefined
+      ? ""
+      : renderRow("Candidate lifecycle issue", `#${version.candidateLifecycleIssue}`),
+  ].filter(Boolean).join("\n");
+
+  return `        <section id="${anchor}" class="version-card${version.isCurrent ? " current" : ""}" aria-labelledby="${anchor}-title">
+          <details${version.isCurrent ? " open" : ""}>
+            <summary>
+              <span id="${anchor}-title">${escapeHtml(version.contractId)}</span>
+              <span class="badges">${badge(classify(version), false)} ${badge(version.status.toUpperCase(), true)}</span>
+            </summary>
+            <div class="version-body">
+              <div class="metric-grid">
+                ${metric("Accepted", yesNo(version.accepted))}
+                ${metric("Acceptance ready", yesNo(version.acceptanceReady))}
+                ${metric("Coverage", version.coverageState)}
+                ${metric("Executable gates", String(version.requiredExecutableGateCount))}
+                ${metric("Negative vectors", String(version.requiredNegativeVectorCount))}
+                ${metric("Semantic delta", yesNo(version.observableSemanticDelta))}
+              </div>
+              <table>
+                <tbody>
+                  ${renderRow("Contract", version.contractId)}
+                  ${renderRow("Conformance", version.conformanceId)}
+                  ${renderRow("Semantic base", version.semanticBase)}
+                  ${renderRow("Contract path", version.contractPath)}
+                  ${renderRow("Conformance path", version.conformancePath)}
+                  ${renderRow("Classification", classify(version))}
+${issueRows}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        </section>`;
+}
+
+function renderDefinition(label: string, value: string): string {
+  return `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`;
+}
+
+function renderRow(label: string, value: string): string {
+  return `                  <tr><th scope="row">${escapeHtml(label)}</th><td>${escapeHtml(value)}</td></tr>`;
+}
+
+function metric(label: string, value: string): string {
+  return `<div class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`;
+}
+
+function badge(value: string, muted: boolean): string {
+  return `<span class="badge${muted ? " badge-muted" : ""}">${escapeHtml(value)}</span>`;
+}
+
+function classify(version: ContractVersionSummary): string {
+  if (version.isCurrent) return "CURRENT";
+  if (version.isPrevious) return "PREVIOUS";
+  return "LIVE";
+}
+
+function yesNo(value: boolean): string {
+  return value ? "YES" : "NO";
+}
+
+function anchorId(ordinal: number): string {
+  return `version-${ordinal + 1}`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/web/contract-observatory/test/site.test.ts
+++ b/web/contract-observatory/test/site.test.ts
@@ -1,0 +1,144 @@
+import {
+  buildContractObservatoryIndex,
+  type ContractObservatoryIndex,
+  type ContractVersionSummary,
+} from "../src/contract-index.js";
+import { renderContractObservatoryHtml } from "../src/site.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Contract Observatory V3b: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function count(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let result = 0;
+  let offset = 0;
+  while (true) {
+    const found = haystack.indexOf(needle, offset);
+    if (found < 0) return result;
+    result += 1;
+    offset = found + needle.length;
+  }
+}
+
+function version(overrides: Partial<ContractVersionSummary> = {}): ContractVersionSummary {
+  return Object.freeze({
+    contractId: "mts-contract/v1.0",
+    conformanceId: "mts-conformance/v1.0",
+    contractPath: "contracts/mts-contract-v1.0.json",
+    conformancePath: "contracts/mts-conformance-v1.0.json",
+    status: "accepted",
+    accepted: true,
+    acceptanceReady: true,
+    semanticBase: "mts-contract/v0.9",
+    observableSemanticDelta: true,
+    coverageState: "complete",
+    requiredExecutableGateCount: 3,
+    requiredNegativeVectorCount: 4,
+    isCurrent: false,
+    isPrevious: false,
+    ...overrides,
+  });
+}
+
+function index(versions: readonly ContractVersionSummary[]): ContractObservatoryIndex {
+  return Object.freeze({
+    schema: "mts-contract-observatory-index/v0.1",
+    acceptancePath: "cutover/acceptance.json",
+    currentContractPath: "contracts/current.json",
+    currentConformancePath: "contracts/current-conformance.json",
+    previousContractPath: "contracts/previous.json",
+    previousConformancePath: "contracts/previous-conformance.json",
+    versions: Object.freeze([...versions]),
+  });
+}
+
+const repositoryRoot = process.cwd();
+const realIndex = buildContractObservatoryIndex(repositoryRoot);
+const realHtml = renderContractObservatoryHtml(realIndex);
+
+same(realIndex.versions.length, 2, "real repository still exposes two live versions");
+assert(realHtml.startsWith("<!doctype html>\n<html lang=\"ru\">"), "browser document baseline");
+assert(realHtml.includes("<meta charset=\"utf-8\">"), "UTF-8 metadata");
+assert(realHtml.includes("name=\"viewport\""), "viewport metadata");
+same(count(realHtml, "<h1>"), 1, "exactly one h1");
+assert(realHtml.includes("<nav class=\"timeline\""), "timeline landmark");
+assert(realHtml.includes("<main class=\"versions\""), "main landmark");
+assert(realHtml.includes(":focus-visible"), "visible keyboard focus styling");
+assert(realHtml.includes("@media (max-width: 680px)"), "responsive baseline");
+assert(!realHtml.includes("<script"), "no client script runtime");
+assert(!realHtml.includes("http://") && !realHtml.includes("https://"), "no external network dependency");
+
+const v010Position = realHtml.indexOf("mts-contract/v0.10");
+const v011Position = realHtml.indexOf("mts-contract/v0.11");
+assert(v010Position >= 0 && v011Position > v010Position, "timeline preserves V3a natural order");
+assert(realHtml.includes("CURRENT"), "current marker visible");
+assert(realHtml.includes("PREVIOUS"), "previous marker visible");
+assert(realHtml.includes(realIndex.acceptancePath), "acceptance provenance visible");
+assert(realHtml.includes(realIndex.currentContractPath), "current contract provenance visible");
+assert(realHtml.includes(realIndex.previousContractPath), "previous contract provenance visible");
+
+const current = realIndex.versions.find((entry) => entry.isCurrent);
+const previous = realIndex.versions.find((entry) => entry.isPrevious);
+assert(current !== undefined, "real current version exists");
+assert(previous !== undefined, "real previous version exists");
+assert(realHtml.includes(String(current.requiredExecutableGateCount)), "current gate count rendered");
+assert(realHtml.includes(String(current.requiredNegativeVectorCount)), "current negative-vector count rendered");
+assert(realHtml.includes(`id=\"version-${realIndex.versions.indexOf(current) + 1}\" class=\"version-card current\"`), "current section classified");
+assert(realHtml.includes(`id=\"version-${realIndex.versions.indexOf(previous) + 1}\" class=\"version-card\"`), "previous section preserves order");
+same(renderContractObservatoryHtml(realIndex), realHtml, "real repository rendering is deterministic");
+
+const malicious = `<script>alert('x')</script>&\" >`;
+const synthetic = index([
+  version({
+    contractId: `contract-${malicious}`,
+    conformanceId: `conformance-${malicious}`,
+    contractPath: `contracts/${malicious}.json`,
+    conformancePath: `contracts/conf-${malicious}.json`,
+    status: malicious,
+    semanticBase: malicious,
+    coverageState: malicious,
+    accepted: false,
+    acceptanceReady: false,
+    observableSemanticDelta: false,
+    isPrevious: true,
+  }),
+  version({
+    contractId: "mts-contract/v9.7",
+    conformanceId: "mts-conformance/v9.7",
+    isCurrent: true,
+    issue: 77,
+    candidateLifecycleIssue: 66,
+  }),
+  version({
+    contractId: "mts-contract/v2.3",
+    conformanceId: "mts-conformance/v2.3",
+  }),
+]);
+
+const syntheticHtml = renderContractObservatoryHtml(synthetic);
+assert(!syntheticHtml.includes(malicious), "untrusted index string never survives as raw markup");
+assert(!syntheticHtml.includes("<script>alert"), "script-like text is escaped");
+assert(syntheticHtml.includes("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;&amp;&quot; &gt;"), "HTML metacharacters escaped");
+
+same(count(syntheticHtml, "href=\"#version-1\""), 1, "first timeline link exactly once");
+same(count(syntheticHtml, "href=\"#version-2\""), 1, "second timeline link exactly once");
+same(count(syntheticHtml, "href=\"#version-3\""), 1, "third timeline link exactly once");
+same(count(syntheticHtml, "id=\"version-1\""), 1, "first version section exactly once");
+same(count(syntheticHtml, "id=\"version-2\""), 1, "second version section exactly once");
+same(count(syntheticHtml, "id=\"version-3\""), 1, "third version section exactly once");
+assert(syntheticHtml.indexOf("contract-&lt;script&gt;") < syntheticHtml.indexOf("mts-contract/v9.7"), "input version order retained");
+assert(syntheticHtml.indexOf("mts-contract/v9.7") < syntheticHtml.indexOf("mts-contract/v2.3"), "renderer does not re-sort input");
+
+same(count(syntheticHtml, "aria-current=\"page\""), 1, "current marker derives from isCurrent only");
+assert(syntheticHtml.includes("<details open>"), "current overview is open by default");
+assert(syntheticHtml.includes("#77"), "optional issue rendered when present");
+assert(syntheticHtml.includes("#66"), "optional lifecycle issue rendered when present");
+same(count(syntheticHtml, "Candidate lifecycle issue"), 1, "missing optional lifecycle fields are omitted");
+same(renderContractObservatoryHtml(synthetic), syntheticHtml, "synthetic rendering is deterministic");
+
+console.log("Contract Observatory V3b static UI checks passed.");


### PR DESCRIPTION
Closes #913
Parent: #902
Predecessor: #911 / PR #912

## Summary

Add the first browser-ready Contract Observatory UI as a pure deterministic static renderer over the already-derived V3a `ContractObservatoryIndex`:

- source-derived Timeline for every live indexed version;
- accessible Version Overview using native HTML `<details>`;
- explicit CURRENT / PREVIOUS / LIVE textual classification;
- compact lifecycle, provenance and executable-evidence metadata;
- ordinal-only presentation anchors rather than evidence-derived identity;
- HTML escaping for every index-provided string;
- no client JavaScript, framework, CDN, network call, font or browser runtime dependency;
- real-repository and synthetic adversarial rendering corpus;
- one additive CI execution line for `site.test.js`.

## Boundary

```text
repository evidence
      ↓
ContractObservatoryIndex   # V3a repository projection
      ↓
renderContractObservatoryHtml(index)
      ↓
static browser document    # V3b presentation only
```

The renderer does not read `contracts/**`, `cutover/**` or `repo-policy.json` and does not import `@mts/core` or `@mts/visual`.

## Exact pre-PR evidence

```text
base main = 62e3c9be944cd54c3bc4f0bddd88a9700d124805
head = a3246133f5ee4c7e71e1fa9bd1578cfc1bb866d9
compare status = ahead
ahead_by = 3
behind_by = 0
changed paths = 3
new files = 2
net added lines = 340
issue budget = 700
contracts/cutover/ts/src/ts/test/packages/visual = untouched
repo-policy/repo-guard workflow = untouched
ci.yml delta = +1 additive site corpus execution line
blocking repo-policy = enabled
open PR before creation = none
```

#913 contains the narrow GovernanceGrant for the additive `.github/workflows/ci.yml` line only, with no policy relaxation.

No contract version is hard-coded by production `site.ts`; current v0.10/v0.11 assertions exist only in the executable real-repository corpus.

CI and blocking repo-guard are required before merge. No accepted MTS semantic change, trusted-kernel change, or v0.12 lifecycle is implied.