### PR TITLE
[Visual/V2f-A] @mts/visual/three scene projection boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Typecheck, test and browser-check current MTS core
         run: npm --prefix ts run check
 
+      - name: Install MTS visual browser companion dependencies
+        run: npm ci --prefix packages/visual --ignore-scripts --no-audit --no-fund
+
       - name: Check renderer-neutral MTS visual package
         run: |
           ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json

--- a/packages/visual/package-lock.json
+++ b/packages/visual/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mts/visual",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mts/visual",
+      "version": "0.1.0",
+      "dependencies": {
+        "three": "0.185.1"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/visual/package.json
+++ b/packages/visual/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
+    },
+    "./three": {
+      "types": "./dist/src/three/index.d.ts",
+      "default": "./dist/src/three/index.js"
     }
   },
   "files": [
@@ -17,5 +21,8 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build --silent && node dist/test/model.test.js",
     "check": "npm test"
+  },
+  "dependencies": {
+    "three": "0.185.1"
   }
 }

--- a/packages/visual/src/three/index.ts
+++ b/packages/visual/src/three/index.ts
@@ -1,0 +1,92 @@
+import {
+  buildVisualGeometry3D,
+  normalizeVisualLinkNetwork,
+  type Physics3DState,
+  type Point3D,
+  type VisualArcOrientation3D,
+  type VisualArcRole3D,
+  type VisualCenterline3D,
+  type VisualKey,
+  type VisualLinkNetwork,
+} from "../index.js";
+
+// Explicit browser-companion presentation data. Geometry authority remains V2c.
+// Three/WebGL renderer lifecycle enters only in V2f-B.
+
+export const VISUAL_THREE_COLORS = Object.freeze({
+  startOuter: 0xff0000,
+  center: 0x00ff00,
+  endOuter: 0x0000ff,
+});
+
+export interface VisualThreeNodeData {
+  readonly key: VisualKey;
+  readonly position: Point3D;
+  readonly label?: string;
+  readonly tags?: readonly string[];
+  readonly draggable: true;
+}
+
+export interface VisualThreeArcData {
+  readonly linkKey: VisualKey;
+  readonly role: VisualArcRole3D;
+  readonly semanticOrientation: VisualArcOrientation3D;
+  readonly colorFrom: number;
+  readonly colorTo: number;
+  readonly centerline: VisualCenterline3D;
+}
+
+export interface VisualThreeSceneData {
+  readonly nodes: readonly VisualThreeNodeData[];
+  readonly arcs: readonly VisualThreeArcData[];
+}
+
+function point(value: Point3D): Point3D {
+  return Object.freeze({ x: value.x, y: value.y, z: value.z });
+}
+
+export function buildVisualThreeSceneData(
+  network: VisualLinkNetwork,
+  state: Physics3DState,
+): VisualThreeSceneData {
+  const normalized = normalizeVisualLinkNetwork(network);
+  const geometry = buildVisualGeometry3D(normalized, state.positions);
+  const geometryByKey = new Map(geometry.links.map((link) => [link.key, link] as const));
+
+  const nodes = normalized.links.map((link): VisualThreeNodeData => {
+    const linkGeometry = geometryByKey.get(link.key)!;
+    return Object.freeze({
+      key: link.key,
+      position: point(linkGeometry.center),
+      draggable: true as const,
+      ...(link.label === undefined ? {} : { label: link.label }),
+      ...(link.tags === undefined ? {} : { tags: Object.freeze([...link.tags]) }),
+    });
+  });
+
+  const arcs: VisualThreeArcData[] = [];
+  for (const link of normalized.links) {
+    const linkGeometry = geometryByKey.get(link.key)!;
+    arcs.push(Object.freeze({
+      linkKey: link.key,
+      role: linkGeometry.start.role,
+      semanticOrientation: linkGeometry.start.semanticOrientation,
+      colorFrom: VISUAL_THREE_COLORS.startOuter,
+      colorTo: VISUAL_THREE_COLORS.center,
+      centerline: linkGeometry.start,
+    }));
+    arcs.push(Object.freeze({
+      linkKey: link.key,
+      role: linkGeometry.end.role,
+      semanticOrientation: linkGeometry.end.semanticOrientation,
+      colorFrom: VISUAL_THREE_COLORS.center,
+      colorTo: VISUAL_THREE_COLORS.endOuter,
+      centerline: linkGeometry.end,
+    }));
+  }
+
+  return Object.freeze({
+    nodes: Object.freeze(nodes),
+    arcs: Object.freeze(arcs),
+  });
+}

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -4,6 +4,7 @@ import "./blueprint-interaction.test.js";
 import "./geometry3d.test.js";
 import "./physics3d.test.js";
 import "./live-physics3d.test.js";
