### PR TITLE
[Syntax/S0] Executable SyntaxAset occurrence topology contract

### DIFF
--- a/ts/src/syntax-aset-contract.ts
+++ b/ts/src/syntax-aset-contract.ts
@@ -1,0 +1,223 @@
+import {
+  ExactSequenceError,
+  materializeExactSequence,
+  readExactSequence,
+} from "./exact-sequence.js";
+import {
+  MemoryError,
+  type LinkHandle,
+  type ReadMemory,
+  type WriteMemory,
+} from "./memory.js";
+
+export type SyntaxAsetContractErrorCode =
+  | "invalid-aset"
+  | "invalid-field-sequence"
+  | "invalid-occurrence-sequence"
+  | "invalid-child-occurrence"
+  | "root-not-final";
+
+export class SyntaxAsetContractError extends Error {
+  override readonly name = "SyntaxAsetContractError";
+
+  constructor(readonly code: SyntaxAsetContractErrorCode) {
+    super(code);
+  }
+}
+
+export interface SyntaxAsetVocabulary {
+  readonly tag: LinkHandle;
+  readonly childRoles: readonly LinkHandle[];
+}
+
+export interface SyntaxAsetField {
+  readonly role: LinkHandle;
+  readonly value: LinkHandle;
+}
+
+export interface SyntaxAsetOccurrence {
+  readonly occurrence: LinkHandle;
+  readonly kind: LinkHandle;
+  readonly fields: readonly SyntaxAsetField[];
+}
+
+export interface SyntaxAsetRead {
+  readonly root: LinkHandle;
+  readonly occurrences: readonly SyntaxAsetOccurrence[];
+}
+
+function contractError(code: SyntaxAsetContractErrorCode): never {
+  throw new SyntaxAsetContractError(code);
+}
+
+function isChildRole(
+  vocabulary: SyntaxAsetVocabulary,
+  role: LinkHandle,
+): boolean {
+  return vocabulary.childRoles.some((candidate) => candidate === role);
+}
+
+function readSequenceOrReject(
+  memory: ReadMemory,
+  final: LinkHandle,
+  code: "invalid-field-sequence" | "invalid-occurrence-sequence",
+) {
+  try {
+    return readExactSequence(memory, final);
+  } catch (error) {
+    if (error instanceof ExactSequenceError || error instanceof MemoryError) {
+      return contractError(code);
+    }
+    throw error;
+  }
+}
+
+export class SyntaxAsetBuilder {
+  private occurrenceOrder: LinkHandle;
+  private readonly occurrences = new Set<LinkHandle>();
+  private finished = false;
+
+  constructor(
+    private readonly memory: WriteMemory,
+    private readonly vocabulary: SyntaxAsetVocabulary,
+  ) {
+    this.occurrenceOrder = memory.root;
+  }
+
+  addOccurrence(
+    kind: LinkHandle,
+    fields: readonly SyntaxAsetField[],
+  ): LinkHandle {
+    if (this.finished) {
+      return contractError("invalid-aset");
+    }
+
+    const fieldLinks = fields.map(({ role, value }) => {
+      if (isChildRole(this.vocabulary, role) && !this.occurrences.has(value)) {
+        return contractError("invalid-child-occurrence");
+      }
+      return this.memory.ensure(role, value);
+    });
+
+    const fieldSequence = materializeExactSequence(this.memory, fieldLinks);
+    const descriptor = this.memory.ensure(kind, fieldSequence);
+    const payload = this.memory.ensure(this.occurrenceOrder, descriptor);
+    const occurrence = this.memory.ensureStartSelfClosed(payload);
+
+    this.occurrenceOrder = occurrence;
+    this.occurrences.add(occurrence);
+    return occurrence;
+  }
+
+  finish(root: LinkHandle): LinkHandle {
+    if (
+      this.finished ||
+      this.occurrenceOrder === this.memory.root ||
+      root !== this.occurrenceOrder
+    ) {
+      return contractError("root-not-final");
+    }
+
+    this.finished = true;
+    const header = this.memory.ensure(this.occurrenceOrder, root);
+    return this.memory.ensure(this.vocabulary.tag, header);
+  }
+}
+
+export function readSyntaxAset(
+  memory: ReadMemory,
+  aset: LinkHandle,
+  vocabulary: SyntaxAsetVocabulary,
+): SyntaxAsetRead {
+  let occurrenceOrder: LinkHandle;
+  let declaredRoot: LinkHandle;
+
+  try {
+    const wrapper = memory.poles(aset);
+    if (wrapper.start !== vocabulary.tag) {
+      return contractError("invalid-aset");
+    }
+    const header = memory.poles(wrapper.end);
+    occurrenceOrder = header.start;
+    declaredRoot = header.end;
+  } catch (error) {
+    if (error instanceof MemoryError) {
+      return contractError("invalid-aset");
+    }
+    throw error;
+  }
+
+  const sequence = readSequenceOrReject(
+    memory,
+    occurrenceOrder,
+    "invalid-occurrence-sequence",
+  );
+
+  const finalOccurrence = sequence.cells.at(-1);
+  if (finalOccurrence === undefined || declaredRoot !== finalOccurrence) {
+    return contractError("root-not-final");
+  }
+
+  const priorOccurrences = new Set<LinkHandle>();
+  const occurrences: SyntaxAsetOccurrence[] = [];
+
+  for (let index = 0; index < sequence.values.length; index += 1) {
+    const descriptor = sequence.values[index];
+    const occurrence = sequence.cells[index];
+    if (descriptor === undefined || occurrence === undefined) {
+      return contractError("invalid-occurrence-sequence");
+    }
+
+    let kind: LinkHandle;
+    let fieldSequence: LinkHandle;
+    try {
+      const descriptorPoles = memory.poles(descriptor);
+      kind = descriptorPoles.start;
+      fieldSequence = descriptorPoles.end;
+    } catch (error) {
+      if (error instanceof MemoryError) {
+        return contractError("invalid-field-sequence");
+      }
+      throw error;
+    }
+
+    const fieldLinks = readSequenceOrReject(
+      memory,
+      fieldSequence,
+      "invalid-field-sequence",
+    ).values;
+
+    const fields: SyntaxAsetField[] = [];
+    for (const fieldLink of fieldLinks) {
+      let role: LinkHandle;
+      let value: LinkHandle;
+      try {
+        const poles = memory.poles(fieldLink);
+        role = poles.start;
+        value = poles.end;
+      } catch (error) {
+        if (error instanceof MemoryError) {
+          return contractError("invalid-field-sequence");
+        }
+        throw error;
+      }
+
+      if (isChildRole(vocabulary, role) && !priorOccurrences.has(value)) {
+        return contractError("invalid-child-occurrence");
+      }
+      fields.push(Object.freeze({ role, value }));
+    }
+
+    occurrences.push(Object.freeze({
+      occurrence,
+      kind,
+      fields: Object.freeze(fields),
+    }));
+    priorOccurrences.add(occurrence);
+  }
+
+  return Object.freeze({
+    root: declaredRoot,
+    occurrences: Object.freeze(occurrences),
+  });
+}

