### PR TITLE
[Proof identity/R3] Portable exact Theory revision lock

### DIFF
--- a/ts/consumer/package-consumer.ts
+++ b/ts/consumer/package-consumer.ts
@@ -1,15 +1,24 @@
 import {
   Memory,
   PORTABLE_MTS_SEMANTIC_BASE,
+  PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
+  PORTABLE_STRUCTURAL_THEORY_SCHEMA,
+  computePortableStructuralTheoryRevision,
   ensureRootBasis,
+  exportPortableStructuralTheory,
   replayPortableStructuralDerivation,
   replayPortableStructuralDerivationWithAssumptions,
+  replayPortableStructuralTheory,
   replayStructuralDerivation,
   replayStructuralDerivationWithAssumptions,
   replayStructuralScopedDerivation,
+  verifyPortableStructuralProofTheoryRevision,
   type LinkHandle,
   type PortableStructuralDerivationReplayResult,
   type PortableStructuralDerivationWithAssumptionsReplayResult,
+  type PortableStructuralTheoryArtifact,
+  type PortableStructuralTheoryReplayResult,
+  type PortableStructuralTheoryRevision,
   type ReadMemory,
 } from "@mts/core";
 import { textToAnum } from "@mts/core/tooling/payload";
@@ -32,6 +41,18 @@ const portableAssumptionReplay: (
   input: unknown,
 ) => PortableStructuralDerivationWithAssumptionsReplayResult =
   replayPortableStructuralDerivationWithAssumptions;
