### PR TITLE
[Visual/V2g-A] Renderer-neutral VisualPresentationState + conformance

### DIFF
--- a/packages/visual/src/index.ts
+++ b/packages/visual/src/index.ts
@@ -100,6 +100,7 @@ export function normalizeVisualLinkNetwork(network: VisualLinkNetwork): VisualLi
   return Object.freeze({ links: Object.freeze(links) });
 }
 
+export * from "./presentation.js";
 export * from "./blueprint-geometry.js";
 export * from "./blueprint-svg.js";
 export * from "./blueprint-interaction.js";

--- a/packages/visual/src/presentation.ts
+++ b/packages/visual/src/presentation.ts
@@ -1,0 +1,116 @@
+import type { VisualKey, VisualLinkNetwork } from "./index.js";
+
+export interface VisualHaloPresentation {
+  readonly color: number;
+  readonly scale?: number;
+  readonly opacity?: number;
+}
+
+export interface VisualLinkPresentation {
+  readonly key: VisualKey;
+  readonly visible?: boolean;
+  readonly emphasis?: number;
+  readonly selected?: boolean;
+  readonly labelVisible?: boolean;
+  readonly halo?: VisualHaloPresentation;
+}
+
+export interface VisualPresentationState {
+  readonly links: readonly VisualLinkPresentation[];
+}
+
+export type VisualPresentationErrorCode =
+  | "empty-key"
+  | "unknown-key"
+  | "duplicate-key"
+  | "invalid-emphasis"
+  | "invalid-halo-scale"
+  | "invalid-halo-opacity"
+  | "invalid-halo-color";
+
+export class VisualPresentationError extends Error {
+  readonly code: VisualPresentationErrorCode;
+  readonly key: VisualKey;
+
+  constructor(code: VisualPresentationErrorCode, key: VisualKey, message: string) {
+    super(message);
+    this.name = "VisualPresentationError";
+    this.code = code;
+    this.key = key;
+  }
+}
+
+function fail(code: VisualPresentationErrorCode, key: VisualKey, message: string): never {
+  throw new VisualPresentationError(code, key, message);
+}
+
+function validateHalo(key: VisualKey, halo: VisualHaloPresentation): void {
+  if (!Number.isInteger(halo.color) || halo.color < 0 || halo.color > 0xffffff) {
+    fail("invalid-halo-color", key, `Presentation halo color for ${key} must be an integer in 0x000000..0xffffff.`);
+  }
+  if (halo.scale !== undefined && (!Number.isFinite(halo.scale) || halo.scale <= 0)) {
+    fail("invalid-halo-scale", key, `Presentation halo scale for ${key} must be finite and > 0.`);
+  }
+  if (
+    halo.opacity !== undefined &&
+    (!Number.isFinite(halo.opacity) || halo.opacity < 0 || halo.opacity > 1)
+  ) {
+    fail("invalid-halo-opacity", key, `Presentation halo opacity for ${key} must be finite and within 0..1.`);
+  }
+}
+
+export function validateVisualPresentationState(
+  network: VisualLinkNetwork,
+  state: VisualPresentationState,
+): void {
+  const knownKeys = new Set(network.links.map((link) => link.key));
+  const seenKeys = new Set<VisualKey>();
+
+  for (const entry of state.links) {
+    if (entry.key.trim().length === 0) {
+      fail("empty-key", entry.key, "Presentation key must not be blank.");
+    }
+    if (!knownKeys.has(entry.key)) {
+      fail("unknown-key", entry.key, `Presentation key ${entry.key} does not exist in the visual network.`);
+    }
+    if (seenKeys.has(entry.key)) {
+      fail("duplicate-key", entry.key, `Presentation key ${entry.key} occurs more than once.`);
+    }
+    seenKeys.add(entry.key);
+
+    if (entry.emphasis !== undefined && (!Number.isFinite(entry.emphasis) || entry.emphasis <= 0)) {
+      fail("invalid-emphasis", entry.key, `Presentation emphasis for ${entry.key} must be finite and > 0.`);
+    }
+    if (entry.halo !== undefined) validateHalo(entry.key, entry.halo);
+  }
+}
+
+function normalizeHalo(halo: VisualHaloPresentation): VisualHaloPresentation {
+  return Object.freeze({
+    color: halo.color,
+    ...(halo.scale === undefined ? {} : { scale: halo.scale }),
+    ...(halo.opacity === undefined ? {} : { opacity: halo.opacity }),
+  });
+}
+
+function normalizeEntry(entry: VisualLinkPresentation): VisualLinkPresentation {
+  return Object.freeze({
+    key: entry.key,
+    ...(entry.visible === undefined ? {} : { visible: entry.visible }),
+    ...(entry.emphasis === undefined ? {} : { emphasis: entry.emphasis }),
+    ...(entry.selected === undefined ? {} : { selected: entry.selected }),
+    ...(entry.labelVisible === undefined ? {} : { labelVisible: entry.labelVisible }),
+    ...(entry.halo === undefined ? {} : { halo: normalizeHalo(entry.halo) }),
+  });
+}
+
+export function normalizeVisualPresentationState(
+  network: VisualLinkNetwork,
+  state: VisualPresentationState,
+): VisualPresentationState {
+  validateVisualPresentationState(network, state);
+  const links = state.links
+    .map(normalizeEntry)
+    .sort((left, right) => (left.key < right.key ? -1 : left.key > right.key ? 1 : 0));
+  return Object.freeze({ links: Object.freeze(links) });
+}

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -44,81 +44,80 @@ function basisLinks(): VisualLink[] {
     { key: "C", startKey: "R", endKey: "C" },
     { key: "L", startKey: "O", endKey: "C" },
     { key: "U", startKey: "C", endKey: "O" },
+    { key: "X", startKey: "L", endKey: "U", tags: ["link-of-links"] },
   ];
 }
 