--- a/ts/test/syntax-aset-contract.test.ts
+++ b/ts/test/syntax-aset-contract.test.ts
@@ -25,7 +25,8 @@ function rejectContract(effect: () => unknown, code: SyntaxAsetContractError["co
     effect();
   } catch (error) {
     assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
-    same(error.code, code, "SyntaxAset error code");
+    const contractError = error as SyntaxAsetContractError;
+    same(contractError.code, code, "SyntaxAset error code");
     return;
   }
   throw new Error(`expected SyntaxAset rejection: ${code}`);

--- a/ts/test/syntax-aset-contract.test.ts
+++ b/ts/test/syntax-aset-contract.test.ts
@@ -1,0 +1,286 @@
+import { materializeExactSequence } from "../src/exact-sequence.js";
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  SyntaxAsetBuilder,
+  SyntaxAsetContractError,
+  readSyntaxAset,
+  type SyntaxAsetVocabulary,
+} from "../src/syntax-aset-contract.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function rejectContract(effect: () => unknown, code: SyntaxAsetContractError["code"]): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
+    same(error.code, code, "SyntaxAset error code");
+    return;
+  }
+  throw new Error(`expected SyntaxAset rejection: ${code}`);
+}
+
+function refFactory(memory: Memory): () => LinkHandle {
+  const seed = memory.ensureEndSelfClosed(memory.root);
+  let tag = memory.ensureStartSelfClosed(memory.root);
+  return () => {
+    tag = memory.ensureStartSelfClosed(tag);
+    return memory.ensure(seed, tag);
+  };
+}
+
+interface Fixture {
+  readonly memory: Memory;
+  readonly vocabulary: SyntaxAsetVocabulary;
+  readonly leafKind: LinkHandle;
+  readonly linkKind: LinkHandle;
+  readonly definitionKind: LinkHandle;
+  readonly sequenceKind: LinkHandle;
+  readonly carrierRole: LinkHandle;
+  readonly startRole: LinkHandle;
+  readonly endRole: LinkHandle;
+  readonly nameRole: LinkHandle;
+  readonly bodyRole: LinkHandle;
+  readonly itemRole: LinkHandle;
+  readonly carrierX: LinkHandle;
+  readonly carrierName: LinkHandle;
+}
+
+function fixture(): Fixture {
+  const memory = new Memory();
+  const next = refFactory(memory);
+  const syntaxTag = next();
+  const carrierRole = next();
+  const startRole = next();
+  const endRole = next();
+  const nameRole = next();
+  const bodyRole = next();
+  const itemRole = next();
+  const vocabulary: SyntaxAsetVocabulary = Object.freeze({
+    tag: syntaxTag,
+    childRoles: Object.freeze([startRole, endRole, bodyRole, itemRole]),
+  });
+  return Object.freeze({
+    memory,
+    vocabulary,
+    leafKind: next(),
+    linkKind: next(),
+    definitionKind: next(),
+    sequenceKind: next(),
+    carrierRole,
+    startRole,
+    endRole,
+    nameRole,
+    bodyRole,
+    itemRole,
+    carrierX: next(),
+    carrierName: next(),
+  });
+}
+
+class ReadProbe implements ReadMemory {
+  polesCalls = 0;
+
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles {
+    this.polesCalls += 1;
+    return this.source.poles(link);
+  }
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined { return this.source.find(start, end); }
+  outgoing(start: LinkHandle): readonly LinkHandle[] { return this.source.outgoing(start); }
+  incoming(end: LinkHandle): readonly LinkHandle[] { return this.source.incoming(end); }
+}
+
+function appendOccurrenceCell(memory: Memory, previous: LinkHandle, descriptor: LinkHandle): LinkHandle {
+  return memory.ensureStartSelfClosed(memory.ensure(previous, descriptor));
+}
+
+function wrapSyntaxAset(
+  memory: Memory,
+  tag: LinkHandle,
+  occurrenceOrder: LinkHandle,
+  rootOccurrence: LinkHandle,
+): LinkHandle {
+  return memory.ensure(tag, memory.ensure(occurrenceOrder, rootOccurrence));
+}
+
+// Equal syntax descriptors remain distinct occurrences because occurrence identity
+// is the structural ExactSequence Cell, never descriptor identity or host index.
+{
+  const f = fixture();
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const first = builder.addOccurrence(f.leafKind, [
+    { role: f.carrierRole, value: f.carrierX },
+  ]);
+  const second = builder.addOccurrence(f.leafKind, [
+    { role: f.carrierRole, value: f.carrierX },
+  ]);
+  assert(first !== second, "equal-looking leaves must have distinct occurrence Links");
+
+  const pair = builder.addOccurrence(f.linkKind, [
+    { role: f.startRole, value: first },
+    { role: f.endRole, value: second },
+  ]);
+  const aset = builder.finish(pair);
+  const read = readSyntaxAset(f.memory, aset, f.vocabulary);
+  same(read.root, pair, "declared root is the final occurrence");
+  same(read.occurrences.length, 3, "three occurrences are preserved");
+  same(read.occurrences[0]?.occurrence, first, "first duplicate occurrence retained");
+  same(read.occurrences[1]?.occurrence, second, "second duplicate occurrence retained");
+  same(read.occurrences[2]?.fields[0]?.value, first, "Link start role targets first occurrence");
+  same(read.occurrences[2]?.fields[1]?.value, second, "Link end role targets second occurrence");
+}
+
+// Nested syntax and repeated ordered fields use explicit structural roles.
+{
+  const f = fixture();
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const value = builder.addOccurrence(f.leafKind, [
+    { role: f.carrierRole, value: f.carrierX },
+  ]);
+  const sequence = builder.addOccurrence(f.sequenceKind, [
+    { role: f.itemRole, value },
+    { role: f.itemRole, value },
+  ]);
+  const definition = builder.addOccurrence(f.definitionKind, [
+    { role: f.nameRole, value: f.carrierName },
+    { role: f.bodyRole, value: sequence },
+  ]);
+  const aset = builder.finish(definition);
+  const read = readSyntaxAset(f.memory, aset, f.vocabulary);
+  const sequenceRead = read.occurrences[1];
+  const definitionRead = read.occurrences[2];
+  assert(sequenceRead !== undefined && definitionRead !== undefined, "nested occurrences exist");
+  same(sequenceRead.fields.length, 2, "repeated sequence positions remain explicit");
+  same(sequenceRead.fields[0]?.role, f.itemRole, "first item role retained");
+  same(sequenceRead.fields[1]?.role, f.itemRole, "second item role retained");
+  same(sequenceRead.fields[0]?.value, value, "first repeated value retained");
+  same(sequenceRead.fields[1]?.value, value, "second repeated value retained");
+  same(definitionRead.fields[0]?.role, f.nameRole, "definition name role is structural");
+  same(definitionRead.fields[0]?.value, f.carrierName, "definition name carrier retained");
+  same(definitionRead.fields[1]?.role, f.bodyRole, "definition body role is structural");
+  same(definitionRead.fields[1]?.value, sequence, "definition body targets occurrence");
+}
+
+// Provenance is external metadata: changing it cannot change SyntaxAset topology.
+{
+  const f = fixture();
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const leaf = builder.addOccurrence(f.leafKind, [
+    { role: f.carrierRole, value: f.carrierX },
+  ]);
+  const aset = builder.finish(leaf);
+  const provenanceA = new Map([[leaf, Object.freeze({ source: "a.mts", start: 0, end: 1 })]]);
+  const provenanceB = new Map([[leaf, Object.freeze({ source: "b.mts", start: 90, end: 120 })]]);
+  assert(provenanceA.get(leaf)?.source !== provenanceB.get(leaf)?.source, "fixture provenance differs");
+  same(readSyntaxAset(f.memory, aset, f.vocabulary).root, leaf, "topology ignores provenance A");
+  same(readSyntaxAset(f.memory, aset, f.vocabulary).root, leaf, "topology ignores provenance B");
+}
+
+// Reading is deterministic and read-only through ReadMemory only.
+{
+  const f = fixture();
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const leaf = builder.addOccurrence(f.leafKind, []);
+  const aset = builder.finish(leaf);
+  const before = f.memory.linkCount;
+  const probe = new ReadProbe(f.memory);
+  const first = readSyntaxAset(probe, aset, f.vocabulary);
+  const second = readSyntaxAset(probe, aset, f.vocabulary);
+  same(f.memory.linkCount, before, "SyntaxAset read must not materialize Links");
+  same(first.root, second.root, "repeat read root deterministic");
+  same(first.occurrences.length, second.occurrences.length, "repeat read occurrence count deterministic");
+  assert(probe.polesCalls > 0, "reader inspects structural Links");
+}
+
+// A child-bearing role may reference only an already-issued occurrence in this
+// builder's post-order sequence; a foreign occurrence cannot become local syntax.
+{
+  const f = fixture();
+  const otherBuilder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const foreign = otherBuilder.addOccurrence(f.leafKind, []);
+  otherBuilder.finish(foreign);
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  rejectContract(
+    () => builder.addOccurrence(f.linkKind, [{ role: f.startRole, value: foreign }]),
+    "invalid-child-occurrence",
+  );
+}
+
+// Reader rejects a child reference that is not a prior occurrence of this Aset.
+{
+  const f = fixture();
+  const foreignBuilder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const foreign = foreignBuilder.addOccurrence(f.leafKind, []);
+  foreignBuilder.finish(foreign);
+
+  const field = f.memory.ensure(f.startRole, foreign);
+  const fieldSequence = materializeExactSequence(f.memory, [field]);
+  const descriptor = f.memory.ensure(f.linkKind, fieldSequence);
+  const localOccurrence = appendOccurrenceCell(f.memory, f.memory.root, descriptor);
+  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, localOccurrence, localOccurrence);
+  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-child-occurrence");
+}
+
+// Exact-sequence shape is mandatory for descriptor fields.
+{
+  const f = fixture();
+  const notAFieldSequence = f.memory.ensure(f.leafKind, f.carrierX);
+  const descriptor = f.memory.ensure(f.leafKind, notAFieldSequence);
+  const occurrence = appendOccurrenceCell(f.memory, f.memory.root, descriptor);
+  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, occurrence, occurrence);
+  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-field-sequence");
+}
+
+// Exact-sequence shape is mandatory for occurrence order.
+{
+  const f = fixture();
+  const notAnOccurrenceSequence = f.memory.ensure(f.leafKind, f.carrierX);
+  const fakeRoot = f.memory.ensureStartSelfClosed(f.carrierX);
+  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, notAnOccurrenceSequence, fakeRoot);
+  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-occurrence-sequence");
+}
+
+// The explicit root in the header must be the final structural occurrence Cell.
+{
+  const f = fixture();
+  const descriptor = f.memory.ensure(f.leafKind, materializeExactSequence(f.memory, []));
+  const first = appendOccurrenceCell(f.memory, f.memory.root, descriptor);
+  const second = appendOccurrenceCell(f.memory, first, descriptor);
+  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, second, first);
+  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "root-not-final");
+}
+
+// Syntax tag and Link ownership are checked structurally, not by scalar IDs.
+{
+  const f = fixture();
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const leaf = builder.addOccurrence(f.leafKind, []);
+  const aset = builder.finish(leaf);
+  const wrongVocabulary: SyntaxAsetVocabulary = Object.freeze({
+    tag: f.carrierX,
+    childRoles: f.vocabulary.childRoles,
+  });
+  rejectContract(() => readSyntaxAset(f.memory, aset, wrongVocabulary), "invalid-aset");
+
+  const foreignMemory = new Memory();
+  rejectContract(() => readSyntaxAset(f.memory, foreignMemory.root, f.vocabulary), "invalid-aset");
+  rejectContract(
+    () => readSyntaxAset(f.memory, 7 as unknown as LinkHandle, f.vocabulary),
+    "invalid-aset",
+  );
+}


