### PR TITLE
[Visual/V2c] Pure true-3D Link geometry over VisualLinkNetwork

### DIFF
--- a/packages/visual/src/geometry3d.ts
+++ b/packages/visual/src/geometry3d.ts
@@ -1,0 +1,355 @@
+import {
+  normalizeVisualLinkNetwork,
+  type VisualKey,
+  type VisualLinkNetwork,
+} from "./index.js";
+
+// Pure presentation geometry adapted from:
+// netkeep80/anum_parser@48b5909d19490d9b27904bfc087ee0e86868fbd8/src/geometry3d.js
+// No parser, renderer, physics, or MTS semantic authority is carried here.
+
+const EPSILON = 1e-12;
+const TANGENT_LENGTH = 0.35;
+const LOOP_RADIUS = 0.8;
+
+export interface Point3D {
+  readonly x: number;
+  readonly y: number;
+  readonly z: number;
+}
+
+export interface VisualPosition3D {
+  readonly key: VisualKey;
+  readonly point: Point3D;
+}
+
+export type VisualGeometry3DErrorCode =
+  | "missing-position"
+  | "extra-position"
+  | "duplicate-position"
+  | "non-finite-position";
+
+export class VisualGeometry3DError extends Error {
+  readonly code: VisualGeometry3DErrorCode;
+  readonly key: VisualKey;
+
+  constructor(code: VisualGeometry3DErrorCode, key: VisualKey) {
+    super(`${code} for ${key}`);
+    this.name = "VisualGeometry3DError";
+    this.code = code;
+    this.key = key;
+  }
+}
+
+export type VisualArcRole3D = "start" | "end";
+export type VisualArcOrientation3D = "outer-to-green" | "green-to-outer";
+export type VisualCenterlineKind3D = "quadratic" | "cubic";
+
+export interface CenterlineInput3D {
+  readonly kind?: VisualCenterlineKind3D;
+  readonly controlPoints: readonly Point3D[];
+}
+
+export interface VisualCenterline3D extends CenterlineInput3D {
+  readonly kind: VisualCenterlineKind3D;
+  readonly role: VisualArcRole3D;
+  readonly semanticOrientation: VisualArcOrientation3D;
+  readonly greenOutwardTangent: Point3D;
+  readonly loop: boolean;
+}
+
+export interface VisualLinkGeometry3D {
+  readonly key: VisualKey;
+  readonly startKey: VisualKey;
+  readonly endKey: VisualKey;
+  readonly center: Point3D;
+  readonly start: VisualCenterline3D;
+  readonly end: VisualCenterline3D;
+}
+
+export interface VisualGeometry3D {
+  readonly positions: readonly VisualPosition3D[];
+  readonly links: readonly VisualLinkGeometry3D[];
+}
+
+const X_AXIS: Point3D = Object.freeze({ x: 1, y: 0, z: 0 });
+const Y_AXIS: Point3D = Object.freeze({ x: 0, y: 1, z: 0 });
+const Z_AXIS: Point3D = Object.freeze({ x: 0, y: 0, z: 1 });
+const AXES: readonly Point3D[] = Object.freeze([X_AXIS, Y_AXIS, Z_AXIS]);
+
+function point(x: number, y: number, z: number): Point3D {
+  return Object.freeze({ x, y, z });
+}
+
+function clonePoint(value: Point3D): Point3D {
+  return point(value.x, value.y, value.z);
+}
+
+function add(left: Point3D, right: Point3D): Point3D {
+  return point(left.x + right.x, left.y + right.y, left.z + right.z);
+}
+
+function subtract(left: Point3D, right: Point3D): Point3D {
+  return point(left.x - right.x, left.y - right.y, left.z - right.z);
+}
+
+function scale(value: Point3D, factor: number): Point3D {
+  return point(value.x * factor, value.y * factor, value.z * factor);
+}
+
+export function dotVec3(left: Point3D, right: Point3D): number {
+  return left.x * right.x + left.y * right.y + left.z * right.z;
+}
+
+function cross(left: Point3D, right: Point3D): Point3D {
+  return point(
+    left.y * right.z - left.z * right.y,
+    left.z * right.x - left.x * right.z,
+    left.x * right.y - left.y * right.x,
+  );
+}
+
+function normalize(value: Point3D): Point3D | undefined {
+  const length = Math.hypot(value.x, value.y, value.z);
+  if (!Number.isFinite(length) || length <= EPSILON) return undefined;
+  return scale(value, 1 / length);
+}
+
+function stableOrthogonal(direction: Point3D): Point3D {
+  const unit = normalize(direction) ?? X_AXIS;
+  let basis = X_AXIS;
+  let alignment = Math.abs(dotVec3(unit, basis));
+  for (const candidate of AXES.slice(1)) {
+    const next = Math.abs(dotVec3(unit, candidate));
+    if (next < alignment) {
+      basis = candidate;
+      alignment = next;
+    }
+  }
+  return normalize(cross(unit, basis))
+    ?? normalize(cross(unit, Z_AXIS))
+    ?? Y_AXIS;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function quadraticPoint(p0: Point3D, p1: Point3D, p2: Point3D, t: number): Point3D {
+  const u = clamp01(t);
+  if (u === 0) return clonePoint(p0);
+  if (u === 1) return clonePoint(p2);
+  const v = 1 - u;
+  return add(add(scale(p0, v * v), scale(p1, 2 * v * u)), scale(p2, u * u));
+}
+
+function cubicPoint(p0: Point3D, p1: Point3D, p2: Point3D, p3: Point3D, t: number): Point3D {
+  const u = clamp01(t);
+  if (u === 0) return clonePoint(p0);
+  if (u === 1) return clonePoint(p3);
+  const v = 1 - u;
+  return add(
+    add(scale(p0, v ** 3), scale(p1, 3 * v * v * u)),
+    add(scale(p2, 3 * v * u * u), scale(p3, u ** 3)),
+  );
+}
+
+function resolvedKind(centerline: CenterlineInput3D): VisualCenterlineKind3D {
+  if (centerline.kind === "quadratic" || centerline.kind === "cubic") return centerline.kind;
+  if (centerline.controlPoints.length === 3) return "quadratic";
+  if (centerline.controlPoints.length === 4) return "cubic";
+  throw new Error(`Unknown 3D centerline with ${centerline.controlPoints.length} control points`);
+}
+
+export function centerlinePoint3D(centerline: CenterlineInput3D, t: number): Point3D {
+  const points = centerline.controlPoints;
+  if (resolvedKind(centerline) === "quadratic") {
+    if (points.length !== 3) throw new Error("Quadratic 3D centerline requires 3 control points");
+    return quadraticPoint(points[0]!, points[1]!, points[2]!, t);
+  }
+  if (points.length !== 4) throw new Error("Cubic 3D centerline requires 4 control points");
+  return cubicPoint(points[0]!, points[1]!, points[2]!, points[3]!, t);
+}
+
+export function sampleCenterline3D(centerline: CenterlineInput3D, segments = 16): readonly Point3D[] {
+  const count = Number.isFinite(segments) ? Math.max(1, Math.floor(segments)) : 16;
+  return Object.freeze(Array.from({ length: count + 1 }, (_, index) =>
+    centerlinePoint3D(centerline, index / count)));
+}
+
+function makeCenterline(
+  kind: VisualCenterlineKind3D,
+  controlPoints: readonly Point3D[],
+  role: VisualArcRole3D,
+  greenOutwardTangent: Point3D,
+  loop: boolean,
+): VisualCenterline3D {
+  return Object.freeze({
+    kind,
+    role,
+    semanticOrientation: role === "start" ? "outer-to-green" : "green-to-outer",
+    greenOutwardTangent: clonePoint(greenOutwardTangent),
+    loop,
+    controlPoints: Object.freeze(controlPoints.map(clonePoint)),
+  });
+}
+
+function pairedArcs(center: Point3D, startPole: Point3D, endPole: Point3D) {
+  const startVector = subtract(startPole, center);
+  const endVector = subtract(endPole, center);
+  const startUnit = normalize(startVector);
+  const endUnit = normalize(endVector);
+
+  let startOutward = normalize(subtract(startUnit ?? point(0, 0, 0), endUnit ?? point(0, 0, 0)));
+  if (startOutward === undefined) {
+    const fallback = startUnit ?? scale(endUnit ?? X_AXIS, -1);
+    startOutward = stableOrthogonal(fallback);
+  }
+  if (startUnit !== undefined && dotVec3(startOutward, startVector) < 0) {
+    startOutward = scale(startOutward, -1);
+  }
+  const endOutward = scale(startOutward, -1);
+
+  return {
+    start: makeCenterline(
+      "quadratic",
+      [startPole, add(center, scale(startOutward, TANGENT_LENGTH)), center],
+      "start",
+      startOutward,
+      false,
+    ),
+    end: makeCenterline(
+      "quadratic",
+      [center, add(center, scale(endOutward, TANGENT_LENGTH)), endPole],
+      "end",
+      endOutward,
+      false,
+    ),
+  } as const;
+}
+
+function loopCenterline(
+  center: Point3D,
+  greenOutward: Point3D,
+  role: VisualArcRole3D,
+  planeNormal: Point3D,
+  handedness: 1 | -1,
+): VisualCenterline3D {
+  const green = normalize(greenOutward) ?? X_AXIS;
+  let normal = normalize(planeNormal) ?? stableOrthogonal(green);
+  normal = normalize(subtract(normal, scale(green, dotVec3(normal, green)))) ?? stableOrthogonal(green);
+  const side = normalize(cross(normal, green)) ?? stableOrthogonal(green);
+  const otherRay = normalize(add(
+    scale(green, -0.35),
+    scale(side, handedness * Math.sqrt(1 - 0.35 ** 2)),
+  )) ?? side;
+
+  const first = role === "start" ? otherRay : green;
+  const second = role === "start" ? green : otherRay;
+  return makeCenterline(
+    "cubic",
+    [center, add(center, scale(first, LOOP_RADIUS)), add(center, scale(second, LOOP_RADIUS)), center],
+    role,
+    green,
+    true,
+  );
+}
+
+function singleSelfArcs(
+  center: Point3D,
+  companionPole: Point3D,
+  selfRole: VisualArcRole3D,
+) {
+  const companionOutward = normalize(subtract(companionPole, center)) ?? X_AXIS;
+  const selfOutward = scale(companionOutward, -1);
+  const baseNormal = stableOrthogonal(companionOutward);
+  const planeNormal = selfRole === "start" ? baseNormal : scale(baseNormal, -1);
+  const selfLoop = loopCenterline(
+    center,
+    selfOutward,
+    selfRole,
+    planeNormal,
+    selfRole === "start" ? 1 : -1,
+  );
+  const companionControl = add(center, scale(companionOutward, TANGENT_LENGTH));
+  const companion = selfRole === "start"
+    ? makeCenterline("quadratic", [center, companionControl, companionPole], "end", companionOutward, false)
+    : makeCenterline("quadratic", [companionPole, companionControl, center], "start", companionOutward, false);
+
+  return selfRole === "start"
+    ? { start: selfLoop, end: companion } as const
+    : { start: companion, end: selfLoop } as const;
+}
+
+function doubleSelfArcs(center: Point3D) {
+  const startOutward = point(-1, 0, 0);
+  const endOutward = point(1, 0, 0);
+  return {
+    start: loopCenterline(center, startOutward, "start", Z_AXIS, 1),
+    end: loopCenterline(center, endOutward, "end", scale(Z_AXIS, -1), 1),
+  } as const;
+}
+
+function semanticArcs(
+  center: Point3D,
+  startPole: Point3D,
+  endPole: Point3D,
+  startSelf: boolean,
+  endSelf: boolean,
+) {
+  if (startSelf && endSelf) return doubleSelfArcs(center);
+  if (startSelf) return singleSelfArcs(center, endPole, "start");
+  if (endSelf) return singleSelfArcs(center, startPole, "end");
+  return pairedArcs(center, startPole, endPole);
+}
+
+function finite(value: Point3D): boolean {
+  return Number.isFinite(value.x) && Number.isFinite(value.y) && Number.isFinite(value.z);
+}
+
+export function buildVisualGeometry3D(
+  network: VisualLinkNetwork,
+  positions: readonly VisualPosition3D[],
+): VisualGeometry3D {
+  const normalized = normalizeVisualLinkNetwork(network);
+  const keys = new Set(normalized.links.map((link) => link.key));
+  const byKey = new Map<VisualKey, Point3D>();
+
+  for (const entry of positions) {
+    if (byKey.has(entry.key)) throw new VisualGeometry3DError("duplicate-position", entry.key);
+    if (!finite(entry.point)) throw new VisualGeometry3DError("non-finite-position", entry.key);
+    if (!keys.has(entry.key)) throw new VisualGeometry3DError("extra-position", entry.key);
+    byKey.set(entry.key, clonePoint(entry.point));
+  }
+
+  for (const link of normalized.links) {
+    if (!byKey.has(link.key)) throw new VisualGeometry3DError("missing-position", link.key);
+  }
+
+  const normalizedPositions = Object.freeze([...byKey.entries()]
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+    .map(([key, value]) => Object.freeze({ key, point: clonePoint(value) })));
+
+  const links = Object.freeze(normalized.links.map((link): VisualLinkGeometry3D => {
+    const center = byKey.get(link.key)!;
+    const startPole = byKey.get(link.startKey)!;
+    const endPole = byKey.get(link.endKey)!;
+    const arcs = semanticArcs(
+      center,
+      startPole,
+      endPole,
+      link.startKey === link.key,
+      link.endKey === link.key,
+    );
+    return Object.freeze({
+      key: link.key,
+      startKey: link.startKey,
+      endKey: link.endKey,
+      center: clonePoint(center),
+      start: arcs.start,
+      end: arcs.end,
+    });
+  }));
+
+  return Object.freeze({ positions: normalizedPositions, links });
+}

--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -103,3 +103,4 @@ export function normalizeVisualLinkNetwork(network: VisualLinkNetwork): VisualLi
 export * from "./blueprint-geometry.js";
 export * from "./blueprint-svg.js";
 export * from "./blueprint-interaction.js";
+export * from "./geometry3d.js";

--- a/packages/visual/test/geometry3d.test.ts
+++ b/packages/visual/test/geometry3d.test.ts
@@ -1,0 +1,183 @@
+import type { VisualLinkNetwork } from "../src/index.js";
+import {
+  VisualGeometry3DError,
+  buildVisualGeometry3D,
+  centerlinePoint3D,
+  dotVec3,
+  sampleCenterline3D,
+  type Point3D,
+  type VisualGeometry3D,
+  type VisualPosition3D,
+} from "../src/geometry3d.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2c: ${message}`);
+}
+
+function approx(actual: number, expected: number, message: string, epsilon = 1e-9): void {
+  assert(Math.abs(actual - expected) <= epsilon, `${message}: ${actual} != ${expected}`);
+}
+
+function samePoint(actual: Point3D, expected: Point3D, message: string): void {
+  approx(actual.x, expected.x, `${message}.x`);
+  approx(actual.y, expected.y, `${message}.y`);
+  approx(actual.z, expected.z, `${message}.z`);
+}
+
+function finitePoint(point: Point3D): boolean {
+  return Number.isFinite(point.x) && Number.isFinite(point.y) && Number.isFinite(point.z);
+}
+
+function linkByKey(geometry: VisualGeometry3D, key: string) {
+  const link = geometry.links.find((candidate) => candidate.key === key);
+  assert(link !== undefined, `missing geometry for ${key}`);
+  return link;
+}
+
+function position(key: string, x: number, y: number, z: number): VisualPosition3D {
+  return { key, point: { x, y, z } };
+}
+
+function expectCode(
+  effect: () => unknown,
+  code: VisualGeometry3DError["code"],
+  message: string,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof VisualGeometry3DError, `${message}: wrong error type`);
+    assert(error.code === code, `${message}: ${error.code} !== ${code}`);
+    return;
+  }
+  throw new Error(`@mts/visual V2c: ${message}: expected rejection`);
+}
+
+const ordinaryNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "A", startKey: "A", endKey: "A" },
+    { key: "B", startKey: "B", endKey: "B" },
+    { key: "X", startKey: "A", endKey: "B" },
+  ],
+};
+const ordinaryPositions: VisualPosition3D[] = [
+  position("A", 2, 1, 3),
+  position("B", -1, 4, 2),
+  position("X", 0, 0, 0),
+];
+const ordinaryTopologyBefore = JSON.stringify(ordinaryNetwork);
+const ordinaryPositionsBefore = JSON.stringify(ordinaryPositions);
+const ordinary = buildVisualGeometry3D(ordinaryNetwork, ordinaryPositions);
+const x = linkByKey(ordinary, "X");
+
+samePoint(centerlinePoint3D(x.start, 0), ordinaryPositions[0].point, "start arc begins at start Link center");
+samePoint(centerlinePoint3D(x.start, 1), ordinaryPositions[2].point, "start arc ends at GREEN center");
+samePoint(centerlinePoint3D(x.end, 0), ordinaryPositions[2].point, "end arc begins at GREEN center");
+samePoint(centerlinePoint3D(x.end, 1), ordinaryPositions[1].point, "end arc ends at end Link center");
+assert(x.start.role === "start", "start role preserved");
+assert(x.start.semanticOrientation === "outer-to-green", "start orientation is RED-to-GREEN capable");
+assert(x.end.role === "end", "end role preserved");
+assert(x.end.semanticOrientation === "green-to-outer", "end orientation is GREEN-to-BLUE capable");
+approx(dotVec3(x.start.greenOutwardTangent, x.end.greenOutwardTangent), -1, "GREEN tangents are 180 degrees");
+assert(centerlinePoint3D(x.start, 0).z === 3, "ordinary non-coplanar z coordinate is preserved");
+assert(JSON.stringify(ordinaryNetwork) === ordinaryTopologyBefore, "geometry cannot mutate visual topology");
+assert(JSON.stringify(ordinaryPositions) === ordinaryPositionsBefore, "geometry cannot mutate caller positions");
+
+const reordered = buildVisualGeometry3D(
+  { links: [...ordinaryNetwork.links].reverse() },
+  [...ordinaryPositions].reverse(),
+);
+assert(JSON.stringify(reordered) === JSON.stringify(ordinary), "input order does not alter normalized 3D geometry");
+
+const degenerate = buildVisualGeometry3D(
+  ordinaryNetwork,
+  [position("A", 0, 0, 0), position("B", 0, 0, 0), position("X", 0, 0, 0)],
+);
+const degenerateX = linkByKey(degenerate, "X");
+for (const point of [...sampleCenterline3D(degenerateX.start, 24), ...sampleCenterline3D(degenerateX.end, 24)]) {
+  assert(finitePoint(point), "coincident geometry remains finite");
+}
+approx(
+  dotVec3(degenerateX.start.greenOutwardTangent, degenerateX.end.greenOutwardTangent),
+  -1,
+  "coincident geometry preserves GREEN 180 degrees",
+);
+
+const startSelfNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "B", startKey: "B", endKey: "B" },
+    { key: "X", startKey: "X", endKey: "B" },
+  ],
+};
+const startSelf = linkByKey(
+  buildVisualGeometry3D(startSelfNetwork, [position("B", 3, 1, 2), position("X", 0, 0, 0)]),
+  "X",
+);
+assert(startSelf.start.loop === true, "start self-reference becomes a finite loop");
+for (const point of sampleCenterline3D(startSelf.start, 32)) assert(finitePoint(point), "start self-loop finite");
+approx(dotVec3(startSelf.start.greenOutwardTangent, startSelf.end.greenOutwardTangent), -1, "start self-loop 180 degrees");
+
+const endSelfNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "A", startKey: "A", endKey: "A" },
+    { key: "X", startKey: "A", endKey: "X" },
+  ],
+};
+const endSelf = linkByKey(
+  buildVisualGeometry3D(endSelfNetwork, [position("A", -2, 5, 1), position("X", 0, 0, 0)]),
+  "X",
+);
+assert(endSelf.end.loop === true, "end self-reference becomes a finite loop");
+for (const point of sampleCenterline3D(endSelf.end, 32)) assert(finitePoint(point), "end self-loop finite");
+approx(dotVec3(endSelf.start.greenOutwardTangent, endSelf.end.greenOutwardTangent), -1, "end self-loop 180 degrees");
+
+const rootNetwork: VisualLinkNetwork = { links: [{ key: "R", startKey: "R", endKey: "R" }] };
+const root = linkByKey(buildVisualGeometry3D(rootNetwork, [position("R", 1, -2, 4)]), "R");
+assert(root.start.loop === true && root.end.loop === true, "double self-link has two loops");
+assert(JSON.stringify(root.start.controlPoints) !== JSON.stringify(root.end.controlPoints), "double self-loops are distinct");
+for (const point of [...sampleCenterline3D(root.start, 32), ...sampleCenterline3D(root.end, 32)]) {
+  assert(finitePoint(point), "double self-loop finite");
+}
+approx(dotVec3(root.start.greenOutwardTangent, root.end.greenOutwardTangent), -1, "double self-link 180 degrees");
+
+const linkOfLinksNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "L", startKey: "L", endKey: "L" },
+    { key: "U", startKey: "U", endKey: "U" },
+    { key: "X", startKey: "L", endKey: "U" },
+  ],
+};
+const linkOfLinksPositions = [
+  position("L", -3, 2, 1),
+  position("U", 4, -1, 5),
+  position("X", 0, 0, 2),
+];
+const linkOfLinks = linkByKey(buildVisualGeometry3D(linkOfLinksNetwork, linkOfLinksPositions), "X");
+samePoint(centerlinePoint3D(linkOfLinks.start, 0), linkOfLinksPositions[0].point, "link-of-links start anchor");
+samePoint(centerlinePoint3D(linkOfLinks.end, 1), linkOfLinksPositions[1].point, "link-of-links end anchor");
+
+expectCode(
+  () => buildVisualGeometry3D(ordinaryNetwork, ordinaryPositions.slice(0, 2)),
+  "missing-position",
+  "missing position",
+);
+expectCode(
+  () => buildVisualGeometry3D(ordinaryNetwork, [...ordinaryPositions, position("EXTRA", 1, 2, 3)]),
+  "extra-position",
+  "extra position",
+);
+expectCode(
+  () => buildVisualGeometry3D(ordinaryNetwork, [...ordinaryPositions, position("A", 9, 9, 9)]),
+  "duplicate-position",
+  "duplicate position",
+);
+expectCode(
+  () => buildVisualGeometry3D(ordinaryNetwork, [ordinaryPositions[0], ordinaryPositions[1], position("X", Number.NaN, 0, 0)]),
+  "non-finite-position",
+  "NaN position",
+);
+expectCode(
+  () => buildVisualGeometry3D(ordinaryNetwork, [ordinaryPositions[0], ordinaryPositions[1], position("X", 0, Number.POSITIVE_INFINITY, 0)]),
+  "non-finite-position",
+  "Infinity position",
+);

