### PR TITLE
[Visual/V2e] Live 3D physics controller: wake/sleep/pin/move/release

### DIFF
--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -105,3 +105,4 @@ export * from "./blueprint-svg.js";
 export * from "./blueprint-interaction.js";
 export * from "./geometry3d.js";
 export * from "./physics3d.js";
+export * from "./live-physics3d.js";

--- a/packages/visual/src/live-physics3d.ts
+++ b/packages/visual/src/live-physics3d.ts
@@ -1,0 +1,331 @@
+import type { Point3D } from "./geometry3d.js";
+import type { VisualKey, VisualLinkNetwork } from "./index.js";
+import {
+  Physics3DError,
+  buildPhysicalModel3D,
+  stepPhysics3D,
+  type PhysicalModel3D,
+  type Physics3DOptions,
+  type Physics3DState,
+  type VisualVelocity3D,
+} from "./physics3d.js";
+
+// Stateful presentation controller adapted from:
+// netkeep80/anum_parser@48b5909d19490d9b27904bfc087ee0e86868fbd8/src/live-physics3d.js
+// Root inference, depth/potential metrics, renderer/browser state, random and wall clock are excluded.
+
+const DEFAULT_SETTLE_VELOCITY = 0.01;
+const DEFAULT_SETTLE_POSITION_DELTA = 0.002;
+const DEFAULT_SETTLE_WINDOW = 8;
+
+export interface LivePhysics3DOptions extends Physics3DOptions {
+  readonly settleVelocity?: number;
+  readonly settlePositionDelta?: number;
+  readonly settleWindow?: number;
+}
+
+export type LivePhysics3DErrorCode =
+  | "invalid-live-option"
+  | "invalid-physics-option"
+  | "unknown-key"
+  | "non-finite-vector"
+  | "not-pinned";
+
+export class LivePhysics3DError extends Error {
+  readonly code: LivePhysics3DErrorCode;
+  readonly detail: string;
+
+  constructor(code: LivePhysics3DErrorCode, detail: string) {
+    super(`${code}: ${detail}`);
+    this.name = "LivePhysics3DError";
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+export interface LivePhysics3DSnapshot {
+  readonly state: Physics3DState;
+  readonly tick: number;
+  readonly awake: boolean;
+  readonly stableTicks: number;
+  readonly pinnedKeys: readonly VisualKey[];
+  readonly maxVelocity: number;
+  readonly maxPositionDelta: number;
+  readonly stepped: boolean;
+}
+
+interface ResolvedLivePhysics3DOptions extends Physics3DOptions {
+  readonly settleVelocity: number;
+  readonly settlePositionDelta: number;
+  readonly settleWindow: number;
+}
+
+export interface LivePhysics3DController {
+  readonly model: PhysicalModel3D;
+}
+
+interface MutableLivePhysics3DController extends LivePhysics3DController {
+  state: Physics3DState;
+  options: ResolvedLivePhysics3DOptions;
+  readonly pinned: Map<VisualKey, Point3D>;
+  awake: boolean;
+  stableTicks: number;
+  tick: number;
+  maxVelocity: number;
+  maxPositionDelta: number;
+}
+
+function point(value: Point3D): Point3D {
+  return Object.freeze({ x: value.x, y: value.y, z: value.z });
+}
+
+function zero(): Point3D {
+  return Object.freeze({ x: 0, y: 0, z: 0 });
+}
+
+function finite(value: Point3D): boolean {
+  return Number.isFinite(value.x) && Number.isFinite(value.y) && Number.isFinite(value.z);
+}
+
+function norm(value: Point3D): number {
+  return Math.hypot(value.x, value.y, value.z);
+}
+
+function cloneState(state: Physics3DState): Physics3DState {
+  return Object.freeze({
+    positions: Object.freeze(state.positions.map((entry) => Object.freeze({ key: entry.key, point: point(entry.point) }))),
+    velocities: Object.freeze(state.velocities.map((entry) => Object.freeze({ key: entry.key, vector: point(entry.vector) }))),
+  });
+}
+
+function resolvedOptions(options: LivePhysics3DOptions): ResolvedLivePhysics3DOptions {
+  const settleVelocity = options.settleVelocity ?? DEFAULT_SETTLE_VELOCITY;
+  const settlePositionDelta = options.settlePositionDelta ?? DEFAULT_SETTLE_POSITION_DELTA;
+  const settleWindow = options.settleWindow ?? DEFAULT_SETTLE_WINDOW;
+  if (!Number.isFinite(settleVelocity) || settleVelocity < 0) {
+    throw new LivePhysics3DError("invalid-live-option", "settleVelocity");
+  }
+  if (!Number.isFinite(settlePositionDelta) || settlePositionDelta < 0) {
+    throw new LivePhysics3DError("invalid-live-option", "settlePositionDelta");
+  }
+  if (!Number.isInteger(settleWindow) || settleWindow <= 0) {
+    throw new LivePhysics3DError("invalid-live-option", "settleWindow");
+  }
+  return Object.freeze({ ...options, settleVelocity, settlePositionDelta, settleWindow });
+}
+
+function physicsOptions(options: ResolvedLivePhysics3DOptions): Physics3DOptions {
+  const { settleVelocity: _velocity, settlePositionDelta: _delta, settleWindow: _window, ...physics } = options;
+  return physics;
+}
+
+function validatePhysics(
+  model: PhysicalModel3D,
+  state: Physics3DState,
+  options: ResolvedLivePhysics3DOptions,
+): void {
+  try {
+    stepPhysics3D(model, state, physicsOptions(options));
+  } catch (error) {
+    if (error instanceof Physics3DError && error.code === "invalid-option") {
+      throw new LivePhysics3DError("invalid-physics-option", error.detail);
+    }
+    throw error;
+  }
+}
+
+function mutable(controller: LivePhysics3DController): MutableLivePhysics3DController {
+  return controller as MutableLivePhysics3DController;
+}
+
+function requireKey(controller: MutableLivePhysics3DController, key: VisualKey): void {
+  if (!controller.model.keys.includes(key)) throw new LivePhysics3DError("unknown-key", key);
+}
+
+function requireFinite(value: Point3D, detail: string): void {
+  if (!finite(value)) throw new LivePhysics3DError("non-finite-vector", detail);
+}
+
+function replaceStateVector(
+  controller: MutableLivePhysics3DController,
+  key: VisualKey,
+  position?: Point3D,
+  velocity?: Point3D,
+): void {
+  controller.state = Object.freeze({
+    positions: Object.freeze(controller.state.positions.map((entry) =>
+      entry.key === key
+        ? Object.freeze({ key, point: point(position ?? entry.point) })
+        : Object.freeze({ key: entry.key, point: point(entry.point) }))),
+    velocities: Object.freeze(controller.state.velocities.map((entry) =>
+      entry.key === key
+        ? Object.freeze({ key, vector: point(velocity ?? entry.vector) })
+        : Object.freeze({ key: entry.key, vector: point(entry.vector) }))),
+  });
+}
+
+function constrainPins(
+  controller: MutableLivePhysics3DController,
+  stepped: Physics3DState,
+): Physics3DState {
+  if (controller.pinned.size === 0) return stepped;
+  return Object.freeze({
+    positions: Object.freeze(stepped.positions.map((entry) => {
+      const pinned = controller.pinned.get(entry.key);
+      return Object.freeze({ key: entry.key, point: point(pinned ?? entry.point) });
+    })),
+    velocities: Object.freeze(stepped.velocities.map((entry) => Object.freeze({
+      key: entry.key,
+      vector: point(controller.pinned.has(entry.key) ? zero() : entry.vector),
+    }))),
+  });
+}
+
+function metrics(previous: Physics3DState, next: Physics3DState): Readonly<{
+  maxVelocity: number;
+  maxPositionDelta: number;
+}> {
+  const previousPositions = new Map(previous.positions.map((entry) => [entry.key, entry.point] as const));
+  let maxVelocity = 0;
+  let maxPositionDelta = 0;
+  for (const entry of next.velocities) maxVelocity = Math.max(maxVelocity, norm(entry.vector));
+  for (const entry of next.positions) {
+    const before = previousPositions.get(entry.key)!;
+    maxPositionDelta = Math.max(maxPositionDelta, Math.hypot(
+      entry.point.x - before.x,
+      entry.point.y - before.y,
+      entry.point.z - before.z,
+    ));
+  }
+  return Object.freeze({ maxVelocity, maxPositionDelta });
+}
+
+function snapshot(controller: MutableLivePhysics3DController, stepped: boolean): LivePhysics3DSnapshot {
+  return Object.freeze({
+    state: cloneState(controller.state),
+    tick: controller.tick,
+    awake: controller.awake,
+    stableTicks: controller.stableTicks,
+    pinnedKeys: Object.freeze(controller.model.keys.filter((key) => controller.pinned.has(key))),
+    maxVelocity: controller.maxVelocity,
+    maxPositionDelta: controller.maxPositionDelta,
+    stepped,
+  });
+}
+
+export function createLivePhysics3D(
+  network: VisualLinkNetwork,
+  initialState: Physics3DState,
+  options: LivePhysics3DOptions = {},
+): LivePhysics3DController {
+  const model = buildPhysicalModel3D(network);
+  const resolved = resolvedOptions(options);
+  validatePhysics(model, initialState, resolved);
+  return {
+    model,
+    state: cloneState(initialState),
+    options: resolved,
+    pinned: new Map(),
+    awake: model.keys.length > 0,
+    stableTicks: 0,
+    tick: 0,
+    maxVelocity: 0,
+    maxPositionDelta: 0,
+  } as MutableLivePhysics3DController;
+}
+
+export function wakeLivePhysics3D(controller: LivePhysics3DController): boolean {
+  const value = mutable(controller);
+  value.awake = value.model.keys.length > 0;
+  value.stableTicks = 0;
+  return value.awake;
+}
+
+export function sleepLivePhysics3D(controller: LivePhysics3DController): false {
+  mutable(controller).awake = false;
+  return false;
+}
+
+export function setLivePhysics3DOptions(
+  controller: LivePhysics3DController,
+  patch: LivePhysics3DOptions,
+): LivePhysics3DOptions {
+  const value = mutable(controller);
+  const candidate = resolvedOptions({ ...value.options, ...patch });
+  validatePhysics(value.model, value.state, candidate);
+  value.options = candidate;
+  wakeLivePhysics3D(value);
+  return candidate;
+}
+
+export function pinLivePhysics3D(
+  controller: LivePhysics3DController,
+  key: VisualKey,
+  position: Point3D,
+): void {
+  const value = mutable(controller);
+  requireKey(value, key);
+  requireFinite(position, key);
+  const pinned = point(position);
+  value.pinned.set(key, pinned);
+  replaceStateVector(value, key, pinned, zero());
+  wakeLivePhysics3D(value);
+}
+
+export function movePinnedLivePhysics3D(
+  controller: LivePhysics3DController,
+  key: VisualKey,
+  position: Point3D,
+): void {
+  const value = mutable(controller);
+  requireKey(value, key);
+  requireFinite(position, key);
+  if (!value.pinned.has(key)) throw new LivePhysics3DError("not-pinned", key);
+  const pinned = point(position);
+  value.pinned.set(key, pinned);
+  replaceStateVector(value, key, pinned, zero());
+  wakeLivePhysics3D(value);
+}
+
+export function releaseLivePhysics3D(
+  controller: LivePhysics3DController,
+  key: VisualKey,
+  velocity: Point3D = zero(),
+): void {
+  const value = mutable(controller);
+  requireKey(value, key);
+  requireFinite(velocity, key);
+  if (!value.pinned.has(key)) throw new LivePhysics3DError("not-pinned", key);
+  value.pinned.delete(key);
+  replaceStateVector(value, key, undefined, velocity);
+  wakeLivePhysics3D(value);
+}
+
+export function isLivePhysics3DPinned(controller: LivePhysics3DController, key: VisualKey): boolean {
+  const value = mutable(controller);
+  requireKey(value, key);
+  return value.pinned.has(key);
+}
+
+export function stepLivePhysics3D(controller: LivePhysics3DController): LivePhysics3DSnapshot {
+  const value = mutable(controller);
+  if (!value.awake) return snapshot(value, false);
+  const previous = value.state;
+  const stepped = stepPhysics3D(value.model, previous, physicsOptions(value.options));
+  value.state = constrainPins(value, stepped);
+  const motion = metrics(previous, value.state);
+  value.maxVelocity = motion.maxVelocity;
+  value.maxPositionDelta = motion.maxPositionDelta;
+  if (
+    motion.maxVelocity <= value.options.settleVelocity
+    && motion.maxPositionDelta <= value.options.settlePositionDelta
+  ) value.stableTicks += 1;
+  else value.stableTicks = 0;
+  value.tick += 1;
+  if (value.stableTicks >= value.options.settleWindow) value.awake = false;
+  return snapshot(value, true);
+}
+
+export function snapshotLivePhysics3D(controller: LivePhysics3DController): LivePhysics3DSnapshot {
+  return snapshot(mutable(controller), false);
+}

--- a/packages/visual/test/live-physics3d.test.ts
+++ b/packages/visual/test/live-physics3d.test.ts
@@ -1,0 +1,367 @@
+import {
+  type Point3D,
+  type VisualLinkNetwork,
+  type VisualPosition3D,
+} from "../src/index.js";
+import {
+  buildPhysicalModel3D,
+  stepPhysics3D,
+  type Physics3DState,
+  type VisualVelocity3D,
+} from "../src/physics3d.js";
+import {
+  LivePhysics3DError,
+  createLivePhysics3D,
+  isLivePhysics3DPinned,
+  movePinnedLivePhysics3D,
+  pinLivePhysics3D,
+  releaseLivePhysics3D,
+  setLivePhysics3DOptions,
+  sleepLivePhysics3D,
+  snapshotLivePhysics3D,
+  stepLivePhysics3D,
+  wakeLivePhysics3D,
+} from "../src/live-physics3d.js";
+
+type LiveErrorCode =
+  | "invalid-live-option"
+  | "invalid-physics-option"
+  | "unknown-key"
+  | "non-finite-vector"
+  | "not-pinned";
+
+type SnapshotProbe = Readonly<{
+  state: Physics3DState;
+  tick: number;
+  awake: boolean;
+  stableTicks: number;
+  pinnedKeys: readonly string[];
+  maxVelocity: number;
+  maxPositionDelta: number;
+  stepped?: boolean;
+}>;
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2e: ${message}`);
+}
+
+function same(actual: unknown, expected: unknown, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function deepSame(actual: unknown, expected: unknown, message: string): void {
+  const left = JSON.stringify(actual);
+  const right = JSON.stringify(expected);
+  assert(left === right, `${message}: ${left} !== ${right}`);
+}
+
+function point(x: number, y: number, z: number): Point3D {
+  return { x, y, z };
+}
+
+function position(key: string, x: number, y: number, z: number): VisualPosition3D {
+  return { key, point: point(x, y, z) };
+}
+
+function velocity(key: string, x: number, y: number, z: number): VisualVelocity3D {
+  return { key, vector: point(x, y, z) };
+}
+
+function state(
+  positions: readonly VisualPosition3D[],
+  velocities: readonly VisualVelocity3D[],
+): Physics3DState {
+  return { positions, velocities };
+}
+
+function snapshot(controller: unknown): SnapshotProbe {
+  return snapshotLivePhysics3D(controller) as SnapshotProbe;
+}
+
+function positionOf(value: SnapshotProbe | Physics3DState, key: string): Point3D {
+  const source = "state" in value ? value.state.positions : value.positions;
+  const entry = source.find((candidate: VisualPosition3D) => candidate.key === key);
+  assert(entry !== undefined, `missing position ${key}`);
+  return entry.point;
+}
+
+function velocityOf(value: SnapshotProbe | Physics3DState, key: string): Point3D {
+  const source = "state" in value ? value.state.velocities : value.velocities;
+  const entry = source.find((candidate: VisualVelocity3D) => candidate.key === key);
+  assert(entry !== undefined, `missing velocity ${key}`);
+  return entry.vector;
+}
+
+function norm(value: Point3D): number {
+  return Math.hypot(value.x, value.y, value.z);
+}
+
+function expectLiveCode(effect: () => unknown, code: LiveErrorCode, message: string): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof LivePhysics3DError, `${message}: wrong error type`);
+    const coded = error as { readonly code?: unknown };
+    same(coded.code, code, `${message}: wrong error code`);
+    return;
+  }
+  throw new Error(`@mts/visual V2e: ${message}: expected rejection`);
+}
+
+const pairNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "A", startKey: "A", endKey: "A" },
+    { key: "B", startKey: "B", endKey: "B" },
+  ],
+};
+const pairState = state(
+  [position("A", -1, 0, 0), position("B", 1, 0, 0)],
+  [velocity("A", 0, 0, 0), velocity("B", 0, 0, 0)],
+);
+const pairOptions = {
+  charge: 1.5,
+  springStiffness: 0,
+  damping: 0.9,
+  timeStep: 0.2,
+  maxVelocity: 1,
+  maxStep: 0.2,
+  coordinateBound: 5,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 100,
+};
+
+const pairBefore = JSON.stringify(pairState);
+const livePair = createLivePhysics3D(pairNetwork, pairState, pairOptions);
+const offlinePair = stepPhysics3D(buildPhysicalModel3D(pairNetwork), pairState, pairOptions);
+const firstLive = stepLivePhysics3D(livePair) as SnapshotProbe;
+same(firstLive.stepped, true, "awake controller performs a physical tick");
+same(firstLive.tick, 1, "first live tick increments tick once");
+deepSame(firstLive.state, offlinePair, "one unpinned live tick equals accepted V2d stepPhysics3D exactly");
+deepSame(pairState, JSON.parse(pairBefore), "create/step do not mutate caller initial state");
+deepSame(firstLive.pinnedKeys, [], "no implicit pins exist by default");
+
+const deterministicA = createLivePhysics3D(pairNetwork, pairState, pairOptions);
+const deterministicB = createLivePhysics3D(pairNetwork, pairState, pairOptions);
+for (let index = 0; index < 12; index += 1) {
+  deepSame(
+    stepLivePhysics3D(deterministicA),
+    stepLivePhysics3D(deterministicB),
+    `deterministic live sequence tick ${index}`,
+  );
+}
+
+const sleeping = createLivePhysics3D(pairNetwork, pairState, pairOptions);
+sleepLivePhysics3D(sleeping);
+const sleepingBefore = snapshot(sleeping);
+const sleepingStep = stepLivePhysics3D(sleeping) as SnapshotProbe;
+same(sleepingStep.stepped, false, "sleeping controller does not step");
+same(sleepingStep.tick, sleepingBefore.tick, "sleeping step does not advance tick");
+deepSame(sleepingStep.state, sleepingBefore.state, "sleeping step does not change state");
+wakeLivePhysics3D(sleeping);
+same(snapshot(sleeping).awake, true, "wake marks non-empty controller awake");
+same(snapshot(sleeping).stableTicks, 0, "wake clears stable window");
+same((stepLivePhysics3D(sleeping) as SnapshotProbe).stepped, true, "wake resumes stepping");
+
+const stableNetwork: VisualLinkNetwork = {
+  links: [{ key: "S", startKey: "S", endKey: "S" }],
+};
+const stableState = state([position("S", 0, 0, 0)], [velocity("S", 0, 0, 0)]);
+const stable = createLivePhysics3D(stableNetwork, stableState, {
+  charge: 0,
+  springStiffness: 0,
+  damping: 1,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 2,
+});
+const stableOne = stepLivePhysics3D(stable) as SnapshotProbe;
+same(stableOne.awake, true, "first stable tick does not sleep before settleWindow");
+same(stableOne.stableTicks, 1, "first stable tick increments stability");
+const stableTwo = stepLivePhysics3D(stable) as SnapshotProbe;
+same(stableTwo.stableTicks, 2, "second stable tick reaches exact settleWindow");
+same(stableTwo.awake, false, "controller automatically sleeps at settleWindow");
+
+const optionController = createLivePhysics3D(pairNetwork, pairState, { ...pairOptions, charge: 0 });
+sleepLivePhysics3D(optionController);
+const optionBefore = snapshot(optionController);
+setLivePhysics3DOptions(optionController, { charge: 3, springStiffness: 0 });
+const optionAfter = snapshot(optionController);
+same(optionAfter.awake, true, "valid option update wakes controller");
+deepSame(optionAfter.state, optionBefore.state, "option update does not reset positions or velocities");
+const updatedStep = stepLivePhysics3D(optionController) as SnapshotProbe;
+const expectedUpdated = stepPhysics3D(buildPhysicalModel3D(pairNetwork), optionBefore.state, {
+  ...pairOptions,
+  charge: 3,
+  springStiffness: 0,
+});
+deepSame(updatedStep.state, expectedUpdated, "updated charge feeds the next accepted V2d tick");
+
+const springNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "A", startKey: "A", endKey: "B" },
+    { key: "B", startKey: "B", endKey: "B" },
+  ],
+};
+const springState = state(
+  [position("A", 0, 0, 0), position("B", 4, 0, 0)],
+  [velocity("A", 0, 0, 0), velocity("B", 0, 0, 0)],
+);
+const springLive = createLivePhysics3D(springNetwork, springState, {
+  charge: 0,
+  springStiffness: 0,
+  restLength: 2,
+  damping: 1,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 100,
+});
+setLivePhysics3DOptions(springLive, { springStiffness: 1 });
+const springStep = stepLivePhysics3D(springLive) as SnapshotProbe;
+assert(positionOf(springStep, "A").x > 0, "updated springStiffness affects subsequent motion");
+
+const dragNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "A", startKey: "A", endKey: "A" },
+    { key: "B", startKey: "B", endKey: "B" },
+  ],
+};
+const dragState = state(
+  [position("A", 0, 0, 0), position("B", 1, 0, 0)],
+  [velocity("A", 0, 0, 0), velocity("B", 0, 0, 0)],
+);
+const drag = createLivePhysics3D(dragNetwork, dragState, {
+  charge: 2,
+  springStiffness: 0,
+  damping: 1,
+  timeStep: 0.2,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 100,
+});
+pinLivePhysics3D(drag, "A", point(0, 0, 0));
+same(isLivePhysics3DPinned(drag, "A"), true, "pin marks key explicitly pinned");
+const pinnedStep = stepLivePhysics3D(drag) as SnapshotProbe;
+deepSame(positionOf(pinnedStep, "A"), point(0, 0, 0), "pinned key remains at exact requested position");
+deepSame(velocityOf(pinnedStep, "A"), point(0, 0, 0), "pinned key velocity remains zero");
+assert(positionOf(pinnedStep, "B").x > 1, "free neighbor still reacts to pinned charged point");
+
+sleepLivePhysics3D(drag);
+movePinnedLivePhysics3D(drag, "A", point(2, 1, -1));
+const movedPin = snapshot(drag);
+same(movedPin.awake, true, "moving a pin wakes entire simulation");
+deepSame(positionOf(movedPin, "A"), point(2, 1, -1), "movePinned sets exact presentation position");
+deepSame(velocityOf(movedPin, "A"), point(0, 0, 0), "movePinned zeros velocity");
+releaseLivePhysics3D(drag, "A", point(-0.5, 0.25, 0));
+same(isLivePhysics3DPinned(drag, "A"), false, "release removes explicit pin");
+const released = snapshot(drag);
+deepSame(velocityOf(released, "A"), point(-0.5, 0.25, 0), "release velocity becomes current physical input");
+const expectedReleased = stepPhysics3D(buildPhysicalModel3D(dragNetwork), released.state, {
+  charge: 2,
+  springStiffness: 0,
+  damping: 1,
+  timeStep: 0.2,
+});
+deepSame((stepLivePhysics3D(drag) as SnapshotProbe).state, expectedReleased, "released node returns exactly to V2d physics");
+
+const multiplePins = createLivePhysics3D(dragNetwork, dragState, {
+  charge: 5,
+  springStiffness: 0,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 100,
+});
+pinLivePhysics3D(multiplePins, "A", point(-2, 1, 0));
+pinLivePhysics3D(multiplePins, "B", point(2, -1, 0));
+const twoPinned = stepLivePhysics3D(multiplePins) as SnapshotProbe;
+deepSame(positionOf(twoPinned, "A"), point(-2, 1, 0), "first independent pin remains exact");
+deepSame(positionOf(twoPinned, "B"), point(2, -1, 0), "second independent pin remains exact");
+deepSame(twoPinned.pinnedKeys, ["A", "B"], "snapshot exposes deterministic pinned-key order");
+
+const rootLookingNetwork: VisualLinkNetwork = {
+  links: [
+    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+    { key: "A", startKey: "A", endKey: "A" },
+  ],
+};
+const rootLookingState = state(
+  [position("A", 1, 0, 0), position("R", 0, 0, 0)],
+  [velocity("A", 0, 0, 0), velocity("R", 0, 0, 0)],
+);
+const rootLooking = createLivePhysics3D(rootLookingNetwork, rootLookingState, {
+  charge: 1,
+  springStiffness: 0,
+  damping: 1,
+  timeStep: 0.1,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 100,
+});
+same(isLivePhysics3DPinned(rootLooking, "R"), false, "R/∞/root metadata never creates implicit presentation pin");
+const rootStep = stepLivePhysics3D(rootLooking) as SnapshotProbe;
+assert(positionOf(rootStep, "R").x < 0, "root-looking presentation key moves under ordinary physics");
+
+const frozen = snapshot(rootLooking);
+assert(Object.isFrozen(frozen), "snapshot object is immutable");
+assert(Object.isFrozen(frozen.state), "snapshot state is immutable");
+assert(Object.isFrozen(frozen.state.positions), "snapshot positions list is immutable");
+assert(Object.isFrozen(frozen.state.velocities), "snapshot velocities list is immutable");
+assert(Object.isFrozen(frozen.pinnedKeys), "snapshot pinned-key list is immutable");
+const frozenBefore = JSON.stringify(frozen);
+stepLivePhysics3D(rootLooking);
+deepSame(frozen, JSON.parse(frozenBefore), "later ticks cannot mutate an earlier snapshot alias");
+
+const disturbed = createLivePhysics3D(pairNetwork, state(
+  [position("A", -1, 0, 0), position("B", 1, 0, 0)],
+  [velocity("A", 1000, -500, 250), velocity("B", -1000, 500, -250)],
+), {
+  charge: 10,
+  springStiffness: 0,
+  damping: 0.95,
+  timeStep: 0.2,
+  maxVelocity: 0.5,
+  maxStep: 0.1,
+  coordinateBound: 3,
+  settleVelocity: 0,
+  settlePositionDelta: 0,
+  settleWindow: 1000,
+});
+for (let index = 0; index < 80; index += 1) {
+  const current = stepLivePhysics3D(disturbed) as SnapshotProbe;
+  for (const entry of current.state.positions) {
+    assert(Number.isFinite(norm(entry.point)), `disturbed position ${entry.key} finite`);
+    assert(Math.max(Math.abs(entry.point.x), Math.abs(entry.point.y), Math.abs(entry.point.z)) <= 3 + 1e-9, `disturbed position ${entry.key} bounded`);
+  }
+  for (const entry of current.state.velocities) {
+    assert(Number.isFinite(norm(entry.vector)), `disturbed velocity ${entry.key} finite`);
+    assert(norm(entry.vector) <= 0.5 + 1e-9, `disturbed velocity ${entry.key} bounded`);
+  }
+}
+
+expectLiveCode(() => pinLivePhysics3D(livePair, "UNKNOWN", point(0, 0, 0)), "unknown-key", "unknown pin key");
+expectLiveCode(() => pinLivePhysics3D(livePair, "A", point(Number.NaN, 0, 0)), "non-finite-vector", "non-finite pin");
+expectLiveCode(() => movePinnedLivePhysics3D(livePair, "A", point(0, 0, 0)), "not-pinned", "move unpinned key");
+expectLiveCode(() => releaseLivePhysics3D(livePair, "A"), "not-pinned", "release unpinned key");
+pinLivePhysics3D(livePair, "A", point(0, 0, 0));
+expectLiveCode(() => movePinnedLivePhysics3D(livePair, "A", point(0, Number.POSITIVE_INFINITY, 0)), "non-finite-vector", "non-finite move");
+expectLiveCode(() => releaseLivePhysics3D(livePair, "A", point(0, 0, Number.NaN)), "non-finite-vector", "non-finite release velocity");
+
+for (const invalid of [
+  { settleVelocity: -1 },
+  { settleVelocity: Number.NaN },
+  { settlePositionDelta: -1 },
+  { settlePositionDelta: Number.POSITIVE_INFINITY },
+  { settleWindow: 0 },
+  { settleWindow: 1.5 },
+]) {
+  expectLiveCode(
+    () => createLivePhysics3D(pairNetwork, pairState, invalid),
+    "invalid-live-option",
+    `invalid live option ${JSON.stringify(invalid)}`,
+  );
+}
+expectLiveCode(
+  () => setLivePhysics3DOptions(optionController, { charge: -1 }),
+  "invalid-physics-option",
+  "invalid V2d option patch fails immediately",
+);

--- a/packages/visual/test/live-physics3d.test.ts
+++ b/packages/visual/test/live-physics3d.test.ts
@@ -21,6 +21,7 @@ import {
   snapshotLivePhysics3D,
   stepLivePhysics3D,
   wakeLivePhysics3D,
+  type LivePhysics3DController,
 } from "../src/live-physics3d.js";
 
 type LiveErrorCode =
@@ -74,7 +75,7 @@ function state(
   return { positions, velocities };
 }
 
-function snapshot(controller: unknown): SnapshotProbe {
+function snapshot(controller: LivePhysics3DController): SnapshotProbe {
   return snapshotLivePhysics3D(controller) as SnapshotProbe;
 }
 

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -3,6 +3,7 @@ import "./blueprint-svg.test.js";
 import "./blueprint-interaction.test.js";
 import "./geometry3d.test.js";
 import "./physics3d.test.js";
+import "./live-physics3d.test.js";
 
 import {
   VisualNetworkError,


### PR DESCRIPTION
Closes #933

V2e adds a renderer-neutral deterministic live 3D presentation controller over accepted V2d physics.

## Authority boundary

```text
one unpinned live tick
==
stepPhysics3D(model, currentState, physicsOptions)
```

V2e owns only controller state:

```text
wake / sleep
live option update
explicit pin / move / release
deterministic settling metrics
immutable observable snapshots
```

Spring/charge laws remain exclusively V2d `stepPhysics3D` authority.

## Presentation constraints

```text
R / ∞ / root metadata -> no special behavior
explicit pin          -> exact presentation constraint
```

Pinned coordinates participate in the V2d force step so free neighbors react, then the pin is restored to its exact requested point with zero velocity. Released points return to ordinary V2d physics.

Changing `charge` or `springStiffness` wakes the controller without resetting current coordinates.

## TDD evidence

RED:

```text
a7937b755a6c57a4978275791b7e341d1d7dfd66
CI #3599 = FAILURE
repo-guard #781 = SUCCESS
exact failure = TS2307 Cannot find module '../src/live-physics3d.js'
```

Intermediate production compile exposed one test-scaffolding type defect only:

```text
625f009b567e1a486a5b8deda944ea9ad6c8b10a
CI #3601 = FAILURE
repo-guard #782 = SUCCESS
exact failure = test helper typed controller as unknown
```

The correction was test-only and did not weaken the production API.

Final GREEN:

```text
031b96df9a03d735bf5c40cf94e622c2ba9905c4
CI #3607 = SUCCESS
repo-guard #785 = SUCCESS
```

The blocking `Check renderer-neutral MTS visual package` step executed `live-physics3d.test.js` successfully on the final head.

## Implemented

```text
[+] exact V2d delegation for free ticks
[+] deterministic wake/sleep/tick state
[+] settleVelocity + settlePositionDelta + settleWindow auto-sleep
[+] live charge/springStiffness updates without state reset
[+] explicit presentation pin/move/release
[+] release velocity support
[+] pinned nodes still transmit force to free neighbors
[+] multiple deterministic pins
[+] immutable detached snapshots
[+] R/∞/root metadata explicitly not privileged
[+] finite/bounded stress corpus
[+] typed fail-closed live commands/options
[+] package-root @mts/visual export
```

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/index.ts
  - packages/visual/src/live-physics3d.ts
  - packages/visual/test/model.test.ts
  - packages/visual/test/live-physics3d.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 800
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/live-physics3d.ts
  - packages/visual/test/live-physics3d.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - web/**
  - repo-policy.json
  - .github/**
  - packages/visual/src/physics3d.ts
expected_effects:
  - "@mts/visual gains a deterministic live 3D controller over accepted V2d physics"
  - "pin move and release are explicit presentation constraints and never inferred from R root labels or tags"
  - "live option changes including charge and springStiffness wake the network without resetting coordinates"
  - "automatic sleep uses deterministic velocity and position-delta thresholds without wall-clock authority"
  - "no renderer browser parser proof or accepted MTS semantics enter the live-controller layer"
```

Accepted MTS semantic delta = NONE. v0.12 is not required.