### PR DESCRIPTION
Closes #952
Parent architecture roadmap: #944
Post-v0.11 roadmap: #657
Downstream A0 inventory: https://github.com/netkeep80/aprover/issues/192

## Intent

Establish the first executable, falsifiable **internal** SyntaxAset topology over existing `Memory` Links and `ExactSequence`, without committing to a public package/API and without changing accepted MTS semantics.

The S0 representation under test is:

```text
Descriptor = Kind ⟼ FieldSequence
Field      = Role ⟼ Value
Occurrence = structural Cell in post-order OccurrenceOrder
Header     = OccurrenceOrder ⟼ RootOccurrence
SyntaxAset = SyntaxTag ⟼ Header
```

Occurrence identity is the structural sequence Cell itself. No UUID, allocation index, VisualKey, source offset, AST object identity, or host array position is semantic/syntax identity.

## TDD evidence

### RED

Initial test-only head:

```text
1fb50c8237e672f0ff5eadc221eefb0468dce66c
```

CI #3701 / run `32723234348` failed on the intentionally absent production module, but also exposed one test-helper narrowing diagnostic. The helper was corrected without adding production code.

Clean RED head:

```text
65becf418648e2606a3f941df3290930fe2afa00
```

CI #3703 / run `32724062959` failed with exactly one TypeScript diagnostic:

