### PR TITLE
[Visual/V2f-C] Live RAF + exact mouse drag over V2e controller

### DIFF
--- a/packages/visual/src/three/index.ts
+++ b/packages/visual/src/three/index.ts
@@ -11,9 +11,21 @@ import {
   type VisualKey,
   type VisualLinkNetwork,
 } from "../index.js";
+import {
+  snapshotLivePhysics3D,
+  type LivePhysics3DController,
+} from "../live-physics3d.js";
+import {
+  attachVisualThreeLiveController,
+  createVisualThreeRenderer,
+  destroyVisualThreeRenderer,
+  type VisualThreeContainer,
+  type VisualThreeLiveRendererOptions,
+  type VisualThreeRendererSnapshot,
+} from "./renderer.js";
 
 // Explicit browser-companion presentation data. Geometry authority remains V2c.
-// Three/WebGL renderer lifecycle enters only in V2f-B.
+// Renderer lifecycle is V2f-B; V2f-C only schedules accepted V2e snapshots over it.
 
 export const VISUAL_THREE_COLORS = Object.freeze({
   startOuter: 0xff0000,
@@ -91,4 +103,29 @@ export function buildVisualThreeSceneData(
     nodes: Object.freeze(nodes),
     arcs: Object.freeze(arcs),
   });
+}
+
+export function createVisualThreeLiveRenderer(
+  container: VisualThreeContainer,
+  network: VisualLinkNetwork,
+  controller: LivePhysics3DController,
+  options: VisualThreeLiveRendererOptions = {},
+): VisualThreeRendererSnapshot {
+  const current = snapshotLivePhysics3D(controller);
+  const renderer = createVisualThreeRenderer(
+    container,
+    buildVisualThreeSceneData(network, current.state),
+    options,
+  );
+  const attached = attachVisualThreeLiveController(
+    container,
+    controller,
+    (state) => buildVisualThreeSceneData(network, state),
+    options,
+  );
+  if (!attached) {
+    destroyVisualThreeRenderer(container);
+    throw new Error("@mts/visual/three: failed to attach live controller");
+  }
+  return renderer;
 }

--- a/packages/visual/src/three/renderer.ts
+++ b/packages/visual/src/three/renderer.ts
@@ -1,5 +1,16 @@
 import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { sampleCenterline3D, type Point3D } from "../geometry3d.js";
