### PR TITLE
[Visual/V2d] Pure deterministic 3D charge/spring dynamics over VisualLinkNetwork

### DIFF
--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -104,3 +104,4 @@ export * from "./blueprint-geometry.js";
 export * from "./blueprint-svg.js";
 export * from "./blueprint-interaction.js";
 export * from "./geometry3d.js";
+export * from "./physics3d.js";

--- a/packages/visual/src/physics3d.ts
+++ b/packages/visual/src/physics3d.ts
@@ -1,0 +1,331 @@
+import {
+  normalizeVisualLinkNetwork,
+  type VisualKey,
+  type VisualLinkNetwork,
+} from "./index.js";
+import type { Point3D, VisualPosition3D } from "./geometry3d.js";
+
+// Pure presentation physics adapted from:
+// netkeep80/anum_parser@48b5909d19490d9b27904bfc087ee0e86868fbd8/src/physics3d.js
+// Parser DTOs, root pinning, depth force, live state, and renderer concerns are excluded.
+
+const EPSILON = 1e-12;
+
+export interface PhysicalSpring3D {
+  readonly linkKey: VisualKey;
+  readonly role: "start" | "end";
+  readonly sourceKey: VisualKey;
+  readonly targetKey: VisualKey;
+}
+
+export interface PhysicalModel3D {
+  readonly keys: readonly VisualKey[];
+  readonly springs: readonly PhysicalSpring3D[];
+}
+
+export interface VisualVelocity3D {
+  readonly key: VisualKey;
+  readonly vector: Point3D;
+}
+
+export interface Physics3DState {
+  readonly positions: readonly VisualPosition3D[];
+  readonly velocities: readonly VisualVelocity3D[];
+}
+
+export interface Physics3DOptions {
+  readonly restLength?: number;
+  readonly springStiffness?: number;
+  readonly charge?: number;
+  readonly softening?: number;
+  readonly minimumDistance?: number;
+  readonly damping?: number;
+  readonly timeStep?: number;
+  readonly maxVelocity?: number;
+  readonly maxStep?: number;
+  readonly coordinateBound?: number;
+}
+
+export type Physics3DErrorCode =
+  | "invalid-option"
+  | "missing-position"
+  | "extra-position"
+  | "duplicate-position"
+  | "non-finite-position"
+  | "missing-velocity"
+  | "extra-velocity"
+  | "duplicate-velocity"
+  | "non-finite-velocity";
+
+export class Physics3DError extends Error {
+  readonly code: Physics3DErrorCode;
+  readonly detail: string;
+
+  constructor(code: Physics3DErrorCode, detail: string) {
+    super(`${code}: ${detail}`);
+    this.name = "Physics3DError";
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+export interface PhysicalForce3D {
+  readonly key: VisualKey;
+  readonly vector: Point3D;
+}
+
+export interface PhysicalForceResult3D {
+  readonly forces: readonly PhysicalForce3D[];
+  readonly evaluations: Readonly<{ springs: number; chargePairs: number }>;
+}
+
+interface NormalizedPhysics3DOptions {
+  readonly restLength: number;
+  readonly springStiffness: number;
+  readonly charge: number;
+  readonly softening: number;
+  readonly minimumDistance: number;
+  readonly damping: number;
+  readonly timeStep: number;
+  readonly maxVelocity: number;
+  readonly maxStep: number;
+  readonly coordinateBound: number;
+}
+
+const DEFAULTS: NormalizedPhysics3DOptions = Object.freeze({
+  restLength: 2,
+  springStiffness: 0.055,
+  charge: 1,
+  softening: 0.35,
+  minimumDistance: 0.2,
+  damping: 0.86,
+  timeStep: 0.2,
+  maxVelocity: 1.5,
+  maxStep: 0.25,
+  coordinateBound: 50,
+});
+
+function point(x: number, y: number, z: number): Point3D {
+  return Object.freeze({ x, y, z });
+}
+
+function clone(value: Point3D): Point3D {
+  return point(value.x, value.y, value.z);
+}
+
+function add(left: Point3D, right: Point3D): Point3D {
+  return point(left.x + right.x, left.y + right.y, left.z + right.z);
+}
+
+function subtract(left: Point3D, right: Point3D): Point3D {
+  return point(left.x - right.x, left.y - right.y, left.z - right.z);
+}
+
+function scale(value: Point3D, factor: number): Point3D {
+  return point(value.x * factor, value.y * factor, value.z * factor);
+}
+
+function norm(value: Point3D): number {
+  return Math.hypot(value.x, value.y, value.z);
+}
+
+function finite(value: Point3D): boolean {
+  return Number.isFinite(value.x) && Number.isFinite(value.y) && Number.isFinite(value.z);
+}
+
+function normalize(value: Point3D): Point3D | undefined {
+  const length = norm(value);
+  return Number.isFinite(length) && length > EPSILON ? scale(value, 1 / length) : undefined;
+}
+
+function clampMagnitude(value: Point3D, maximum: number): Point3D {
+  const length = norm(value);
+  return length > maximum && length > EPSILON ? scale(value, maximum / length) : clone(value);
+}
+
+function clampCoordinate(value: Point3D, bound: number): Point3D {
+  return point(
+    Math.max(-bound, Math.min(bound, value.x)),
+    Math.max(-bound, Math.min(bound, value.y)),
+    Math.max(-bound, Math.min(bound, value.z)),
+  );
+}
+
+function stableUnit(key: string): Point3D {
+  let hash = 2166136261;
+  for (let index = 0; index < key.length; index += 1) {
+    hash ^= key.charCodeAt(index);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  const x = ((hash & 1023) / 511.5) - 1;
+  const y = (((hash >>> 10) & 1023) / 511.5) - 1;
+  const z = (((hash >>> 20) & 1023) / 511.5) - 1;
+  return normalize(point(x, y, z)) ?? point(1, 0, 0);
+}
+
+function directionBetween(
+  sourceKey: VisualKey,
+  targetKey: VisualKey,
+  source: Point3D,
+  target: Point3D,
+): Readonly<{ direction: Point3D; distance: number }> {
+  const delta = subtract(target, source);
+  const distance = norm(delta);
+  return Object.freeze({
+    direction: normalize(delta) ?? stableUnit(`${sourceKey}->${targetKey}`),
+    distance,
+  });
+}
+
+function normalizedOptions(options: Physics3DOptions): NormalizedPhysics3DOptions {
+  const value = { ...DEFAULTS, ...options };
+  const invalid = (name: keyof NormalizedPhysics3DOptions, condition: boolean): void => {
+    const current = value[name];
+    if (!Number.isFinite(current) || condition) throw new Physics3DError("invalid-option", String(name));
+  };
+  invalid("restLength", value.restLength <= 0);
+  invalid("springStiffness", value.springStiffness < 0);
+  invalid("charge", value.charge < 0);
+  invalid("softening", value.softening <= 0);
+  invalid("minimumDistance", value.minimumDistance <= 0);
+  invalid("damping", value.damping < 0 || value.damping > 1);
+  invalid("timeStep", value.timeStep <= 0);
+  invalid("maxVelocity", value.maxVelocity <= 0);
+  invalid("maxStep", value.maxStep <= 0);
+  invalid("coordinateBound", value.coordinateBound <= 0);
+  return Object.freeze(value);
+}
+
+export function buildPhysicalModel3D(network: VisualLinkNetwork): PhysicalModel3D {
+  const normalized = normalizeVisualLinkNetwork(network);
+  const springs: PhysicalSpring3D[] = [];
+  for (const link of normalized.links) {
+    if (link.startKey !== link.key) {
+      springs.push(Object.freeze({
+        linkKey: link.key,
+        role: "start",
+        sourceKey: link.startKey,
+        targetKey: link.key,
+      }));
+    }
+    if (link.endKey !== link.key) {
+      springs.push(Object.freeze({
+        linkKey: link.key,
+        role: "end",
+        sourceKey: link.key,
+        targetKey: link.endKey,
+      }));
+    }
+  }
+  return Object.freeze({
+    keys: Object.freeze(normalized.links.map((link) => link.key)),
+    springs: Object.freeze(springs),
+  });
+}
+
+function exactVectors<T extends { readonly key: VisualKey }>(
+  model: PhysicalModel3D,
+  entries: readonly T[],
+  select: (entry: T) => Point3D,
+  kind: "position" | "velocity",
+): Map<VisualKey, Point3D> {
+  const allowed = new Set(model.keys);
+  const result = new Map<VisualKey, Point3D>();
+  for (const entry of entries) {
+    const duplicateCode = kind === "position" ? "duplicate-position" : "duplicate-velocity";
+    const extraCode = kind === "position" ? "extra-position" : "extra-velocity";
+    const finiteCode = kind === "position" ? "non-finite-position" : "non-finite-velocity";
+    if (result.has(entry.key)) throw new Physics3DError(duplicateCode, entry.key);
+    if (!allowed.has(entry.key)) throw new Physics3DError(extraCode, entry.key);
+    const vector = select(entry);
+    if (!finite(vector)) throw new Physics3DError(finiteCode, entry.key);
+    result.set(entry.key, clone(vector));
+  }
+  for (const key of model.keys) {
+    if (!result.has(key)) {
+      throw new Physics3DError(kind === "position" ? "missing-position" : "missing-velocity", key);
+    }
+  }
+  return result;
+}
+
+function addForce(forces: Map<VisualKey, Point3D>, key: VisualKey, contribution: Point3D): void {
+  forces.set(key, add(forces.get(key)!, contribution));
+}
+
+export function computePhysicalForces3D(
+  model: PhysicalModel3D,
+  positions: readonly VisualPosition3D[],
+  options: Physics3DOptions = {},
+): PhysicalForceResult3D {
+  const normalized = normalizedOptions(options);
+  const byKey = exactVectors(model, positions, (entry) => entry.point, "position");
+  const forces = new Map(model.keys.map((key) => [key, point(0, 0, 0)] as const));
+  let springEvaluations = 0;
+  let chargePairs = 0;
+
+  for (const spring of model.springs) {
+    const source = byKey.get(spring.sourceKey)!;
+    const target = byKey.get(spring.targetKey)!;
+    const { direction, distance } = directionBetween(spring.sourceKey, spring.targetKey, source, target);
+    const contribution = scale(direction, normalized.springStiffness * (distance - normalized.restLength));
+    addForce(forces, spring.sourceKey, contribution);
+    addForce(forces, spring.targetKey, scale(contribution, -1));
+    springEvaluations += 1;
+  }
+
+  for (let left = 0; left < model.keys.length; left += 1) {
+    const leftKey = model.keys[left]!;
+    const leftPosition = byKey.get(leftKey)!;
+    for (let right = left + 1; right < model.keys.length; right += 1) {
+      const rightKey = model.keys[right]!;
+      const rightPosition = byKey.get(rightKey)!;
+      const raw = subtract(leftPosition, rightPosition);
+      const distance = norm(raw);
+      const direction = normalize(raw) ?? stableUnit(`${rightKey}|${leftKey}`);
+      const guarded = Math.max(normalized.minimumDistance, distance);
+      const denominator = guarded * guarded + normalized.softening * normalized.softening;
+      const contribution = scale(direction, normalized.charge * normalized.charge / denominator);
+      addForce(forces, leftKey, contribution);
+      addForce(forces, rightKey, scale(contribution, -1));
+      chargePairs += 1;
+    }
+  }
+
+  return Object.freeze({
+    forces: Object.freeze(model.keys.map((key) => Object.freeze({ key, vector: clone(forces.get(key)!) }))),
+    evaluations: Object.freeze({ springs: springEvaluations, chargePairs }),
+  });
+}
+
+export function stepPhysics3D(
+  model: PhysicalModel3D,
+  state: Physics3DState,
+  options: Physics3DOptions = {},
+): Physics3DState {
+  const normalized = normalizedOptions(options);
+  const positions = exactVectors(model, state.positions, (entry) => entry.point, "position");
+  const velocities = exactVectors(model, state.velocities, (entry) => entry.vector, "velocity");
+  const forceResult = computePhysicalForces3D(model, state.positions, normalized);
+  const forces = new Map(forceResult.forces.map((entry) => [entry.key, entry.vector] as const));
+  const nextPositions: VisualPosition3D[] = [];
+  const nextVelocities: VisualVelocity3D[] = [];
+
+  for (const key of model.keys) {
+    let velocity = add(velocities.get(key)!, scale(forces.get(key)!, normalized.timeStep));
+    velocity = clampMagnitude(scale(velocity, normalized.damping), normalized.maxVelocity);
+    let displacement = scale(velocity, normalized.timeStep);
+    const unclamped = norm(displacement);
+    displacement = clampMagnitude(displacement, normalized.maxStep);
+    if (norm(displacement) + EPSILON < unclamped) velocity = scale(displacement, 1 / normalized.timeStep);
+    const next = clampCoordinate(add(positions.get(key)!, displacement), normalized.coordinateBound);
+    if (!finite(next) || !finite(velocity)) throw new Physics3DError("non-finite-position", key);
+    nextPositions.push(Object.freeze({ key, point: clone(next) }));
+    nextVelocities.push(Object.freeze({ key, vector: clone(velocity) }));
+  }
+
+  return Object.freeze({
+    positions: Object.freeze(nextPositions),
+    velocities: Object.freeze(nextVelocities),
+  });
+}

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -2,6 +2,7 @@ import "./blueprint-geometry.test.js";
 import "./blueprint-svg.test.js";
 import "./blueprint-interaction.test.js";
 import "./geometry3d.test.js";
+import "./physics3d.test.js";
 
 import {
   VisualNetworkError,

--- a/packages/visual/test/physics3d.test.ts
+++ b/packages/visual/test/physics3d.test.ts
@@ -1,0 +1,321 @@
+import {
+  type Point3D,
+  type VisualLinkNetwork,
+  type VisualPosition3D,
+} from "../src/index.js";
+import {
+  Physics3DError,
+  buildPhysicalModel3D,
+  computePhysicalForces3D,
+  stepPhysics3D,
+} from "../src/physics3d.js";
+
+type SpringProbe = Readonly<{
+  linkKey: string;
+  role: "start" | "end";
+  sourceKey: string;
+  targetKey: string;
+}>;
+
+type PhysicalModelProbe = Readonly<{
+  keys: readonly string[];
+  springs: readonly SpringProbe[];
+}>;
+
+type ForceProbe = Readonly<{ key: string; vector: Point3D }>;
+type ForceResultProbe = Readonly<{
+  forces: readonly ForceProbe[];
+  evaluations: Readonly<{ springs: number; chargePairs: number }>;
+}>;
+type VelocityProbe = Readonly<{ key: string; vector: Point3D }>;
+type StateProbe = Readonly<{
+  positions: readonly VisualPosition3D[];
+  velocities: readonly VelocityProbe[];
+}>;
+
+type PhysicsErrorCode =
+  | "invalid-option"
+  | "missing-velocity"
+  | "extra-velocity"
+  | "duplicate-velocity"
+  | "non-finite-velocity";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2d: ${message}`);
+}
+
+function approx(actual: number, expected: number, message: string, epsilon = 1e-9): void {
+  assert(Math.abs(actual - expected) <= epsilon, `${message}: ${actual} != ${expected}`);
+}
+
+function point(x: number, y: number, z: number): Point3D {
+  return { x, y, z };
+}
+
+function position(key: string, x: number, y: number, z: number): VisualPosition3D {
+  return { key, point: point(x, y, z) };
+}
+
+function velocity(key: string, x: number, y: number, z: number): VelocityProbe {
+  return { key, vector: point(x, y, z) };
+}
+
+function norm(value: Point3D): number {
+  return Math.hypot(value.x, value.y, value.z);
+}
+
+function model(network: VisualLinkNetwork): PhysicalModelProbe {
+  return buildPhysicalModel3D(network) as PhysicalModelProbe;
+}
+
+function forceByKey(result: ForceResultProbe, key: string): Point3D {
+  const force = result.forces.find((entry: ForceProbe) => entry.key === key);
+  assert(force !== undefined, `missing force for ${key}`);
+  return force.vector;
+}
+
+function expectPhysicsCode(effect: () => unknown, code: PhysicsErrorCode, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof Physics3DError, `${message}: wrong error type`);
+    const coded = error as { readonly code?: unknown };
+    assert(coded.code === code, `${message}: ${String(coded.code)} !== ${code}`);
+    return;
+  }
+  throw new Error(`@mts/visual V2d: ${message}: expected rejection`);
+}
+
+function expectReject(effect: () => unknown, message: string): void {
+  try {
+    effect();
+  } catch {
+    return;
+  }
+  throw new Error(`@mts/visual V2d: ${message}: expected rejection`);
+}
+
+const topologyNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "R", startKey: "R", endKey: "R", label: "root-looking presentation only" },
+    { key: "A", startKey: "R", endKey: "B" },
+    { key: "B", startKey: "A", endKey: "R" },
+    { key: "C", startKey: "C", endKey: "B", tags: ["self-start"] },
+  ],
+};
+const physical = model(topologyNetwork);
+assert(JSON.stringify(physical.keys) === JSON.stringify(["A", "B", "C", "R"]), "one physical point per normalized VisualKey");
+assert(
+  JSON.stringify(physical.springs) === JSON.stringify([
+    { linkKey: "A", role: "start", sourceKey: "R", targetKey: "A" },
+    { linkKey: "A", role: "end", sourceKey: "A", targetKey: "B" },
+    { linkKey: "B", role: "start", sourceKey: "A", targetKey: "B" },
+    { linkKey: "B", role: "end", sourceKey: "B", targetKey: "R" },
+    { linkKey: "C", role: "end", sourceKey: "C", targetKey: "B" },
+  ]),
+  "non-self START/END arcs map one-for-one to role-preserving springs",
+);
+assert(physical.springs.every((spring: SpringProbe) => spring.sourceKey !== spring.targetKey), "self arcs never create self-force springs");
+
+const reorderedPhysical = model({ links: [...topologyNetwork.links].reverse() });
+assert(JSON.stringify(reorderedPhysical) === JSON.stringify(physical), "network input order does not change physical topology");
+const relabeledPhysical = model({
+  links: topologyNetwork.links.map((link) => ({ ...link, label: `label:${link.key}`, tags: ["debug"] })),
+});
+assert(JSON.stringify(relabeledPhysical) === JSON.stringify(physical), "metadata does not change physical topology");
+
+const linkOfLinks = model({
+  links: [
+    { key: "L", startKey: "L", endKey: "L" },
+    { key: "U", startKey: "U", endKey: "U" },
+    { key: "X", startKey: "L", endKey: "U" },
+  ],
+});
+assert(
+  JSON.stringify(linkOfLinks.springs) === JSON.stringify([
+    { linkKey: "X", role: "start", sourceKey: "L", targetKey: "X" },
+    { linkKey: "X", role: "end", sourceKey: "X", targetKey: "U" },
+  ]),
+  "link-of-links uses represented Link centers without a special node layer",
+);
+
+const chargeModel = model({
+  links: [
+    { key: "A", startKey: "A", endKey: "A" },
+    { key: "B", startKey: "B", endKey: "B" },
+  ],
+});
+const pairPositions = [position("A", -1, 0, 0), position("B", 1, 0, 0)];
+const chargeResult = computePhysicalForces3D(chargeModel, pairPositions, {
+  charge: 1,
+  springStiffness: 0,
+  minimumDistance: 0.1,
+  softening: 0.1,
+}) as ForceResultProbe;
+const chargeA = forceByKey(chargeResult, "A");
+const chargeB = forceByKey(chargeResult, "B");
+assert(chargeA.x < 0 && chargeB.x > 0, "same-sign GREEN centers repel");
+approx(chargeA.x + chargeB.x, 0, "pairwise charge force is symmetric");
+approx(chargeA.y + chargeB.y, 0, "pairwise charge y force is symmetric");
+approx(chargeA.z + chargeB.z, 0, "pairwise charge z force is symmetric");
+assert(chargeResult.evaluations.chargePairs === 1, "one pairwise charge evaluation");
+
+const noCharge = computePhysicalForces3D(chargeModel, pairPositions, {
+  charge: 0,
+  springStiffness: 0,
+}) as ForceResultProbe;
+approx(norm(forceByKey(noCharge, "A")), 0, "charge=0 disables charge force");
+const charge2 = computePhysicalForces3D(chargeModel, pairPositions, {
+  charge: 2,
+  springStiffness: 0,
+  minimumDistance: 0.1,
+  softening: 0.1,
+}) as ForceResultProbe;
+assert(norm(forceByKey(charge2, "A")) > norm(chargeA), "larger global charge increases repulsion magnitude");
+
+const springModel = model({
+  links: [
+    { key: "A", startKey: "A", endKey: "B" },
+    { key: "B", startKey: "B", endKey: "B" },
+  ],
+});
+function springForce(distance: number, stiffness: number): ForceResultProbe {
+  return computePhysicalForces3D(
+    springModel,
+    [position("A", 0, 0, 0), position("B", distance, 0, 0)],
+    { charge: 0, restLength: 2, springStiffness: stiffness },
+  ) as ForceResultProbe;
+}
+assert(forceByKey(springForce(4, 1), "A").x > 0, "stretched spring attracts");
+assert(forceByKey(springForce(1, 1), "A").x < 0, "compressed spring repels");
+approx(norm(forceByKey(springForce(2, 1), "A")), 0, "spring at restLength has zero force");
+approx(norm(forceByKey(springForce(4, 0), "A")), 0, "springStiffness=0 disables spring force");
+assert(
+  norm(forceByKey(springForce(4, 1), "A")) > norm(forceByKey(springForce(4, 0.5), "A")),
+  "larger springStiffness increases fixed-extension force",
+);
+
+const coincidentPositions = [position("A", 0, 0, 0), position("B", 0, 0, 0)];
+const coincidentFirst = computePhysicalForces3D(chargeModel, coincidentPositions, {
+  charge: 1,
+  springStiffness: 0,
+}) as ForceResultProbe;
+const coincidentSecond = computePhysicalForces3D(chargeModel, coincidentPositions, {
+  charge: 1,
+  springStiffness: 0,
+}) as ForceResultProbe;
+assert(JSON.stringify(coincidentFirst) === JSON.stringify(coincidentSecond), "coincident separation direction is deterministic");
+const coincidentA = forceByKey(coincidentFirst, "A");
+const coincidentB = forceByKey(coincidentFirst, "B");
+assert(Number.isFinite(norm(coincidentA)) && norm(coincidentA) > 0, "coincident charge force is finite and nonzero");
+approx(coincidentA.x + coincidentB.x, 0, "coincident forces oppose on x");
+approx(coincidentA.y + coincidentB.y, 0, "coincident forces oppose on y");
+approx(coincidentA.z + coincidentB.z, 0, "coincident forces oppose on z");
+
+const state: StateProbe = {
+  positions: [position("A", -1, 0, 0), position("B", 1, 0, 0)],
+  velocities: [velocity("A", 0, 0, 0), velocity("B", 0, 0, 0)],
+};
+const stateBefore = JSON.stringify(state);
+const networkBefore = JSON.stringify(chargeModel);
+const stepOptions = {
+  charge: 25,
+  springStiffness: 0,
+  damping: 0.8,
+  timeStep: 0.2,
+  maxVelocity: 0.5,
+  maxStep: 0.05,
+  coordinateBound: 2,
+};
+const stepped = stepPhysics3D(chargeModel, state, stepOptions) as StateProbe;
+const steppedAgain = stepPhysics3D(chargeModel, state, stepOptions) as StateProbe;
+assert(JSON.stringify(stepped) === JSON.stringify(steppedAgain), "same state/options give deep-equal next state");
+assert(JSON.stringify(state) === stateBefore, "step does not mutate caller state");
+assert(JSON.stringify(chargeModel) === networkBefore, "step does not mutate physical topology");
+for (const entry of stepped.positions) {
+  assert(Number.isFinite(norm(entry.point)), `stepped position ${entry.key} finite`);
+  assert(norm(entry.point) <= 2 + 1e-9, `stepped position ${entry.key} coordinate bounded`);
+}
+for (const entry of stepped.velocities) {
+  assert(Number.isFinite(norm(entry.vector)), `stepped velocity ${entry.key} finite`);
+  assert(norm(entry.vector) <= 0.5 + 1e-9, `stepped velocity ${entry.key} bounded`);
+}
+
+const rootLookingState: StateProbe = {
+  positions: [position("A", 1, 0, 0), position("R", 0, 0, 0)],
+  velocities: [velocity("A", 0, 0, 0), velocity("R", 0, 0, 0)],
+};
+const rootLookingModel = model({
+  links: [
+    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+    { key: "A", startKey: "A", endKey: "A" },
+  ],
+});
+const movedRootLooking = stepPhysics3D(rootLookingModel, rootLookingState, {
+  charge: 1,
+  springStiffness: 0,
+  damping: 1,
+  timeStep: 0.1,
+}) as StateProbe;
+const movedR = movedRootLooking.positions.find((entry) => entry.key === "R");
+assert(movedR !== undefined && movedR.point.x < 0, "presentation key/label R is not implicitly pinned as semantic root");
+
+expectReject(
+  () => computePhysicalForces3D(chargeModel, [pairPositions[0]!], {}),
+  "missing position",
+);
+expectReject(
+  () => computePhysicalForces3D(chargeModel, [...pairPositions, position("EXTRA", 0, 0, 0)], {}),
+  "extra position",
+);
+expectReject(
+  () => computePhysicalForces3D(chargeModel, [...pairPositions, position("A", 0, 0, 0)], {}),
+  "duplicate position",
+);
+expectReject(
+  () => computePhysicalForces3D(chargeModel, [pairPositions[0]!, position("B", Number.NaN, 0, 0)], {}),
+  "non-finite position",
+);
+
+expectPhysicsCode(
+  () => stepPhysics3D(chargeModel, { positions: pairPositions, velocities: [velocity("A", 0, 0, 0)] }, {}),
+  "missing-velocity",
+  "missing velocity",
+);
+expectPhysicsCode(
+  () => stepPhysics3D(chargeModel, { positions: pairPositions, velocities: [velocity("A", 0, 0, 0), velocity("B", 0, 0, 0), velocity("EXTRA", 0, 0, 0)] }, {}),
+  "extra-velocity",
+  "extra velocity",
+);
+expectPhysicsCode(
+  () => stepPhysics3D(chargeModel, { positions: pairPositions, velocities: [velocity("A", 0, 0, 0), velocity("B", 0, 0, 0), velocity("A", 0, 0, 0)] }, {}),
+  "duplicate-velocity",
+  "duplicate velocity",
+);
+expectPhysicsCode(
+  () => stepPhysics3D(chargeModel, { positions: pairPositions, velocities: [velocity("A", 0, 0, 0), velocity("B", 0, Number.POSITIVE_INFINITY, 0)] }, {}),
+  "non-finite-velocity",
+  "non-finite velocity",
+);
+
+for (const invalid of [
+  { restLength: 0 },
+  { springStiffness: -1 },
+  { charge: -1 },
+  { softening: 0 },
+  { minimumDistance: 0 },
+  { damping: -0.1 },
+  { damping: 1.1 },
+  { timeStep: 0 },
+  { maxVelocity: 0 },
+  { maxStep: 0 },
+  { coordinateBound: 0 },
+  { charge: Number.NaN },
+  { springStiffness: Number.POSITIVE_INFINITY },
+]) {
+  expectPhysicsCode(
+    () => computePhysicalForces3D(chargeModel, pairPositions, invalid),
+    "invalid-option",
+    `invalid option ${JSON.stringify(invalid)}`,
+  );
+}


### PR DESCRIPTION
Closes #931

V2d adds renderer-neutral deterministic 3D physical dynamics directly over `VisualLinkNetwork`.

## Accepted boundary

```text
VisualLinkNetwork
+ exact V2c positions
+ velocities
+ explicit physical options
    -> deterministic charge + Hooke spring forces
    -> pure bounded next state
```

Presentation laws:

```text
non-self START arc -> one START spring
non-self END arc   -> one END spring
self arc           -> no self-force spring
all represented centers -> same global charge

charge            = future global node-charge slider
springStiffness   = future global spring-stiffness slider
```

No animation loop, pin/drag/wake/sleep controller, renderer, DOM, parser semantics or proof authority enters this slice.

## TDD evidence

RED:

```text
beb7bbb64a40f211b6c3286b7c062d7df02f6b83
CI #3590 = FAILURE
repo-guard #777 = SUCCESS
exact failure = TS2307: Cannot find module '../src/physics3d.js'
```

GREEN final head:

```text
deaa43b534bafdc913b488a09169e2babeb3ef87
CI #3596 = SUCCESS
repo-guard #780 = SUCCESS
```

The blocking visual runtime entry executes `physics3d.test.js` on the final head.

## Implemented

```text
[+] direct VisualLinkNetwork -> physical point/spring topology
[+] role-preserving START/END springs
[+] no self-force spring for self arcs
[+] deterministic symmetric charge repulsion
[+] deterministic zero-distance separation direction
[+] Hooke attraction/repulsion/rest-length behavior
[+] explicit charge and springStiffness parameters
[+] strict fail-closed physical option validation
[+] exact position/velocity validation
[+] explicit timeStep
[+] finite bounded one-step integration
[+] no caller state/network mutation
[+] package-root export through @mts/visual
```

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/index.ts
  - packages/visual/src/physics3d.ts
  - packages/visual/test/model.test.ts
  - packages/visual/test/physics3d.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 800
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/physics3d.ts
  - packages/visual/test/physics3d.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - web/**
  - repo-policy.json
  - .github/**
expected_effects:
  - "@mts/visual gains deterministic renderer-neutral 3D charge/spring dynamics directly over VisualLinkNetwork"
  - "every non-self START/END arc contributes one role-preserving spring while self arcs contribute no self-force"
  - "global charge and springStiffness are explicit pure parameters suitable for later UI sliders"
  - "one-step dynamics are finite bounded deterministic and do not mutate semantic/presentation topology"
  - "no live controller renderer parser or proof semantics enter the physical-law layer"
  - "accepted MTS v0.11 semantics remain unchanged"
```

Accepted MTS semantic delta = NONE. v0.12 is not required.