```text
TS2307: Cannot find module '../src/syntax-aset-contract.js'
```

Production `ts/src/syntax-aset-contract.ts` was still absent on that head.

### GREEN

Production witness added only after clean RED.

Exact GREEN head:

```text
7f2f3fc0aed321225dd35089418476cdccb44335
```

CI #3705 / run `32724261869` = SUCCESS, including:

```text
npm --prefix ts run check
renderer-neutral visual package checks
Contract Observatory checks
no-python
validate-docs
validate-structure
protect-readonly-files
```

Draft-state repo-guard #828 / run `32724261837` is skipped by design. A new blocking ready-state repo-guard on the same exact head is required before merge.

## Executable contract established

The implementation proves:

- equal-looking descriptors can be distinct syntax occurrences because occurrence identity is the ExactSequence Cell;
- operator/binding/sequence roles are explicit `Role ⟼ Value` Links;
- child-bearing roles can refer only to already-issued occurrences of the same post-order SyntaxAset;
- occurrence and field order must be canonical ExactSequence topology;
- the explicitly declared root must be the final occurrence;
- reader is deterministic and read-only through `ReadMemory`;
- foreign/forged handles and malformed topology fail closed;
- source provenance is deliberately external metadata and cannot affect syntax topology.

## Exact scope on GREEN head

