### PR TITLE
[Visual/V2f-D] Fullscreen + generic charge/springStiffness controls

### DIFF
--- a/packages/visual/src/three/controls.ts
+++ b/packages/visual/src/three/controls.ts
@@ -1,0 +1,283 @@
+import {
+  setLivePhysics3DOptions,
+  type LivePhysics3DController,
+} from "../live-physics3d.js";
+import type { Physics3DOptions } from "../physics3d.js";
+import {
+  getVisualThreeRendererSnapshot,
+  resizeVisualThreeRenderer,
+  setVisualThreeLivePaused,
+  type VisualThreeContainer,
+} from "./renderer.js";
+
+export type VisualThreeLivePhysicsPatch = Pick<Physics3DOptions, "charge" | "springStiffness">;
+
+type Listener = () => void;
+
+export interface VisualThreeControlNode {
+  textContent: string | null;
+  addEventListener(type: string, listener: Listener): void;
+  removeEventListener(type: string, listener: Listener): void;
+  setAttribute?(name: string, value: string): void;
+}
+
+export interface VisualThreeControlInput extends VisualThreeControlNode {
+  value: string;
+}
+
+export interface VisualThreeControlHost {
+  appendChild(node: VisualThreeControlNode): unknown;
+  removeChild(node: VisualThreeControlNode): unknown;
+  contains(node: VisualThreeControlNode): boolean;
+}
+
+export interface VisualThreeControlBarElements {
+  readonly root: VisualThreeControlNode;
+  readonly chargeInput: VisualThreeControlInput;
+  readonly springStiffnessInput: VisualThreeControlInput;
+  readonly fullscreenButton: VisualThreeControlNode;
+}
+
+export interface VisualThreeFullscreenDocument {
+  readonly fullscreenElement: unknown | null;
+  exitFullscreen?(): Promise<void>;
+  addEventListener(type: "fullscreenchange", listener: Listener): void;
+  removeEventListener(type: "fullscreenchange", listener: Listener): void;
+}
+
+export interface VisualThreeControlBarOptions {
+  readonly charge: number;
+  readonly springStiffness: number;
+  readonly elementsFactory?: () => VisualThreeControlBarElements;
+  readonly fullscreenDocument?: VisualThreeFullscreenDocument;
+}
+
+export interface VisualThreeControlBarSnapshot {
+  readonly mounted: true;
+  readonly charge: number;
+  readonly springStiffness: number;
+  readonly fullscreen: boolean;
+}
+
+interface MountedControlBar {
+  readonly container: VisualThreeContainer;
+  readonly host: VisualThreeControlHost;
+  readonly elements: VisualThreeControlBarElements;
+  readonly fullscreenDocument: VisualThreeFullscreenDocument | undefined;
+  readonly onChargeInput: Listener;
+  readonly onSpringInput: Listener;
+  readonly onFullscreenClick: Listener;
+  readonly onFullscreenChange: Listener;
+  charge: number;
+  springStiffness: number;
+  fullscreen: boolean;
+  destroyed: boolean;
+}
+
+const liveControllers = new WeakMap<object, LivePhysics3DController>();
+const controlBars = new WeakMap<object, MountedControlBar>();
+
+function key(container: VisualThreeContainer): object {
+  return container as object;
+}
+
+function finitePresentationValue(value: number, name: string): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`@mts/visual/three: ${name} presentation value must be finite`);
+  }
+  return value;
+}
+
+function defaultFullscreenDocument(): VisualThreeFullscreenDocument | undefined {
+  if (typeof document === "undefined") return undefined;
+  return document as unknown as VisualThreeFullscreenDocument;
+}
+
+function defaultElements(): VisualThreeControlBarElements {
+  if (typeof document === "undefined") {
+    throw new Error("@mts/visual/three: document is unavailable for default control bar elements");
+  }
+
+  const root = document.createElement("div");
+  root.setAttribute("data-mts-visual-three-controls", "true");
+
+  const chargeLabel = document.createElement("label");
+  chargeLabel.textContent = "Charge ";
+  const chargeInput = document.createElement("input");
+  chargeInput.type = "range";
+  chargeInput.min = "0";
+  chargeInput.step = "0.05";
+  chargeInput.setAttribute("aria-label", "Charge");
+  chargeLabel.appendChild(chargeInput);
+
+  const springLabel = document.createElement("label");
+  springLabel.textContent = "Spring stiffness ";
+  const springStiffnessInput = document.createElement("input");
+  springStiffnessInput.type = "range";
+  springStiffnessInput.min = "0";
+  springStiffnessInput.step = "0.005";
+  springStiffnessInput.setAttribute("aria-label", "Spring stiffness");
+  springLabel.appendChild(springStiffnessInput);
+
+  const fullscreenButton = document.createElement("button");
+  fullscreenButton.type = "button";
+  fullscreenButton.textContent = "Fullscreen";
+
+  root.append(chargeLabel, springLabel, fullscreenButton);
+  return {
+    root: root as unknown as VisualThreeControlNode,
+    chargeInput: chargeInput as unknown as VisualThreeControlInput,
+    springStiffnessInput: springStiffnessInput as unknown as VisualThreeControlInput,
+    fullscreenButton: fullscreenButton as unknown as VisualThreeControlNode,
+  };
+}
+
+function snapshot(state: MountedControlBar): VisualThreeControlBarSnapshot {
+  return Object.freeze({
+    mounted: true as const,
+    charge: state.charge,
+    springStiffness: state.springStiffness,
+    fullscreen: state.fullscreen,
+  });
+}
+
+function parseInput(input: VisualThreeControlInput): number | undefined {
+  const raw = input.value.trim();
+  if (raw === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function syncFullscreen(state: MountedControlBar, resize: boolean): void {
+  if (state.destroyed) return;
+  state.fullscreen = state.fullscreenDocument?.fullscreenElement === state.container;
+  state.elements.fullscreenButton.setAttribute?.("aria-pressed", state.fullscreen ? "true" : "false");
+  state.elements.fullscreenButton.textContent = state.fullscreen ? "Exit fullscreen" : "Fullscreen";
+  if (resize) resizeVisualThreeRenderer(state.container);
+}
+
+export function bindVisualThreeLiveController(
+  container: VisualThreeContainer,
+  controller: LivePhysics3DController,
+): boolean {
+  if (!getVisualThreeRendererSnapshot(container)) return false;
+  liveControllers.set(key(container), controller);
+  return true;
+}
+
+export function unbindVisualThreeLiveController(container: VisualThreeContainer): boolean {
+  return liveControllers.delete(key(container));
+}
+
+export function setVisualThreeLivePhysicsOptions(
+  container: VisualThreeContainer,
+  patch: VisualThreeLivePhysicsPatch,
+): boolean {
+  if (!getVisualThreeRendererSnapshot(container)) return false;
+  const controller = liveControllers.get(key(container));
+  if (!controller) return false;
+  setLivePhysics3DOptions(controller, patch);
+  setVisualThreeLivePaused(container, false);
+  return true;
+}
+
+export function createVisualThreeControlBar(
+  container: VisualThreeContainer,
+  host: VisualThreeControlHost,
+  options: VisualThreeControlBarOptions,
+): VisualThreeControlBarSnapshot {
+  if (!getVisualThreeRendererSnapshot(container)) {
+    throw new Error("@mts/visual/three: cannot mount controls without renderer");
+  }
+  if (!liveControllers.has(key(container))) {
+    throw new Error("@mts/visual/three: cannot mount live controls without V2e controller");
+  }
+  if (controlBars.has(key(container))) {
+    throw new Error("@mts/visual/three: control bar already mounted for container");
+  }
+
+  const elements = options.elementsFactory?.() ?? defaultElements();
+  const fullscreenDocument = options.fullscreenDocument ?? defaultFullscreenDocument();
+  const charge = finitePresentationValue(options.charge, "charge");
+  const springStiffness = finitePresentationValue(options.springStiffness, "springStiffness");
+  const state = {} as MountedControlBar;
+
+  Object.assign(state, {
+    container,
+    host,
+    elements,
+    fullscreenDocument,
+    charge,
+    springStiffness,
+    fullscreen: false,
+    destroyed: false,
+    onChargeInput: () => {
+      const value = parseInput(elements.chargeInput);
+      if (value === undefined) return;
+      if (setVisualThreeLivePhysicsOptions(container, { charge: value })) state.charge = value;
+    },
+    onSpringInput: () => {
+      const value = parseInput(elements.springStiffnessInput);
+      if (value === undefined) return;
+      if (setVisualThreeLivePhysicsOptions(container, { springStiffness: value })) state.springStiffness = value;
+    },
+    onFullscreenClick: () => {
+      void toggleVisualThreeFullscreen(container).catch(() => { syncFullscreen(state, false); });
+    },
+    onFullscreenChange: () => { syncFullscreen(state, true); },
+  } satisfies Partial<MountedControlBar>);
+
+  elements.chargeInput.value = String(charge);
+  elements.springStiffnessInput.value = String(springStiffness);
+  elements.chargeInput.addEventListener("input", state.onChargeInput);
+  elements.springStiffnessInput.addEventListener("input", state.onSpringInput);
+  elements.fullscreenButton.addEventListener("click", state.onFullscreenClick);
+  fullscreenDocument?.addEventListener("fullscreenchange", state.onFullscreenChange);
+  host.appendChild(elements.root);
+  controlBars.set(key(container), state);
+  syncFullscreen(state, false);
+  return snapshot(state);
+}
+
+export function getVisualThreeControlBarSnapshot(
+  container: VisualThreeContainer,
+): VisualThreeControlBarSnapshot | undefined {
+  const state = controlBars.get(key(container));
+  return state && !state.destroyed ? snapshot(state) : undefined;
+}
+
+export async function toggleVisualThreeFullscreen(container: VisualThreeContainer): Promise<boolean> {
+  const state = controlBars.get(key(container));
+  if (!state || state.destroyed || !getVisualThreeRendererSnapshot(container)) return false;
+  const fullscreenDocument = state.fullscreenDocument;
+  if (!fullscreenDocument) return false;
+
+  const current = fullscreenDocument.fullscreenElement;
+  if (current !== null && current !== container) return false;
+
+  if (current === container) {
+    if (typeof fullscreenDocument.exitFullscreen !== "function") return false;
+    await fullscreenDocument.exitFullscreen();
+    syncFullscreen(state, true);
+    return true;
+  }
+
+  const target = container as VisualThreeContainer & { requestFullscreen?: () => Promise<void> };
+  if (typeof target.requestFullscreen !== "function") return false;
+  await target.requestFullscreen();
+  syncFullscreen(state, true);
+  return true;
+}
+
+export function destroyVisualThreeControlBar(container: VisualThreeContainer): boolean {
+  const state = controlBars.get(key(container));
+  if (!state || state.destroyed) return false;
+  state.destroyed = true;
+  state.elements.chargeInput.removeEventListener("input", state.onChargeInput);
+  state.elements.springStiffnessInput.removeEventListener("input", state.onSpringInput);
+  state.elements.fullscreenButton.removeEventListener("click", state.onFullscreenClick);
+  state.fullscreenDocument?.removeEventListener("fullscreenchange", state.onFullscreenChange);
+  if (state.host.contains(state.elements.root)) state.host.removeChild(state.elements.root);
+  controlBars.delete(key(container));
+  return true;
+}

--- a/packages/visual/src/three/controls.ts
+++ b/packages/visual/src/three/controls.ts
@@ -1,16 +1,10 @@
 import {
-  setLivePhysics3DOptions,
-  type LivePhysics3DController,
-} from "../live-physics3d.js";
-import type { Physics3DOptions } from "../physics3d.js";
-import {
   getVisualThreeRendererSnapshot,
+  hasVisualThreeLiveController,
   resizeVisualThreeRenderer,
-  setVisualThreeLivePaused,
+  setVisualThreeLivePhysicsOptions,
   type VisualThreeContainer,
 } from "./renderer.js";
-
-export type VisualThreeLivePhysicsPatch = Pick<Physics3DOptions, "charge" | "springStiffness">;
 
 type Listener = () => void;
 
@@ -74,7 +68,6 @@ interface MountedControlBar {
   destroyed: boolean;
 }
 
-const liveControllers = new WeakMap<object, LivePhysics3DController>();
 const controlBars = new WeakMap<object, MountedControlBar>();
 
 function key(container: VisualThreeContainer): object {
@@ -156,31 +149,6 @@ function syncFullscreen(state: MountedControlBar, resize: boolean): void {
   if (resize) resizeVisualThreeRenderer(state.container);
 }
 
-export function bindVisualThreeLiveController(
-  container: VisualThreeContainer,
-  controller: LivePhysics3DController,
-): boolean {
-  if (!getVisualThreeRendererSnapshot(container)) return false;
-  liveControllers.set(key(container), controller);
-  return true;
-}
-
-export function unbindVisualThreeLiveController(container: VisualThreeContainer): boolean {
-  return liveControllers.delete(key(container));
-}
-
-export function setVisualThreeLivePhysicsOptions(
-  container: VisualThreeContainer,
-  patch: VisualThreeLivePhysicsPatch,
-): boolean {
-  if (!getVisualThreeRendererSnapshot(container)) return false;
-  const controller = liveControllers.get(key(container));
-  if (!controller) return false;
-  setLivePhysics3DOptions(controller, patch);
-  setVisualThreeLivePaused(container, false);
-  return true;
-}
-
 export function createVisualThreeControlBar(
   container: VisualThreeContainer,
   host: VisualThreeControlHost,
@@ -189,7 +157,7 @@ export function createVisualThreeControlBar(
   if (!getVisualThreeRendererSnapshot(container)) {
     throw new Error("@mts/visual/three: cannot mount controls without renderer");
   }
-  if (!liveControllers.has(key(container))) {
+  if (!hasVisualThreeLiveController(container)) {
     throw new Error("@mts/visual/three: cannot mount live controls without V2e controller");
   }
   if (controlBars.has(key(container))) {

--- a/packages/visual/src/three/index.ts
+++ b/packages/visual/src/three/index.ts
@@ -1,4 +1,5 @@
 export * from "./renderer.js";
+export * from "./controls.js";
 
 import {
   buildVisualGeometry3D,
@@ -16,9 +17,14 @@ import {
   type LivePhysics3DController,
 } from "../live-physics3d.js";
 import {
+  bindVisualThreeLiveController,
+  destroyVisualThreeControlBar,
+  unbindVisualThreeLiveController,
+} from "./controls.js";
+import {
   attachVisualThreeLiveController,
   createVisualThreeRenderer,
-  destroyVisualThreeRenderer,
+  destroyVisualThreeRenderer as destroyRenderer,
   type VisualThreeContainer,
   type VisualThreeLiveRendererOptions,
   type VisualThreeRendererSnapshot,
@@ -26,6 +32,7 @@ import {
 
 // Explicit browser-companion presentation data. Geometry authority remains V2c.
 // Renderer lifecycle is V2f-B; V2f-C only schedules accepted V2e snapshots over it.
+// V2f-D composes presentation controls without changing renderer or physics authority.
 
 export const VISUAL_THREE_COLORS = Object.freeze({
   startOuter: 0xff0000,
@@ -124,8 +131,18 @@ export function createVisualThreeLiveRenderer(
     options,
   );
   if (!attached) {
-    destroyVisualThreeRenderer(container);
+    destroyRenderer(container);
     throw new Error("@mts/visual/three: failed to attach live controller");
   }
+  if (!bindVisualThreeLiveController(container, controller)) {
+    destroyRenderer(container);
+    throw new Error("@mts/visual/three: failed to bind V2f-D live controls");
+  }
   return renderer;
+}
+
+export function destroyVisualThreeRenderer(container: VisualThreeContainer): boolean {
+  destroyVisualThreeControlBar(container);
+  unbindVisualThreeLiveController(container);
+  return destroyRenderer(container);
 }

--- a/packages/visual/src/three/index.ts
+++ b/packages/visual/src/three/index.ts
@@ -16,11 +16,7 @@ import {
   snapshotLivePhysics3D,
   type LivePhysics3DController,
 } from "../live-physics3d.js";
-import {
-  bindVisualThreeLiveController,
-  destroyVisualThreeControlBar,
-  unbindVisualThreeLiveController,
-} from "./controls.js";
+import { destroyVisualThreeControlBar } from "./controls.js";
 import {
   attachVisualThreeLiveController,
   createVisualThreeRenderer,
@@ -31,8 +27,8 @@ import {
 } from "./renderer.js";
 
 // Explicit browser-companion presentation data. Geometry authority remains V2c.
-// Renderer lifecycle is V2f-B; V2f-C only schedules accepted V2e snapshots over it.
-// V2f-D composes presentation controls without changing renderer or physics authority.
+// Renderer lifecycle is V2f-B; V2f-C owns the current V2e live binding and RAF lifecycle.
+// V2f-D delegates controls through that same renderer-owned live binding.
 
 export const VISUAL_THREE_COLORS = Object.freeze({
   startOuter: 0xff0000,
@@ -134,15 +130,10 @@ export function createVisualThreeLiveRenderer(
     destroyRenderer(container);
     throw new Error("@mts/visual/three: failed to attach live controller");
   }
-  if (!bindVisualThreeLiveController(container, controller)) {
-    destroyRenderer(container);
-    throw new Error("@mts/visual/three: failed to bind V2f-D live controls");
-  }
   return renderer;
 }
 
 export function destroyVisualThreeRenderer(container: VisualThreeContainer): boolean {
   destroyVisualThreeControlBar(container);
-  unbindVisualThreeLiveController(container);
   return destroyRenderer(container);
 }

--- a/packages/visual/src/three/renderer.ts
+++ b/packages/visual/src/three/renderer.ts
@@ -5,11 +5,12 @@ import {
   movePinnedLivePhysics3D,
   pinLivePhysics3D,
   releaseLivePhysics3D,
+  setLivePhysics3DOptions,
   snapshotLivePhysics3D,
   stepLivePhysics3D,
   type LivePhysics3DController,
 } from "../live-physics3d.js";
-import type { Physics3DState } from "../physics3d.js";
+import type { Physics3DOptions, Physics3DState } from "../physics3d.js";
 import type { VisualKey } from "../index.js";
 import type { VisualThreeArcData, VisualThreeSceneData } from "./index.js";
 
@@ -65,6 +66,8 @@ export interface VisualThreeRendererSnapshot {
   readonly height: number;
   readonly cameraPosition: Point3D;
 }
+
+export type VisualThreeLivePhysicsPatch = Pick<Physics3DOptions, "charge" | "springStiffness">;
 
 type PresentationObject = THREE.Mesh | THREE.Line;
 type SceneProjector = (state: Physics3DState) => VisualThreeSceneData;
@@ -591,6 +594,24 @@ export function attachVisualThreeLiveController(
   element.addEventListener("pointercancel", live.onPointerCancel);
   controls.addEventListener("change", live.onControlsChange);
   syncControls(state);
+  scheduleLiveFrame(state);
+  return true;
+}
+
+export function hasVisualThreeLiveController(container: VisualThreeContainer): boolean {
+  const live = mounts.get(container)?.live;
+  return !!live && !live.destroyed;
+}
+
+export function setVisualThreeLivePhysicsOptions(
+  container: VisualThreeContainer,
+  patch: VisualThreeLivePhysicsPatch,
+): boolean {
+  const state = mounts.get(container);
+  const live = state?.live;
+  if (!state || !live || live.destroyed) return false;
+  setLivePhysics3DOptions(live.controller, patch);
+  live.paused = false;
   scheduleLiveFrame(state);
   return true;
 }

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -6,6 +6,7 @@ import "./physics3d.test.js";
 import "./live-physics3d.test.js";
 import "./three-scene.test.js";
 import "./three-renderer.test.js";
+import "./three-controls.test.js";
 
 import {
   VisualNetworkError,

--- a/packages/visual/test/three-controls.test.ts
+++ b/packages/visual/test/three-controls.test.ts
@@ -1,13 +1,290 @@
-import { setVisualThreeLivePhysicsOptions } from "../src/three/renderer.js";
 import {
+  createLivePhysics3D,
+  sleepLivePhysics3D,
+  snapshotLivePhysics3D,
+  LivePhysics3DError,
+} from "../src/live-physics3d.js";
+import type { Physics3DState } from "../src/physics3d.js";
+import type { VisualLinkNetwork } from "../src/index.js";
+import {
+  createVisualThreeLiveRenderer,
   createVisualThreeControlBar,
   destroyVisualThreeControlBar,
+  destroyVisualThreeRenderer,
   getVisualThreeControlBarSnapshot,
+  setVisualThreeLivePhysicsOptions,
   toggleVisualThreeFullscreen,
 } from "../src/three/index.js";
 
-void setVisualThreeLivePhysicsOptions;
-void createVisualThreeControlBar;
-void destroyVisualThreeControlBar;
-void getVisualThreeControlBarSnapshot;
-void toggleVisualThreeFullscreen;
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2f-D: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+type Listener = () => void;
+
+type EventProbe = {
+  addEventListener(type: string, listener: Listener): void;
+  removeEventListener(type: string, listener: Listener): void;
+  dispatch(type: string): void;
+  listenerCount(): number;
+};
+
+function eventProbe<T extends object>(base: T): T & EventProbe {
+  const listeners = new Map<string, Set<Listener>>();
+  return Object.assign(base, {
+    addEventListener(type: string, listener: Listener) {
+      const set = listeners.get(type) ?? new Set<Listener>();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener(type: string, listener: Listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(type: string) {
+      for (const listener of [...(listeners.get(type) ?? [])]) listener();
+    },
+    listenerCount() {
+      return [...listeners.values()].reduce((total, set) => total + set.size, 0);
+    },
+  });
+}
+
+type NodeProbe = EventProbe & {
+  token: string;
+  parentNode: HostProbe | null;
+  textContent: string | null;
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | undefined;
+};
+
+type InputProbe = NodeProbe & { value: string };
+type HostProbe = {
+  clientWidth: number;
+  clientHeight: number;
+  readonly children: NodeProbe[];
+  appendChild(node: NodeProbe): NodeProbe;
+  removeChild(node: NodeProbe): NodeProbe;
+  contains(node: NodeProbe): boolean;
+  getBoundingClientRect(): { width: number; height: number };
+  requestFullscreen?: () => Promise<void>;
+};
+
+function node(token: string): NodeProbe {
+  const attributes = new Map<string, string>();
+  return eventProbe({
+    token,
+    parentNode: null as HostProbe | null,
+    textContent: null as string | null,
+    setAttribute(name: string, value: string) { attributes.set(name, value); },
+    getAttribute(name: string) { return attributes.get(name); },
+  });
+}
+
+function input(token: string): InputProbe {
+  return Object.assign(node(token), { value: "" });
+}
+
+function host(width = 400, height = 300): HostProbe {
+  const children: NodeProbe[] = [];
+  const value: HostProbe = {
+    clientWidth: width,
+    clientHeight: height,
+    children,
+    appendChild(child) {
+      if (!children.includes(child)) children.push(child);
+      child.parentNode = value;
+      return child;
+    },
+    removeChild(child) {
+      const index = children.indexOf(child);
+      if (index >= 0) children.splice(index, 1);
+      child.parentNode = null;
+      return child;
+    },
+    contains: (child) => children.includes(child),
+    getBoundingClientRect: () => ({ width: value.clientWidth, height: value.clientHeight }),
+  };
+  return value;
+}
+
+type FullscreenDocumentProbe = EventProbe & {
+  fullscreenElement: unknown | null;
+  exitFullscreen(): Promise<void>;
+};
+
+function fullscreenDocument(): FullscreenDocumentProbe {
+  const value = eventProbe({
+    fullscreenElement: null as unknown | null,
+    async exitFullscreen() {
+      value.fullscreenElement = null;
+      value.dispatch("fullscreenchange");
+    },
+  });
+  return value;
+}
+
+const network: VisualLinkNetwork = {
+  links: [{ key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] }],
+};
+const initial: Physics3DState = {
+  positions: [{ key: "R", point: { x: 0, y: 0, z: 0 } }],
+  velocities: [{ key: "R", vector: { x: 0, y: 0, z: 0 } }],
+};
+const controller = createLivePhysics3D(network, initial, { settleWindow: 1 });
+const rendererHost = host();
+const surfaceElement = node("surface");
+const frames = new Map<number, (timestamp: number) => void>();
+let nextFrame = 1;
+let resizeCount = 0;
+
+createVisualThreeLiveRenderer(rendererHost as never, network, controller, {
+  surfaceFactory: () => ({
+    domElement: surfaceElement as never,
+    setSize() { resizeCount += 1; },
+    render() {},
+    dispose() {},
+  }),
+  resizeObserverFactory: () => ({ disconnect() {} }),
+  controlsFactory: () => ({
+    enabled: true,
+    target: { copy() { return this; } },
+    update() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispose() {},
+  }),
+  requestFrame(callback: (timestamp: number) => void) {
+    const id = nextFrame++;
+    frames.set(id, callback);
+    return id;
+  },
+  cancelFrame(id: number) { frames.delete(id); },
+} as never);
+
+const firstFrame = [...frames.entries()][0]!;
+frames.delete(firstFrame[0]);
+firstFrame[1](123456);
+same(snapshotLivePhysics3D(controller).awake, false, "settled controller sleeps before option update");
+
+const positionsBeforeCharge = JSON.stringify(snapshotLivePhysics3D(controller).state.positions);
+same(setVisualThreeLivePhysicsOptions(rendererHost as never, { charge: 2 }), true, "charge patch accepted by live renderer");
+same(snapshotLivePhysics3D(controller).awake, true, "charge patch wakes existing V2e controller");
+same(JSON.stringify(snapshotLivePhysics3D(controller).state.positions), positionsBeforeCharge, "charge patch preserves coordinates immediately");
+same(frames.size, 1, "charge patch schedules one RAF after wake");
+
+sleepLivePhysics3D(controller);
+frames.clear();
+const positionsBeforeSpring = JSON.stringify(snapshotLivePhysics3D(controller).state.positions);
+same(setVisualThreeLivePhysicsOptions(rendererHost as never, { springStiffness: 0.2 }), true, "spring patch accepted by live renderer");
+same(snapshotLivePhysics3D(controller).awake, true, "spring patch wakes existing V2e controller");
+same(JSON.stringify(snapshotLivePhysics3D(controller).state.positions), positionsBeforeSpring, "spring patch preserves coordinates immediately");
+
+sleepLivePhysics3D(controller);
+frames.clear();
+const beforeInvalid = JSON.stringify(snapshotLivePhysics3D(controller));
+let invalidCode: string | undefined;
+try {
+  setVisualThreeLivePhysicsOptions(rendererHost as never, { charge: -1 });
+} catch (error) {
+  assert(error instanceof LivePhysics3DError, "negative charge fails through V2e error boundary");
+  invalidCode = error.code;
+}
+same(invalidCode, "invalid-physics-option", "negative charge is validated by accepted V2e/V2d boundary");
+same(JSON.stringify(snapshotLivePhysics3D(controller)), beforeInvalid, "rejected physics patch leaves live state untouched");
+
+const controlHost = host();
+const root = node("controls");
+const chargeInput = input("charge");
+const springInput = input("spring");
+const fullscreenButton = node("fullscreen");
+const documentProbe = fullscreenDocument();
+rendererHost.requestFullscreen = async () => {
+  documentProbe.fullscreenElement = rendererHost;
+  documentProbe.dispatch("fullscreenchange");
+};
+
+const beforeCreate = JSON.stringify(snapshotLivePhysics3D(controller));
+createVisualThreeControlBar(rendererHost as never, controlHost as never, {
+  charge: 2,
+  springStiffness: 0.2,
+  elementsFactory: () => ({ root, chargeInput, springStiffnessInput: springInput, fullscreenButton }),
+  fullscreenDocument: documentProbe,
+} as never);
+same(controlHost.children.length, 1, "control bar attaches one owned root");
+same(JSON.stringify(snapshotLivePhysics3D(controller)), beforeCreate, "control bar creation is presentation-only");
+let controlSnapshot = getVisualThreeControlBarSnapshot(rendererHost as never)!;
+same(controlSnapshot.charge, 2, "control bar displays caller presentation charge");
+same(controlSnapshot.springStiffness, 0.2, "control bar displays caller presentation spring stiffness");
+same(controlSnapshot.fullscreen, false, "control bar starts outside fullscreen");
+
+chargeInput.value = "not-a-number";
+chargeInput.dispatch("input");
+same(JSON.stringify(snapshotLivePhysics3D(controller)), beforeCreate, "non-numeric input does not mutate live controller");
+same(getVisualThreeControlBarSnapshot(rendererHost as never)!.charge, 2, "non-numeric input does not change displayed accepted value");
+
+chargeInput.value = "3";
+chargeInput.dispatch("input");
+same(snapshotLivePhysics3D(controller).awake, true, "charge input delegates to V2e and wakes network");
+same(getVisualThreeControlBarSnapshot(rendererHost as never)!.charge, 3, "accepted charge input updates presentation value");
+
+sleepLivePhysics3D(controller);
+frames.clear();
+springInput.value = "0.12";
+springInput.dispatch("input");
+same(snapshotLivePhysics3D(controller).awake, true, "spring input delegates to V2e and wakes network");
+same(getVisualThreeControlBarSnapshot(rendererHost as never)!.springStiffness, 0.12, "accepted spring input updates presentation value");
+
+sleepLivePhysics3D(controller);
+frames.clear();
+chargeInput.value = "-4";
+let controlInvalidCode: string | undefined;
+try {
+  chargeInput.dispatch("input");
+} catch (error) {
+  assert(error instanceof LivePhysics3DError, "negative slider value reaches accepted V2e validation");
+  controlInvalidCode = error.code;
+}
+same(controlInvalidCode, "invalid-physics-option", "control bar does not duplicate negative physics validation");
+same(getVisualThreeControlBarSnapshot(rendererHost as never)!.charge, 3, "rejected slider value is not committed to presentation state");
+
+const resizeBeforeEnter = resizeCount;
+same(await toggleVisualThreeFullscreen(rendererHost as never), true, "native fullscreen enter accepted");
+controlSnapshot = getVisualThreeControlBarSnapshot(rendererHost as never)!;
+same(controlSnapshot.fullscreen, true, "fullscreenchange synchronizes entered state");
+assert(resizeCount > resizeBeforeEnter, "fullscreen enter triggers renderer resize");
+same(fullscreenButton.getAttribute("aria-pressed"), "true", "fullscreen button aria state synchronized");
+
+const resizeBeforeExit = resizeCount;
+same(await toggleVisualThreeFullscreen(rendererHost as never), true, "native fullscreen exit accepted for owned container");
+same(getVisualThreeControlBarSnapshot(rendererHost as never)!.fullscreen, false, "fullscreen exit synchronizes state");
+assert(resizeCount > resizeBeforeExit, "fullscreen exit triggers renderer resize");
+
+const foreignFullscreen = {};
+documentProbe.fullscreenElement = foreignFullscreen;
+same(await toggleVisualThreeFullscreen(rendererHost as never), false, "foreign fullscreen element is not exited or replaced");
+same(documentProbe.fullscreenElement, foreignFullscreen, "foreign fullscreen ownership is preserved");
+documentProbe.fullscreenElement = null;
+documentProbe.dispatch("fullscreenchange");
+
+same(destroyVisualThreeControlBar(rendererHost as never), true, "explicit control bar destroy succeeds");
+same(controlHost.children.length, 0, "explicit destroy removes owned control DOM");
+same(documentProbe.listenerCount(), 0, "explicit destroy removes fullscreen listener");
+same(destroyVisualThreeControlBar(rendererHost as never), false, "control bar destroy is idempotent");
+
+createVisualThreeControlBar(rendererHost as never, controlHost as never, {
+  charge: 3,
+  springStiffness: 0.12,
+  elementsFactory: () => ({ root, chargeInput, springStiffnessInput: springInput, fullscreenButton }),
+  fullscreenDocument: documentProbe,
+} as never);
+same(documentProbe.listenerCount(), 1, "recreated control bar owns one fullscreen listener");
+same(destroyVisualThreeRenderer(rendererHost as never), true, "renderer destroy succeeds with attached control bar");
+same(controlHost.children.length, 0, "renderer destroy removes attached control bar DOM");
+same(documentProbe.listenerCount(), 0, "renderer destroy removes attached fullscreen listener");
+same(getVisualThreeControlBarSnapshot(rendererHost as never), undefined, "renderer destroy clears control bar state");
+same(setVisualThreeLivePhysicsOptions(rendererHost as never, { charge: 1 }), false, "physics patch on missing renderer is safe false");
+same(await toggleVisualThreeFullscreen(rendererHost as never), false, "fullscreen toggle on missing control bar is safe false");

--- a/packages/visual/test/three-controls.test.ts
+++ b/packages/visual/test/three-controls.test.ts
@@ -196,6 +196,57 @@ try {
 same(invalidCode, "invalid-physics-option", "negative charge is validated by accepted V2e/V2d boundary");
 same(JSON.stringify(snapshotLivePhysics3D(controller)), beforeInvalid, "rejected physics patch leaves live state untouched");
 
+const { attachVisualThreeLiveController, buildVisualThreeSceneData } = await import("../src/three/index.js");
+const replacementController = createLivePhysics3D(network, initial, { settleWindow: 1 });
+sleepLivePhysics3D(controller);
+sleepLivePhysics3D(replacementController);
+frames.clear();
+const replacementPositions = JSON.stringify(snapshotLivePhysics3D(replacementController).state.positions);
+const reattachOptions = {
+  controlsFactory: () => ({
+    enabled: true,
+    target: { copy() { return this; } },
+    update() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispose() {},
+  }),
+  requestFrame(callback: (timestamp: number) => void) {
+    const id = nextFrame++;
+    frames.set(id, callback);
+    return id;
+  },
+  cancelFrame(id: number) { frames.delete(id); },
+} as never;
+same(
+  attachVisualThreeLiveController(
+    rendererHost as never,
+    replacementController,
+    (state) => buildVisualThreeSceneData(network, state),
+    reattachOptions,
+  ),
+  true,
+  "public reattach replaces current V2e controller",
+);
+same(setVisualThreeLivePhysicsOptions(rendererHost as never, { charge: 4 }), true, "D patch accepted after public reattach");
+same(snapshotLivePhysics3D(replacementController).awake, true, "D patch targets current reattached V2e controller");
+same(snapshotLivePhysics3D(controller).awake, false, "D patch does not wake stale former V2e controller");
+same(
+  JSON.stringify(snapshotLivePhysics3D(replacementController).state.positions),
+  replacementPositions,
+  "D patch preserves current controller coordinates after reattach",
+);
+same(
+  attachVisualThreeLiveController(
+    rendererHost as never,
+    controller,
+    (state) => buildVisualThreeSceneData(network, state),
+    reattachOptions,
+  ),
+  true,
+  "original controller restored for remaining control-bar checks",
+);
+
 const controlHost = host();
 const root = node("controls");
 const chargeInput = input("charge");

--- a/packages/visual/test/three-controls.test.ts
+++ b/packages/visual/test/three-controls.test.ts
@@ -1,0 +1,13 @@
+import { setVisualThreeLivePhysicsOptions } from "../src/three/renderer.js";
+import {
+  createVisualThreeControlBar,
+  destroyVisualThreeControlBar,
+  getVisualThreeControlBarSnapshot,
+  toggleVisualThreeFullscreen,
+} from "../src/three/index.js";
+
+void setVisualThreeLivePhysicsOptions;
+void createVisualThreeControlBar;
+void destroyVisualThreeControlBar;
+void getVisualThreeControlBarSnapshot;
+void toggleVisualThreeFullscreen;


### PR DESCRIPTION
Closes #942
Parent: #935

## Slice

V2f-D only:

- thin live `charge` / `springStiffness` delegation to accepted V2e;
- optional reusable browser control bar;
- native Fullscreen API over renderer container;
- fullscreenchange state sync + renderer resize;
- exact DOM/fullscreen teardown.

Explicitly excluded: parser/aprover cutover, proof overlays, semantic editing, damping/pause/reset generic UI, new physics equations, root-specific UI.

## TDD evidence

Initial missing-API RED:

```text
head = e4080fb5cb1637cdc4126917e3a16bd33f8b38f9
CI #3649 = FAILURE
repo-guard #804 = SUCCESS
```

Behavioral RED:

```text
head = 94f904d6b9bbeaecd4c07ff41732128992bfbc7d
CI #3651 = FAILURE
repo-guard #805 = SUCCESS
```

First full behavioral GREEN before final audit:

```text
head = ca41773d2772ceba3f1d814efa7233a9a6de8871
CI #3657 = SUCCESS
repo-guard #808 = SUCCESS
```

## Final-audit blocker and root cause

The first D implementation kept a second `container -> controller` WeakMap in `controls.ts`. That can become stale because accepted V2f-C still publicly exposes `attachVisualThreeLiveController(...)`, which replaces renderer `state.live` without updating the D WeakMap. Result: RAF may render controller B while sliders mutate controller A.

The corrected authority boundary therefore returns to the original #942 design: the renderer's existing `state.live.controller` is the single current-controller authority. No duplicate controller registry is allowed.

## Authority boundary

```text
V2d physics3d.ts      = sole force-law authority
V2e live-physics3d.ts = sole option validation/wake/controller authority
V2f-C renderer state  = sole current live-controller binding for a renderer
V2f-D renderer API    = thin delegation through state.live.controller + existing RAF scheduling
V2f-D controls.ts     = DOM/fullscreen presentation only; no controller registry
V2f-D three/index.ts  = public scene/live composition + control teardown
```

## ChangeIntent

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/three/renderer.ts
  - packages/visual/src/three/controls.ts
  - packages/visual/src/three/index.ts
  - packages/visual/test/three-controls.test.ts
  - packages/visual/test/model.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 700
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/three/renderer.ts
  - packages/visual/src/three/controls.ts
  - packages/visual/src/three/index.ts
  - packages/visual/test/three-controls.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - repo-policy.json
  - .github/workflows/**
  - ts/**
  - web/**
  - packages/visual/src/geometry3d.ts
  - packages/visual/src/physics3d.ts
  - packages/visual/src/live-physics3d.ts
expected_effects:
  - charge/springStiffness updates always target the controller currently attached to the renderer
  - option updates delegate only to accepted V2e and preserve coordinates/topology immediately
  - accepted V2f-C RAF resumes through its existing renderer scheduling state
  - fullscreen changes renderer-container presentation only and resizes after transition
  - public renderer destroy removes owned control DOM/fullscreen listeners
  - no second controller registry or solver is introduced
  - accepted MTS v0.11 and proof semantics remain unchanged
```

## Merge gates

Full CI + blocking repo-guard green, behind_by=0, mergeable=true, draft=false, stable exact head, final code/invariant audit, expected-head merge only.