+import {
+  movePinnedLivePhysics3D,
+  pinLivePhysics3D,
+  releaseLivePhysics3D,
+  snapshotLivePhysics3D,
+  stepLivePhysics3D,
+  type LivePhysics3DController,
+} from "../live-physics3d.js";
+import type { Physics3DState } from "../physics3d.js";
+import type { VisualKey } from "../index.js";
 import type { VisualThreeArcData, VisualThreeSceneData } from "./index.js";
 
 export interface VisualThreeContainer {
@@ -29,6 +40,22 @@ export interface VisualThreeRendererOptions {
   readonly resizeObserverFactory?: (callback: () => void) => VisualThreeResizeObserver;
 }
 
+export interface VisualThreeControls {
+  enabled: boolean;
+  readonly target: { copy(value: THREE.Vector3): unknown };
+  update(): void;
+  addEventListener(type: "change", listener: () => void): void;
+  removeEventListener(type: "change", listener: () => void): void;
+  dispose(): void;
+}
+
+export interface VisualThreeLiveRendererOptions extends VisualThreeRendererOptions {
+  readonly requestFrame?: (callback: (timestamp: number) => void) => number;
+  readonly cancelFrame?: (handle: number) => void;
+  readonly controlsFactory?: (camera: THREE.PerspectiveCamera, element: Node) => VisualThreeControls;
+  readonly dragThreshold?: number;
+}
+
 export interface VisualThreeRendererSnapshot {
   readonly mounted: true;
   readonly nodeCount: number;
@@ -40,6 +67,60 @@ export interface VisualThreeRendererSnapshot {
 }
 
 type PresentationObject = THREE.Mesh | THREE.Line;
+type SceneProjector = (state: Physics3DState) => VisualThreeSceneData;
+
+interface VisualThreePointerEvent {
+  readonly button: number;
+  readonly pointerId: number;
+  readonly clientX: number;
+  readonly clientY: number;
+  preventDefault(): void;
+}
+
+interface VisualThreePointerSurface {
+  addEventListener(type: string, listener: (event: VisualThreePointerEvent) => void): void;
+  removeEventListener(type: string, listener: (event: VisualThreePointerEvent) => void): void;
+  setPointerCapture?(pointerId: number): void;
+  releasePointerCapture?(pointerId: number): void;
+  hasPointerCapture?(pointerId: number): boolean;
+  getBoundingClientRect?(): {
+    readonly left?: number;
+    readonly top?: number;
+    readonly width: number;
+    readonly height: number;
+  };
+}
+
+interface DragCandidate {
+  readonly key: VisualKey;
+  readonly pointerId: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly plane: THREE.Plane;
+  readonly offset: THREE.Vector3;
+}
+
+interface LiveBinding {
+  readonly controller: LivePhysics3DController;
+  readonly project: SceneProjector;
+  readonly requestFrame: (callback: (timestamp: number) => void) => number;
+  readonly cancelFrame: (handle: number) => void;
+  readonly controls: VisualThreeControls;
+  readonly element: VisualThreePointerSurface;
+  readonly dragThreshold: number;
+  readonly raycaster: THREE.Raycaster;
+  readonly pointer: THREE.Vector2;
+  readonly onPointerDown: (event: VisualThreePointerEvent) => void;
+  readonly onPointerMove: (event: VisualThreePointerEvent) => void;
+  readonly onPointerUp: (event: VisualThreePointerEvent) => void;
+  readonly onPointerCancel: (event: VisualThreePointerEvent) => void;
+  readonly onControlsChange: () => void;
+  paused: boolean;
+  destroyed: boolean;
+  frameHandle?: number;
+  candidate?: DragCandidate;
+  active?: DragCandidate;
+}
 
 interface MountedRenderer {
   readonly container: VisualThreeContainer;
@@ -52,6 +133,7 @@ interface MountedRenderer {
   readonly fitPoints: THREE.Vector3[];
   readonly target: THREE.Vector3;
   observer?: VisualThreeResizeObserver;
+  live?: LiveBinding;
   nodeCount: number;
   arcCount: number;
   arrowCount: number;
@@ -106,6 +188,10 @@ function clearPresentation(state: MountedRenderer): void {
 
 function threePoint(point: Point3D): THREE.Vector3 {
   return new THREE.Vector3(point.x, point.y, point.z);
+}
+
+function point3D(point: THREE.Vector3): Point3D {
+  return Object.freeze({ x: point.x, y: point.y, z: point.z });
 }
 
 function addNode(state: MountedRenderer, node: VisualThreeSceneData["nodes"][number]): void {
@@ -189,6 +275,30 @@ function defaultSurface(): VisualThreeRenderingSurface {
   return new THREE.WebGLRenderer({ antialias: true });
 }
 
+function defaultControls(camera: THREE.PerspectiveCamera, element: Node): VisualThreeControls {
+  const controls = new OrbitControls(camera, element as HTMLElement);
+  return {
+    get enabled() { return controls.enabled; },
+    set enabled(value: boolean) { controls.enabled = value; },
+    target: controls.target,
+    update: () => { controls.update(); },
+    addEventListener: (_type, listener) => { controls.addEventListener("change", listener as never); },
+    removeEventListener: (_type, listener) => { controls.removeEventListener("change", listener as never); },
+    dispose: () => { controls.dispose(); },
+  };
+}
+
+function browserRequestFrame(callback: (timestamp: number) => void): number {
+  if (typeof requestAnimationFrame === "undefined") {
+    throw new Error("@mts/visual/three: requestAnimationFrame is unavailable");
+  }
+  return requestAnimationFrame(callback);
+}
+
+function browserCancelFrame(handle: number): void {
+  if (typeof cancelAnimationFrame !== "undefined") cancelAnimationFrame(handle);
+}
+
 function snapshot(state: MountedRenderer): VisualThreeRendererSnapshot {
   return Object.freeze({
     mounted: true as const,
@@ -199,6 +309,192 @@ function snapshot(state: MountedRenderer): VisualThreeRendererSnapshot {
     height: state.height,
     cameraPosition: Object.freeze({ x: state.camera.position.x, y: state.camera.position.y, z: state.camera.position.z }),
   });
+}
+
+function liveProject(state: MountedRenderer, physicsState?: Physics3DState): void {
+  const live = state.live;
+  if (!live || live.destroyed) return;
+  const current = physicsState ?? snapshotLivePhysics3D(live.controller).state;
+  populate(state, live.project(current));
+  render(state);
+}
+
+function scheduleLiveFrame(state: MountedRenderer): void {
+  const live = state.live;
+  if (!live || live.destroyed || live.frameHandle !== undefined) return;
+  const current = snapshotLivePhysics3D(live.controller);
+  if (!live.active && (live.paused || !current.awake)) return;
+  live.frameHandle = live.requestFrame(() => { runLiveFrame(state); });
+}
+
+function runLiveFrame(state: MountedRenderer): void {
+  const live = state.live;
+  if (!live || live.destroyed) return;
+  live.frameHandle = undefined;
+  if (!live.paused) {
+    const current = snapshotLivePhysics3D(live.controller);
+    if (current.awake) {
+      const stepped = stepLivePhysics3D(live.controller);
+      liveProject(state, stepped.state);
+    } else if (live.active) render(state);
+  } else if (live.active) render(state);
+  scheduleLiveFrame(state);
+}
+
+function pointerSurface(state: MountedRenderer): VisualThreePointerSurface {
+  return state.surface.domElement as unknown as VisualThreePointerSurface;
+}
+
+function pointerRect(state: MountedRenderer, live: LiveBinding): Readonly<{
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}> {
+  const raw = live.element.getBoundingClientRect?.() ?? state.container.getBoundingClientRect();
+  const width = Number.isFinite(raw.width) && raw.width > 0 ? raw.width : state.width;
+  const height = Number.isFinite(raw.height) && raw.height > 0 ? raw.height : state.height;
+  const left = "left" in raw && Number.isFinite(raw.left) ? raw.left ?? 0 : 0;
+  const top = "top" in raw && Number.isFinite(raw.top) ? raw.top ?? 0 : 0;
+  return { left, top, width: Math.max(1, width), height: Math.max(1, height) };
+}
+
+function setPointerRay(state: MountedRenderer, live: LiveBinding, event: VisualThreePointerEvent): void {
+  const rect = pointerRect(state, live);
+  live.pointer.set(
+    ((event.clientX - rect.left) / rect.width) * 2 - 1,
+    -((event.clientY - rect.top) / rect.height) * 2 + 1,
+  );
+  state.camera.updateMatrixWorld();
+  state.scene.updateMatrixWorld(true);
+  live.raycaster.setFromCamera(live.pointer, state.camera);
+}
+
+function centerMeshes(state: MountedRenderer): THREE.Mesh[] {
+  return state.objects.filter((object): object is THREE.Mesh =>
+    object instanceof THREE.Mesh && object.userData.kind === "link-center");
+}
+
+function currentPoint(controller: LivePhysics3DController, key: VisualKey): Point3D | undefined {
+  return snapshotLivePhysics3D(controller).state.positions.find((entry) => entry.key === key)?.point;
+}
+
+function beginCandidate(state: MountedRenderer, event: VisualThreePointerEvent): void {
+  const live = state.live;
+  if (!live || live.destroyed || event.button !== 0 || live.candidate || live.active) return;
+  setPointerRay(state, live, event);
+  const hit = live.raycaster.intersectObjects(centerMeshes(state), false)[0];
+  if (!hit) return;
+  const mesh = hit.object as THREE.Mesh;
+  const key = mesh.userData.key;
+  if (typeof key !== "string") return;
+  const normal = state.camera.getWorldDirection(new THREE.Vector3());
+  if (normal.lengthSq() <= 1e-24) return;
+  const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(normal.normalize(), mesh.position);
+  const intersection = live.raycaster.ray.intersectPlane(plane, new THREE.Vector3());
+  if (!intersection) return;
+  live.candidate = {
+    key,
+    pointerId: event.pointerId,
+    startX: event.clientX,
+    startY: event.clientY,
+    plane,
+    offset: mesh.position.clone().sub(intersection),
+  };
+}
+
+function activateCandidate(state: MountedRenderer, live: LiveBinding, candidate: DragCandidate): boolean {
+  const current = currentPoint(live.controller, candidate.key);
+  if (!current) return false;
+  pinLivePhysics3D(live.controller, candidate.key, current);
+  live.active = candidate;
+  live.controls.enabled = false;
+  live.element.setPointerCapture?.(candidate.pointerId);
+  return true;
+}
+
+function moveActive(state: MountedRenderer, event: VisualThreePointerEvent): boolean {
+  const live = state.live;
+  const active = live?.active;
+  if (!live || !active || active.pointerId !== event.pointerId) return false;
+  setPointerRay(state, live, event);
+  const intersection = live.raycaster.ray.intersectPlane(active.plane, new THREE.Vector3());
+  if (!intersection) return false;
+  const target = intersection.add(active.offset);
+  movePinnedLivePhysics3D(live.controller, active.key, point3D(target));
+  liveProject(state);
+  event.preventDefault();
+  scheduleLiveFrame(state);
+  return true;
+}
+
+function continueCandidate(state: MountedRenderer, event: VisualThreePointerEvent): void {
+  const live = state.live;
+  const candidate = live?.candidate;
+  if (!live || !candidate || candidate.pointerId !== event.pointerId) return;
+  if (!live.active) {
+    const distance = Math.hypot(event.clientX - candidate.startX, event.clientY - candidate.startY);
+    if (distance < live.dragThreshold || !activateCandidate(state, live, candidate)) return;
+  }
+  moveActive(state, event);
+}
+
+function releaseCapture(live: LiveBinding, pointerId: number): void {
+  if (!live.element.hasPointerCapture || live.element.hasPointerCapture(pointerId)) {
+    live.element.releasePointerCapture?.(pointerId);
+  }
+}
+
+function finishCandidate(state: MountedRenderer, event: VisualThreePointerEvent, finalMove: boolean): void {
+  const live = state.live;
+  const candidate = live?.candidate;
+  if (!live || !candidate || candidate.pointerId !== event.pointerId) return;
+  const active = live.active;
+  if (active) {
+    if (finalMove) moveActive(state, event);
+    if (snapshotLivePhysics3D(live.controller).pinnedKeys.includes(active.key)) {
+      releaseLivePhysics3D(live.controller, active.key);
+    }
+    live.controls.enabled = true;
+    releaseCapture(live, active.pointerId);
+    live.active = undefined;
+    liveProject(state);
+    scheduleLiveFrame(state);
+  }
+  live.candidate = undefined;
+}
+
+function detachLive(state: MountedRenderer): void {
+  const live = state.live;
+  if (!live) return;
+  live.destroyed = true;
+  if (live.frameHandle !== undefined) {
+    live.cancelFrame(live.frameHandle);
+    live.frameHandle = undefined;
+  }
+  if (live.active) {
+    if (snapshotLivePhysics3D(live.controller).pinnedKeys.includes(live.active.key)) {
+      releaseLivePhysics3D(live.controller, live.active.key);
+    }
+    releaseCapture(live, live.active.pointerId);
+    live.active = undefined;
+  }
+  live.candidate = undefined;
+  live.controls.enabled = true;
+  live.element.removeEventListener("pointerdown", live.onPointerDown);
+  live.element.removeEventListener("pointermove", live.onPointerMove);
+  live.element.removeEventListener("pointerup", live.onPointerUp);
+  live.element.removeEventListener("pointercancel", live.onPointerCancel);
+  live.controls.removeEventListener("change", live.onControlsChange);
+  live.controls.dispose();
+  state.live = undefined;
+}
+
+function syncControls(state: MountedRenderer): void {
+  const live = state.live;
+  if (!live || live.destroyed) return;
+  live.controls.target.copy(state.target);
+  live.controls.update();
 }
 
 export function createVisualThreeRenderer(
@@ -243,6 +539,66 @@ export function createVisualThreeRenderer(
   return snapshot(state);
 }
 
+export function attachVisualThreeLiveController(
+  container: VisualThreeContainer,
+  controller: LivePhysics3DController,
+  project: SceneProjector,
+  options: VisualThreeLiveRendererOptions = {},
+): boolean {
+  const state = mounts.get(container);
+  if (!state) return false;
+  detachLive(state);
+  const element = pointerSurface(state);
+  if (typeof element.addEventListener !== "function" || typeof element.removeEventListener !== "function") {
+    throw new Error("@mts/visual/three: rendering surface does not support pointer events");
+  }
+  const controls = options.controlsFactory?.(state.camera, state.surface.domElement)
+    ?? defaultControls(state.camera, state.surface.domElement);
+  const requestFrame = options.requestFrame ?? browserRequestFrame;
+  const cancelFrame = options.cancelFrame ?? browserCancelFrame;
+  const live = {} as LiveBinding;
+  Object.assign(live, {
+    controller,
+    project,
+    requestFrame,
+    cancelFrame,
+    controls,
+    element,
+    dragThreshold: positiveFinite(options.dragThreshold, 4),
+    raycaster: new THREE.Raycaster(),
+    pointer: new THREE.Vector2(),
+    paused: false,
+    destroyed: false,
+    onPointerDown: (event: VisualThreePointerEvent) => { beginCandidate(state, event); },
+    onPointerMove: (event: VisualThreePointerEvent) => { continueCandidate(state, event); },
+    onPointerUp: (event: VisualThreePointerEvent) => { finishCandidate(state, event, true); },
+    onPointerCancel: (event: VisualThreePointerEvent) => { finishCandidate(state, event, false); },
+    onControlsChange: () => { if (state.live === live && !live.destroyed) render(state); },
+  } satisfies Partial<LiveBinding>);
+  state.live = live;
+  element.addEventListener("pointerdown", live.onPointerDown);
+  element.addEventListener("pointermove", live.onPointerMove);
+  element.addEventListener("pointerup", live.onPointerUp);
+  element.addEventListener("pointercancel", live.onPointerCancel);
+  controls.addEventListener("change", live.onControlsChange);
+  syncControls(state);
+  scheduleLiveFrame(state);
+  return true;
+}
+
+export function setVisualThreeLivePaused(container: VisualThreeContainer, paused: boolean): boolean {
+  const state = mounts.get(container);
+  const live = state?.live;
+  if (!state || !live || live.destroyed) return false;
+  live.paused = paused;
+  if (paused && live.frameHandle !== undefined) {
+    live.cancelFrame(live.frameHandle);
+    live.frameHandle = undefined;
+  }
+  scheduleLiveFrame(state);
+  return true;
+}
+
 export function updateVisualThreeRenderer(container: VisualThreeContainer, data: VisualThreeSceneData): boolean {
   const state = mounts.get(container);
   if (!state) return false;
@@ -277,6 +633,7 @@ export function fitVisualThreeRenderer(container: VisualThreeContainer, padding 
   state.camera.position.set(center.x, center.y, center.z + distance);
   state.camera.lookAt(center);
   state.camera.updateMatrixWorld();
+  syncControls(state);
   render(state);
   return true;
 }
@@ -301,6 +658,7 @@ export function getVisualThreeRendererSnapshot(container: VisualThreeContainer):
 export function destroyVisualThreeRenderer(container: VisualThreeContainer): boolean {
   const state = mounts.get(container);
   if (!state) return false;
+  detachLive(state);
   state.observer?.disconnect();
   clearPresentation(state);
   if (container.contains(state.surface.domElement)) container.removeChild(state.surface.domElement);

--- a/packages/visual/src/three/renderer.ts
+++ b/packages/visual/src/three/renderer.ts
@@ -351,11 +351,16 @@ function pointerRect(state: MountedRenderer, live: LiveBinding): Readonly<{
   width: number;
   height: number;
 }> {
-  const raw = live.element.getBoundingClientRect?.() ?? state.container.getBoundingClientRect();
+  const raw = (live.element.getBoundingClientRect?.() ?? state.container.getBoundingClientRect()) as {
+    readonly left?: number;
+    readonly top?: number;
+    readonly width: number;
+    readonly height: number;
+  };
   const width = Number.isFinite(raw.width) && raw.width > 0 ? raw.width : state.width;
   const height = Number.isFinite(raw.height) && raw.height > 0 ? raw.height : state.height;
-  const left = "left" in raw && Number.isFinite(raw.left) ? raw.left ?? 0 : 0;
-  const top = "top" in raw && Number.isFinite(raw.top) ? raw.top ?? 0 : 0;
+  const left = typeof raw.left === "number" && Number.isFinite(raw.left) ? raw.left : 0;
+  const top = typeof raw.top === "number" && Number.isFinite(raw.top) ? raw.top : 0;
   return { left, top, width: Math.max(1, width), height: Math.max(1, height) };
 }
 

--- a/packages/visual/src/three/renderer.ts
+++ b/packages/visual/src/three/renderer.ts
@@ -117,9 +117,9 @@ interface LiveBinding {
   readonly onControlsChange: () => void;
   paused: boolean;
   destroyed: boolean;
-  frameHandle?: number;
-  candidate?: DragCandidate;
-  active?: DragCandidate;
+  frameHandle: number | undefined;
+  candidate: DragCandidate | undefined;
+  active: DragCandidate | undefined;
 }
 
 interface MountedRenderer {
@@ -133,7 +133,7 @@ interface MountedRenderer {
   readonly fitPoints: THREE.Vector3[];
   readonly target: THREE.Vector3;
   observer?: VisualThreeResizeObserver;
-  live?: LiveBinding;
+  live: LiveBinding | undefined;
   nodeCount: number;
   arcCount: number;
   arrowCount: number;
@@ -517,6 +517,7 @@ export function createVisualThreeRenderer(
     objects: [],
     fitPoints: [],
     target: new THREE.Vector3(),
+    live: undefined,
     nodeCount: 0,
     arcCount: 0,
     arrowCount: 0,
@@ -569,6 +570,9 @@ export function attachVisualThreeLiveController(
     pointer: new THREE.Vector2(),
     paused: false,
     destroyed: false,
+    frameHandle: undefined,
+    candidate: undefined,
+    active: undefined,
     onPointerDown: (event: VisualThreePointerEvent) => { beginCandidate(state, event); },
     onPointerMove: (event: VisualThreePointerEvent) => { continueCandidate(state, event); },
     onPointerUp: (event: VisualThreePointerEvent) => { finishCandidate(state, event, true); },

--- a/packages/visual/test/three-renderer.test.ts
+++ b/packages/visual/test/three-renderer.test.ts
@@ -315,8 +315,188 @@ same(zoomVisualThreeRenderer(host as never, 1.1), false, "zoom missing mount is 
 same(updateVisualThreeRenderer(host as never, initialScene), false, "update missing mount is safe false");
 
 import {
+  createLivePhysics3D,
+  snapshotLivePhysics3D,
+} from "../src/live-physics3d.js";
+import {
   createVisualThreeLiveRenderer,
   setVisualThreeLivePaused,
 } from "../src/three/index.js";
-void createVisualThreeLiveRenderer;
-void setVisualThreeLivePaused;
+
+type PointerProbe = {
+  readonly button: number;
+  readonly pointerId: number;
+  readonly clientX: number;
+  readonly clientY: number;
+  preventDefault: () => void;
+};
+
+type InteractiveElement = FakeElement & {
+  addEventListener: (type: string, listener: (event: PointerProbe) => void) => void;
+  removeEventListener: (type: string, listener: (event: PointerProbe) => void) => void;
+  setPointerCapture: (pointerId: number) => void;
+  releasePointerCapture: (pointerId: number) => void;
+  hasPointerCapture: (pointerId: number) => boolean;
+  dispatch: (type: string, event: PointerProbe) => void;
+  listenerCount: () => number;
+};
+
+type ControlsProbe = {
+  enabled: boolean;
+  readonly target: { copy: (value: unknown) => unknown };
+  update: () => void;
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+  dispose: () => void;
+};
+
+function interactiveElement(token: string): InteractiveElement {
+  const listeners = new Map<string, Set<(event: PointerProbe) => void>>();
+  const captures = new Set<number>();
+  return {
+    token,
+    parentNode: null,
+    addEventListener(type, listener) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    setPointerCapture(pointerId) { captures.add(pointerId); },
+    releasePointerCapture(pointerId) { captures.delete(pointerId); },
+    hasPointerCapture: (pointerId) => captures.has(pointerId),
+    dispatch(type, event) {
+      for (const listener of [...(listeners.get(type) ?? [])]) listener(event);
+    },
+    listenerCount() {
+      return [...listeners.values()].reduce((total, set) => total + set.size, 0);
+    },
+  };
+}
+
+function pointer(clientX: number, clientY: number, pointerId = 7): PointerProbe {
+  return { button: 0, pointerId, clientX, clientY, preventDefault() {} };
+}
+
+const liveNetwork: VisualLinkNetwork = {
+  links: [{ key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] }],
+};
+const liveInitialState: Physics3DState = {
+  positions: [{ key: "R", point: { x: 0, y: 0, z: 0 } }],
+  velocities: [{ key: "R", vector: { x: 0, y: 0, z: 0 } }],
+};
+const liveController = createLivePhysics3D(liveNetwork, liveInitialState, { settleWindow: 1 });
+const liveHost = container(400, 300);
+const liveElement = interactiveElement("live-surface");
+let liveScene: SceneProbe | undefined;
+let liveCamera: CameraProbe | undefined;
+let liveDisposed = 0;
+let controlDisposed = 0;
+let controlUpdates = 0;
+const controlListeners = new Set<() => void>();
+const liveControls: ControlsProbe = {
+  enabled: true,
+  target: { copy: () => liveControls.target },
+  update() { controlUpdates += 1; },
+  addEventListener(type, listener) { if (type === "change") controlListeners.add(listener); },
+  removeEventListener(type, listener) { if (type === "change") controlListeners.delete(listener); },
+  dispose() { controlDisposed += 1; },
+};
+let nextFrameId = 1;
+const frames = new Map<number, (timestamp: number) => void>();
+const cancelledFrames: number[] = [];
+const requestFrame = (callback: (timestamp: number) => void): number => {
+  const id = nextFrameId++;
+  frames.set(id, callback);
+  return id;
+};
+const cancelFrame = (id: number): void => {
+  frames.delete(id);
+  cancelledFrames.push(id);
+};
+const liveSurface: SurfaceProbe = {
+  domElement: liveElement,
+  setSize() {},
+  render(scene, camera) {
+    liveScene = scene as SceneProbe;
+    liveCamera = camera as CameraProbe;
+  },
+  dispose() { liveDisposed += 1; },
+};
+
+createVisualThreeLiveRenderer(liveHost as never, liveNetwork, liveController, {
+  nodeRadius: 0.4,
+  surfaceFactory: () => liveSurface,
+  resizeObserverFactory: () => ({ disconnect() {} }),
+  requestFrame,
+  cancelFrame,
+  controlsFactory: () => liveControls,
+  dragThreshold: 5,
+} as never);
+assert(liveScene !== undefined && liveCamera !== undefined, "V2f-C live renderer uses real Three scene/camera");
+same(frames.size, 1, "awake controller schedules one RAF");
+const stalePausedFrame = [...frames.values()][0]!;
+same(setVisualThreeLivePaused(liveHost as never, true), true, "pause mounted live renderer");
+same(frames.size, 0, "pause cancels pending RAF");
+stalePausedFrame(123456789);
+same(snapshotLivePhysics3D(liveController).tick, 0, "stale paused RAF cannot tick physics");
+same(setVisualThreeLivePaused(liveHost as never, false), true, "resume mounted live renderer");
+same(frames.size, 1, "resume awake controller schedules RAF");
+const resumedFrame = [...frames.entries()][0]!;
+frames.delete(resumedFrame[0]);
+resumedFrame[1](987654321);
+const settled = snapshotLivePhysics3D(liveController);
+same(settled.tick, 1, "one RAF means one V2e tick independent of timestamp");
+same(settled.awake, false, "settled V2e controller sleeps");
+same(frames.size, 0, "sleeping controller stops continuous RAF");
+
+liveElement.dispatch("pointerdown", pointer(200, 150));
+same(snapshotLivePhysics3D(liveController).pinnedKeys.length, 0, "pointerdown alone does not pin");
+same(liveControls.enabled, true, "pointerdown alone leaves OrbitControls enabled");
+liveElement.dispatch("pointerup", pointer(200, 150));
+same(snapshotLivePhysics3D(liveController).pinnedKeys.length, 0, "simple tap never pins");
+
+liveElement.dispatch("pointerdown", pointer(200, 150));
+liveElement.dispatch("pointermove", pointer(220, 150));
+let dragged = snapshotLivePhysics3D(liveController);
+same(dragged.pinnedKeys.length, 1, "movement over threshold pins one exact key");
+same(dragged.pinnedKeys[0], "R", "root follows ordinary draggable VisualKey path");
+same(liveControls.enabled, false, "OrbitControls disabled only during active center drag");
+const draggedRoot = dragged.state.positions.find((entry) => entry.key === "R")!.point;
+assert(Math.abs(draggedRoot.x) + Math.abs(draggedRoot.y) + Math.abs(draggedRoot.z) > 1e-9, "drag moves V2e pinned presentation point");
+liveElement.dispatch("pointerup", pointer(220, 150));
+dragged = snapshotLivePhysics3D(liveController);
+same(dragged.pinnedKeys.length, 0, "pointerup releases V2e pin");
+same(liveControls.enabled, true, "pointerup restores OrbitControls");
+assert(frames.size <= 1, "release keeps at most one live RAF scheduled");
+
+for (const id of [...frames.keys()]) { frames.delete(id); }
+liveElement.dispatch("pointerdown", pointer(200, 150, 9));
+liveElement.dispatch("pointermove", pointer(218, 150, 9));
+same(snapshotLivePhysics3D(liveController).pinnedKeys[0], "R", "second root drag can activate");
+same(liveControls.enabled, false, "second active drag disables controls");
+liveElement.dispatch("pointercancel", pointer(218, 150, 9));
+same(snapshotLivePhysics3D(liveController).pinnedKeys.length, 0, "pointercancel releases V2e pin");
+same(liveControls.enabled, true, "pointercancel restores controls");
+
+liveElement.dispatch("pointerdown", pointer(200, 150, 11));
+liveElement.dispatch("pointermove", pointer(215, 150, 11));
+same(snapshotLivePhysics3D(liveController).pinnedKeys[0], "R", "destroy test begins with active pin");
+const tickBeforeDestroy = snapshotLivePhysics3D(liveController).tick;
+const staleDestroyFrames = [...frames.values()];
+same(destroyVisualThreeRenderer(liveHost as never), true, "destroy tears down live renderer through common lifecycle");
+same(snapshotLivePhysics3D(liveController).pinnedKeys.length, 0, "destroy releases active V2e pin");
+same(liveControls.enabled, true, "destroy restores controls before disposal");
+same(controlDisposed, 1, "destroy disposes controls exactly once");
+same(controlListeners.size, 0, "destroy removes controls change listener");
+same(liveElement.listenerCount(), 0, "destroy removes pointer listeners");
+same(frames.size, 0, "destroy cancels pending RAF");
+assert(cancelledFrames.length > 0, "RAF cancellation is observable");
+same(liveDisposed, 1, "common renderer surface disposed once");
+for (const callback of staleDestroyFrames) callback(555555555);
+liveElement.dispatch("pointermove", pointer(260, 150, 11));
+same(snapshotLivePhysics3D(liveController).tick, tickBeforeDestroy, "stale callbacks/events cannot tick after destroy");
+assert(controlUpdates >= 0, "controls probe remains finite and deterministic");
+same(setVisualThreeLivePaused(liveHost as never, true), false, "pause missing live mount is safe false");

--- a/packages/visual/test/three-renderer.test.ts
+++ b/packages/visual/test/three-renderer.test.ts
@@ -313,3 +313,10 @@ same(resizeVisualThreeRenderer(host as never), false, "resize missing mount is s
 same(fitVisualThreeRenderer(host as never), false, "fit missing mount is safe false");
 same(zoomVisualThreeRenderer(host as never, 1.1), false, "zoom missing mount is safe false");
 same(updateVisualThreeRenderer(host as never, initialScene), false, "update missing mount is safe false");
+
+import {
+  createVisualThreeLiveRenderer,
+  setVisualThreeLivePaused,
+} from "../src/three/index.js";
+void createVisualThreeLiveRenderer;
+void setVisualThreeLivePaused;


### PR DESCRIPTION
Closes #940
Parent: #935

## Slice

V2f-C only:

- live `requestAnimationFrame` scheduling bridge over accepted V2e;
- exact Three raycast + camera-facing drag plane for Link-center mouse drag;
- V2e `pin/move/release` delegation;
- OrbitControls disabled only during active drag;
- complete RAF/pointer/control teardown.

Explicitly excluded: fullscreen, charge/spring sliders, downstream cutover, proof overlays, semantic editing.

## TDD state

Initial head contains **RED tests only**. Production implementation intentionally does not exist yet.

Expected clean RED:

```text
packages/visual/test/three-renderer.test.ts imports
  createVisualThreeLiveRenderer
  setVisualThreeLivePaused

from @mts/visual/three before those APIs exist.
```

The next production write is allowed only after this failure is observed in CI and confirmed unrelated to tooling/governance.

## Authority boundary

```text
V2c geometry3d.ts      = sole 3D centerline authority
V2d physics3d.ts       = sole charge/spring force-law authority
V2e live-physics3d.ts  = sole live wake/sleep/pin/move/release authority
V2f-C                  = scheduling + pointer + camera-control presentation only
```

No RAF timestamp / `performance.now()` / `Date` value may enter physics. No root-specific drag rule. `R`/`∞`/`root` remains ordinary draggable presentation metadata.

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/three/renderer.ts
  - packages/visual/src/three/index.ts
  - packages/visual/test/three-renderer.test.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 700
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/three/renderer.ts
  - packages/visual/test/three-renderer.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - repo-policy.json
  - .github/workflows/**
  - ts/**
  - web/**
  - packages/visual/src/geometry3d.ts
  - packages/visual/src/physics3d.ts
  - packages/visual/src/live-physics3d.ts
expected_effects:
  - accepted V2e controller becomes the sole live-motion authority behind the Three browser renderer
  - RAF supplies scheduling only and stops after settling when no drag is active
  - primary mouse drag delegates exact pin/move/release to V2e with no root special-case
  - OrbitControls are disabled only during active node drag and teardown leaves no RAF/listener residue
  - accepted MTS v0.11 and proof semantics remain unchanged
```

## Merge gates

Full CI + blocking repo-guard green, behind_by=0, mergeable=true, draft=false, stable exact head, expected-head merge only.