### PR TITLE
[Visual/V2g-B] Three presentation core + exact-key activation

### DIFF
--- a/packages/visual/src/presentation.ts
+++ b/packages/visual/src/presentation.ts
@@ -1,4 +1,4 @@
-import type { VisualKey, VisualLinkNetwork } from "./index.js";
+import type { VisualKey } from "./index.js";
 
 export interface VisualHaloPresentation {
   readonly color: number;
@@ -17,6 +17,10 @@ export interface VisualLinkPresentation {
 
 export interface VisualPresentationState {
   readonly links: readonly VisualLinkPresentation[];
+}
+
+export interface VisualPresentationKeySpace {
+  readonly links: readonly Readonly<{ key: VisualKey }>[];
 }
 
 export type VisualPresentationErrorCode =
@@ -60,10 +64,10 @@ function validateHalo(key: VisualKey, halo: VisualHaloPresentation): void {
 }
 
 export function validateVisualPresentationState(
-  network: VisualLinkNetwork,
+  keySpace: VisualPresentationKeySpace,
   state: VisualPresentationState,
 ): void {
-  const knownKeys = new Set(network.links.map((link) => link.key));
+  const knownKeys = new Set(keySpace.links.map((link) => link.key));
   const seenKeys = new Set<VisualKey>();
 
   for (const entry of state.links) {
@@ -105,10 +109,10 @@ function normalizeEntry(entry: VisualLinkPresentation): VisualLinkPresentation {
 }
 
 export function normalizeVisualPresentationState(
-  network: VisualLinkNetwork,
+  keySpace: VisualPresentationKeySpace,
   state: VisualPresentationState,
 ): VisualPresentationState {
-  validateVisualPresentationState(network, state);
+  validateVisualPresentationState(keySpace, state);
   const links = state.links
     .map(normalizeEntry)
     .sort((left, right) => (left.key < right.key ? -1 : left.key > right.key ? 1 : 0));

--- a/packages/visual/src/three/renderer.ts
+++ b/packages/visual/src/three/renderer.ts
@@ -11,6 +11,11 @@ import {
   type LivePhysics3DController,
 } from "../live-physics3d.js";
 import type { Physics3DOptions, Physics3DState } from "../physics3d.js";
+import {
+  normalizeVisualPresentationState,
+  type VisualPresentationKeySpace,
+  type VisualPresentationState,
+} from "../presentation.js";
 import type { VisualKey } from "../index.js";
 import type { VisualThreeArcData, VisualThreeSceneData } from "./index.js";
 
@@ -55,6 +60,7 @@ export interface VisualThreeLiveRendererOptions extends VisualThreeRendererOptio
   readonly cancelFrame?: (handle: number) => void;
   readonly controlsFactory?: (camera: THREE.PerspectiveCamera, element: Node) => VisualThreeControls;
   readonly dragThreshold?: number;
+  readonly onActivateKey?: (key: VisualKey) => void;
 }
 
 export interface VisualThreeRendererSnapshot {
@@ -101,6 +107,7 @@ interface DragCandidate {
   readonly startY: number;
   readonly plane: THREE.Plane;
   readonly offset: THREE.Vector3;
+  crossedThreshold: boolean;
 }
 
 interface LiveBinding {
@@ -111,6 +118,7 @@ interface LiveBinding {
   readonly controls: VisualThreeControls;
   readonly element: VisualThreePointerSurface;
   readonly dragThreshold: number;
+  readonly onActivateKey: ((key: VisualKey) => void) | undefined;
   readonly raycaster: THREE.Raycaster;
   readonly pointer: THREE.Vector2;
   readonly onPointerDown: (event: VisualThreePointerEvent) => void;
@@ -133,10 +141,13 @@ interface MountedRenderer {
   readonly samples: number;
   readonly nodeRadius: number;
   readonly objects: PresentationObject[];
+  readonly halos: THREE.Mesh[];
   readonly fitPoints: THREE.Vector3[];
   readonly target: THREE.Vector3;
   observer?: VisualThreeResizeObserver;
   live: LiveBinding | undefined;
+  presentation: VisualPresentationState;
+  keySpace: VisualPresentationKeySpace;
   nodeCount: number;
   arcCount: number;
   arrowCount: number;
@@ -146,6 +157,7 @@ interface MountedRenderer {
 
 const mounts = new WeakMap<object, MountedRenderer>();
 const UP = new THREE.Vector3(0, 1, 0);
+const EMPTY_PRESENTATION: VisualPresentationState = Object.freeze({ links: Object.freeze([]) });
 
 function positiveFinite(value: number | undefined, fallback: number): number {
   return value !== undefined && Number.isFinite(value) && value > 0 ? value : fallback;
@@ -177,7 +189,16 @@ function disposeObject(object: PresentationObject): void {
   for (const material of materialList(object.material)) material.dispose();
 }
 
+function clearHalos(state: MountedRenderer): void {
+  for (const halo of state.halos) {
+    state.scene.remove(halo);
+    disposeObject(halo);
+  }
+  state.halos.length = 0;
+}
+
 function clearPresentation(state: MountedRenderer): void {
+  clearHalos(state);
   for (const object of state.objects) {
     state.scene.remove(object);
     disposeObject(object);
@@ -265,13 +286,63 @@ function addEndArrow(state: MountedRenderer, arc: VisualThreeArcData, points: re
   state.arrowCount += 1;
 }
 
+function reconcilePresentation(state: MountedRenderer, data: VisualThreeSceneData): void {
+  const knownKeys = new Set(data.nodes.map((node) => node.key));
+  state.keySpace = Object.freeze({ links: data.nodes });
+  const retained = state.presentation.links.filter((entry) => knownKeys.has(entry.key));
+  if (retained.length !== state.presentation.links.length) {
+    state.presentation = Object.freeze({ links: Object.freeze(retained) });
+  }
+}
+
+function applyPresentation(state: MountedRenderer): void {
+  clearHalos(state);
+  const byKey = new Map(state.presentation.links.map((entry) => [entry.key, entry] as const));
+  const centers = new Map<VisualKey, THREE.Mesh>();
+
+  for (const object of state.objects) {
+    const key = object.userData.key;
+    if (typeof key !== "string") continue;
+    const entry = byKey.get(key);
+    object.visible = entry?.visible ?? true;
+    if (object instanceof THREE.Mesh && object.userData.kind === "link-center") {
+      object.scale.setScalar(entry?.emphasis ?? 1);
+      centers.set(key, object);
+    }
+  }
+
+  for (const entry of state.presentation.links) {
+    if (!entry.selected && entry.halo === undefined) continue;
+    const center = centers.get(entry.key);
+    if (!center) continue;
+    const halo = entry.halo;
+    const geometry = new THREE.SphereGeometry(state.nodeRadius, 12, 8);
+    const material = new THREE.MeshBasicMaterial({
+      color: halo?.color ?? 0xffffff,
+      wireframe: true,
+      transparent: true,
+      opacity: halo?.opacity ?? 0.22,
+      depthWrite: false,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.copy(center.position);
+    mesh.scale.setScalar(halo?.scale ?? 1.55);
+    mesh.visible = entry.visible ?? true;
+    mesh.userData = { kind: "presentation-halo", key: entry.key };
+    state.scene.add(mesh);
+    state.halos.push(mesh);
+  }
+}
+
 function populate(state: MountedRenderer, data: VisualThreeSceneData): void {
+  reconcilePresentation(state, data);
   clearPresentation(state);
   for (const node of data.nodes) addNode(state, node);
   for (const arc of data.arcs) {
     const points = addArc(state, arc);
     addEndArrow(state, arc, points);
   }
+  applyPresentation(state);
 }
 
 function defaultSurface(): VisualThreeRenderingSurface {
@@ -408,6 +479,7 @@ function beginCandidate(state: MountedRenderer, event: VisualThreePointerEvent):
     startY: event.clientY,
     plane,
     offset: mesh.position.clone().sub(intersection),
+    crossedThreshold: false,
   };
 }
 
@@ -442,7 +514,9 @@ function continueCandidate(state: MountedRenderer, event: VisualThreePointerEven
   if (!live || !candidate || candidate.pointerId !== event.pointerId) return;
   if (!live.active) {
     const distance = Math.hypot(event.clientX - candidate.startX, event.clientY - candidate.startY);
-    if (distance < live.dragThreshold || !activateCandidate(state, live, candidate)) return;
+    if (distance < live.dragThreshold) return;
+    candidate.crossedThreshold = true;
+    if (!activateCandidate(state, live, candidate)) return;
   }
   moveActive(state, event);
 }
@@ -458,6 +532,8 @@ function finishCandidate(state: MountedRenderer, event: VisualThreePointerEvent,
   const candidate = live?.candidate;
   if (!live || !candidate || candidate.pointerId !== event.pointerId) return;
   const active = live.active;
+  const shouldActivate = finalMove && !active && !candidate.crossedThreshold;
+  const onActivateKey = live.onActivateKey;
   if (active) {
     if (finalMove) moveActive(state, event);
     if (snapshotLivePhysics3D(live.controller).pinnedKeys.includes(active.key)) {
@@ -470,6 +546,7 @@ function finishCandidate(state: MountedRenderer, event: VisualThreePointerEvent,
     scheduleLiveFrame(state);
   }
   live.candidate = undefined;
+  if (shouldActivate && onActivateKey) onActivateKey(candidate.key);
 }
 
 function detachLive(state: MountedRenderer): void {
@@ -523,9 +600,12 @@ export function createVisualThreeRenderer(
     samples: segmentCount(options.samples),
     nodeRadius: positiveFinite(options.nodeRadius, 0.12),
     objects: [],
+    halos: [],
     fitPoints: [],
     target: new THREE.Vector3(),
     live: undefined,
+    presentation: EMPTY_PRESENTATION,
+    keySpace: Object.freeze({ links: Object.freeze([]) }),
     nodeCount: 0,
     arcCount: 0,
     arrowCount: 0,
@@ -574,6 +654,7 @@ export function attachVisualThreeLiveController(
     controls,
     element,
     dragThreshold: positiveFinite(options.dragThreshold, 4),
+    onActivateKey: options.onActivateKey,
     raycaster: new THREE.Raycaster(),
     pointer: new THREE.Vector2(),
     paused: false,
@@ -626,6 +707,19 @@ export function setVisualThreeLivePaused(container: VisualThreeContainer, paused
     live.frameHandle = undefined;
   }
   scheduleLiveFrame(state);
+  return true;
+}
+
+export function setVisualThreePresentation(
+  container: VisualThreeContainer,
+  presentation: VisualPresentationState,
+): boolean {
+  const state = mounts.get(container);
+  if (!state) return false;
+  const normalized = normalizeVisualPresentationState(state.keySpace, presentation);
+  state.presentation = normalized;
+  applyPresentation(state);
+  render(state);
   return true;
 }
 

--- a/packages/visual/test/model.test.ts
+++ b/packages/visual/test/model.test.ts
@@ -8,6 +8,7 @@ import "./three-scene.test.js";
 import "./three-renderer.test.js";
 import "./three-controls.test.js";
 import "./presentation.test.js";
+import "./three-presentation.test.js";
 
 import {
   VisualNetworkError,

--- a/packages/visual/test/three-presentation.test.ts
+++ b/packages/visual/test/three-presentation.test.ts
@@ -1,0 +1,300 @@
+import * as THREE from "three";
+import {
+  VisualPresentationError,
+  validateVisualPresentationState,
+  type Physics3DState,
+  type Point3D,
+  type VisualLinkNetwork,
+} from "../src/index.js";
+import { createLivePhysics3D, snapshotLivePhysics3D } from "../src/live-physics3d.js";
+import {
+  buildVisualThreeSceneData,
+  createVisualThreeLiveRenderer,
+  createVisualThreeRenderer,
+  destroyVisualThreeRenderer,
+  setVisualThreeLivePaused,
+  setVisualThreePresentation,
+  updateVisualThreeRenderer,
+  type VisualThreeSceneData,
+} from "../src/three/index.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`@mts/visual V2g-B: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+type PointerProbe = {
+  readonly button: number;
+  readonly pointerId: number;
+  readonly clientX: number;
+  readonly clientY: number;
+  preventDefault(): void;
+};
+
+type FakeElement = {
+  readonly token: string;
+  parentNode?: FakeContainer | null;
+  addEventListener?: (type: string, listener: (event: PointerProbe) => void) => void;
+  removeEventListener?: (type: string, listener: (event: PointerProbe) => void) => void;
+  setPointerCapture?: (pointerId: number) => void;
+  releasePointerCapture?: (pointerId: number) => void;
+  hasPointerCapture?: (pointerId: number) => boolean;
+  dispatch?: (type: string, event: PointerProbe) => void;
+};
+
+type FakeContainer = {
+  clientWidth: number;
+  clientHeight: number;
+  readonly children: FakeElement[];
+  appendChild: (element: FakeElement) => FakeElement;
+  removeChild: (element: FakeElement) => FakeElement;
+  contains: (element: FakeElement) => boolean;
+  getBoundingClientRect: () => { width: number; height: number };
+};
+
+type SceneProbe = THREE.Scene;
+
+type SurfaceProbe = {
+  readonly domElement: FakeElement;
+  setSize(width: number, height: number, updateStyle?: boolean): void;
+  render(scene: THREE.Scene, camera: THREE.Camera): void;
+  dispose(): void;
+};
+
+function container(width = 640, height = 360): FakeContainer {
+  const children: FakeElement[] = [];
+  const result: FakeContainer = {
+    clientWidth: width,
+    clientHeight: height,
+    children,
+    appendChild(element) {
+      if (!children.includes(element)) children.push(element);
+      element.parentNode = result;
+      return element;
+    },
+    removeChild(element) {
+      const index = children.indexOf(element);
+      if (index >= 0) children.splice(index, 1);
+      element.parentNode = null;
+      return element;
+    },
+    contains: (element) => children.includes(element),
+    getBoundingClientRect: () => ({ width: result.clientWidth, height: result.clientHeight }),
+  };
+  return result;
+}
+
+function interactiveElement(token: string): FakeElement {
+  const listeners = new Map<string, Set<(event: PointerProbe) => void>>();
+  const captures = new Set<number>();
+  const element: FakeElement = {
+    token,
+    parentNode: null,
+    addEventListener(type, listener) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(listener);
+      listeners.set(type, set);
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    setPointerCapture(pointerId) { captures.add(pointerId); },
+    releasePointerCapture(pointerId) { captures.delete(pointerId); },
+    hasPointerCapture: (pointerId) => captures.has(pointerId),
+    dispatch(type, event) {
+      for (const listener of [...(listeners.get(type) ?? [])]) listener(event);
+    },
+  };
+  return element;
+}
+
+function pointer(clientX: number, clientY: number, pointerId = 7): PointerProbe {
+  return { button: 0, pointerId, clientX, clientY, preventDefault() {} };
+}
+
+function network(): VisualLinkNetwork {
+  return {
+    links: [
+      { key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] },
+      { key: "O", startKey: "O", endKey: "R", label: "ordinary" },
+    ],
+  };
+}
+
+function physicsState(): Physics3DState {
+  return {
+    positions: [
+      { key: "R", point: { x: 0, y: 0, z: 0 } },
+      { key: "O", point: { x: 2, y: 0, z: 0 } },
+    ],
+    velocities: [
+      { key: "R", vector: { x: 0, y: 0, z: 0 } },
+      { key: "O", vector: { x: 0, y: 0, z: 0 } },
+    ],
+  };
+}
+
+function sceneData(): VisualThreeSceneData {
+  return buildVisualThreeSceneData(network(), physicsState());
+}
+
+function rootOnlyScene(): VisualThreeSceneData {
+  const rootNetwork: VisualLinkNetwork = {
+    links: [{ key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] }],
+  };
+  return buildVisualThreeSceneData(rootNetwork, {
+    positions: [{ key: "R", point: { x: 0, y: 0, z: 0 } }],
+    velocities: [{ key: "R", vector: { x: 0, y: 0, z: 0 } }],
+  });
+}
+
+function findObject(scene: SceneProbe, kind: string, key: string): THREE.Object3D | undefined {
+  return scene.children.find((object) => object.userData.kind === kind && object.userData.key === key);
+}
+
+function linkObjects(scene: SceneProbe, key: string): THREE.Object3D[] {
+  return scene.children.filter((object) =>
+    object.userData.key === key && ["link-center", "link-arc", "end-arrow"].includes(String(object.userData.kind)));
+}
+
+const data = sceneData();
+validateVisualPresentationState({ links: data.nodes }, { links: [] });
+
+const host = container();
+let staticScene: SceneProbe | undefined;
+let renderCount = 0;
+const staticSurface: SurfaceProbe = {
+  domElement: { token: "static", parentNode: null },
+  setSize() {},
+  render(scene) { staticScene = scene; renderCount += 1; },
+  dispose() {},
+};
+createVisualThreeRenderer(host as never, data, {
+  nodeRadius: 0.2,
+  surfaceFactory: () => staticSurface as never,
+  resizeObserverFactory: () => ({ disconnect() {} }),
+});
+assert(staticScene !== undefined, "static renderer exposes scene");
+
+const rootCenter = findObject(staticScene, "link-center", "R") as THREE.Mesh;
+const rootArcs = staticScene.children.filter((object) => object.userData.kind === "link-arc" && object.userData.key === "R") as THREE.Line[];
+const rootArrow = findObject(staticScene, "end-arrow", "R");
+assert(rootCenter !== undefined && rootArcs.length === 2 && rootArrow !== undefined, "root has center/two arcs/END arrow");
+const rootColorBefore = (rootCenter.material as THREE.MeshBasicMaterial).color.getHex();
+const arcColorsBefore = rootArcs.map((arc) => Array.from((arc.geometry.getAttribute("color") as THREE.BufferAttribute).array));
+const renderBeforePresentation = renderCount;
+
+same(setVisualThreePresentation(host as never, {
+  links: [
+    { key: "R", visible: false, emphasis: 1.4, selected: true },
+    { key: "O", halo: { color: 0x336699, scale: 1.7, opacity: 0.4 } },
+  ],
+}), true, "mounted renderer accepts presentation state");
+same(renderCount, renderBeforePresentation + 1, "presentation setter renders exactly once");
+for (const object of linkObjects(staticScene, "R")) same(object.visible, false, "visible=false hides whole represented Link");
+same(rootCenter.scale.x, 1.4, "emphasis scales center only");
+const hiddenRootHalo = findObject(staticScene, "presentation-halo", "R") as THREE.Mesh | undefined;
+assert(hiddenRootHalo !== undefined, "selected root creates neutral presentation halo");
+same(hiddenRootHalo.visible, false, "halo follows Link visibility");
+const ordinaryHalo = findObject(staticScene, "presentation-halo", "O") as THREE.Mesh | undefined;
+assert(ordinaryHalo !== undefined, "explicit halo may exist without selected role");
+same((ordinaryHalo.material as THREE.MeshBasicMaterial).color.getHex(), 0x336699, "explicit halo color retained");
+same(ordinaryHalo.scale.x, 1.7, "explicit halo scale retained");
+same((ordinaryHalo.material as THREE.MeshBasicMaterial).opacity, 0.4, "explicit halo opacity retained");
+same((rootCenter.material as THREE.MeshBasicMaterial).color.getHex(), rootColorBefore, "presentation never recolors GREEN center");
+for (let index = 0; index < rootArcs.length; index += 1) {
+  same(
+    JSON.stringify(Array.from((rootArcs[index]!.geometry.getAttribute("color") as THREE.BufferAttribute).array)),
+    JSON.stringify(arcColorsBefore[index]),
+    "presentation never mutates RGB arc colors",
+  );
+}
+
+let haloDisposeEvents = 0;
+ordinaryHalo.geometry.addEventListener("dispose", () => { haloDisposeEvents += 1; });
+(ordinaryHalo.material as THREE.Material).addEventListener("dispose", () => { haloDisposeEvents += 1; });
+same(setVisualThreePresentation(host as never, { links: [{ key: "R", visible: true, emphasis: 1.2 }] }), true, "presentation can replace prior state");
+assert(haloDisposeEvents >= 2, "replacing presentation disposes halo resources");
+same(findObject(staticScene, "presentation-halo", "O"), undefined, "removed halo leaves scene");
+same(rootCenter.visible, true, "replacement restores root visibility");
+same(rootCenter.scale.x, 1.2, "replacement updates root emphasis");
+
+const acceptedRenderCount = renderCount;
+try {
+  setVisualThreePresentation(host as never, { links: [{ key: "missing", selected: true }] });
+  throw new Error("@mts/visual V2g-B: unknown presentation key should reject");
+} catch (error) {
+  assert(error instanceof VisualPresentationError, "unknown Three presentation key uses typed V2g-A error");
+  same(error.code, "unknown-key", "unknown Three presentation key classification");
+}
+same(renderCount, acceptedRenderCount, "rejected presentation does not render/mutate accepted state");
+same(rootCenter.scale.x, 1.2, "rejected presentation preserves previous accepted state");
+
+same(updateVisualThreeRenderer(host as never, rootOnlyScene()), true, "scene update reconciles stale presentation keys");
+assert(staticScene.children.every((object) => object.userData.key !== "O"), "removed key has no presentation residue");
+same(updateVisualThreeRenderer(host as never, data), true, "later scene update can reintroduce topology key");
+const restoredOrdinaryCenter = findObject(staticScene, "link-center", "O") as THREE.Mesh | undefined;
+assert(restoredOrdinaryCenter !== undefined, "ordinary center reintroduced");
+same(restoredOrdinaryCenter.scale.x, 1, "stale O presentation override is not transferred/revived");
+same(destroyVisualThreeRenderer(host as never), true, "static presentation renderer destroys cleanly");
+
+const liveNetwork: VisualLinkNetwork = {
+  links: [{ key: "R", startKey: "R", endKey: "R", label: "∞", tags: ["root"] }],
+};
+const liveInitialState: Physics3DState = {
+  positions: [{ key: "R", point: { x: 0, y: 0, z: 0 } }],
+  velocities: [{ key: "R", vector: { x: 0, y: 0, z: 0 } }],
+};
+const controller = createLivePhysics3D(liveNetwork, liveInitialState, { settleWindow: 1 });
+const liveHost = container(400, 300);
+const liveElement = interactiveElement("live");
+const liveSurface: SurfaceProbe = {
+  domElement: liveElement,
+  setSize() {},
+  render() {},
+  dispose() {},
+};
+const callbacks: string[] = [];
+let nextFrame = 1;
+const frames = new Map<number, (timestamp: number) => void>();
+const controls = {
+  enabled: true,
+  target: { copy: () => controls.target },
+  update() {},
+  addEventListener() {},
+  removeEventListener() {},
+  dispose() {},
+};
+createVisualThreeLiveRenderer(liveHost as never, liveNetwork, controller, {
+  nodeRadius: 0.4,
+  surfaceFactory: () => liveSurface as never,
+  resizeObserverFactory: () => ({ disconnect() {} }),
+  requestFrame(callback: (timestamp: number) => void) { const id = nextFrame++; frames.set(id, callback); return id; },
+  cancelFrame(id: number) { frames.delete(id); },
+  controlsFactory: () => controls,
+  dragThreshold: 5,
+  onActivateKey: (key: string) => { callbacks.push(key); },
+} as never);
+same(setVisualThreeLivePaused(liveHost as never, true), true, "activation fixture pauses physics RAF");
+const tickBeforeTap = snapshotLivePhysics3D(controller).tick;
+liveElement.dispatch?.("pointerdown", pointer(200, 150));
+same(callbacks.length, 0, "pointerdown alone never activates");
+liveElement.dispatch?.("pointerup", pointer(200, 150));
+same(callbacks.join(","), "R", "simple root tap activates exact VisualKey once");
+same(snapshotLivePhysics3D(controller).tick, tickBeforeTap, "tap activation never ticks physics");
+same(snapshotLivePhysics3D(controller).pinnedKeys.length, 0, "tap activation never pins physics");
+
+callbacks.length = 0;
+liveElement.dispatch?.("pointerdown", pointer(200, 150, 9));
+liveElement.dispatch?.("pointermove", pointer(220, 150, 9));
+liveElement.dispatch?.("pointermove", pointer(201, 150, 9));
+liveElement.dispatch?.("pointerup", pointer(201, 150, 9));
+same(callbacks.length, 0, "gesture that crossed drag threshold never reclassifies as click");
+
+liveElement.dispatch?.("pointerdown", pointer(200, 150, 11));
+liveElement.dispatch?.("pointercancel", pointer(200, 150, 11));
+same(callbacks.length, 0, "pointercancel never activates");
+same(destroyVisualThreeRenderer(liveHost as never), true, "activation renderer destroys cleanly");

--- a/packages/visual/test/three-presentation.test.ts
+++ b/packages/visual/test/three-presentation.test.ts
@@ -3,7 +3,6 @@ import {
   VisualPresentationError,
   validateVisualPresentationState,
   type Physics3DState,
-  type Point3D,
   type VisualLinkNetwork,
 } from "../src/index.js";
 import { createLivePhysics3D, snapshotLivePhysics3D } from "../src/live-physics3d.js";


### PR DESCRIPTION
Implements #948 in TDD RED -> GREEN form.

Current PR state is intentionally RED.

Exact base at PR creation:

```text
main = 85ffbfb62e5989ecd5977bf26b036a127cd3d826
RED head = 5cf85d1deb03b0bd8157ec6a9eae60930ec1b2f2
behind_by = 0
accepted MTS = v0.11
semantic delta = NONE
```

RED diff only:

```text
packages/visual/test/model.test.ts              +1
packages/visual/test/three-presentation.test.ts +300
production files                                unchanged
```

Expected RED failures are exactly the missing V2g-B contract:

```text
setVisualThreePresentation is not exported/implemented yet
VisualPresentationState validation still expects the old full-network key-space shape
```

The RED corpus already asserts the future behavior rather than accepting a stub:

- whole-Link visibility (center + START/END arcs + END arrow + halo);
- center-only emphasis;
- selected/default and explicit halo lifecycle;
- fixed GREEN center and RED→GREEN / GREEN→BLUE arc colors unchanged;
- fail-closed unknown keys preserve prior accepted presentation;
- stale presentation keys do not revive after scene-data replacement;
- simple tap activates exact VisualKey once without physics pin/tick;
- threshold-crossed drag never reclassifies as click;
- pointercancel never activates;
- root follows the ordinary key path.

No AST/proof/parser role model, no second Raycaster, no second physics controller, no geometry authority changes.

## Refined ChangeIntent

The issue opening plan expected additions inside the mature `three-renderer.test.ts`. Exact test-harness inspection showed that an isolated behavioral corpus is safer and avoids full-file churn. This ChangeIntent narrows that reviewed refinement without changing production scope or repository policy.

```repo-guard-yaml
change_type: feature
scope:
  - packages/visual/src/presentation.ts
  - packages/visual/src/three/renderer.ts
  - packages/visual/test/model.test.ts
  - packages/visual/test/three-presentation.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 560
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - packages/visual/test/three-presentation.test.ts
  - packages/visual/src/three/renderer.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - packages/visual/src/geometry3d.ts
  - packages/visual/src/physics3d.ts
  - packages/visual/src/live-physics3d.ts
  - packages/visual/test/three-renderer.test.ts
  - packages/visual/test/presentation.test.ts
  - repo-policy.json
  - .github/workflows/**
expected_effects:
  - make accepted VisualPresentationState directly consumable by the existing Three renderer
  - keep exact semantic RGB geometry and V2e live physics unchanged
  - reuse the existing Raycaster for click activation and drag without a second picking authority
  - preserve root-neutral behavior
  - introduce no AST, ordinary graph, parser role, or prover role ontology
  - leave text-label rendering for a separate upstream V2g-C slice before downstream P2
  - make no accepted MTS semantic delta
```

Do not merge in RED state. After machine RED evidence is recorded, production implementation will be added on this same branch and the full exact-head gates rerun.

Closes #948