--- a/packages/visual/test/geometry3d.test.ts
+++ b/packages/visual/test/geometry3d.test.ts
@@ -5,10 +5,33 @@ import {
   centerlinePoint3D,
   dotVec3,
   sampleCenterline3D,
-  type Point3D,
-  type VisualGeometry3D,
-  type VisualPosition3D,
 } from "../src/geometry3d.js";
+
+type Point3D = Readonly<{ x: number; y: number; z: number }>;
+type VisualPosition3D = Readonly<{ key: string; point: Point3D }>;
+type GeometryErrorCode =
+  | "missing-position"
+  | "extra-position"
+  | "duplicate-position"
+  | "non-finite-position";
+
+type CenterlineProbe = Readonly<{
+  role: "start" | "end";
+  semanticOrientation: "outer-to-green" | "green-to-outer";
+  greenOutwardTangent: Point3D;
+  loop: boolean;
+  controlPoints: readonly Point3D[];
+}>;
+
+type LinkGeometryProbe = Readonly<{
+  key: string;
+  start: CenterlineProbe;
+  end: CenterlineProbe;
+}>;
+
+type VisualGeometry3DProbe = Readonly<{
+  links: readonly LinkGeometryProbe[];
+}>;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`@mts/visual V2c: ${message}`);
@@ -28,8 +51,8 @@ function finitePoint(point: Point3D): boolean {
   return Number.isFinite(point.x) && Number.isFinite(point.y) && Number.isFinite(point.z);
 }
 