-const input: VisualLinkNetwork = {
-  links: [
-    { key: "U", startKey: "C", endKey: "O", tags: ["upper"] },
-    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
-    { key: "L", startKey: "O", endKey: "C" },
-    { key: "C", startKey: "R", endKey: "C" },
-    { key: "O", startKey: "O", endKey: "R" },
-  ],
-};
-const normalized = normalizeVisualLinkNetwork(input);
-same(normalized.links.map((link) => link.key).join(","), "C,L,O,R,U", "stable key order");
-assert(Object.isFrozen(normalized), "network is frozen");
-assert(Object.isFrozen(normalized.links), "links are frozen");
-for (const link of normalized.links) {
-  assert(Object.isFrozen(link), `link ${link.key} is frozen`);
-  if (link.tags !== undefined) assert(Object.isFrozen(link.tags), `tags ${link.key} are frozen`);
-}
+const basis: VisualLinkNetwork = { links: basisLinks() };
+validateVisualLinkNetwork(basis);
 
-same(input.links[0]?.key, "U", "input order is unchanged");
-same(input.links[0]?.tags?.[0], "upper", "input metadata is unchanged");
+const normalized = normalizeVisualLinkNetwork(basis);
+same(normalized.links.length, 6, "all links preserved");
+same(normalized.links.map((link) => link.key).join(","), "C,L,O,R,U,X", "stable key order");
 
 const root = normalized.links.find((link) => link.key === "R");
-assert(root !== undefined, "root retained");
-same(root.startKey, "R", "root self start retained");
-same(root.endKey, "R", "root self end retained");
+assert(root !== undefined, "root presentation retained");
+same(root.startKey, "R", "self-link start retained");
+same(root.endKey, "R", "self-link end retained");
 same(root.label, "∞", "presentation label retained");
-same(root.tags?.[0], "root", "presentation tag retained");
+same(root.tags?.join(","), "root", "presentation tags retained");
 