+import "./three-scene.test.js";
 
 import {
   VisualNetworkError,

--- a/packages/visual/test/three-scene.test.ts
+++ b/packages/visual/test/three-scene.test.ts
@@ -1,0 +1,192 @@
+import {
+  VisualGeometry3DError,
+  dotVec3,
+  type Physics3DState,
+  type Point3D,
+  type VisualLink,
+  type VisualLinkNetwork,
+} from "../src/index.js";
+import {
+  VISUAL_THREE_COLORS,
+  buildVisualThreeSceneData,
+} from "../src/three/index.js";
+
+type CenterlineProbe = {
+  readonly role: "start" | "end";
+  readonly semanticOrientation: "outer-to-green" | "green-to-outer";
+  readonly greenOutwardTangent: Point3D;
+  readonly loop: boolean;
+  readonly controlPoints: readonly Point3D[];
+};
+
+type NodeProbe = {
+  readonly key: string;
+  readonly position: Point3D;
+  readonly label?: string;
+  readonly tags?: readonly string[];
+  readonly draggable: boolean;
+};
+
+type ArcProbe = {
+  readonly linkKey: string;
+  readonly role: "start" | "end";
+  readonly semanticOrientation: "outer-to-green" | "green-to-outer";
+  readonly colorFrom: number;
+  readonly colorTo: number;
+  readonly centerline: CenterlineProbe;
+};
+
+type SceneProbe = {
+  readonly nodes: readonly NodeProbe[];
+  readonly arcs: readonly ArcProbe[];
+};
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2f-A: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function deepSame(actual: unknown, expected: unknown, message: string): void {
+  assert(JSON.stringify(actual) === JSON.stringify(expected), message);
+}
+
+function samePoint(actual: Point3D, expected: Point3D, message: string): void {
+  same(actual.x, expected.x, `${message}.x`);
+  same(actual.y, expected.y, `${message}.y`);
+  same(actual.z, expected.z, `${message}.z`);
+}
+
+function finitePoint(value: Point3D): boolean {
+  return Number.isFinite(value.x) && Number.isFinite(value.y) && Number.isFinite(value.z);
+}
+
+function links(): VisualLink[] {
+  return [
+    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+    { key: "O", startKey: "O", endKey: "R" },
+    { key: "C", startKey: "R", endKey: "C" },
+    { key: "L", startKey: "O", endKey: "C" },
+    { key: "U", startKey: "C", endKey: "O" },
+    { key: "X", startKey: "L", endKey: "U", tags: ["link-of-links"] },
+  ];
+}
+
+const positionByKey: Readonly<Record<string, Point3D>> = Object.freeze({
+  R: Object.freeze({ x: 0, y: 0, z: 0 }),
+  O: Object.freeze({ x: -2, y: 1, z: 0.5 }),
+  C: Object.freeze({ x: 2, y: -1, z: -0.5 }),
+  L: Object.freeze({ x: -1, y: 2, z: 1.5 }),
+  U: Object.freeze({ x: 1, y: -2, z: -1.5 }),
+  X: Object.freeze({ x: 0.5, y: 0.75, z: 2.5 }),
+});
+
+function state(order = ["R", "O", "C", "L", "U", "X"]): Physics3DState {
+  return {
+    positions: order.map((key) => ({ key, point: positionByKey[key]! })),
+    velocities: order.map((key) => ({ key, vector: { x: 0, y: 0, z: 0 } })),
+  };
+}
+
+function node(scene: SceneProbe, key: string): NodeProbe {
+  const result = scene.nodes.find((candidate: NodeProbe) => candidate.key === key);
+  assert(result !== undefined, `missing node ${key}`);
+  return result;
+}
+
+function arc(scene: SceneProbe, key: string, role: "start" | "end"): ArcProbe {
+  const result = scene.arcs.find(
+    (candidate: ArcProbe) => candidate.linkKey === key && candidate.role === role,
+  );
+  assert(result !== undefined, `missing ${role} arc ${key}`);
+  return result;
+}
+
+function allFinite(centerline: CenterlineProbe): boolean {
+  return centerline.controlPoints.every((value: Point3D) => finitePoint(value))
+    && finitePoint(centerline.greenOutwardTangent);
+}
+
+const network: VisualLinkNetwork = { links: links() };
+const initial = state();
+const inputBefore = JSON.stringify({ network, initial });
+const scene = buildVisualThreeSceneData(network, initial) as SceneProbe;
+
+same(JSON.stringify(scene.nodes.map((value: NodeProbe) => value.key)), JSON.stringify(["C", "L", "O", "R", "U", "X"]), "normalized node order");
+same(scene.nodes.length, 6, "one represented center per Link");
+same(scene.arcs.length, 12, "two graphical arcs per represented Link");
+same(JSON.stringify({ network, initial }), inputBefore, "scene projection does not mutate inputs");
+
+const root = node(scene, "R");
+same(root.draggable, true, "R remains draggable");
+same(root.label, "∞", "root label remains presentation metadata");
+same(root.tags?.join(","), "root", "root tag remains presentation metadata");
+samePoint(root.position, positionByKey.R!, "root position unchanged by metadata");
+
+for (const linkKey of ["C", "L", "O", "R", "U", "X"]) {
+  const start = arc(scene, linkKey, "start");
+  const end = arc(scene, linkKey, "end");
+  same(start.role, "start", `${linkKey} start role`);
+  same(start.semanticOrientation, "outer-to-green", `${linkKey} start orientation`);
+  same(start.colorFrom, VISUAL_THREE_COLORS.startOuter, `${linkKey} start RED`);
+  same(start.colorTo, VISUAL_THREE_COLORS.center, `${linkKey} start GREEN`);
+  same(end.role, "end", `${linkKey} end role`);
+  same(end.semanticOrientation, "green-to-outer", `${linkKey} end orientation`);
+  same(end.colorFrom, VISUAL_THREE_COLORS.center, `${linkKey} end GREEN`);
+  same(end.colorTo, VISUAL_THREE_COLORS.endOuter, `${linkKey} end BLUE`);
+  assert(allFinite(start.centerline), `${linkKey} start centerline finite`);
+  assert(allFinite(end.centerline), `${linkKey} end centerline finite`);
+  assert(
+    Math.abs(dotVec3(start.centerline.greenOutwardTangent, end.centerline.greenOutwardTangent) + 1) < 1e-10,
+    `${linkKey} arcs leave GREEN center at 180 degrees`,
+  );
+}
+
+const startSelf = arc(scene, "O", "start");
+same(startSelf.centerline.loop, true, "start self-link remains a finite loop");
+const endSelf = arc(scene, "C", "end");
+same(endSelf.centerline.loop, true, "end self-link remains a finite loop");
+const rootStart = arc(scene, "R", "start");
+const rootEnd = arc(scene, "R", "end");
+same(rootStart.centerline.loop, true, "double-self start loop visible");
+same(rootEnd.centerline.loop, true, "double-self end loop visible");
+assert(
+  JSON.stringify(rootStart.centerline.controlPoints) !== JSON.stringify(rootEnd.centerline.controlPoints),
+  "double-self loops are geometrically distinct",
+);
+
+const xStart = arc(scene, "X", "start");
+const xEnd = arc(scene, "X", "end");
+samePoint(xStart.centerline.controlPoints[0]!, positionByKey.L!, "link-of-links start anchors represented L center");
+samePoint(xStart.centerline.controlPoints.at(-1)!, positionByKey.X!, "link-of-links start reaches X center");
+samePoint(xEnd.centerline.controlPoints[0]!, positionByKey.X!, "link-of-links end leaves X center");
+samePoint(xEnd.centerline.controlPoints.at(-1)!, positionByKey.U!, "link-of-links end anchors represented U center");
+
+const reversedNetwork: VisualLinkNetwork = { links: links().reverse() };
+const reversed = buildVisualThreeSceneData(
+  reversedNetwork,
+  state(["X", "U", "R", "O", "L", "C"]),
+) as SceneProbe;
+deepSame(reversed, scene, "input order does not alter deterministic scene projection");
+
+assert(Object.isFrozen(scene), "scene snapshot frozen");
+assert(Object.isFrozen(scene.nodes), "scene node list frozen");
+assert(Object.isFrozen(scene.arcs), "scene arc list frozen");
+assert(Object.isFrozen(root), "scene node frozen");
+assert(Object.isFrozen(root.position), "scene node position detached/frozen");
+assert(Object.isFrozen(root.tags), "scene node metadata detached/frozen");
+assert(Object.isFrozen(rootStart.centerline), "V2c centerline remains frozen");
+assert(Object.isFrozen(rootStart.centerline.controlPoints), "V2c control points remain frozen");
+
+try {
+  buildVisualThreeSceneData(network, {
+    positions: initial.positions.filter((entry) => entry.key !== "X"),
+    velocities: initial.velocities,
+  });
+  throw new Error("missing position must reject");
+} catch (error) {
+  assert(error instanceof VisualGeometry3DError, "missing position rejects through V2c geometry boundary");
+  same(error.code, "missing-position", "missing position error code preserved");
+}


### PR DESCRIPTION
Closes #936
Parent: #935

## Result

V2f-A introduces the explicit browser companion entry while keeping the default visual package renderer-neutral:

```text
@mts/visual       -> renderer-neutral model/geometry/physics/live controller
@mts/visual/three -> explicit browser/Three companion boundary
```

Implemented:

- exact `three@0.185.1` dependency + lockfile;
- explicit package export `./three` without root re-export;
- reproducible `npm ci --prefix packages/visual` in blocking CI;
- deterministic `buildVisualThreeSceneData(...)` as a thin projection over accepted `buildVisualGeometry3D(...)`;
- RED→GREEN and GREEN→BLUE role/orientation mapping;
- root/∞/root-tag remains presentation-only and draggable;
- blocking runtime integration through `model.test.js`.

No WebGL renderer, OrbitControls, RAF, raycaster, drag, fullscreen, sliders, parser DTO or proof semantics enter this slice.

## TDD evidence

Clean RED head:

```text
d4c308c82516d9429eea36462a968868d523ec18
CI #3610: FAILURE
exact failure: TS2307 Cannot find module '../src/three/index.js'
repo-guard #786: SUCCESS
```

Final GREEN head:

```text
db2df98f67281624936fa527f29fe4efd2af75d6
CI #3620: SUCCESS
repo-guard #791: SUCCESS
behind_by=0
mergeable=true
draft=false
```

CI #3620 executes:

```text
./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
node packages/visual/dist/test/model.test.js
```

so `three-scene.test.js`, imported by `model.test.js`, is runtime evidence rather than compile-only evidence.

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/package.json
  - packages/visual/package-lock.json
  - packages/visual/src/three/index.ts
  - packages/visual/test/three-scene.test.ts
  - packages/visual/test/model.test.ts
  - .github/workflows/ci.yml
budgets:
  max_new_files: 3
  max_new_docs: 0
  max_net_added_lines: 650
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/package.json
  - packages/visual/src/three/index.ts
  - packages/visual/test/three-scene.test.ts
  - .github/workflows/ci.yml
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - web/**
  - repo-policy.json
  - packages/visual/src/geometry3d.ts
  - packages/visual/src/physics3d.ts
  - packages/visual/src/live-physics3d.ts
expected_effects:
  - "@mts/visual gains an explicit opt-in @mts/visual/three browser companion subpath while the default entry stays renderer-neutral"
  - "scene projection consumes accepted V2c geometry directly and preserves RED-to-GREEN / GREEN-to-BLUE orientation"
  - "R infinity and root metadata never imply fixed or non-draggable presentation behavior"
  - "Three.js 0.185.1 is reproducibly available to the explicit browser subpath"
  - "accepted MTS v0.11 and proof semantics remain unchanged"
```

Accepted MTS semantic delta = NONE. v0.12 is not required.