-function linkByKey(geometry: VisualGeometry3D, key: string) {
-  const link = geometry.links.find((candidate) => candidate.key === key);
+function linkByKey(geometry: VisualGeometry3DProbe, key: string): LinkGeometryProbe {
+  const link = geometry.links.find((candidate: LinkGeometryProbe) => candidate.key === key);
   assert(link !== undefined, `missing geometry for ${key}`);
   return link;
 }
@@ -38,16 +61,13 @@ function position(key: string, x: number, y: number, z: number): VisualPosition3
   return { key, point: { x, y, z } };
 }
 
-function expectCode(
-  effect: () => unknown,
-  code: VisualGeometry3DError["code"],
-  message: string,
-): void {
+function expectCode(effect: () => unknown, code: GeometryErrorCode, message: string): void {
   try {
     effect();
   } catch (error) {
     assert(error instanceof VisualGeometry3DError, `${message}: wrong error type`);
-    assert(error.code === code, `${message}: ${error.code} !== ${code}`);
+    const coded = error as { readonly code?: unknown };
+    assert(coded.code === code, `${message}: ${String(coded.code)} !== ${code}`);
     return;
   }
   throw new Error(`@mts/visual V2c: ${message}: expected rejection`);
@@ -67,7 +87,7 @@ const ordinaryPositions: VisualPosition3D[] = [
 ];
 const ordinaryTopologyBefore = JSON.stringify(ordinaryNetwork);
 const ordinaryPositionsBefore = JSON.stringify(ordinaryPositions);
-const ordinary = buildVisualGeometry3D(ordinaryNetwork, ordinaryPositions);
+const ordinary = buildVisualGeometry3D(ordinaryNetwork, ordinaryPositions) as VisualGeometry3DProbe;
 const x = linkByKey(ordinary, "X");
 
 samePoint(centerlinePoint3D(x.start, 0), ordinaryPositions[0].point, "start arc begins at start Link center");
@@ -86,13 +106,13 @@ assert(JSON.stringify(ordinaryPositions) === ordinaryPositionsBefore, "geometry 
 const reordered = buildVisualGeometry3D(
   { links: [...ordinaryNetwork.links].reverse() },
   [...ordinaryPositions].reverse(),
-);
+) as VisualGeometry3DProbe;
 assert(JSON.stringify(reordered) === JSON.stringify(ordinary), "input order does not alter normalized 3D geometry");
 
 const degenerate = buildVisualGeometry3D(
   ordinaryNetwork,
   [position("A", 0, 0, 0), position("B", 0, 0, 0), position("X", 0, 0, 0)],
-);
+) as VisualGeometry3DProbe;
 const degenerateX = linkByKey(degenerate, "X");
 for (const point of [...sampleCenterline3D(degenerateX.start, 24), ...sampleCenterline3D(degenerateX.end, 24)]) {
   assert(finitePoint(point), "coincident geometry remains finite");
@@ -110,7 +130,7 @@ const startSelfNetwork: VisualLinkNetwork = {
   ],
 };
 const startSelf = linkByKey(
-  buildVisualGeometry3D(startSelfNetwork, [position("B", 3, 1, 2), position("X", 0, 0, 0)]),
+  buildVisualGeometry3D(startSelfNetwork, [position("B", 3, 1, 2), position("X", 0, 0, 0)]) as VisualGeometry3DProbe,
   "X",
 );
 assert(startSelf.start.loop === true, "start self-reference becomes a finite loop");
@@ -124,7 +144,7 @@ const endSelfNetwork: VisualLinkNetwork = {
   ],
 };
 const endSelf = linkByKey(
-  buildVisualGeometry3D(endSelfNetwork, [position("A", -2, 5, 1), position("X", 0, 0, 0)]),
+  buildVisualGeometry3D(endSelfNetwork, [position("A", -2, 5, 1), position("X", 0, 0, 0)]) as VisualGeometry3DProbe,
   "X",
 );
 assert(endSelf.end.loop === true, "end self-reference becomes a finite loop");