-validateVisualLinkNetwork({ links: basisLinks() });
-validateVisualLinkNetwork({
-  links: [
-    ...basisLinks(),
-    { key: "X", startKey: "L", endKey: "U" },
-    { key: "Y", startKey: "X", endKey: "R" },
-  ],
-});
+const linkOfLinks = normalized.links.find((link) => link.key === "X");
+assert(linkOfLinks !== undefined, "link-of-links retained");
+same(linkOfLinks.startKey, "L", "link-of-links start retained");
+same(linkOfLinks.endKey, "U", "link-of-links end retained");
+
+const reordered: VisualLinkNetwork = { links: [...basisLinks()].reverse() };
+const normalizedReordered = normalizeVisualLinkNetwork(reordered);
+const topology = (network: VisualLinkNetwork): string =>
+  JSON.stringify(network.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
+same(topology(normalizedReordered), topology(normalized), "input order does not alter normalized topology");
+
+const relabeled: VisualLinkNetwork = {
+  links: basisLinks().map((link) =>
+    link.key === "X" ? { ...link, label: "display only", tags: ["selected", "debug"] } : link,
+  ),
+};
+same(topology(normalizeVisualLinkNetwork(relabeled)), topology(normalized), "metadata does not alter topology");
 
 expectCode(
-  () => validateVisualLinkNetwork({ links: [{ key: "", startKey: "R", endKey: "R" }] }),
-  "empty-key",
-  "blank link key",
-);
-expectCode(
-  () =>
-    validateVisualLinkNetwork({
-      links: [
-        { key: "R", startKey: "R", endKey: "R" },
-        { key: "R", startKey: "R", endKey: "R" },
-      ],
-    }),
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "R", startKey: "R", endKey: "R" }] }),
   "duplicate-key",
-  "duplicate key",
+  "duplicate visual key",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [{ key: "   ", startKey: "   ", endKey: "   " }] }),
+  "empty-key",
+  "blank visual key",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "missing", endKey: "R" }] }),
+  "missing-start",
+  "missing start reference",
+);
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "R", endKey: "missing" }] }),
+  "missing-end",
+  "missing end reference",
 );
 expectCode(
   () =>
     validateVisualLinkNetwork({
-      links: [
-        { key: "R", startKey: "R", endKey: "R" },
-        { key: "X", startKey: "missing", endKey: "R" },
-      ],
+      links: [...basisLinks(), { key: "Y", startKey: "missing", endKey: "R", label: "missing", tags: ["missing"] }],
     }),
-  "dangling-start",
-  "dangling start",
+  "missing-start",
+  "metadata cannot repair invalid topology",
 );
 expectCode(
-  () =>
-    validateVisualLinkNetwork({
-      links: [
-        { key: "R", startKey: "R", endKey: "R" },
-        { key: "X", startKey: "R", endKey: "missing" },
-      ],
-    }),
-  "dangling-end",
-  "dangling end",
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: " ", endKey: "R" }] }),
+  "empty-start",
+  "blank start reference",
 );
+expectCode(
+  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "R", endKey: "\t" }] }),
+  "empty-end",
+  "blank end reference",
+);
+
+assert(Object.isFrozen(normalized), "normalized network is immutable presentation snapshot");
+assert(Object.isFrozen(normalized.links), "normalized link list is immutable presentation snapshot");

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -7,6 +7,7 @@ import "./live-physics3d.test.js";
 import "./three-scene.test.js";
 import "./three-renderer.test.js";
 import "./three-controls.test.js";
+import "./presentation.test.js";
 
 import {
   VisualNetworkError,
@@ -43,80 +44,81 @@ function basisLinks(): VisualLink[] {
     { key: "C", startKey: "R", endKey: "C" },
     { key: "L", startKey: "O", endKey: "C" },
     { key: "U", startKey: "C", endKey: "O" },
-    { key: "X", startKey: "L", endKey: "U", tags: ["link-of-links"] },
   ];
 }
 
