### PR TITLE
[Visual/V2f-B] Three renderer lifecycle over immutable scene data

### DIFF
--- a/packages/visual/package-lock.json
+++ b/packages/visual/package-lock.json
@@ -9,7 +9,60 @@
       "version": "0.1.0",
       "dependencies": {
         "three": "0.185.1"
+      },
+      "devDependencies": {
+        "@types/three": "0.185.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+      "dev": true,
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true
     },
     "node_modules/three": {
       "version": "0.185.1",

--- a/packages/visual/package.json
+++ b/packages/visual/package.json
@@ -24,5 +24,8 @@
   },
   "dependencies": {
     "three": "0.185.1"
+  },
+  "devDependencies": {
+    "@types/three": "0.185.0"
   }
 }

--- a/packages/visual/src/three/index.ts
+++ b/packages/visual/src/three/index.ts
@@ -1,3 +1,5 @@
+export * from "./renderer.js";
+
 import {
   buildVisualGeometry3D,
   normalizeVisualLinkNetwork,

--- a/packages/visual/src/three/renderer.ts
+++ b/packages/visual/src/three/renderer.ts
@@ -1,0 +1,310 @@
+import * as THREE from "three";
+import { sampleCenterline3D, type Point3D } from "../geometry3d.js";
+import type { VisualThreeArcData, VisualThreeSceneData } from "./index.js";
+
+export interface VisualThreeContainer {
+  readonly clientWidth: number;
+  readonly clientHeight: number;
+  appendChild(node: Node): Node;
+  removeChild(node: Node): Node;
+  contains(node: Node): boolean;
+  getBoundingClientRect(): { readonly width: number; readonly height: number };
+}
+
+export interface VisualThreeRenderingSurface {
+  readonly domElement: Node;
+  setSize(width: number, height: number, updateStyle?: boolean): void;
+  render(scene: THREE.Scene, camera: THREE.Camera): void;
+  dispose(): void;
+}
+
+export interface VisualThreeResizeObserver {
+  disconnect(): void;
+}
+
+export interface VisualThreeRendererOptions {
+  readonly samples?: number;
+  readonly nodeRadius?: number;
+  readonly surfaceFactory?: () => VisualThreeRenderingSurface;
+  readonly resizeObserverFactory?: (callback: () => void) => VisualThreeResizeObserver;
+}
+
+export interface VisualThreeRendererSnapshot {
+  readonly mounted: true;
+  readonly nodeCount: number;
+  readonly arcCount: number;
+  readonly arrowCount: number;
+  readonly width: number;
+  readonly height: number;
+  readonly cameraPosition: Point3D;
+}
+
+type PresentationObject = THREE.Mesh | THREE.Line;
+
+interface MountedRenderer {
+  readonly container: VisualThreeContainer;
+  readonly scene: THREE.Scene;
+  readonly camera: THREE.PerspectiveCamera;
+  readonly surface: VisualThreeRenderingSurface;
+  readonly samples: number;
+  readonly nodeRadius: number;
+  readonly objects: PresentationObject[];
+  readonly fitPoints: THREE.Vector3[];
+  readonly target: THREE.Vector3;
+  observer?: VisualThreeResizeObserver;
+  nodeCount: number;
+  arcCount: number;
+  arrowCount: number;
+  width: number;
+  height: number;
+}
+
+const mounts = new WeakMap<object, MountedRenderer>();
+const UP = new THREE.Vector3(0, 1, 0);
+
+function positiveFinite(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function segmentCount(value: number | undefined): number {
+  return Math.max(1, Math.floor(positiveFinite(value, 16)));
+}
+
+function viewport(container: VisualThreeContainer): readonly [number, number] {
+  const rect = container.getBoundingClientRect();
+  const width = Number.isFinite(container.clientWidth) && container.clientWidth > 0
+    ? container.clientWidth : rect.width;
+  const height = Number.isFinite(container.clientHeight) && container.clientHeight > 0
+    ? container.clientHeight : rect.height;
+  return [Math.max(1, Number.isFinite(width) ? width : 1), Math.max(1, Number.isFinite(height) ? height : 1)];
+}
+
+function render(state: MountedRenderer): void {
+  state.surface.render(state.scene, state.camera);
+}
+
+function materialList(material: THREE.Material | THREE.Material[]): THREE.Material[] {
+  return Array.isArray(material) ? material : [material];
+}
+
+function disposeObject(object: PresentationObject): void {
+  object.geometry.dispose();
+  for (const material of materialList(object.material)) material.dispose();
+}
+
+function clearPresentation(state: MountedRenderer): void {
+  for (const object of state.objects) {
+    state.scene.remove(object);
+    disposeObject(object);
+  }
+  state.objects.length = 0;
+  state.fitPoints.length = 0;
+  state.nodeCount = 0;
+  state.arcCount = 0;
+  state.arrowCount = 0;
+}
+
+function threePoint(point: Point3D): THREE.Vector3 {
+  return new THREE.Vector3(point.x, point.y, point.z);
+}
+
+function addNode(state: MountedRenderer, node: VisualThreeSceneData["nodes"][number]): void {
+  const geometry = new THREE.SphereGeometry(state.nodeRadius, 12, 8);
+  const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.set(node.position.x, node.position.y, node.position.z);
+  mesh.userData = { kind: "link-center", key: node.key };
+  state.scene.add(mesh);
+  state.objects.push(mesh);
+  state.fitPoints.push(threePoint(node.position));
+  state.nodeCount += 1;
+}
+
+function addArc(state: MountedRenderer, arc: VisualThreeArcData): readonly THREE.Vector3[] {
+  const sampled = sampleCenterline3D(arc.centerline, state.samples);
+  const points = sampled.map(threePoint);
+  const positions = new Float32Array(points.length * 3);
+  const colors = new Float32Array(points.length * 3);
+  const from = new THREE.Color(arc.colorFrom);
+  const to = new THREE.Color(arc.colorTo);
+  const mixed = new THREE.Color();
+
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index]!;
+    const offset = index * 3;
+    positions[offset] = point.x;
+    positions[offset + 1] = point.y;
+    positions[offset + 2] = point.z;
+    mixed.copy(from).lerp(to, points.length === 1 ? 0 : index / (points.length - 1));
+    colors[offset] = mixed.r;
+    colors[offset + 1] = mixed.g;
+    colors[offset + 2] = mixed.b;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+  const material = new THREE.LineBasicMaterial({ vertexColors: true });
+  const line = new THREE.Line(geometry, material);
+  line.userData = { kind: "link-arc", key: arc.linkKey, role: arc.role };
+  state.scene.add(line);
+  state.objects.push(line);
+  state.fitPoints.push(...points.map((point) => point.clone()));
+  state.arcCount += 1;
+  return points;
+}
+
+function addEndArrow(state: MountedRenderer, arc: VisualThreeArcData, points: readonly THREE.Vector3[]): void {
+  if (arc.role !== "end" || points.length < 2) return;
+  const tip = points.at(-1)!;
+  const before = points.at(-2)!;
+  const direction = tip.clone().sub(before);
+  const length = direction.length();
+  if (!Number.isFinite(length) || length <= 1e-12) return;
+  direction.multiplyScalar(1 / length);
+
+  const height = Math.max(state.nodeRadius * 1.3, 0.08);
+  const geometry = new THREE.ConeGeometry(Math.max(state.nodeRadius * 0.45, 0.025), height, 8);
+  const material = new THREE.MeshBasicMaterial({ color: arc.colorTo });
+  const arrow = new THREE.Mesh(geometry, material);
+  arrow.position.copy(tip).addScaledVector(direction, -height * 0.35);
+  arrow.quaternion.setFromUnitVectors(UP, direction);
+  arrow.userData = { kind: "end-arrow", key: arc.linkKey, role: arc.role };
+  state.scene.add(arrow);
+  state.objects.push(arrow);
+  state.fitPoints.push(tip.clone());
+  state.arrowCount += 1;
+}
+
+function populate(state: MountedRenderer, data: VisualThreeSceneData): void {
+  clearPresentation(state);
+  for (const node of data.nodes) addNode(state, node);
+  for (const arc of data.arcs) {
+    const points = addArc(state, arc);
+    addEndArrow(state, arc, points);
+  }
+}
+
+function defaultSurface(): VisualThreeRenderingSurface {
+  return new THREE.WebGLRenderer({ antialias: true });
+}
+
+function snapshot(state: MountedRenderer): VisualThreeRendererSnapshot {
+  return Object.freeze({
+    mounted: true as const,
+    nodeCount: state.nodeCount,
+    arcCount: state.arcCount,
+    arrowCount: state.arrowCount,
+    width: state.width,
+    height: state.height,
+    cameraPosition: Object.freeze({ x: state.camera.position.x, y: state.camera.position.y, z: state.camera.position.z }),
+  });
+}
+
+export function createVisualThreeRenderer(
+  container: VisualThreeContainer,
+  data: VisualThreeSceneData,
+  options: VisualThreeRendererOptions = {},
+): VisualThreeRendererSnapshot {
+  destroyVisualThreeRenderer(container);
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, 1, 0.01, 100000);
+  camera.position.set(0, 0, 5);
+  const surface = options.surfaceFactory?.() ?? defaultSurface();
+  const state: MountedRenderer = {
+    container,
+    scene,
+    camera,
+    surface,
+    samples: segmentCount(options.samples),
+    nodeRadius: positiveFinite(options.nodeRadius, 0.12),
+    objects: [],
+    fitPoints: [],
+    target: new THREE.Vector3(),
+    nodeCount: 0,
+    arcCount: 0,
+    arrowCount: 0,
+    width: 1,
+    height: 1,
+  };
+  mounts.set(container, state);
+  container.appendChild(surface.domElement);
+  populate(state, data);
+  resizeVisualThreeRenderer(container);
+  fitVisualThreeRenderer(container);
+
+  if (options.resizeObserverFactory) {
+    state.observer = options.resizeObserverFactory(() => { resizeVisualThreeRenderer(container); });
+  } else if (typeof ResizeObserver !== "undefined" && container instanceof Element) {
+    const observer = new ResizeObserver(() => { resizeVisualThreeRenderer(container); });
+    observer.observe(container);
+    state.observer = observer;
+  }
+  return snapshot(state);
+}
+
+export function updateVisualThreeRenderer(container: VisualThreeContainer, data: VisualThreeSceneData): boolean {
+  const state = mounts.get(container);
+  if (!state) return false;
+  populate(state, data);
+  render(state);
+  return true;
+}
+
+export function resizeVisualThreeRenderer(container: VisualThreeContainer): boolean {
+  const state = mounts.get(container);
+  if (!state) return false;
+  const [width, height] = viewport(container);
+  state.width = width;
+  state.height = height;
+  state.surface.setSize(width, height, false);
+  state.camera.aspect = width / height;
+  state.camera.updateProjectionMatrix();
+  render(state);
+  return true;
+}
+
+export function fitVisualThreeRenderer(container: VisualThreeContainer, padding = 1.15): boolean {
+  const state = mounts.get(container);
+  if (!state || state.fitPoints.length === 0 || !Number.isFinite(padding) || padding <= 0) return false;
+  const box = new THREE.Box3().setFromPoints(state.fitPoints);
+  const center = box.getCenter(new THREE.Vector3());
+  let radius = 0;
+  for (const point of state.fitPoints) radius = Math.max(radius, point.distanceTo(center));
+  const halfFov = THREE.MathUtils.degToRad(state.camera.fov) / 2;
+  const distance = Math.max(radius / Math.max(Math.sin(halfFov), 1e-6), state.nodeRadius * 4, 1) * padding;
+  state.target.copy(center);
+  state.camera.position.set(center.x, center.y, center.z + distance);
+  state.camera.lookAt(center);
+  state.camera.updateMatrixWorld();
+  render(state);
+  return true;
+}
+
+export function zoomVisualThreeRenderer(container: VisualThreeContainer, factor: number): boolean {
+  const state = mounts.get(container);
+  if (!state || !Number.isFinite(factor) || factor <= 0) return false;
+  const offset = state.camera.position.clone().sub(state.target);
+  if (offset.lengthSq() <= 1e-24) offset.set(0, 0, 1);
+  state.camera.position.copy(state.target).add(offset.multiplyScalar(factor));
+  state.camera.lookAt(state.target);
+  state.camera.updateMatrixWorld();
+  render(state);
+  return true;
+}
+
+export function getVisualThreeRendererSnapshot(container: VisualThreeContainer): VisualThreeRendererSnapshot | undefined {
+  const state = mounts.get(container);
+  return state ? snapshot(state) : undefined;
+}
+
+export function destroyVisualThreeRenderer(container: VisualThreeContainer): boolean {
+  const state = mounts.get(container);
+  if (!state) return false;
+  state.observer?.disconnect();
+  clearPresentation(state);
+  if (container.contains(state.surface.domElement)) container.removeChild(state.surface.domElement);
+  state.surface.dispose();
+  mounts.delete(container);
+  return true;
+}

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -5,6 +5,7 @@ import "./geometry3d.test.js";
 import "./physics3d.test.js";
 import "./live-physics3d.test.js";
 import "./three-scene.test.js";