@@ -132,7 +152,10 @@ for (const point of sampleCenterline3D(endSelf.end, 32)) assert(finitePoint(poin
 approx(dotVec3(endSelf.start.greenOutwardTangent, endSelf.end.greenOutwardTangent), -1, "end self-loop 180 degrees");
 
 const rootNetwork: VisualLinkNetwork = { links: [{ key: "R", startKey: "R", endKey: "R" }] };
-const root = linkByKey(buildVisualGeometry3D(rootNetwork, [position("R", 1, -2, 4)]), "R");
+const root = linkByKey(
+  buildVisualGeometry3D(rootNetwork, [position("R", 1, -2, 4)]) as VisualGeometry3DProbe,
+  "R",
+);
 assert(root.start.loop === true && root.end.loop === true, "double self-link has two loops");
 assert(JSON.stringify(root.start.controlPoints) !== JSON.stringify(root.end.controlPoints), "double self-loops are distinct");
 for (const point of [...sampleCenterline3D(root.start, 32), ...sampleCenterline3D(root.end, 32)]) {
@@ -152,7 +175,10 @@ const linkOfLinksPositions = [
   position("U", 4, -1, 5),
   position("X", 0, 0, 2),
 ];
-const linkOfLinks = linkByKey(buildVisualGeometry3D(linkOfLinksNetwork, linkOfLinksPositions), "X");
+const linkOfLinks = linkByKey(
+  buildVisualGeometry3D(linkOfLinksNetwork, linkOfLinksPositions) as VisualGeometry3DProbe,
+  "X",
+);
 samePoint(centerlinePoint3D(linkOfLinks.start, 0), linkOfLinksPositions[0].point, "link-of-links start anchor");
 samePoint(centerlinePoint3D(linkOfLinks.end, 1), linkOfLinksPositions[1].point, "link-of-links end anchor");
 

--- a/packages/visual/test/geometry3d.test.ts
+++ b/packages/visual/test/geometry3d.test.ts
@@ -90,10 +90,10 @@ const ordinaryPositionsBefore = JSON.stringify(ordinaryPositions);
 const ordinary = buildVisualGeometry3D(ordinaryNetwork, ordinaryPositions) as VisualGeometry3DProbe;
 const x = linkByKey(ordinary, "X");
 
-samePoint(centerlinePoint3D(x.start, 0), ordinaryPositions[0].point, "start arc begins at start Link center");
-samePoint(centerlinePoint3D(x.start, 1), ordinaryPositions[2].point, "start arc ends at GREEN center");
-samePoint(centerlinePoint3D(x.end, 0), ordinaryPositions[2].point, "end arc begins at GREEN center");
-samePoint(centerlinePoint3D(x.end, 1), ordinaryPositions[1].point, "end arc ends at end Link center");
+samePoint(centerlinePoint3D(x.start, 0), ordinaryPositions[0]!.point, "start arc begins at start Link center");
+samePoint(centerlinePoint3D(x.start, 1), ordinaryPositions[2]!.point, "start arc ends at GREEN center");
+samePoint(centerlinePoint3D(x.end, 0), ordinaryPositions[2]!.point, "end arc begins at GREEN center");
+samePoint(centerlinePoint3D(x.end, 1), ordinaryPositions[1]!.point, "end arc ends at end Link center");
 assert(x.start.role === "start", "start role preserved");
 assert(x.start.semanticOrientation === "outer-to-green", "start orientation is RED-to-GREEN capable");
 assert(x.end.role === "end", "end role preserved");
@@ -179,8 +179,8 @@ const linkOfLinks = linkByKey(
   buildVisualGeometry3D(linkOfLinksNetwork, linkOfLinksPositions) as VisualGeometry3DProbe,
   "X",
 );
-samePoint(centerlinePoint3D(linkOfLinks.start, 0), linkOfLinksPositions[0].point, "link-of-links start anchor");
-samePoint(centerlinePoint3D(linkOfLinks.end, 1), linkOfLinksPositions[1].point, "link-of-links end anchor");
+samePoint(centerlinePoint3D(linkOfLinks.start, 0), linkOfLinksPositions[0]!.point, "link-of-links start anchor");
+samePoint(centerlinePoint3D(linkOfLinks.end, 1), linkOfLinksPositions[1]!.point, "link-of-links end anchor");
 
 expectCode(
   () => buildVisualGeometry3D(ordinaryNetwork, ordinaryPositions.slice(0, 2)),
@@ -198,12 +198,12 @@ expectCode(
   "duplicate position",
 );
 expectCode(
-  () => buildVisualGeometry3D(ordinaryNetwork, [ordinaryPositions[0], ordinaryPositions[1], position("X", Number.NaN, 0, 0)]),
+  () => buildVisualGeometry3D(ordinaryNetwork, [ordinaryPositions[0]!, ordinaryPositions[1]!, position("X", Number.NaN, 0, 0)]),
   "non-finite-position",
   "NaN position",
 );
 expectCode(
-  () => buildVisualGeometry3D(ordinaryNetwork, [ordinaryPositions[0], ordinaryPositions[1], position("X", 0, Number.POSITIVE_INFINITY, 0)]),
+  () => buildVisualGeometry3D(ordinaryNetwork, [ordinaryPositions[0]!, ordinaryPositions[1]!, position("X", 0, Number.POSITIVE_INFINITY, 0)]),
   "non-finite-position",
   "Infinity position",
 );

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -1,6 +1,7 @@
 import "./blueprint-geometry.test.js";
 import "./blueprint-svg.test.js";
 import "./blueprint-interaction.test.js";
+import "./geometry3d.test.js";
 
 import {
   VisualNetworkError,


### PR DESCRIPTION
Refs #929

Adds deterministic renderer-independent true-3D geometry directly over `VisualLinkNetwork`.

## Invariant

```text
START arc: outer/start -> GREEN center   (future RED -> GREEN)
END arc:   GREEN center -> outer/end     (future GREEN -> BLUE)

dot(start.greenOutwardTangent, end.greenOutwardTangent) = -1
```

The 180° law is checked in true 3D for ordinary/non-coplanar, coincident/degenerate, single-self and double-self Links. Positions are presentation-only and fail closed on missing/extra/duplicate/non-finite coordinates.

## TDD evidence

Clean RED:

```text
head = 74a1993cea4f567d43bc0a32a64ce5dc0e2dcfb7
CI #3581 = FAILURE
repo-guard #773 = SUCCESS
only TypeScript error = TS2307 missing ../src/geometry3d.js
```

Current GREEN:

```text
head = 07974738ad7b9246ca8346c4f7ffcbd90a14063a
CI #3587 = SUCCESS
repo-guard #776 = SUCCESS
visual runtime corpus = SUCCESS
behind_by = 0
mergeable = true
draft = false
net additions = 566 / 800
```

Donor provenance is retained in production from `netkeep80/anum_parser@48b5909d19490d9b27904bfc087ee0e86868fbd8/src/geometry3d.js`.

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/index.ts
  - packages/visual/src/geometry3d.ts
  - packages/visual/test/model.test.ts
  - packages/visual/test/geometry3d.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 800
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/geometry3d.ts
  - packages/visual/test/geometry3d.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - web/**
  - repo-policy.json
  - .github/**
expected_effects:
  - "@mts/visual gains deterministic true-3D Link centerline geometry directly over VisualLinkNetwork"
  - "start/end orientation preserves future RED->GREEN and GREEN->BLUE rendering"
  - "start/end graphical arcs are exactly antiparallel at GREEN center in true 3D"
  - "self-links remain finite visible and deterministic"
  - "no physics renderer parser or proof semantics enter the common geometry layer"
  - "accepted MTS v0.11 semantics remain unchanged"
```

No accepted MTS semantic delta; v0.12 is not required.