-const basis: VisualLinkNetwork = { links: basisLinks() };
-validateVisualLinkNetwork(basis);
+const input: VisualLinkNetwork = {
+  links: [
+    { key: "U", startKey: "C", endKey: "O", tags: ["upper"] },
+    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+    { key: "L", startKey: "O", endKey: "C" },
+    { key: "C", startKey: "R", endKey: "C" },
+    { key: "O", startKey: "O", endKey: "R" },
+  ],
+};
+const normalized = normalizeVisualLinkNetwork(input);
+same(normalized.links.map((link) => link.key).join(","), "C,L,O,R,U", "stable key order");
+assert(Object.isFrozen(normalized), "network is frozen");
+assert(Object.isFrozen(normalized.links), "links are frozen");
+for (const link of normalized.links) {
+  assert(Object.isFrozen(link), `link ${link.key} is frozen`);
+  if (link.tags !== undefined) assert(Object.isFrozen(link.tags), `tags ${link.key} are frozen`);
+}
 
-const normalized = normalizeVisualLinkNetwork(basis);
-same(normalized.links.length, 6, "all links preserved");
-same(normalized.links.map((link) => link.key).join(","), "C,L,O,R,U,X", "stable key order");
+same(input.links[0]?.key, "U", "input order is unchanged");
+same(input.links[0]?.tags?.[0], "upper", "input metadata is unchanged");
 
 const root = normalized.links.find((link) => link.key === "R");
-assert(root !== undefined, "root presentation retained");
-same(root.startKey, "R", "self-link start retained");
-same(root.endKey, "R", "self-link end retained");
+assert(root !== undefined, "root retained");
+same(root.startKey, "R", "root self start retained");
+same(root.endKey, "R", "root self end retained");
 same(root.label, "∞", "presentation label retained");
-same(root.tags?.join(","), "root", "presentation tags retained");
+same(root.tags?.[0], "root", "presentation tag retained");
 
-const linkOfLinks = normalized.links.find((link) => link.key === "X");
-assert(linkOfLinks !== undefined, "link-of-links retained");
-same(linkOfLinks.startKey, "L", "link-of-links start retained");
-same(linkOfLinks.endKey, "U", "link-of-links end retained");
-
-const reordered: VisualLinkNetwork = { links: [...basisLinks()].reverse() };
-const normalizedReordered = normalizeVisualLinkNetwork(reordered);
-const topology = (network: VisualLinkNetwork): string =>
-  JSON.stringify(network.links.map(({ key, startKey, endKey }) => ({ key, startKey, endKey })));
-same(topology(normalizedReordered), topology(normalized), "input order does not alter normalized topology");
-
-const relabeled: VisualLinkNetwork = {
-  links: basisLinks().map((link) =>
-    link.key === "X" ? { ...link, label: "display only", tags: ["selected", "debug"] } : link,
-  ),
-};
-same(topology(normalizeVisualLinkNetwork(relabeled)), topology(normalized), "metadata does not alter topology");
+validateVisualLinkNetwork({ links: basisLinks() });
+validateVisualLinkNetwork({
+  links: [
+    ...basisLinks(),
+    { key: "X", startKey: "L", endKey: "U" },
+    { key: "Y", startKey: "X", endKey: "R" },
+  ],
+});
 
 expectCode(
-  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "R", startKey: "R", endKey: "R" }] }),
-  "duplicate-key",
-  "duplicate visual key",
-);
-expectCode(
-  () => validateVisualLinkNetwork({ links: [{ key: "   ", startKey: "   ", endKey: "   " }] }),
+  () => validateVisualLinkNetwork({ links: [{ key: "", startKey: "R", endKey: "R" }] }),
   "empty-key",
-  "blank visual key",
-);
-expectCode(
-  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "missing", endKey: "R" }] }),
-  "missing-start",
-  "missing start reference",
-);
-expectCode(
-  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "R", endKey: "missing" }] }),
-  "missing-end",
-  "missing end reference",
+  "blank link key",
 );
 expectCode(
   () =>
     validateVisualLinkNetwork({
-      links: [...basisLinks(), { key: "Y", startKey: "missing", endKey: "R", label: "missing", tags: ["missing"] }],
+      links: [
+        { key: "R", startKey: "R", endKey: "R" },
+        { key: "R", startKey: "R", endKey: "R" },
+      ],
     }),
-  "missing-start",
-  "metadata cannot repair invalid topology",
+  "duplicate-key",
+  "duplicate key",
 );
 expectCode(
-  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: " ", endKey: "R" }] }),
-  "empty-start",
-  "blank start reference",
+  () =>
+    validateVisualLinkNetwork({
+      links: [
+        { key: "R", startKey: "R", endKey: "R" },
+        { key: "X", startKey: "missing", endKey: "R" },
+      ],
+    }),
+  "dangling-start",
+  "dangling start",
 );
 expectCode(
-  () => validateVisualLinkNetwork({ links: [...basisLinks(), { key: "Y", startKey: "R", endKey: "\t" }] }),
-  "empty-end",
-  "blank end reference",
+  () =>
+    validateVisualLinkNetwork({
+      links: [
+        { key: "R", startKey: "R", endKey: "R" },
+        { key: "X", startKey: "R", endKey: "missing" },
+      ],
+    }),
+  "dangling-end",
+  "dangling end",
 );
