### PR TITLE
[Node 24] Run anum_docs workflows on Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
   typescript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -45,7 +45,7 @@ jobs:
   no-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Reject Python sources or runtime dependencies
         shell: bash
@@ -64,7 +64,7 @@ jobs:
   validate-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check documentation file sizes
         run: |
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
   validate-structure:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check root directory cleanliness
         shell: bash

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,10 +32,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./_site
 
@@ -75,8 +75,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Deploy Contract Observatory
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Run repo-guard
         id: repo_guard
-        uses: netkeep80/repo-guard@e95fe766b0e13219d09a16d7f64761e2a8dab872
+        uses: netkeep80/repo-guard@03e24a781f024ab1c91e79678737fe4ded743d48
         with:
           mode: check-pr
           enforcement: blocking

--- a/ts/package.json
+++ b/ts/package.json
@@ -30,7 +30,7 @@
     "package:check": "tsc -p tsconfig.consumer.json --noEmit",
     "package:artifact": "npm run build --silent && npm pack",
     "browser:typecheck": "tsc -p tsconfig.browser.json",
-    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
+    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node24 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
     "test": "npm run build && npm run package:check && node dist/src/tooling/test-runner.js",
     "docs:sync": "npm run build --silent && node dist/src/tooling/docs-sync.js --write",
     "docs:check": "npm run build --silent && node dist/src/tooling/docs-sync.js --check",


### PR DESCRIPTION
Closes #921

## Summary

Complete the repository-wide Node.js 24 toolchain/runtime migration for active `anum_docs` workflows without changing accepted MTS v0.11 semantics.

Exact branch baseline/evidence at PR creation:

```text
base main = f4dbcd2aea715af5423de9d4848e654ddc615cbd
head = 2a30c2e6f0441253e1bce1d9f30ebcadd79c4bdd
behind_by = 0
ahead_by = 4
changed files = 4
accepted MTS = v0.11
active semantic candidate = NONE
repo-policy enforcement = blocking
```

## Delta

```text
.github/workflows/ci.yml
  actions/checkout@v4 -> @v6
  actions/setup-node@v4 -> @v6

.github/workflows/pages.yml
  actions/checkout@v4 -> @v6
  actions/setup-node@v4 -> @v6
  actions/upload-pages-artifact@v3 -> @v5
  actions/configure-pages@v5 -> @v6
  actions/deploy-pages@v4 -> @v5

.github/workflows/repo-guard.yml
  actions/checkout@v4 -> @v6
  repo-guard pin -> 03e24a781f024ab1c91e79678737fe4ded743d48

ts/package.json
  esbuild Node test target node22 -> node24
```

The Pages majors are intentional runtime migrations, not cosmetic bumps: the replaced versions ultimately execute Node 20, while the selected majors use Node 24-bearing actions.

The repo-guard pin is the exact immutable accepted Node24 infrastructure revision from `netkeep80/repo-guard#303`:

```text
03e24a781f024ab1c91e79678737fe4ded743d48
```

## Scope safety

No changes to:

```text
contracts/**
cutover/**
ts/src/**
ts/test/**
packages/visual/src/**
web/contract-observatory/src/**
repo-policy.json
package lock/dependencies
```

Issue #921 contains the ordinary ChangeIntent and the separate trusted GovernanceGrant for the governance workflow paths. No policy relaxation is requested.