+import "./three-renderer.test.js";
 
 import {
   VisualNetworkError,

--- a/packages/visual/test/three-renderer.test.ts
+++ b/packages/visual/test/three-renderer.test.ts
@@ -1,0 +1,315 @@
+import {
+  type Physics3DState,
+  type Point3D,
+  type VisualLinkNetwork,
+} from "../src/index.js";
+import {
+  VISUAL_THREE_COLORS,
+  buildVisualThreeSceneData,
+  type VisualThreeSceneData,
+} from "../src/three/index.js";
+import {
+  createVisualThreeRenderer,
+  destroyVisualThreeRenderer,
+  fitVisualThreeRenderer,
+  getVisualThreeRendererSnapshot,
+  resizeVisualThreeRenderer,
+  updateVisualThreeRenderer,
+  zoomVisualThreeRenderer,
+} from "../src/three/renderer.js";
+
+type DisposableProbe = {
+  addEventListener?: (type: string, listener: () => void) => void;
+};
+
+type GeometryProbe = DisposableProbe & {
+  getAttribute?: (name: string) => { readonly array: ArrayLike<number> } | undefined;
+};
+
+type MaterialProbe = DisposableProbe;
+
+type ObjectProbe = {
+  readonly userData?: Readonly<Record<string, unknown>>;
+  readonly position?: Point3D;
+  readonly quaternion?: Readonly<{ x: number; y: number; z: number; w: number }>;
+  readonly scale?: Point3D;
+  readonly geometry?: GeometryProbe;
+  readonly material?: MaterialProbe | readonly MaterialProbe[];
+};
+
+type SceneProbe = {
+  readonly children: readonly ObjectProbe[];
+};
+
+type CameraProbe = {
+  readonly position: Point3D;
+  readonly aspect: number;
+};
+
+type RendererSnapshotProbe = {
+  readonly mounted: true;
+  readonly nodeCount: number;
+  readonly arcCount: number;
+  readonly arrowCount: number;
+  readonly width: number;
+  readonly height: number;
+  readonly cameraPosition: Point3D;
+};
+
+type FakeElement = { readonly token: string; parentNode?: FakeContainer | null };
+
+type FakeContainer = {
+  clientWidth: number;
+  clientHeight: number;
+  readonly children: FakeElement[];
+  appendChild: (element: FakeElement) => FakeElement;
+  removeChild: (element: FakeElement) => FakeElement;
+  contains: (element: FakeElement) => boolean;
+  getBoundingClientRect: () => { width: number; height: number };
+};
+
+type SurfaceProbe = {
+  readonly domElement: FakeElement;
+  setSize: (width: number, height: number, updateStyle?: boolean) => void;
+  render: (scene: unknown, camera: unknown) => void;
+  dispose: () => void;
+};
+
+type ObserverProbe = { disconnect: () => void };
+
+type RendererOptionsProbe = {
+  readonly samples?: number;
+  readonly nodeRadius?: number;
+  readonly surfaceFactory?: () => SurfaceProbe;
+  readonly resizeObserverFactory?: (callback: () => void) => ObserverProbe;
+};
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2f-B: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function close(actual: number, expected: number, message: string, epsilon = 1e-6): void {
+  assert(Math.abs(actual - expected) <= epsilon, `${message}: ${actual} != ${expected}`);
+}
+
+function finitePoint(value: Point3D): boolean {
+  return Number.isFinite(value.x) && Number.isFinite(value.y) && Number.isFinite(value.z);
+}
+
+function container(width = 640, height = 360): FakeContainer {
+  const children: FakeElement[] = [];
+  const result: FakeContainer = {
+    clientWidth: width,
+    clientHeight: height,
+    children,
+    appendChild(element) {
+      if (!children.includes(element)) children.push(element);
+      element.parentNode = result;
+      return element;
+    },
+    removeChild(element) {
+      const index = children.indexOf(element);
+      if (index >= 0) children.splice(index, 1);
+      element.parentNode = null;
+      return element;
+    },
+    contains: (element) => children.includes(element),
+    getBoundingClientRect: () => ({ width: result.clientWidth, height: result.clientHeight }),
+  };
+  return result;
+}
+
+function sceneData(): VisualThreeSceneData {
+  const network: VisualLinkNetwork = {
+    links: [
+      { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+      { key: "O", startKey: "O", endKey: "R" },
+      { key: "C", startKey: "R", endKey: "C" },
+      { key: "L", startKey: "O", endKey: "C" },
+      { key: "U", startKey: "C", endKey: "O" },
+      { key: "X", startKey: "L", endKey: "U" },
+    ],
+  };
+  const points: Readonly<Record<string, Point3D>> = {
+    R: { x: 0, y: 0, z: 0 },
+    O: { x: -2, y: 1, z: 0.5 },
+    C: { x: 2, y: -1, z: -0.5 },
+    L: { x: -1, y: 2, z: 1.5 },
+    U: { x: 1, y: -2, z: -1.5 },
+    X: { x: 0.5, y: 0.75, z: 2.5 },
+  };
+  const keys = Object.keys(points);
+  const state: Physics3DState = {
+    positions: keys.map((key) => ({ key, point: points[key]! })),
+    velocities: keys.map((key) => ({ key, vector: { x: 0, y: 0, z: 0 } })),
+  };
+  return buildVisualThreeSceneData(network, state);
+}
+
+function rootOnlyScene(): VisualThreeSceneData {
+  const network: VisualLinkNetwork = {
+    links: [{ key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] }],
+  };
+  return buildVisualThreeSceneData(network, {
+    positions: [{ key: "R", point: { x: 0, y: 0, z: 0 } }],
+    velocities: [{ key: "R", vector: { x: 0, y: 0, z: 0 } }],
+  });
+}
+
+const host = container();
+let latestScene: SceneProbe | undefined;
+let latestCamera: CameraProbe | undefined;
+const sizes: Array<readonly [number, number, boolean | undefined]> = [];
+let renderCount = 0;
+let surfaceDisposeCount = 0;
+let observerDisconnectCount = 0;
+let observerCallback: (() => void) | undefined;
+
+function surface(): SurfaceProbe {
+  return {
+    domElement: { token: `surface-${surfaceDisposeCount}-${renderCount}`, parentNode: null },
+    setSize(width, height, updateStyle) {
+      sizes.push([width, height, updateStyle]);
+    },
+    render(scene, camera) {
+      latestScene = scene as SceneProbe;
+      latestCamera = camera as CameraProbe;
+      renderCount += 1;
+    },
+    dispose() {
+      surfaceDisposeCount += 1;
+    },
+  };
+}
+
+const options: RendererOptionsProbe = {
+  samples: 12,
+  nodeRadius: 0.12,
+  surfaceFactory: surface,
+  resizeObserverFactory(callback) {
+    observerCallback = callback;
+    return { disconnect: () => { observerDisconnectCount += 1; } };
+  },
+};
+
+const initialScene = sceneData();
+const first = createVisualThreeRenderer(host as never, initialScene, options as never) as RendererSnapshotProbe;
+same(first.nodeCount, 6, "one center mesh per represented Link");
+same(first.arcCount, 12, "two graphical arc lines per represented Link");
+same(first.arrowCount, 6, "one direction arrow per END arc");
+same(first.width, 640, "initial viewport width");
+same(first.height, 360, "initial viewport height");
+assert(finitePoint(first.cameraPosition), "initial camera position finite");
+same(host.children.length, 1, "rendering surface attached once");
+assert(renderCount > 0, "create renders at least once");
+assert(latestScene !== undefined, "create supplies real Three scene to rendering surface");
+assert(latestCamera !== undefined, "create supplies real Three camera to rendering surface");
+
+const centers = latestScene.children.filter((object) => object.userData?.kind === "link-center");
+const arcs = latestScene.children.filter((object) => object.userData?.kind === "link-arc");
+const arrows = latestScene.children.filter((object) => object.userData?.kind === "end-arrow");
+same(centers.length, 6, "scene has exactly one center Mesh per Link");
+same(arcs.length, 12, "scene has exact arc Line count");
+same(arrows.length, 6, "scene has END arrows only");
+
+const rootMesh = centers.find((object) => object.userData?.key === "R");
+assert(rootMesh !== undefined, "root center mesh present");
+same(rootMesh.userData?.kind, "link-center", "root has ordinary center kind");
+same(rootMesh.userData?.key, "R", "root key remains presentation identity");
+close(rootMesh.scale?.x ?? 1, 1, "root gets no special scale.x");
+close(rootMesh.scale?.y ?? 1, 1, "root gets no special scale.y");
+close(rootMesh.scale?.z ?? 1, 1, "root gets no special scale.z");
+
+function line(role: "start" | "end", key: string): ObjectProbe {
+  const result = arcs.find((object) => object.userData?.role === role && object.userData?.key === key);
+  assert(result !== undefined, `missing ${role} line ${key}`);
+  return result;
+}
+
+function colors(object: ObjectProbe): ArrayLike<number> {
+  const attribute = object.geometry?.getAttribute?.("color");
+  assert(attribute !== undefined, "gradient line has color attribute");
+  return attribute.array;
+}
+
+function colorAt(values: ArrayLike<number>, vertex: number): readonly [number, number, number] {
+  const offset = vertex * 3;
+  return [values[offset]!, values[offset + 1]!, values[offset + 2]!];
+}
+
+const startLine = line("start", "X");
+const endLine = line("end", "X");
+const startColors = colors(startLine);
+const endColors = colors(endLine);
+const startLast = startColors.length / 3 - 1;
+const endLast = endColors.length / 3 - 1;
+const [sr, sg, sb] = colorAt(startColors, 0);
+close(sr, 1, "START outer is red.r"); close(sg, 0, "START outer is red.g"); close(sb, 0, "START outer is red.b");
+const [scr, scg, scb] = colorAt(startColors, startLast);
+close(scr, 0, "START center is green.r"); close(scg, 1, "START center is green.g"); close(scb, 0, "START center is green.b");
+const [ecr, ecg, ecb] = colorAt(endColors, 0);
+close(ecr, 0, "END center is green.r"); close(ecg, 1, "END center is green.g"); close(ecb, 0, "END center is green.b");
+const [er, eg, eb] = colorAt(endColors, endLast);
+close(er, 0, "END outer is blue.r"); close(eg, 0, "END outer is blue.g"); close(eb, 1, "END outer is blue.b");
+same(VISUAL_THREE_COLORS.startOuter, 0xff0000, "shared RED identity retained");
+same(VISUAL_THREE_COLORS.center, 0x00ff00, "shared GREEN identity retained");
+same(VISUAL_THREE_COLORS.endOuter, 0x0000ff, "shared BLUE identity retained");
+
+const firstSnapshot = getVisualThreeRendererSnapshot(host as never) as RendererSnapshotProbe | undefined;
+assert(firstSnapshot !== undefined, "mounted snapshot available");
+const beforeInvalidZoom = JSON.stringify(firstSnapshot.cameraPosition);
+same(zoomVisualThreeRenderer(host as never, 0), false, "zero zoom rejected");
+same(zoomVisualThreeRenderer(host as never, Number.NaN), false, "NaN zoom rejected");
+same(JSON.stringify((getVisualThreeRendererSnapshot(host as never) as RendererSnapshotProbe).cameraPosition), beforeInvalidZoom, "invalid zoom does not mutate camera");
+same(zoomVisualThreeRenderer(host as never, 0.5), true, "positive finite zoom accepted");
+assert(finitePoint((getVisualThreeRendererSnapshot(host as never) as RendererSnapshotProbe).cameraPosition), "zoomed camera finite");
+
+host.clientWidth = 800;
+host.clientHeight = 500;
+same(resizeVisualThreeRenderer(host as never), true, "resize mounted renderer");
+same(sizes.at(-1)?.[0], 800, "resize width propagated");
+same(sizes.at(-1)?.[1], 500, "resize height propagated");
+close(latestCamera?.aspect ?? 0, 1.6, "camera aspect updated");
+observerCallback?.();
+same(sizes.at(-1)?.[0], 800, "observer callback uses current width");
+
+same(fitVisualThreeRenderer(host as never, 1.2), true, "fit finite non-coplanar scene");
+assert(finitePoint((getVisualThreeRendererSnapshot(host as never) as RendererSnapshotProbe).cameraPosition), "fit camera finite");
+
+const disposableObjects = [...latestScene.children];
+let objectDisposeEvents = 0;
+for (const object of disposableObjects) {
+  object.geometry?.addEventListener?.("dispose", () => { objectDisposeEvents += 1; });
+  const materials = Array.isArray(object.material) ? object.material : object.material ? [object.material] : [];
+  for (const material of materials) material.addEventListener?.("dispose", () => { objectDisposeEvents += 1; });
+}
+
+same(updateVisualThreeRenderer(host as never, rootOnlyScene()), true, "scene data update succeeds");
+const updated = getVisualThreeRendererSnapshot(host as never) as RendererSnapshotProbe;
+same(updated.nodeCount, 1, "update replaces center meshes");
+same(updated.arcCount, 2, "update replaces arc lines");
+same(updated.arrowCount, 1, "update retains END-only arrow count");
+assert(objectDisposeEvents > 0, "update disposes replaced Three resources");
+same(fitVisualThreeRenderer(host as never), true, "self-loop-only scene fits finitely");
+assert(finitePoint((getVisualThreeRendererSnapshot(host as never) as RendererSnapshotProbe).cameraPosition), "self-loop fit finite");
+
+const disposedBeforeReplace = surfaceDisposeCount;
+createVisualThreeRenderer(host as never, initialScene, options as never);
+same(surfaceDisposeCount, disposedBeforeReplace + 1, "second create destroys previous rendering surface");
+same(observerDisconnectCount, 1, "second create disconnects previous observer");
+same(host.children.length, 1, "second create leaves one attached surface");
+
+same(destroyVisualThreeRenderer(host as never), true, "destroy mounted renderer");
+same(surfaceDisposeCount, disposedBeforeReplace + 2, "destroy disposes current rendering surface");
+same(observerDisconnectCount, 2, "destroy disconnects current observer");
+same(host.children.length, 0, "destroy removes owned rendering element");
+same(destroyVisualThreeRenderer(host as never), false, "destroy is idempotent");
+same(getVisualThreeRendererSnapshot(host as never), undefined, "destroy removes mount snapshot");
+same(resizeVisualThreeRenderer(host as never), false, "resize missing mount is safe false");
+same(fitVisualThreeRenderer(host as never), false, "fit missing mount is safe false");
+same(zoomVisualThreeRenderer(host as never, 1.1), false, "zoom missing mount is safe false");
+same(updateVisualThreeRenderer(host as never, initialScene), false, "update missing mount is safe false");


### PR DESCRIPTION
Closes #938
Parent: #935

## Result

Adds the disposable Three.js renderer lifecycle to the explicit `@mts/visual/three` browser companion while keeping root `@mts/visual` renderer-neutral.

Boundary remains presentation-only:

```text
VisualThreeSceneData
  -> Three scene objects + camera + rendering surface lifecycle
```

No V2e controller, RAF physics stepping, pointer drag, fullscreen, charge/spring controls, parser DTO, proof semantics, or implicit root behavior enters this slice.

## TDD evidence

Clean RED:

```text
head = 66196c67d4c5e3a2c823abcc757814d1e58170f1
CI #3623 = FAILURE
repo-guard #792 = SUCCESS
exact failure:
packages/visual/test/three-renderer.test.ts(19,8): TS2307 Cannot find module '../src/three/renderer.js'
```

Final GREEN:

```text
head = 6094c6a14678bf34fb606858f5b67a678dc8865b
CI #3633 = SUCCESS
repo-guard #797 = SUCCESS
behind_by = 0
mergeable = true
draft = false
diff = +684/-0
budget = 800
```

The blocking visual step explicitly ran:

```text
./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
node packages/visual/dist/test/model.test.js
```

with `three-renderer.test.js` imported by the runtime entry.

## Dependency boundary

Runtime remains exact:

```text
three = 0.185.1
```

Strict TypeScript declarations are exact type-only development dependency:

```text
@types/three = 0.185.0
```

The npm lock is reproducible; CI `npm ci --prefix packages/visual` succeeds.

## Implemented lifecycle

```text
create/update/destroy
resize
fit
zoom
one center mesh per represented Link
V2c sampled RED->GREEN / GREEN->BLUE gradient arcs
presentation-only END arrows
finite self-links/link-of-links inherited from V2c/V2f-A
resource disposal
single mount per container
optional rendering-surface seam for Node CI
```

`R`, label `∞`, and tag `root` receive no structural special case.

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/package.json
  - packages/visual/package-lock.json
  - packages/visual/src/three/renderer.ts
  - packages/visual/src/three/index.ts
  - packages/visual/test/three-renderer.test.ts
  - packages/visual/test/model.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 800
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/three/renderer.ts
  - packages/visual/test/three-renderer.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - web/**
  - repo-policy.json
  - .github/**
  - packages/visual/src/index.ts
  - packages/visual/src/geometry3d.ts
  - packages/visual/src/physics3d.ts
  - packages/visual/src/live-physics3d.ts
expected_effects:
  - "@mts/visual/three gains a disposable Three renderer lifecycle over immutable VisualThreeSceneData"
  - "renderer objects preserve accepted V2c/V2f-A RED-to-GREEN and GREEN-to-BLUE presentation identity"
  - "renderer lifecycle contains no physics controller pointer fullscreen or parser/proof semantics"
  - "strict renderer typing is supplied by exact @types/three 0.185.0 while runtime Three remains 0.185.1"
  - "accepted MTS v0.11 semantics remain unchanged"
```

Accepted MTS semantic delta = NONE. v0.12 is not required.