-
-assert(Object.isFrozen(normalized), "normalized network is immutable presentation snapshot");
-assert(Object.isFrozen(normalized.links), "normalized link list is immutable presentation snapshot");

--- a/packages/visual/test/presentation.test.ts
+++ b/packages/visual/test/presentation.test.ts
@@ -1,0 +1,129 @@
+import {
+  VisualPresentationError,
+  normalizeVisualPresentationState,
+  validateVisualPresentationState,
+  type VisualLinkNetwork,
+  type VisualPresentationErrorCode,
+  type VisualPresentationState,
+} from "../src/index.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2g-A: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectCode(
+  effect: () => unknown,
+  code: VisualPresentationErrorCode,
+  message: string,
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof VisualPresentationError, `${message}: wrong error type`);
+    same(error.code, code, `${message}: wrong error code`);
+    return;
+  }
+  throw new Error(`@mts/visual V2g-A: ${message}: expected rejection`);
+}
+
+const network: VisualLinkNetwork = {
+  links: [
+    { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+    { key: "O", startKey: "O", endKey: "R" },
+    { key: "C", startKey: "R", endKey: "C" },
+    { key: "L", startKey: "O", endKey: "C" },
+    { key: "U", startKey: "C", endKey: "O" },
+    { key: "X", startKey: "L", endKey: "U", label: "link-of-links" },
+  ],
+};
+
+const topologyBefore = JSON.stringify(network);
+const inputHalo = { color: 0x336699, scale: 1.4, opacity: 0.6 };
+const state: VisualPresentationState = {
+  links: [
+    { key: "X", visible: false },
+    { key: "R", emphasis: 1.35, selected: true, labelVisible: true, halo: inputHalo },
+  ],
+};
+const stateBefore = JSON.stringify(state);
+
+validateVisualPresentationState(network, { links: [] });
+validateVisualPresentationState(network, state);
+
+const normalized = normalizeVisualPresentationState(network, state);
+same(normalized.links.length, 2, "all overrides preserved");
+same(normalized.links.map((entry) => entry.key).join(","), "R,X", "stable key order");
+same(JSON.stringify(network), topologyBefore, "network remains unchanged");
+same(JSON.stringify(state), stateBefore, "input state remains unchanged");
+assert(Object.isFrozen(normalized), "normalized state is frozen");
+assert(Object.isFrozen(normalized.links), "normalized links array is frozen");
+
+const root = normalized.links[0];
+assert(root !== undefined && root.key === "R", "root override retained as ordinary key");
+same(root.emphasis, 1.35, "root emphasis retained");
+same(root.selected, true, "root selected retained");
+same(root.labelVisible, true, "root label visibility retained");
+assert(root.halo !== undefined, "root halo retained");
+same(root.halo.color, 0x336699, "halo color retained");
+same(root.halo.scale, 1.4, "halo scale retained");
+same(root.halo.opacity, 0.6, "halo opacity retained");
+assert(root.halo !== inputHalo, "halo is cloned rather than aliased");
+assert(Object.isFrozen(root), "normalized override is frozen");
+assert(Object.isFrozen(root.halo), "normalized halo is frozen");
+
+const reordered = normalizeVisualPresentationState(network, {
+  links: [...state.links].reverse(),
+});
+same(JSON.stringify(reordered), JSON.stringify(normalized), "input order does not alter normalized state");
+
+expectCode(
+  () => validateVisualPresentationState(network, { links: [{ key: "   " }] }),
+  "empty-key",
+  "blank presentation key",
+);
+expectCode(
+  () => validateVisualPresentationState(network, { links: [{ key: "missing" }] }),
+  "unknown-key",
+  "unknown presentation key",
+);
+expectCode(
+  () => validateVisualPresentationState(network, { links: [{ key: "R" }, { key: "R" }] }),
+  "duplicate-key",
+  "duplicate presentation key",
+);
+
+for (const emphasis of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+  expectCode(
+    () => validateVisualPresentationState(network, { links: [{ key: "R", emphasis }] }),
+    "invalid-emphasis",
+    `invalid emphasis ${String(emphasis)}`,
+  );
+}
+
+for (const scale of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+  expectCode(
+    () => validateVisualPresentationState(network, { links: [{ key: "R", halo: { color: 0, scale } }] }),
+    "invalid-halo-scale",
+    `invalid halo scale ${String(scale)}`,
+  );
+}
+
+for (const opacity of [-0.01, 1.01, Number.NaN, Number.POSITIVE_INFINITY]) {
+  expectCode(
+    () => validateVisualPresentationState(network, { links: [{ key: "R", halo: { color: 0, opacity } }] }),
+    "invalid-halo-opacity",
+    `invalid halo opacity ${String(opacity)}`,
+  );
+}
+
+for (const color of [-1, 0x1000000, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+  expectCode(
+    () => validateVisualPresentationState(network, { links: [{ key: "R", halo: { color } }] }),
+    "invalid-halo-color",
+    `invalid halo color ${String(color)}`,
+  );
+}


### PR DESCRIPTION
Parent: #945
Architecture: #944
Closes #946

This PR is intentionally opened in a TDD **RED** state first. The initial commits contain only the V2g-A conformance test and runner wiring; production presentation API will follow only after CI confirms the expected missing-API failure.

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/presentation.ts
  - packages/visual/src/index.ts
  - packages/visual/test/presentation.test.ts
  - packages/visual/test/model.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 420
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/src/index.ts
  - packages/visual/test/model.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - packages/visual/src/three/**
  - packages/visual/test/three-*.test.ts
  - repo-policy.json
  - .github/workflows/**
expected_effects:
  - add one immutable renderer-neutral presentation-state contract keyed only by existing VisualKey values
  - fail closed on stale/duplicate/invalid presentation state
  - keep topology, semantics, proof, physics and browser rendering outside the presentation normalization boundary
  - introduce no AST, ordinary graph or parser/prover role ontology
  - make no accepted MTS semantic delta
```

Target invariants:

- presentation state is immutable and deterministic;
- unknown/duplicate keys fail closed;
- root is ordinary;
- no Three/DOM dependency in package-root presentation model;
- no AST/ordinary graph/proof semantics;
- accepted MTS v0.11 semantics remain unchanged.