### PR TITLE
[Visual/V3c] Materialize and deploy Contract Observatory with GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,82 @@
+name: Contract Observatory Pages
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "contracts/**"
+      - "cutover/**"
+      - "repo-policy.json"
+      - "web/contract-observatory/**"
+      - ".github/workflows/pages.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "contracts/**"
+      - "cutover/**"
+      - "repo-policy.json"
+      - "web/contract-observatory/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: contract-observatory-pages
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install TypeScript toolchain
+        run: npm ci --prefix ts --ignore-scripts --no-audit --no-fund
+
+      - name: Compile Contract Observatory
+        run: ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
+
+      - name: Verify Contract Observatory evidence and static site
+        run: |
+          node web/contract-observatory/dist/test/contract-index.test.js
+          node web/contract-observatory/dist/test/site.test.js
+
+      - name: Materialize Pages artifact
+        run: |
+          node web/contract-observatory/dist/src/build-site.js . _site
+          test -s _site/index.html
+          test -f _site/.nojekyll
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy Contract Observatory
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/contract-observatory/src/build-site.ts
+++ b/web/contract-observatory/src/build-site.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildContractObservatoryIndex } from "./contract-index.js";
+import { renderContractObservatoryHtml } from "./site.js";
+
+export interface MaterializedContractObservatorySite {
+  readonly outputDirectory: string;
+  readonly indexPath: string;
+  readonly noJekyllPath: string;
+  readonly indexBytes: number;
+}
+
+export function materializeContractObservatorySite(
+  repositoryRoot: string,
+  outputDirectory: string,
+): MaterializedContractObservatorySite {
+  const repositoryPath = resolve(repositoryRoot);
+  const outputPath = resolve(outputDirectory);
+  assertSafeOutputPath(repositoryPath, outputPath);
+
+  const index = buildContractObservatoryIndex(repositoryPath);
+  const html = renderContractObservatoryHtml(index);
+  const indexPath = resolve(outputPath, "index.html");
+  const noJekyllPath = resolve(outputPath, ".nojekyll");
+
+  mkdirSync(outputPath, { recursive: true });
+  writeFileSync(indexPath, html, "utf8");
+  writeFileSync(noJekyllPath, "", "utf8");
+
+  return Object.freeze({
+    outputDirectory: outputPath,
+    indexPath,
+    noJekyllPath,
+    indexBytes: Buffer.byteLength(html, "utf8"),
+  });
+}
+
+function assertSafeOutputPath(repositoryRoot: string, outputPath: string): void {
+  if (samePath(repositoryRoot, outputPath)) {
+    throw new Error("Contract Observatory output must not be the repository root");
+  }
+
+  const protectedRoots = [
+    resolve(repositoryRoot, "contracts"),
+    resolve(repositoryRoot, "cutover"),
+    resolve(repositoryRoot, "ts", "src"),
+    resolve(repositoryRoot, "ts", "test"),
+  ];
+
+  for (const protectedRoot of protectedRoots) {
+    if (isAtOrInside(outputPath, protectedRoot)) {
+      throw new Error(`Contract Observatory output targets protected source tree: ${protectedRoot}`);
+    }
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return left === right;
+}
+
+function isAtOrInside(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${sep}`);
+}
+
+function runCli(): void {
+  const repositoryRoot = process.argv[2] ?? ".";
+  const outputDirectory = process.argv[3] ?? "_site";
+  const result = materializeContractObservatorySite(repositoryRoot, outputDirectory);
+  console.log(`Contract Observatory materialized: ${result.indexPath} (${result.indexBytes} bytes)`);
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  runCli();
+}

--- a/web/contract-observatory/src/build-site.ts
+++ b/web/contract-observatory/src/build-site.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { buildContractObservatoryIndex } from "./contract-index.js";
 import { renderContractObservatoryHtml } from "./site.js";
@@ -71,7 +70,6 @@ function runCli(): void {
   console.log(`Contract Observatory materialized: ${result.indexPath} (${result.indexBytes} bytes)`);
 }
 
-const invokedPath = process.argv[1];
-if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+if (require.main === module) {
   runCli();
 }

--- a/web/contract-observatory/test/site.test.ts
+++ b/web/contract-observatory/test/site.test.ts
@@ -1,3 +1,8 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { materializeContractObservatorySite } from "../src/build-site.js";
 import {
   buildContractObservatoryIndex,
   type ContractObservatoryIndex,
@@ -6,11 +11,21 @@ import {
 import { renderContractObservatoryHtml } from "../src/site.js";
 
 function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(`Contract Observatory V3b: ${message}`);
+  if (!condition) throw new Error(`Contract Observatory V3b/V3c: ${message}`);
 }
 
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function throws(action: () => void, message: string): void {
+  let rejected = false;
+  try {
+    action();
+  } catch {
+    rejected = true;
+  }
+  assert(rejected, message);
 }
 
 function count(haystack: string, needle: string): number {
@@ -141,4 +156,36 @@ assert(syntheticHtml.includes("#66"), "optional lifecycle issue rendered when pr
 same(count(syntheticHtml, "Candidate lifecycle issue"), 1, "missing optional lifecycle fields are omitted");
 same(renderContractObservatoryHtml(synthetic), syntheticHtml, "synthetic rendering is deterministic");
 
-console.log("Contract Observatory V3b static UI checks passed.");
+const sourcePath = join(repositoryRoot, realIndex.currentContractPath);
+const sourceBefore = readFileSync(sourcePath, "utf8");
+const temporaryRoot = mkdtempSync(join(tmpdir(), "mts-contract-observatory-"));
+const materializedDirectory = join(temporaryRoot, "nested", "site");
+try {
+  const first = materializeContractObservatorySite(repositoryRoot, materializedDirectory);
+  assert(existsSync(first.indexPath), "materialized index.html exists");
+  assert(existsSync(first.noJekyllPath), "materialized .nojekyll exists");
+  same(readFileSync(first.indexPath, "utf8"), realHtml, "materialized HTML equals pure renderer bytes");
+  same(readFileSync(first.noJekyllPath, "utf8"), "", ".nojekyll is empty");
+  same(first.indexBytes, Buffer.byteLength(realHtml, "utf8"), "reported byte size is deterministic");
+
+  const second = materializeContractObservatorySite(repositoryRoot, materializedDirectory);
+  same(readFileSync(second.indexPath, "utf8"), realHtml, "repeated materialization is byte-identical");
+  same(readFileSync(sourcePath, "utf8"), sourceBefore, "materialization does not mutate current contract source");
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}
+
+for (const unsafeTarget of [
+  repositoryRoot,
+  join(repositoryRoot, "contracts", "generated-site"),
+  join(repositoryRoot, "cutover", "generated-site"),
+  join(repositoryRoot, "ts", "src", "generated-site"),
+  join(repositoryRoot, "ts", "test", "generated-site"),
+]) {
+  throws(
+    () => materializeContractObservatorySite(repositoryRoot, unsafeTarget),
+    `unsafe materialization target rejects: ${unsafeTarget}`,
+  );
+}
+
+console.log("Contract Observatory V3b/V3c static UI and materialization checks passed.");


### PR DESCRIPTION
Closes #915
Parent: #902
Predecessor: #913 / PR #914

## Summary

Complete the V3 Contract Observatory delivery pipeline without committing generated site output:

- add deterministic `materializeContractObservatorySite(repositoryRoot, outputDirectory)`;
- write only derived `index.html` + `.nojekyll` into an explicitly supplied output directory;
- fail closed for repository root and protected evidence/runtime source subtrees;
- extend the existing static-site corpus with filesystem materialization, byte equality, repeatability, source non-mutation and unsafe-target rejection;
- add a dedicated `Contract Observatory Pages` workflow;
- on pull requests, execute compile/test/materialization only with `contents: read`;
- on `main`/manual dispatch, upload the derived Pages artifact and give `pages:write` + `id-token:write` only to the deploy job;
- deploy through official GitHub Pages actions only.

## Pages enablement boundary

Before workflow implementation, the official `actions/configure-pages@v5/action.yml` was verified. Its `enablement` option explicitly requires a token other than ordinary `GITHUB_TOKEN` (and broader administration permission for a GitHub App).

Accordingly this PR deliberately does **not** add a PAT/App secret or `administration:write`. `configure-pages@v5` is used without `enablement`. If repository Pages is not already configured for Actions, the post-merge deploy may expose that external settings blocker; it must not be bypassed with broader credentials.

## Boundary

```text
repository evidence
      ↓
ContractObservatoryIndex
      ↓
renderContractObservatoryHtml
      ↓
materializeContractObservatorySite
      ↓
_site/index.html + .nojekyll
      ↓
GitHub Pages artifact/deployment
```

Pages output remains disposable presentation state, never semantic authority.

## Exact pre-PR evidence

```text
base main = 6332a9d4372f51b879604d06f0252bdd9daf7af8
head = d63979af280676ba7ec07ed09ed2475f1b0d8c1f
compare status = ahead
ahead_by = 3
behind_by = 0
changed paths = 3
new files = 2
additions = 208
deletions = 2
issue max_net_added_lines = 500
open PR before creation = none
classic statuses on exact base main = none
main workflows before creation = ci.yml + repo-guard.yml
blocking repo-policy = enabled
```

Changed paths are exactly:

```text
.github/workflows/pages.yml
web/contract-observatory/src/build-site.ts
web/contract-observatory/test/site.test.ts
```

`contracts/**`, `cutover/**`, `ts/src/**`, `ts/test/**`, `packages/visual/**`, `repo-policy.json`, `.github/workflows/ci.yml`, and `.github/workflows/repo-guard.yml` are untouched.

#915 contains the explicit GovernanceGrant for the new Pages workflow and records the corrected enablement constraint.

## Required merge evidence

Before merge require on this exact head:

```text
normal CI = SUCCESS
blocking repo-guard = SUCCESS
Contract Observatory Pages PR build = SUCCESS
deploy job on pull_request = skipped/not executed
behind_by = 0
mergeable = true
draft = false
head stable
```

Merge only with `expected_head_sha`. No semantic MTS delta, trusted-kernel delta or v0.12 lifecycle is implied.