+
+// Exact Theory selection is separately package-root consumable and remains
+// identity/provenance evidence rather than a substitute for proof replay.
+const theory = memory.ensure(basis.L, basis.U);
+const theoryArtifact: PortableStructuralTheoryArtifact = exportPortableStructuralTheory(memory, theory);
+const theoryReplay: PortableStructuralTheoryReplayResult = replayPortableStructuralTheory(theoryArtifact);
+const theoryRevision: Promise<PortableStructuralTheoryRevision> =
+  computePortableStructuralTheoryRevision(theoryArtifact);
+const theorySchema: "mts-portable-structural-theory/v0.1" = PORTABLE_STRUCTURAL_THEORY_SCHEMA;
+const theoryRevisionScheme: "mts-portable-structural-theory-revision/sha-256/v0.1" =
+  PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME;
+const verifyTheoryRevision = verifyPortableStructuralProofTheoryRevision;
 void [
   read,
   link,
@@ -39,6 +60,12 @@ void [
   semanticBase,
   portableReplay,
   portableAssumptionReplay,
+  theoryArtifact,
+  theoryReplay,
+  theoryRevision,
+  theorySchema,
+  theoryRevisionScheme,
+  verifyTheoryRevision,
   replayStructuralDerivation,
   replayStructuralDerivationWithAssumptions,
   replayStructuralScopedDerivation,

--- a/ts/src/portable-theory-digest.ts
+++ b/ts/src/portable-theory-digest.ts
@@ -1,0 +1,38 @@
+import type { PortableStructuralTheoryArtifact } from "./portable-theory.js";
+
+export const PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME =
+  "mts-portable-structural-theory-revision/sha-256/v0.1" as const;
+
+export interface PortableStructuralTheoryRevision {
+  readonly scheme: typeof PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME;
+  readonly value: string;
+}
+
+function lowercaseHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function canonicalJson(artifact: PortableStructuralTheoryArtifact): string {
+  return JSON.stringify({
+    schema: artifact.schema,
+    mtsSemanticBase: artifact.mtsSemanticBase,
+    topology: {
+      schema: artifact.topology.schema,
+      root: artifact.topology.root,
+      links: artifact.topology.links.map(([start, end]) => [start, end]),
+    },
+    theoryCoordinate: artifact.theoryCoordinate,
+  });
+}
+
+export async function computePortableStructuralTheoryRevision(
+  artifact: PortableStructuralTheoryArtifact,
+): Promise<PortableStructuralTheoryRevision> {
+  const preimage = `${PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME}\n${canonicalJson(artifact)}`;
+  const encoded = new TextEncoder().encode(preimage);
+  const raw = await globalThis.crypto.subtle.digest("SHA-256", encoded);
+  return Object.freeze({
+    scheme: PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
+    value: lowercaseHex(new Uint8Array(raw)),
+  });
+}

--- a/ts/src/portable-theory.ts
+++ b/ts/src/portable-theory.ts
@@ -1,0 +1,283 @@
+import {
+  CanonicalTopologyError,
+  exportCanonicalTopology,
+} from "./canonical-topology.js";
+import {
+  Memory,
+  MemoryError,
+  type EnumerableReadMemory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "./memory.js";
+import {
+  PersistenceTopologyError,
+  STORAGE_TOPOLOGY_SCHEMA,
+  restoreTopology,
+  type StorageTopologyImage,
+} from "./persistence-topology.js";
+import { PORTABLE_MTS_SEMANTIC_BASE } from "./portable-derivation.js";
+import { replayPortableStructuralProof } from "./portable-proof-replay.js";
+import {
+  PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
+  computePortableStructuralTheoryRevision,
+  type PortableStructuralTheoryRevision,
+} from "./portable-theory-digest.js";
+
+export const PORTABLE_STRUCTURAL_THEORY_SCHEMA =
+  "mts-portable-structural-theory/v0.1" as const;
+
+export interface PortableStructuralTheoryArtifact {
+  readonly schema: typeof PORTABLE_STRUCTURAL_THEORY_SCHEMA;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+  readonly theoryCoordinate: number;
+}
+
+export interface PortableStructuralTheoryReplayResult {
+  readonly memory: Memory;
+  readonly theory: LinkHandle;
+  readonly artifact: PortableStructuralTheoryArtifact;
+}
+
+export type PortableStructuralTheoryErrorCode =
+  | "invalid-envelope"
+  | "unsupported-schema"
+  | "unsupported-semantic-base"
+  | "invalid-topology"
+  | "noncanonical-topology"
+  | "invalid-coordinate"
+  | "invalid-revision"
+  | "theory-revision-mismatch"
+  | "proof-theory-mismatch";
+
+export class PortableStructuralTheoryError extends Error {
+  override readonly name = "PortableStructuralTheoryError";
+
+  constructor(readonly code: PortableStructuralTheoryErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: PortableStructuralTheoryErrorCode): never {
+  throw new PortableStructuralTheoryError(code);
+}
+
+class TheoryAuthorityView implements EnumerableReadMemory {
+  readonly root: LinkHandle;
+  private readonly support: ReadonlySet<LinkHandle>;
+  private readonly ordered: readonly LinkHandle[];
+
+  constructor(
+    private readonly source: ReadMemory,
+    links: ReadonlySet<LinkHandle>,
+  ) {
+    this.root = source.root;
+    this.support = links;
+    this.ordered = Object.freeze([...links]);
+  }
+
+  get linkCount(): number {
+    return this.ordered.length;
+  }
+
+  private require(link: LinkHandle): void {
+    if (!this.support.has(link)) throw new MemoryError("Link is outside Theory authority support");
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    this.require(link);
+    const poles = this.source.poles(link);
+    if (!this.support.has(poles.start) || !this.support.has(poles.end)) {
+      throw new MemoryError("Theory authority support is not pole-closed");
+    }
+    return poles;
+  }
+
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    this.require(start);
+    this.require(end);
+    const found = this.source.find(start, end);
+    return found !== undefined && this.support.has(found) ? found : undefined;
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.require(start);
+    return Object.freeze(this.source.outgoing(start).filter((link) => this.support.has(link)));
+  }
+
+  incoming(end: LinkHandle): readonly LinkHandle[] {
+    this.require(end);
+    return Object.freeze(this.source.incoming(end).filter((link) => this.support.has(link)));
+  }
+
+  allLinks(): readonly LinkHandle[] {
+    return this.ordered;
+  }
+}
+
+function includePoleClosure(
+  memory: ReadMemory,
+  support: Set<LinkHandle>,
+  roots: readonly LinkHandle[],
+): void {
+  const pending = [...roots];
+  while (pending.length > 0) {
+    const link = pending.pop();
+    if (link === undefined || support.has(link)) continue;
+    const poles = memory.poles(link);
+    support.add(link);
+    pending.push(poles.start, poles.end);
+  }
+}
+
+function projected(
+  memory: ReadMemory,
+  roots: readonly LinkHandle[],
+): { readonly topology: StorageTopologyImage; readonly coordinates: ReadonlyMap<LinkHandle, number> } {
+  const support = new Set<LinkHandle>();
+  includePoleClosure(memory, support, [memory.root, ...roots]);
+  return exportCanonicalTopology(new TheoryAuthorityView(memory, support));
+}
+
+function linkFingerprint(memory: ReadMemory, link: LinkHandle): string {
+  const canonical = projected(memory, [link]);
+  const coordinate = canonical.coordinates.get(link);
+  if (coordinate === undefined) fail("invalid-coordinate");
+  return JSON.stringify({ topology: canonical.topology, coordinate });
+}
+
+export function exportPortableStructuralTheory(
+  memory: ReadMemory,
+  theory: LinkHandle,
+): PortableStructuralTheoryArtifact {
+  const before = memory.linkCount;
+  try {
+    const canonical = projected(memory, [theory, ...memory.outgoing(theory)]);
+    const theoryCoordinate = canonical.coordinates.get(theory);
+    if (theoryCoordinate === undefined) fail("invalid-coordinate");
+    if (memory.linkCount !== before) fail("invalid-topology");
+    return Object.freeze({
+      schema: PORTABLE_STRUCTURAL_THEORY_SCHEMA,
+      mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+      topology: canonical.topology,
+      theoryCoordinate,
+    });
+  } catch (error) {
+    if (error instanceof PortableStructuralTheoryError) throw error;
+    if (error instanceof MemoryError || error instanceof CanonicalTopologyError) {
+      fail("invalid-topology");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) fail("invalid-topology");
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) fail("invalid-envelope");
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    fail("invalid-envelope");
+  }
+}
+
+function coordinate(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) fail("invalid-coordinate");
+  return value;
+}
+
+function parseTopology(value: unknown): StorageTopologyImage {
+  const item = record(value);
+  exactKeys(item, ["schema", "root", "links"]);
+  if (item.schema !== STORAGE_TOPOLOGY_SCHEMA) fail("invalid-topology");
+  const root = coordinate(item.root);
+  if (!Array.isArray(item.links) || item.links.length === 0) fail("invalid-topology");
+  const links = item.links.map((raw) => {
+    if (!Array.isArray(raw) || raw.length !== 2) fail("invalid-topology");
+    return Object.freeze([coordinate(raw[0]), coordinate(raw[1])] as const);
+  });
+  return Object.freeze({ schema: STORAGE_TOPOLOGY_SCHEMA, root, links: Object.freeze(links) });
+}
+
+function parseArtifact(input: unknown): PortableStructuralTheoryArtifact {
+  const item = record(input);
+  if (item.schema !== PORTABLE_STRUCTURAL_THEORY_SCHEMA) fail("unsupported-schema");
+  if (item.mtsSemanticBase !== PORTABLE_MTS_SEMANTIC_BASE) fail("unsupported-semantic-base");
+  exactKeys(item, ["schema", "mtsSemanticBase", "topology", "theoryCoordinate"]);
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_THEORY_SCHEMA,
+    mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+    topology: parseTopology(item.topology),
+    theoryCoordinate: coordinate(item.theoryCoordinate),
+  });
+}
+
+export function replayPortableStructuralTheory(input: unknown): PortableStructuralTheoryReplayResult {
+  const artifact = parseArtifact(input);
+  let memory: Memory;
+  try {
+    memory = restoreTopology(artifact.topology);
+  } catch (error) {
+    if (error instanceof PersistenceTopologyError) fail("noncanonical-topology");
+    throw error;
+  }
+  const theory = memory.allLinks()[artifact.theoryCoordinate];
+  if (theory === undefined) fail("invalid-coordinate");
+
+  let canonical: PortableStructuralTheoryArtifact;
+  try {
+    canonical = exportPortableStructuralTheory(memory, theory);
+  } catch (error) {
+    if (error instanceof PortableStructuralTheoryError) fail("noncanonical-topology");
+    throw error;
+  }
+  if (JSON.stringify(canonical) !== JSON.stringify(artifact)) fail("noncanonical-topology");
+  return Object.freeze({ memory, theory, artifact });
+}
+
+function parseRevision(input: unknown): PortableStructuralTheoryRevision {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) fail("invalid-revision");
+  const item = input as Record<string, unknown>;
+  const keys = Object.keys(item).sort();
+  if (keys.length !== 2 || keys[0] !== "scheme" || keys[1] !== "value") fail("invalid-revision");
+  if (
+    item.scheme !== PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME ||
+    typeof item.value !== "string" ||
+    !/^[0-9a-f]{64}$/.test(item.value)
+  ) fail("invalid-revision");
+  return Object.freeze({ scheme: PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME, value: item.value });
+}
+
+export async function verifyPortableStructuralProofTheoryRevision(
+  proofArtifact: unknown,
+  expectedTheoryArtifact: unknown,
+  expectedRevisionInput: unknown,
+): Promise<void> {
+  const expected = replayPortableStructuralTheory(expectedTheoryArtifact);
+  const expectedRevision = parseRevision(expectedRevisionInput);
+  const actualRevision = await computePortableStructuralTheoryRevision(expected.artifact);
+  if (actualRevision.value !== expectedRevision.value) fail("theory-revision-mismatch");
+
+  // Ordinary proof replay remains the proof-truth authority. This operation only
+  // adds the external Theory-selection boundary required by a trusted consumer.
+  const proof = replayPortableStructuralProof(proofArtifact);
+  const proofTheory = "theory" in proof.evidence
+    ? proof.evidence.theory
+    : proof.evidence.derivation.theory;
+  if (linkFingerprint(proof.memory, proofTheory) !== linkFingerprint(expected.memory, expected.theory)) {
+    fail("proof-theory-mismatch");
+  }
+
+  const admitted = new Set(
+    expected.memory.outgoing(expected.theory).map((link) => linkFingerprint(expected.memory, link)),
+  );
+  for (const used of proof.memory.outgoing(proofTheory)) {
+    if (!admitted.has(linkFingerprint(proof.memory, used))) fail("proof-theory-mismatch");
+  }
+}

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -216,6 +216,26 @@ export type {
 } from "./portable-derivation-digest.js";
 
 export {
+  PORTABLE_STRUCTURAL_THEORY_SCHEMA,
+  PortableStructuralTheoryError,
+  exportPortableStructuralTheory,
+  replayPortableStructuralTheory,
+  verifyPortableStructuralProofTheoryRevision,
+} from "./portable-theory.js";
+export type {
+  PortableStructuralTheoryArtifact,
+  PortableStructuralTheoryErrorCode,
+  PortableStructuralTheoryReplayResult,
+} from "./portable-theory.js";
+export {
+  PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
+  computePortableStructuralTheoryRevision,
+} from "./portable-theory-digest.js";
+export type {
+  PortableStructuralTheoryRevision,
+} from "./portable-theory-digest.js";
+
+export {
   PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
   PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,

--- a/ts/test/portable-theory.test.ts
+++ b/ts/test/portable-theory.test.ts
@@ -1,0 +1,318 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  ensureRootBasis,
+  type LinkHandle,
+} from "../src/memory.js";
+import {
+  exportPortableStructuralDerivation,
+  replayPortableStructuralDerivation,
+} from "../src/portable-derivation.js";
+import {
+  PORTABLE_STRUCTURAL_THEORY_SCHEMA,
+  PortableStructuralTheoryError,
+  exportPortableStructuralTheory,
+  replayPortableStructuralTheory,
+  verifyPortableStructuralProofTheoryRevision,
+} from "../src/portable-theory.js";
+import {
+  PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
+  computePortableStructuralTheoryRevision,
+} from "../src/portable-theory-digest.js";
+import { defineContext } from "../src/state.js";
+import { defineActField, defineActHeader } from "../src/structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+  type StructuralInterpreter,
+} from "../src/structural-rule.js";
+import {
+  admitStructuralDerivationRule,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  defineStructuralTheorem,
+  type StructuralDerivationEvidence,
+  type StructuralJudgmentEvidence,
+} from "../src/derivation.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+async function expectTheory(
+  code: string,
+  effect: () => unknown | Promise<unknown>,
+): Promise<void> {
+  try {
+    await effect();
+  } catch (error) {
+    assert(error instanceof PortableStructuralTheoryError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected exact Theory boundary rejection`);
+}
+
+interface TheoryFixture {
+  readonly memory: Memory;
+  readonly theory: LinkHandle;
+  readonly dictionary: LinkHandle;
+  readonly grammar: LinkHandle;
+  readonly role: LinkHandle;
+  readonly value: LinkHandle;
+  readonly roleDictionary: LinkHandle;
+  readonly rule: LinkHandle;
+  readonly ruleAdmission: LinkHandle;
+  readonly derivationRule: LinkHandle;
+  readonly derivationRuleAdmission: LinkHandle;
+}
+
+function theoryFixture(templateKind: "role" | "value" = "role"): TheoryFixture {
+  const memory = new Memory();
+  const { R, O, C, L, U } = ensureRootBasis(memory);
+  const theory = memory.ensure(L, U);
+  const dictionary = L;
+  const grammar = C;
+  const role = O;
+  const value = U;
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const rule = defineStructuralRule(
+    memory,
+    roleDictionary,
+    templateKind === "role" ? role : value,
+  );
+  const ruleAdmission = admitStructuralRule(memory, theory, rule);
+  const derivationRule = defineStructuralDerivationRule(memory, rule, []);
+  const derivationRuleAdmission = admitStructuralDerivationRule(memory, theory, derivationRule);
+  void R;
+  return {
+    memory,
+    theory,
+    dictionary,
+    grammar,
+    role,
+    value,
+    roleDictionary,
+    rule,
+    ruleAdmission,
+    derivationRule,
+    derivationRuleAdmission,
+  };
+}
+
+function oneNodeProof(
+  fixture: TheoryFixture,
+  options: {
+    readonly role?: LinkHandle;
+    readonly value?: LinkHandle;
+    readonly roleDictionary?: LinkHandle;
+    readonly rule?: LinkHandle;
+    readonly ruleAdmission?: LinkHandle;
+    readonly derivationRule?: LinkHandle;
+    readonly derivationRuleAdmission?: LinkHandle;
+  } = {},
+): StructuralDerivationEvidence {
+  const { memory, theory, dictionary, grammar } = fixture;
+  const role = options.role ?? fixture.role;
+  const value = options.value ?? fixture.value;
+  const roleDictionary = options.roleDictionary ?? fixture.roleDictionary;
+  const rule = options.rule ?? fixture.rule;
+  const ruleAdmission = options.ruleAdmission ?? fixture.ruleAdmission;
+  const derivationRule = options.derivationRule ?? fixture.derivationRule;
+  const derivationRuleAdmission = options.derivationRuleAdmission ?? fixture.derivationRuleAdmission;
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const context = defineContext(memory, grammar, value);
+  const act = defineActHeader(memory, interpreter, roleDictionary, context);
+  defineActField(memory, act, role, value);
+  const judgment: StructuralJudgmentEvidence = {
+    application: {
+      act,
+      rule,
+      ruleAdmission,
+      claimedBody: value,
+      expectedInterpreter,
+      expectedAfterContext: context,
+    },
+    judgment: { theory, context, claim: value },
+  };
+  const occurrence = defineStructuralProofOccurrence(memory, act, value);
+  return {
+    theory,
+    targetOccurrence: occurrence,
+    nodes: [{
+      occurrence,
+      judgment,
+      derivationRule,
+      derivationRuleAdmission,
+      premiseOccurrenceSequence: materializeExactSequence(memory, []),
+    }],
+  };
+}
+
+async function main(): Promise<void> {
+  // Exact Theory identity is independent of proof history and unrelated topology.
+  const stable = theoryFixture();
+  const beforeExport = stable.memory.linkCount;
+  const artifactBefore = exportPortableStructuralTheory(stable.memory, stable.theory);
+  same(artifactBefore.schema, PORTABLE_STRUCTURAL_THEORY_SCHEMA, "Theory schema is versioned");
+  same(artifactBefore.schema, "mts-portable-structural-theory/v0.1", "Theory schema is pinned");
+  same(stable.memory.linkCount, beforeExport, "Theory export is read-only");
+
+  const revisionBefore = await computePortableStructuralTheoryRevision(artifactBefore);
+  same(
+    revisionBefore.scheme,
+    PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
+    "Theory revision scheme is pinned",
+  );
+  assert(/^[0-9a-f]{64}$/.test(revisionBefore.value), "Theory revision is lowercase SHA-256 hex");
+
+  const proof = oneNodeProof(stable);
+  const proofArtifact = exportPortableStructuralDerivation(stable.memory, proof);
+  replayPortableStructuralDerivation(proofArtifact);
+  stable.memory.ensure(stable.grammar, stable.theory); // unrelated incoming Link to Theory
+  defineStructuralTheorem(stable.memory, stable.value, stable.theory); // Claim-first theorem metadata
+  stable.memory.ensure(stable.value, stable.dictionary); // unrelated ambient Link
+
+  const artifactAfter = exportPortableStructuralTheory(stable.memory, stable.theory);
+  const revisionAfter = await computePortableStructuralTheoryRevision(artifactAfter);
+  same(JSON.stringify(artifactAfter), JSON.stringify(artifactBefore), "proof/ambient history is excluded");
+  same(revisionAfter.value, revisionBefore.value, "proof/ambient history leaves Theory revision stable");
+
+  await verifyPortableStructuralProofTheoryRevision(proofArtifact, artifactBefore, revisionBefore);
+
+  // Portable round-trip preserves exact Theory identity and does not materialize during replay.
+  const restored = replayPortableStructuralTheory(artifactBefore);
+  same(restored.memory.linkCount, artifactBefore.topology.links.length, "Theory replay is read-only");
+  const roundTrip = exportPortableStructuralTheory(restored.memory, restored.theory);
+  same(JSON.stringify(roundTrip), JSON.stringify(artifactBefore), "Theory round-trip is byte-stable");
+  const roundTripRevision = await computePortableStructuralTheoryRevision(roundTrip);
+  same(roundTripRevision.value, revisionBefore.value, "Theory round-trip preserves revision");
+
+  // Changing admitted Rule structure changes the revision.
+  const structurallyChanged = theoryFixture("value");
+  const changedRuleArtifact = exportPortableStructuralTheory(
+    structurallyChanged.memory,
+    structurallyChanged.theory,
+  );
+  const changedRuleRevision = await computePortableStructuralTheoryRevision(changedRuleArtifact);
+  assert(changedRuleRevision.value !== revisionBefore.value, "changed admitted Rule must change revision");
+
+  // Adding an admitted DerivationRule changes the revision.
+  const derivationChanged = theoryFixture();
+  const derivationBefore = await computePortableStructuralTheoryRevision(
+    exportPortableStructuralTheory(derivationChanged.memory, derivationChanged.theory),
+  );
+  const extraDerivationRule = defineStructuralDerivationRule(
+    derivationChanged.memory,
+    derivationChanged.rule,
+    [derivationChanged.role],
+  );
+  admitStructuralDerivationRule(derivationChanged.memory, derivationChanged.theory, extraDerivationRule);
+  const derivationAfter = await computePortableStructuralTheoryRevision(
+    exportPortableStructuralTheory(derivationChanged.memory, derivationChanged.theory),
+  );
+  assert(derivationAfter.value !== derivationBefore.value, "extra admitted DerivationRule changes revision");
+
+  // The authority namespace is generic: any additional outgoing(Theory) admission changes identity.
+  const genericAdmission = theoryFixture();
+  const genericBefore = await computePortableStructuralTheoryRevision(
+    exportPortableStructuralTheory(genericAdmission.memory, genericAdmission.theory),
+  );
+  const futureAdmissionTarget = genericAdmission.memory.ensure(
+    genericAdmission.value,
+    genericAdmission.grammar,
+  );
+  genericAdmission.memory.ensure(genericAdmission.theory, futureAdmissionTarget);
+  const genericAfter = await computePortableStructuralTheoryRevision(
+    exportPortableStructuralTheory(genericAdmission.memory, genericAdmission.theory),
+  );
+  assert(genericAfter.value !== genericBefore.value, "new outgoing Theory admission family cannot be ignored");
+
+  // Core attack witness: a proof under stronger self-authored T' can replay, but cannot bind to pinned T.
+  const stronger = theoryFixture();
+  const pinnedArtifact = exportPortableStructuralTheory(stronger.memory, stronger.theory);
+  const pinnedRevision = await computePortableStructuralTheoryRevision(pinnedArtifact);
+  const pinnedProof = exportPortableStructuralDerivation(stronger.memory, oneNodeProof(stronger));
+  replayPortableStructuralDerivation(pinnedProof);
+  await verifyPortableStructuralProofTheoryRevision(pinnedProof, pinnedArtifact, pinnedRevision);
+
+  const extraRole = stronger.grammar;
+  const extraValue = stronger.dictionary;
+  const extraDictionary = defineStructuralRoleDictionary(stronger.memory, [extraRole]);
+  const extraRule = defineStructuralRule(stronger.memory, extraDictionary, extraRole);
+  const extraRuleAdmission = admitStructuralRule(stronger.memory, stronger.theory, extraRule);
+  const extraDerivationRule = defineStructuralDerivationRule(stronger.memory, extraRule, []);
+  const extraDerivationRuleAdmission = admitStructuralDerivationRule(
+    stronger.memory,
+    stronger.theory,
+    extraDerivationRule,
+  );
+  const strongerEvidence = oneNodeProof(stronger, {
+    role: extraRole,
+    value: extraValue,
+    roleDictionary: extraDictionary,
+    rule: extraRule,
+    ruleAdmission: extraRuleAdmission,
+    derivationRule: extraDerivationRule,
+    derivationRuleAdmission: extraDerivationRuleAdmission,
+  });
+  const strongerProof = exportPortableStructuralDerivation(stronger.memory, strongerEvidence);
+  replayPortableStructuralDerivation(strongerProof); // Valid under T'.
+  const strongerRevision = await computePortableStructuralTheoryRevision(
+    exportPortableStructuralTheory(stronger.memory, stronger.theory),
+  );
+  assert(strongerRevision.value !== pinnedRevision.value, "T' must have a different exact revision");
+  await expectTheory(
+    "proof-theory-mismatch",
+    () => verifyPortableStructuralProofTheoryRevision(strongerProof, pinnedArtifact, pinnedRevision),
+  );
+
+  // Fail closed on transport/revision forgery. A local proof coordinate is never an external revision.
+  await expectTheory("unsupported-schema", () => replayPortableStructuralTheory({
+    ...artifactBefore,
+    schema: "mts-portable-structural-theory/v999",
+  }));
+  await expectTheory("unsupported-semantic-base", () => replayPortableStructuralTheory({
+    ...artifactBefore,
+    mtsSemanticBase: "mts-contract/v0.10",
+  }));
+  await expectTheory("invalid-envelope", () => replayPortableStructuralTheory({
+    ...artifactBefore,
+    trusted: true,
+  }));
+  await expectTheory("noncanonical-topology", () => replayPortableStructuralTheory({
+    ...artifactBefore,
+    topology: {
+      ...artifactBefore.topology,
+      links: [...artifactBefore.topology.links].reverse(),
+    },
+  }));
+  await expectTheory(
+    "invalid-revision",
+    () => verifyPortableStructuralProofTheoryRevision(
+      proofArtifact,
+      artifactBefore,
+      proofArtifact.theoryCoordinate as never,
+    ),
+  );
+  await expectTheory(
+    "theory-revision-mismatch",
+    () => verifyPortableStructuralProofTheoryRevision(
+      proofArtifact,
+      artifactBefore,
+      { ...revisionBefore, value: "0".repeat(64) },
+    ),
+  );
+
+  // R3 classification: exact Theory selection is identity/provenance only.
+  // Matching this revision never substitutes for ordinary proof replay.
+}
+
+await main();

--- a/ts/test/portable-theory.test.ts
+++ b/ts/test/portable-theory.test.ts
@@ -53,7 +53,8 @@ async function expectTheory(
     await effect();
   } catch (error) {
     assert(error instanceof PortableStructuralTheoryError, `${code}: wrong error type`);
-    same(error.code, code, `${code}: wrong error code`);
+    const theoryError = error as { readonly code: string };
+    same(theoryError.code, code, `${code}: wrong error code`);
     return;
   }
   throw new Error(`${code}: expected exact Theory boundary rejection`);
@@ -209,12 +210,16 @@ async function main(): Promise<void> {
   const derivationBefore = await computePortableStructuralTheoryRevision(
     exportPortableStructuralTheory(derivationChanged.memory, derivationChanged.theory),
   );
-  const extraDerivationRule = defineStructuralDerivationRule(
+  const additionalDerivationRule = defineStructuralDerivationRule(
     derivationChanged.memory,
     derivationChanged.rule,
     [derivationChanged.role],
   );
-  admitStructuralDerivationRule(derivationChanged.memory, derivationChanged.theory, extraDerivationRule);
+  admitStructuralDerivationRule(
+    derivationChanged.memory,
+    derivationChanged.theory,
+    additionalDerivationRule,
+  );
   const derivationAfter = await computePortableStructuralTheoryRevision(
     exportPortableStructuralTheory(derivationChanged.memory, derivationChanged.theory),
   );

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -85,10 +85,13 @@ const expectedRuntimeExports = [
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA",
+  "PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME",
+  "PORTABLE_STRUCTURAL_THEORY_SCHEMA",
   "PersistentStore",
   "PersistentStoreError",
   "PortableStructuralDerivationError",
   "PortableStructuralDerivationProvenanceError",
+  "PortableStructuralTheoryError",
   "ProofRuleReplayError",
   "QuaternaryDecodeError",
   "RunReplayError",
@@ -107,6 +110,7 @@ const expectedRuntimeExports = [
   "computePortableStructuralDerivationProvenanceDigest",
   "computePortableStructuralDerivationWithAssumptionsContentDigest",
   "computePortableStructuralDerivationWithAssumptionsProvenanceDigest",
+  "computePortableStructuralTheoryRevision",
   "createPortableStructuralDerivationProvenanceClaim",
   "createPortableStructuralDerivationWithAssumptionsProvenanceClaim",
   "deserializeAnum",
@@ -116,6 +120,7 @@ const expectedRuntimeExports = [
   "executeAbits",
   "exportPortableStructuralDerivation",
   "exportPortableStructuralDerivationWithAssumptions",
+  "exportPortableStructuralTheory",
   "materializePersistentSequence",
   "materializeSequence",
   "normalizeRawForm",
@@ -132,6 +137,7 @@ const expectedRuntimeExports = [
   "replayPortableStructuralDerivation",
   "replayPortableStructuralDerivationWithAssumptions",
   "replayPortableStructuralProof",
+  "replayPortableStructuralTheory",
   "replayRelationStep",
   "replayRelationSubselectionStep",
   "replayResolvedSequenceGrouping",
@@ -149,9 +155,10 @@ const expectedRuntimeExports = [
   "valuesEqual",
   "verifyPortableStructuralDerivationProvenanceClaim",
   "verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim",
+  "verifyPortableStructuralProofTheoryRevision",
 ].sort();
 
-assert(expectedRuntimeExports.length === 81, "P9a1 runtime export budget must be exactly 81");
+assert(expectedRuntimeExports.length === 88, "R3 Theory lock runtime export budget must be exactly 88");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,


### PR DESCRIPTION
Refs #927

Implement the exact external Theory-selection boundary required by aprover R3 without changing accepted MTS v0.11 semantics.

## Clean TDD RED evidence

The branch first established the executable contract with tests only.

Clean RED head:

```text
e63077a8a70a1bf86e12aedf4e4db5dc39503db3
```

Exact RED gates:

```text
repo-guard #765 = SUCCESS
CI #3564 = FAILURE
```

The TypeScript job failed **only** because the two intended production modules did not yet exist:

```text
TS2307 ../src/portable-theory.js
TS2307 ../src/portable-theory-digest.js
```

No other type/test error remained.

## Security boundary

```text
proof valid under artifact-selected Theory
!=
proof valid under externally selected/pinned Theory revision
```

The implementation keeps two distinct witnesses:

```text
PortableStructuralTheoryArtifact
  = exact external Theory authority selection

PortableStructuralProof
  = minimal replay-support proof evidence
```

Theory revision identity is selection/provenance only. It never substitutes for proof replay.

The exact Theory projection is structural and generic:

```text
selected Theory
+ ALL outgoing(Theory) admissions
+ recursive pole closure of those admissions
+ root
```

It reuses the existing `exportCanonicalTopology(...)`; no second topology serializer is introduced.

Trusted proof↔Theory binding must reject any proof that uses an admission outside the pinned exact Theory, while allowing minimal proof artifacts to omit pinned admissions they do not use.

Core adversarial witness:

```text
T' = T + extra admitted Rule/DerivationRule
proof under T' ordinary replay = SUCCESS
R(T') != R(T)
proof uses extra authority not present in pinned T
=> exact Theory binding REJECT
```

## Scope

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/portable-theory.ts
  - ts/src/portable-theory-digest.ts
  - ts/src/public.ts
  - ts/test/portable-theory.test.ts
  - ts/test/public-api.test.ts
  - ts/consumer/package-consumer.ts
budgets:
  max_new_files: 3
  max_new_docs: 0
  max_net_added_lines: 750
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/public.ts
  - ts/test/portable-theory.test.ts
  - ts/consumer/package-consumer.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - repo-policy.json
  - .github/workflows/**
  - packages/visual/**
  - web/**
expected_effects:
  - external consumers can pin exact structural Theory revision independently of proof-local coordinates
  - untrusted proof/search evidence cannot self-authorize extra Theory admissions while still matching the selected revision
  - Theory revision identity remains independent of proof history and unrelated ambient topology
  - revision/digest remains a selection coordinate only; proof truth still requires generic replay
  - accepted MTS v0.11 semantics remain unchanged
```

`ts/test/public-api.test.ts` was added to scope after exact CI #3570 diagnosed the existing package-root runtime export allowlist as the only failing contract after the new Theory exports were introduced. This is a package-boundary test synchronization, not a semantic expansion.

Classification:

```text
production proof semantic delta = NONE
accepted MTS semantic delta = NONE
active semantic candidate = NONE
v0.12 = NOT REQUIRED
```