```text
ts/src/syntax-aset-contract.ts       +223/-0
ts/test/syntax-aset-contract.test.ts +287/-0
TOTAL                                 +510/-0
changed files                         2
behind_by                             0
```

No changes to:

```text
ts/src/public.ts
package manifests/lock
contracts/**
cutover/**
packages/**
web/**
.github/**
repo-policy.json
docs/**
```

## Architecture boundary

S0 is deliberately non-public:

```text
NO @mts/syntax package yet
NO public.ts export
NO parser cutover
NO AST encoder yet
NO semantic lowering
NO accepted semantic delta
NO v0.12 candidate
NO visual/proof dependency
```

The reusable public/package boundary is deferred to S1 after this executable S0 topology is accepted. S2 can then use the existing AST only as a temporary AST -> SyntaxAset migration oracle with an explicit deletion criterion.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/syntax-aset-contract.ts
  - ts/test/syntax-aset-contract.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 520
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/syntax-aset-contract.ts
  - ts/test/syntax-aset-contract.test.ts
must_not_touch:
  - ts/src/public.ts
  - ts/package.json
  - ts/package-lock.json
  - contracts/**
  - cutover/**
  - packages/**
  - web/**
  - repo-policy.json
  - .github/**
  - README.md
  - docs/**
expected_effects:
  - "establish a falsifiable internal SyntaxAset topology over existing Links and ExactSequence"
  - "represent syntax occurrence identity structurally without UUID host index visual key or source offset"
  - "make child operator binding and sequence roles explicit structural Links"
  - "keep source provenance outside syntax and semantic identity"
  - "reject malformed cross-aset or non-postorder occurrence references"
  - "make no public package commitment and no accepted semantic delta"
```

Final acceptance requires full exact-head CI, blocking ready-state repo-guard, `behind_by=0`, `mergeable=true`, `draft=false`, stable exact head, reviews/threads/comments audit, exact two-file scope, and merge only with `expected_head_sha`.