### PR TITLE
[Proof transport/R3] Portable theorem-reuse transport

### DIFF
--- a/ts/consumer/package-consumer.ts
+++ b/ts/consumer/package-consumer.ts
@@ -1,21 +1,29 @@
 import {
   Memory,
   PORTABLE_MTS_SEMANTIC_BASE,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA,
   PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
   PORTABLE_STRUCTURAL_THEORY_SCHEMA,
+  computePortableStructuralDerivationWithTheoremsContentDigest,
   computePortableStructuralTheoryRevision,
+  createPortableStructuralDerivationWithTheoremsProvenanceClaim,
   ensureRootBasis,
+  exportPortableStructuralDerivationWithTheorems,
   exportPortableStructuralTheory,
   replayPortableStructuralDerivation,
   replayPortableStructuralDerivationWithAssumptions,
+  replayPortableStructuralDerivationWithTheorems,
+  replayPortableStructuralProof,
   replayPortableStructuralTheory,
   replayStructuralDerivation,
   replayStructuralDerivationWithAssumptions,
   replayStructuralScopedDerivation,
+  verifyPortableStructuralDerivationWithTheoremsProvenanceClaim,
   verifyPortableStructuralProofTheoryRevision,
   type LinkHandle,
   type PortableStructuralDerivationReplayResult,
   type PortableStructuralDerivationWithAssumptionsReplayResult,
+  type PortableStructuralDerivationWithTheoremsReplayResult,
   type PortableStructuralTheoryArtifact,
   type PortableStructuralTheoryReplayResult,
   type PortableStructuralTheoryRevision,
@@ -41,6 +49,17 @@ const portableAssumptionReplay: (
   input: unknown,
 ) => PortableStructuralDerivationWithAssumptionsReplayResult =
   replayPortableStructuralDerivationWithAssumptions;
+const theoremSchema: "mts-portable-structural-derivation-with-theorems/v0.1" =
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA;
+const portableTheoremReplay: (
+  input: unknown,
+) => PortableStructuralDerivationWithTheoremsReplayResult =
+  replayPortableStructuralDerivationWithTheorems;
+const portableTheoremExport = exportPortableStructuralDerivationWithTheorems;
+const portableProofReplay = replayPortableStructuralProof;
+const portableTheoremDigest = computePortableStructuralDerivationWithTheoremsContentDigest;
+const portableTheoremProvenance = createPortableStructuralDerivationWithTheoremsProvenanceClaim;
+const verifyPortableTheoremProvenance = verifyPortableStructuralDerivationWithTheoremsProvenanceClaim;
 
 // Exact Theory selection is separately package-root consumable and remains
 // identity/provenance evidence rather than a substitute for proof replay.
@@ -60,6 +79,13 @@ void [
   semanticBase,
   portableReplay,
   portableAssumptionReplay,
+  theoremSchema,
+  portableTheoremReplay,
+  portableTheoremExport,
+  portableProofReplay,
+  portableTheoremDigest,
+  portableTheoremProvenance,
+  verifyPortableTheoremProvenance,
   theoryArtifact,
   theoryReplay,
   theoryRevision,

--- a/ts/src/portable-derivation-digest.ts
+++ b/ts/src/portable-derivation-digest.ts
@@ -2,11 +2,16 @@ import {
   canonicalPortableStructuralDerivationV02Json,
   canonicalPortableStructuralDerivationWithAssumptionsV01Json,
 } from "./portable-derivation.js";
+import {
+  canonicalPortableStructuralDerivationWithTheoremsV01Json,
+} from "./portable-proof-replay.js";
 
 export const PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME =
   "mts-portable-structural-derivation-content/sha-256/v0.1" as const;
 export const PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME =
   "mts-portable-structural-derivation-with-assumptions-content/sha-256/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME =
+  "mts-portable-structural-derivation-with-theorems-content/sha-256/v0.1" as const;
 
 export interface PortableStructuralDerivationContentDigest {
   readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME;
@@ -15,6 +20,11 @@ export interface PortableStructuralDerivationContentDigest {
 
 export interface PortableStructuralDerivationWithAssumptionsContentDigest {
   readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME;
+  readonly value: string;
+}
+
+export interface PortableStructuralDerivationWithTheoremsContentDigest {
+  readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME;
   readonly value: string;
 }
 
@@ -50,6 +60,19 @@ export async function computePortableStructuralDerivationWithAssumptionsContentD
     scheme: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
     value: await digestCanonicalJson(
       PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
+      canonicalJson,
+    ),
+  });
+}
+
+export async function computePortableStructuralDerivationWithTheoremsContentDigest(
+  input: unknown,
+): Promise<PortableStructuralDerivationWithTheoremsContentDigest> {
+  const canonicalJson = canonicalPortableStructuralDerivationWithTheoremsV01Json(input);
+  return Object.freeze({
+    scheme: PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME,
+    value: await digestCanonicalJson(
+      PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME,
       canonicalJson,
     ),
   });

--- a/ts/src/portable-derivation-provenance.ts
+++ b/ts/src/portable-derivation-provenance.ts
@@ -1,10 +1,13 @@
 import {
   PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME,
   computePortableStructuralDerivationContentDigest,
   computePortableStructuralDerivationWithAssumptionsContentDigest,
+  computePortableStructuralDerivationWithTheoremsContentDigest,
   type PortableStructuralDerivationContentDigest,
   type PortableStructuralDerivationWithAssumptionsContentDigest,
+  type PortableStructuralDerivationWithTheoremsContentDigest,
 } from "./portable-derivation-digest.js";
 
 export const PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA =
@@ -15,6 +18,10 @@ export const PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA =
   "mts-portable-structural-derivation-with-assumptions-provenance/v0.1" as const;
 export const PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME =
   "mts-portable-structural-derivation-with-assumptions-provenance/sha-256/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA =
+  "mts-portable-structural-derivation-with-theorems-provenance/v0.1" as const;
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_DIGEST_SCHEME =
+  "mts-portable-structural-derivation-with-theorems-provenance/sha-256/v0.1" as const;
 
 export interface PortableStructuralDerivationSourceProvenance {
   readonly locator: string;
@@ -51,6 +58,18 @@ export interface PortableStructuralDerivationWithAssumptionsProvenanceDigest {
   readonly value: string;
 }
 
+export interface PortableStructuralDerivationWithTheoremsProvenanceClaim {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA;
+  readonly contentDigest: PortableStructuralDerivationWithTheoremsContentDigest;
+  readonly source: PortableStructuralDerivationSourceProvenance;
+  readonly producer: PortableStructuralDerivationProducerProvenance;
+}
+
+export interface PortableStructuralDerivationWithTheoremsProvenanceDigest {
+  readonly scheme: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_DIGEST_SCHEME;
+  readonly value: string;
+}
+
 export type PortableStructuralDerivationProvenanceErrorCode =
   | "invalid-envelope"
   | "unsupported-schema"
@@ -71,9 +90,7 @@ function fail(code: PortableStructuralDerivationProvenanceErrorCode): never {
 }
 
 function record(value: unknown): Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    fail("invalid-envelope");
-  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) fail("invalid-envelope");
   return value as Record<string, unknown>;
 }
 
@@ -81,50 +98,26 @@ function exactRecord(value: unknown, keys: readonly string[]): Record<string, un
   const candidate = record(value);
   const actual = Object.keys(candidate).sort();
   const expected = [...keys].sort();
-  if (
-    actual.length !== expected.length ||
-    actual.some((key, index) => key !== expected[index])
-  ) {
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
     fail("invalid-envelope");
   }
   return candidate;
 }
 
 function exactText(value: unknown): string {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    fail("invalid-provenance-string");
-  }
+  if (typeof value !== "string" || value.trim().length === 0) fail("invalid-provenance-string");
   return value;
 }
 
-function parseContentDigest(value: unknown): PortableStructuralDerivationContentDigest {
-  const digest = exactRecord(value, ["scheme", "value"]);
-  if (digest.scheme !== PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME) {
-    fail("invalid-content-digest");
-  }
-  if (typeof digest.value !== "string" || !/^[0-9a-f]{64}$/.test(digest.value)) {
-    fail("invalid-content-digest");
-  }
-  return Object.freeze({
-    scheme: PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
-    value: digest.value,
-  });
-}
-
-function parseContentDigestWithAssumptions(
+function parseContentDigest<T extends string>(
   value: unknown,
-): PortableStructuralDerivationWithAssumptionsContentDigest {
+  scheme: T,
+): Readonly<{ scheme: T; value: string }> {
   const digest = exactRecord(value, ["scheme", "value"]);
-  if (digest.scheme !== PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME) {
+  if (digest.scheme !== scheme || typeof digest.value !== "string" || !/^[0-9a-f]{64}$/.test(digest.value)) {
     fail("invalid-content-digest");
   }
-  if (typeof digest.value !== "string" || !/^[0-9a-f]{64}$/.test(digest.value)) {
-    fail("invalid-content-digest");
-  }
-  return Object.freeze({
-    scheme: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
-    value: digest.value,
-  });
+  return Object.freeze({ scheme, value: digest.value });
 }
 
 function parseSource(value: unknown): PortableStructuralDerivationSourceProvenance {
@@ -138,20 +131,15 @@ function parseSource(value: unknown): PortableStructuralDerivationSourceProvenan
 
 function parseProducer(value: unknown): PortableStructuralDerivationProducerProvenance {
   const producer = exactRecord(value, ["id", "version"]);
-  return Object.freeze({
-    id: exactText(producer.id),
-    version: exactText(producer.version),
-  });
+  return Object.freeze({ id: exactText(producer.id), version: exactText(producer.version) });
 }
 
 function parseClaim(value: unknown): PortableStructuralDerivationProvenanceClaim {
   const claim = exactRecord(value, ["schema", "contentDigest", "source", "producer"]);
-  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA) {
-    fail("unsupported-schema");
-  }
+  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA) fail("unsupported-schema");
   return Object.freeze({
     schema: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
-    contentDigest: parseContentDigest(claim.contentDigest),
+    contentDigest: parseContentDigest(claim.contentDigest, PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME),
     source: parseSource(claim.source),
     producer: parseProducer(claim.producer),
   });
@@ -161,20 +149,35 @@ function parseClaimWithAssumptions(
   value: unknown,
 ): PortableStructuralDerivationWithAssumptionsProvenanceClaim {
   const claim = exactRecord(value, ["schema", "contentDigest", "source", "producer"]);
-  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA) {
-    fail("unsupported-schema");
-  }
+  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA) fail("unsupported-schema");
   return Object.freeze({
     schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
-    contentDigest: parseContentDigestWithAssumptions(claim.contentDigest),
+    contentDigest: parseContentDigest(
+      claim.contentDigest,
+      PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
+    ),
     source: parseSource(claim.source),
     producer: parseProducer(claim.producer),
   });
 }
 
-export function canonicalPortableStructuralDerivationProvenanceClaimJson(
-  input: unknown,
-): string {
+function parseClaimWithTheorems(
+  value: unknown,
+): PortableStructuralDerivationWithTheoremsProvenanceClaim {
+  const claim = exactRecord(value, ["schema", "contentDigest", "source", "producer"]);
+  if (claim.schema !== PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA) fail("unsupported-schema");
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA,
+    contentDigest: parseContentDigest(
+      claim.contentDigest,
+      PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME,
+    ),
+    source: parseSource(claim.source),
+    producer: parseProducer(claim.producer),
+  });
+}
+
+export function canonicalPortableStructuralDerivationProvenanceClaimJson(input: unknown): string {
   return JSON.stringify(parseClaim(input));
 }
 
@@ -184,15 +187,20 @@ export function canonicalPortableStructuralDerivationWithAssumptionsProvenanceCl
   return JSON.stringify(parseClaimWithAssumptions(input));
 }
 
+export function canonicalPortableStructuralDerivationWithTheoremsProvenanceClaimJson(
+  input: unknown,
+): string {
+  return JSON.stringify(parseClaimWithTheorems(input));
+}
+
 export async function createPortableStructuralDerivationProvenanceClaim(
   artifact: unknown,
   source: PortableStructuralDerivationSourceProvenance,
   producer: PortableStructuralDerivationProducerProvenance,
 ): Promise<PortableStructuralDerivationProvenanceClaim> {
-  const contentDigest = await computePortableStructuralDerivationContentDigest(artifact);
   return Object.freeze({
     schema: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
-    contentDigest,
+    contentDigest: await computePortableStructuralDerivationContentDigest(artifact),
     source: parseSource(source),
     producer: parseProducer(producer),
   });
@@ -203,10 +211,22 @@ export async function createPortableStructuralDerivationWithAssumptionsProvenanc
   source: PortableStructuralDerivationSourceProvenance,
   producer: PortableStructuralDerivationProducerProvenance,
 ): Promise<PortableStructuralDerivationWithAssumptionsProvenanceClaim> {
-  const contentDigest = await computePortableStructuralDerivationWithAssumptionsContentDigest(artifact);
   return Object.freeze({
     schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
-    contentDigest,
+    contentDigest: await computePortableStructuralDerivationWithAssumptionsContentDigest(artifact),
+    source: parseSource(source),
+    producer: parseProducer(producer),
+  });
+}
+
+export async function createPortableStructuralDerivationWithTheoremsProvenanceClaim(
+  artifact: unknown,
+  source: PortableStructuralDerivationSourceProvenance,
+  producer: PortableStructuralDerivationProducerProvenance,
+): Promise<PortableStructuralDerivationWithTheoremsProvenanceClaim> {
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA,
+    contentDigest: await computePortableStructuralDerivationWithTheoremsContentDigest(artifact),
     source: parseSource(source),
     producer: parseProducer(producer),
   });
@@ -216,28 +236,42 @@ function lowercaseHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+async function provenanceDigest<T extends string>(
+  scheme: T,
+  canonicalJson: string,
+): Promise<Readonly<{ scheme: T; value: string }>> {
+  const raw = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${scheme}\n${canonicalJson}`),
+  );
+  return Object.freeze({ scheme, value: lowercaseHex(new Uint8Array(raw)) });
+}
+
 export async function computePortableStructuralDerivationProvenanceDigest(
   input: unknown,
 ): Promise<PortableStructuralDerivationProvenanceDigest> {
-  const canonicalJson = canonicalPortableStructuralDerivationProvenanceClaimJson(input);
-  const preimage = `${PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME}\n${canonicalJson}`;
-  const raw = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(preimage));
-  return Object.freeze({
-    scheme: PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
-    value: lowercaseHex(new Uint8Array(raw)),
-  });
+  return provenanceDigest(
+    PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_DIGEST_SCHEME,
+    canonicalPortableStructuralDerivationProvenanceClaimJson(input),
+  );
 }
 
 export async function computePortableStructuralDerivationWithAssumptionsProvenanceDigest(
   input: unknown,
 ): Promise<PortableStructuralDerivationWithAssumptionsProvenanceDigest> {
-  const canonicalJson = canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson(input);
-  const preimage = `${PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME}\n${canonicalJson}`;
-  const raw = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(preimage));
-  return Object.freeze({
-    scheme: PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
-    value: lowercaseHex(new Uint8Array(raw)),
-  });
+  return provenanceDigest(
+    PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
+    canonicalPortableStructuralDerivationWithAssumptionsProvenanceClaimJson(input),
+  );
+}
+
+export async function computePortableStructuralDerivationWithTheoremsProvenanceDigest(
+  input: unknown,
+): Promise<PortableStructuralDerivationWithTheoremsProvenanceDigest> {
+  return provenanceDigest(
+    PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_DIGEST_SCHEME,
+    canonicalPortableStructuralDerivationWithTheoremsProvenanceClaimJson(input),
+  );
 }
 
 export async function verifyPortableStructuralDerivationProvenanceClaim(
@@ -256,6 +290,16 @@ export async function verifyPortableStructuralDerivationWithAssumptionsProvenanc
 ): Promise<PortableStructuralDerivationWithAssumptionsProvenanceClaim> {
   const claim = parseClaimWithAssumptions(input);
   const actual = await computePortableStructuralDerivationWithAssumptionsContentDigest(artifact);
+  if (actual.value !== claim.contentDigest.value) fail("content-digest-mismatch");
+  return claim;
+}
+
+export async function verifyPortableStructuralDerivationWithTheoremsProvenanceClaim(
+  artifact: unknown,
+  input: unknown,
+): Promise<PortableStructuralDerivationWithTheoremsProvenanceClaim> {
+  const claim = parseClaimWithTheorems(input);
+  const actual = await computePortableStructuralDerivationWithTheoremsContentDigest(artifact);
   if (actual.value !== claim.contentDigest.value) fail("content-digest-mismatch");
   return claim;
 }

--- a/ts/src/portable-proof-replay.ts
+++ b/ts/src/portable-proof-replay.ts
@@ -1,14 +1,541 @@
 import {
+  CanonicalTopologyError,
+  exportCanonicalTopology,
+} from "./canonical-topology.js";
+import {
+  replayStructuralDerivationWithTheorems,
+  type StructuralDerivationEvidence,
+  type StructuralDerivationWithTheoremsEvidence,
+  type StructuralDerivationWithTheoremsReplayResult,
+  type StructuralTheoremEvidence,
+} from "./derivation.js";
+import {
+  Memory,
+  MemoryError,
+  type EnumerableReadMemory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "./memory.js";
+import {
+  PORTABLE_MTS_SEMANTIC_BASE,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA,
+  PortableStructuralDerivationError,
   replayPortableStructuralDerivation,
   replayPortableStructuralDerivationWithAssumptions,
+  type PortableStructuralDerivationErrorCode,
+  type PortableStructuralDerivationNode,
   type PortableStructuralDerivationReplayResult,
   type PortableStructuralDerivationWithAssumptionsReplayResult,
 } from "./portable-derivation.js";
+import {
+  PersistenceTopologyError,
+  STORAGE_TOPOLOGY_SCHEMA,
+  restoreTopology,
+  type StorageTopologyImage,
+} from "./persistence-topology.js";
+import {
+  StructuralDerivationSupportTopologyError,
+  exportStructuralDerivationSupportTopology,
+} from "./proof-support-topology.js";
+
+export const PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA =
+  "mts-portable-structural-derivation-with-theorems/v0.1" as const;
+
+interface PortableStructuralDerivationCoordinates {
+  readonly theoryCoordinate: number;
+  readonly targetOccurrenceCoordinate: number;
+  readonly nodes: readonly PortableStructuralDerivationNode[];
+}
+
+export interface PortableStructuralTheoremEvidenceCoordinates {
+  readonly theoremCoordinate: number;
+  readonly proof: PortableStructuralDerivationCoordinates;
+}
+
+export interface PortableStructuralDerivationWithTheoremsArtifact
+  extends PortableStructuralDerivationCoordinates {
+  readonly schema: typeof PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA;
+  readonly mtsSemanticBase: typeof PORTABLE_MTS_SEMANTIC_BASE;
+  readonly topology: StorageTopologyImage;
+  readonly theorems: readonly PortableStructuralTheoremEvidenceCoordinates[];
+}
+
+export type PortableStructuralDerivationWithTheoremsErrorCode =
+  PortableStructuralDerivationErrorCode;
+
+export interface PortableStructuralDerivationWithTheoremsReplayResult {
+  readonly memory: Memory;
+  readonly evidence: StructuralDerivationWithTheoremsEvidence;
+  readonly replay: StructuralDerivationWithTheoremsReplayResult;
+}
 
 export type PortableStructuralProofReplayResult =
   | PortableStructuralDerivationReplayResult
-  | PortableStructuralDerivationWithAssumptionsReplayResult;
+  | PortableStructuralDerivationWithAssumptionsReplayResult
+  | PortableStructuralDerivationWithTheoremsReplayResult;
+
+function fail(code: PortableStructuralDerivationErrorCode): never {
+  throw new PortableStructuralDerivationError(code);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    fail("invalid-envelope");
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactRecord(value: unknown, keys: readonly string[]): Record<string, unknown> {
+  const candidate = record(value);
+  const actual = Object.keys(candidate).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    fail("invalid-envelope");
+  }
+  return candidate;
+}
+
+function coordinate(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    fail("invalid-coordinate");
+  }
+  return value;
+}
+
+function parseTopology(value: unknown): StorageTopologyImage {
+  const image = exactRecord(value, ["schema", "root", "links"]);
+  if (image.schema !== STORAGE_TOPOLOGY_SCHEMA) fail("invalid-topology");
+  const root = coordinate(image.root);
+  if (!Array.isArray(image.links) || image.links.length === 0) fail("invalid-topology");
+  const links = image.links.map((item) => {
+    if (!Array.isArray(item) || item.length !== 2) fail("invalid-topology");
+    return Object.freeze([coordinate(item[0]), coordinate(item[1])] as const);
+  });
+  return Object.freeze({
+    schema: STORAGE_TOPOLOGY_SCHEMA,
+    root,
+    links: Object.freeze(links),
+  });
+}
+
+function parseInterpreter(value: unknown) {
+  const item = exactRecord(value, ["dictionary", "grammar", "theory"]);
+  return Object.freeze({
+    dictionary: coordinate(item.dictionary),
+    grammar: coordinate(item.grammar),
+    theory: coordinate(item.theory),
+  });
+}
+
+function parseApplication(value: unknown) {
+  const item = exactRecord(value, [
+    "act",
+    "rule",
+    "ruleAdmission",
+    "claimedBody",
+    "expectedInterpreter",
+    "expectedAfterContext",
+  ]);
+  return Object.freeze({
+    act: coordinate(item.act),
+    rule: coordinate(item.rule),
+    ruleAdmission: coordinate(item.ruleAdmission),
+    claimedBody: coordinate(item.claimedBody),
+    expectedInterpreter: parseInterpreter(item.expectedInterpreter),
+    expectedAfterContext: coordinate(item.expectedAfterContext),
+  });
+}
+
+function parseJudgment(value: unknown) {
+  const item = exactRecord(value, ["application", "judgment"]);
+  const judgment = exactRecord(item.judgment, ["theory", "context", "claim"]);
+  return Object.freeze({
+    application: parseApplication(item.application),
+    judgment: Object.freeze({
+      theory: coordinate(judgment.theory),
+      context: coordinate(judgment.context),
+      claim: coordinate(judgment.claim),
+    }),
+  });
+}
+
+function parseNode(value: unknown): PortableStructuralDerivationNode {
+  const item = exactRecord(value, [
+    "occurrence",
+    "judgment",
+    "derivationRule",
+    "derivationRuleAdmission",
+    "premiseOccurrenceSequence",
+  ]);
+  return Object.freeze({
+    occurrence: coordinate(item.occurrence),
+    judgment: parseJudgment(item.judgment),
+    derivationRule: coordinate(item.derivationRule),
+    derivationRuleAdmission: coordinate(item.derivationRuleAdmission),
+    premiseOccurrenceSequence: coordinate(item.premiseOccurrenceSequence),
+  });
+}
+
+function parseNodes(value: unknown): readonly PortableStructuralDerivationNode[] {
+  if (!Array.isArray(value)) fail("invalid-envelope");
+  const nodes = value.map(parseNode);
+  for (let index = 1; index < nodes.length; index += 1) {
+    if (nodes[index - 1]!.occurrence >= nodes[index]!.occurrence) {
+      fail("noncanonical-node-order");
+    }
+  }
+  return Object.freeze(nodes);
+}
+
+function parseDerivation(value: unknown): PortableStructuralDerivationCoordinates {
+  const item = exactRecord(value, ["theoryCoordinate", "targetOccurrenceCoordinate", "nodes"]);
+  return Object.freeze({
+    theoryCoordinate: coordinate(item.theoryCoordinate),
+    targetOccurrenceCoordinate: coordinate(item.targetOccurrenceCoordinate),
+    nodes: parseNodes(item.nodes),
+  });
+}
+
+function parseTheorem(value: unknown): PortableStructuralTheoremEvidenceCoordinates {
+  const item = exactRecord(value, ["theoremCoordinate", "proof"]);
+  return Object.freeze({
+    theoremCoordinate: coordinate(item.theoremCoordinate),
+    proof: parseDerivation(item.proof),
+  });
+}
+
+function parseArtifactWithTheorems(
+  input: unknown,
+): PortableStructuralDerivationWithTheoremsArtifact {
+  const item = exactRecord(input, [
+    "schema",
+    "mtsSemanticBase",
+    "topology",
+    "theoryCoordinate",
+    "targetOccurrenceCoordinate",
+    "nodes",
+    "theorems",
+  ]);
+  if (item.schema !== PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA) {
+    fail("unsupported-schema");
+  }
+  if (item.mtsSemanticBase !== PORTABLE_MTS_SEMANTIC_BASE) {
+    fail("unsupported-semantic-base");
+  }
+  if (!Array.isArray(item.theorems)) fail("invalid-envelope");
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA,
+    mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+    topology: parseTopology(item.topology),
+    theoryCoordinate: coordinate(item.theoryCoordinate),
+    targetOccurrenceCoordinate: coordinate(item.targetOccurrenceCoordinate),
+    nodes: parseNodes(item.nodes),
+    theorems: Object.freeze(item.theorems.map(parseTheorem)),
+  });
+}
+
+class ReplaySupportView implements EnumerableReadMemory {
+  readonly root: LinkHandle;
+  private readonly ordered: readonly LinkHandle[];
+
+  constructor(
+    private readonly source: ReadMemory,
+    private readonly support: ReadonlySet<LinkHandle>,
+  ) {
+    this.root = source.root;
+    this.ordered = Object.freeze([...support]);
+  }
+
+  get linkCount(): number {
+    return this.ordered.length;
+  }
+
+  private require(link: LinkHandle): void {
+    if (!this.support.has(link)) throw new MemoryError("Link is outside theorem replay support");
+  }
+
+  poles(link: LinkHandle): LinkPoles {
+    this.require(link);
+    const poles = this.source.poles(link);
+    if (!this.support.has(poles.start) || !this.support.has(poles.end)) {
+      throw new MemoryError("theorem replay support is not pole-closed");
+    }
+    return poles;
+  }
+
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    this.require(start);
+    this.require(end);
+    const found = this.source.find(start, end);
+    return found !== undefined && this.support.has(found) ? found : undefined;
+  }
+
+  outgoing(start: LinkHandle): readonly LinkHandle[] {
+    this.require(start);
+    return Object.freeze(this.source.outgoing(start).filter((link) => this.support.has(link)));
+  }
+
+  incoming(end: LinkHandle): readonly LinkHandle[] {
+    this.require(end);
+    return Object.freeze(this.source.incoming(end).filter((link) => this.support.has(link)));
+  }
+
+  allLinks(): readonly LinkHandle[] {
+    return this.ordered;
+  }
+}
+
+function includePoleClosure(
+  memory: ReadMemory,
+  support: Set<LinkHandle>,
+  roots: readonly LinkHandle[],
+): void {
+  const pending = [...roots];
+  while (pending.length > 0) {
+    const link = pending.pop();
+    if (link === undefined || support.has(link)) continue;
+    const poles = memory.poles(link);
+    support.add(link);
+    pending.push(poles.start, poles.end);
+  }
+}
+
+function exportWithTheoremsSupport(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithTheoremsEvidence,
+) {
+  const before = memory.linkCount;
+  try {
+    const support = new Set<LinkHandle>();
+    const addDerivation = (derivation: StructuralDerivationEvidence): void => {
+      const exported = exportStructuralDerivationSupportTopology(memory, derivation);
+      for (const link of exported.links) support.add(link);
+    };
+    addDerivation(evidence.derivation);
+    for (const theorem of evidence.theorems) {
+      addDerivation(theorem.proof);
+      includePoleClosure(memory, support, [theorem.theorem]);
+    }
+    includePoleClosure(memory, support, [memory.root]);
+    const canonical = exportCanonicalTopology(new ReplaySupportView(memory, support));
+    if (memory.linkCount !== before) fail("invalid-envelope");
+    return canonical;
+  } catch (error) {
+    if (error instanceof PortableStructuralDerivationError) throw error;
+    if (
+      error instanceof StructuralDerivationSupportTopologyError ||
+      error instanceof CanonicalTopologyError ||
+      error instanceof MemoryError
+    ) {
+      fail("invalid-topology");
+    }
+    throw error;
+  } finally {
+    if (memory.linkCount !== before) fail("invalid-envelope");
+  }
+}
+
+function sourceCoordinate(
+  coordinates: ReadonlyMap<LinkHandle, number>,
+  handle: LinkHandle,
+): number {
+  const found = coordinates.get(handle);
+  if (found === undefined) fail("invalid-coordinate");
+  return found;
+}
+
+function encodeNode(
+  coordinates: ReadonlyMap<LinkHandle, number>,
+  node: StructuralDerivationEvidence["nodes"][number],
+): PortableStructuralDerivationNode {
+  const c = (handle: LinkHandle): number => sourceCoordinate(coordinates, handle);
+  return Object.freeze({
+    occurrence: c(node.occurrence),
+    judgment: Object.freeze({
+      application: Object.freeze({
+        act: c(node.judgment.application.act),
+        rule: c(node.judgment.application.rule),
+        ruleAdmission: c(node.judgment.application.ruleAdmission),
+        claimedBody: c(node.judgment.application.claimedBody),
+        expectedInterpreter: Object.freeze({
+          dictionary: c(node.judgment.application.expectedInterpreter.dictionary),
+          grammar: c(node.judgment.application.expectedInterpreter.grammar),
+          theory: c(node.judgment.application.expectedInterpreter.theory),
+        }),
+        expectedAfterContext: c(node.judgment.application.expectedAfterContext),
+      }),
+      judgment: Object.freeze({
+        theory: c(node.judgment.judgment.theory),
+        context: c(node.judgment.judgment.context),
+        claim: c(node.judgment.judgment.claim),
+      }),
+    }),
+    derivationRule: c(node.derivationRule),
+    derivationRuleAdmission: c(node.derivationRuleAdmission),
+    premiseOccurrenceSequence: c(node.premiseOccurrenceSequence),
+  });
+}
+
+function encodeDerivation(
+  coordinates: ReadonlyMap<LinkHandle, number>,
+  evidence: StructuralDerivationEvidence,
+): PortableStructuralDerivationCoordinates {
+  const c = (handle: LinkHandle): number => sourceCoordinate(coordinates, handle);
+  const nodes = evidence.nodes
+    .map((node) => encodeNode(coordinates, node))
+    .sort((left, right) => left.occurrence - right.occurrence);
+  for (let index = 1; index < nodes.length; index += 1) {
+    if (nodes[index - 1]!.occurrence === nodes[index]!.occurrence) {
+      fail("noncanonical-node-order");
+    }
+  }
+  return Object.freeze({
+    theoryCoordinate: c(evidence.theory),
+    targetOccurrenceCoordinate: c(evidence.targetOccurrence),
+    nodes: Object.freeze(nodes),
+  });
+}
+
+export function exportPortableStructuralDerivationWithTheorems(
+  memory: ReadMemory,
+  evidence: StructuralDerivationWithTheoremsEvidence,
+): PortableStructuralDerivationWithTheoremsArtifact {
+  const before = memory.linkCount;
+  const support = exportWithTheoremsSupport(memory, evidence);
+  const derivation = encodeDerivation(support.coordinates, evidence.derivation);
+  const theorems = evidence.theorems.map((theorem) => Object.freeze({
+    theoremCoordinate: sourceCoordinate(support.coordinates, theorem.theorem),
+    proof: encodeDerivation(support.coordinates, theorem.proof),
+  }));
+  if (memory.linkCount !== before) fail("invalid-envelope");
+  return Object.freeze({
+    schema: PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA,
+    mtsSemanticBase: PORTABLE_MTS_SEMANTIC_BASE,
+    topology: support.topology,
+    ...derivation,
+    theorems: Object.freeze(theorems),
+  });
+}
+
+function sameTopology(left: StorageTopologyImage, right: StorageTopologyImage): boolean {
+  return left.schema === right.schema &&
+    left.root === right.root &&
+    left.links.length === right.links.length &&
+    left.links.every((pair, index) => {
+      const other = right.links[index];
+      return other !== undefined && pair[0] === other[0] && pair[1] === other[1];
+    });
+}
+
+function restoreCanonicalTopology(topology: StorageTopologyImage): {
+  readonly memory: Memory;
+  readonly refs: ReadonlyMap<number, LinkHandle>;
+} {
+  let memory: Memory;
+  try {
+    memory = restoreTopology(topology);
+  } catch (error) {
+    if (error instanceof PersistenceTopologyError) fail("invalid-topology");
+    throw error;
+  }
+  let canonical;
+  try {
+    canonical = exportCanonicalTopology(memory);
+  } catch (error) {
+    if (error instanceof CanonicalTopologyError) fail("invalid-topology");
+    throw error;
+  }
+  if (!sameTopology(canonical.topology, topology)) fail("noncanonical-topology");
+  const refs = new Map<number, LinkHandle>();
+  for (const [handle, local] of canonical.coordinates) {
+    if (refs.has(local)) fail("invalid-topology");
+    refs.set(local, handle);
+  }
+  if (refs.size !== topology.links.length) fail("invalid-topology");
+  return Object.freeze({ memory, refs });
+}
+
+function freshHandle(refs: ReadonlyMap<number, LinkHandle>, local: number): LinkHandle {
+  const handle = refs.get(local);
+  if (handle === undefined) fail("invalid-coordinate");
+  return handle;
+}
+
+function reconstructDerivation(
+  artifact: PortableStructuralDerivationCoordinates,
+  refs: ReadonlyMap<number, LinkHandle>,
+): StructuralDerivationEvidence {
+  const h = (local: number): LinkHandle => freshHandle(refs, local);
+  return Object.freeze({
+    theory: h(artifact.theoryCoordinate),
+    targetOccurrence: h(artifact.targetOccurrenceCoordinate),
+    nodes: Object.freeze(artifact.nodes.map((node) => Object.freeze({
+      occurrence: h(node.occurrence),
+      judgment: Object.freeze({
+        application: Object.freeze({
+          act: h(node.judgment.application.act),
+          rule: h(node.judgment.application.rule),
+          ruleAdmission: h(node.judgment.application.ruleAdmission),
+          claimedBody: h(node.judgment.application.claimedBody),
+          expectedInterpreter: Object.freeze({
+            dictionary: h(node.judgment.application.expectedInterpreter.dictionary),
+            grammar: h(node.judgment.application.expectedInterpreter.grammar),
+            theory: h(node.judgment.application.expectedInterpreter.theory),
+          }),
+          expectedAfterContext: h(node.judgment.application.expectedAfterContext),
+        }),
+        judgment: Object.freeze({
+          theory: h(node.judgment.judgment.theory),
+          context: h(node.judgment.judgment.context),
+          claim: h(node.judgment.judgment.claim),
+        }),
+      }),
+      derivationRule: h(node.derivationRule),
+      derivationRuleAdmission: h(node.derivationRuleAdmission),
+      premiseOccurrenceSequence: h(node.premiseOccurrenceSequence),
+    }))),
+  });
+}
+
+function reconstructTheorem(
+  artifact: PortableStructuralTheoremEvidenceCoordinates,
+  refs: ReadonlyMap<number, LinkHandle>,
+): StructuralTheoremEvidence {
+  return Object.freeze({
+    theorem: freshHandle(refs, artifact.theoremCoordinate),
+    proof: reconstructDerivation(artifact.proof, refs),
+  });
+}
+
+export function replayPortableStructuralDerivationWithTheorems(
+  input: unknown,
+): PortableStructuralDerivationWithTheoremsReplayResult {
+  const artifact = parseArtifactWithTheorems(input);
+  const restored = restoreCanonicalTopology(artifact.topology);
+  const evidence: StructuralDerivationWithTheoremsEvidence = Object.freeze({
+    derivation: reconstructDerivation(artifact, restored.refs),
+    theorems: Object.freeze(artifact.theorems.map((theorem) => reconstructTheorem(theorem, restored.refs))),
+  });
+  const beforeReplay = restored.memory.linkCount;
+  const replay = replayStructuralDerivationWithTheorems(restored.memory, evidence);
+  if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+  const support = exportWithTheoremsSupport(restored.memory, evidence);
+  if (!sameTopology(support.topology, artifact.topology)) {
+    fail("noncanonical-support-topology");
+  }
+  if (restored.memory.linkCount !== beforeReplay) fail("invalid-envelope");
+  return Object.freeze({ memory: restored.memory, evidence, replay });
+}
+
+export function canonicalPortableStructuralDerivationWithTheoremsV01Json(
+  input: unknown,
+): string {
+  return JSON.stringify(parseArtifactWithTheorems(input));
+}
 
 function schemaOf(input: unknown): unknown {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
@@ -17,17 +544,15 @@ function schemaOf(input: unknown): unknown {
   return (input as Record<string, unknown>).schema;
 }
 
-/**
- * Single fail-closed portable proof replay boundary.
- *
- * The schema selects only an existing transport parser/reconstruction family.
- * Rule and theorem semantics remain downstream in the generic structural replay
- * kernel. In particular, there is no callback/opcode/rule-name dispatch here.
- */
+/** Single fail-closed portable proof replay boundary. */
 export function replayPortableStructuralProof(
   input: unknown,
 ): PortableStructuralProofReplayResult {
-  if (schemaOf(input) === PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA) {
+  const schema = schemaOf(input);
+  if (schema === PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA) {
+    return replayPortableStructuralDerivationWithTheorems(input);
+  }
+  if (schema === PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA) {
     return replayPortableStructuralDerivationWithAssumptions(input);
   }
   return replayPortableStructuralDerivation(input);

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -198,21 +198,31 @@ export type {
 } from "./portable-derivation.js";
 
 export {
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA,
+  exportPortableStructuralDerivationWithTheorems,
+  replayPortableStructuralDerivationWithTheorems,
   replayPortableStructuralProof,
 } from "./portable-proof-replay.js";
 export type {
+  PortableStructuralDerivationWithTheoremsArtifact,
+  PortableStructuralDerivationWithTheoremsErrorCode,
+  PortableStructuralDerivationWithTheoremsReplayResult,
   PortableStructuralProofReplayResult,
+  PortableStructuralTheoremEvidenceCoordinates,
 } from "./portable-proof-replay.js";
 
 export {
   PORTABLE_STRUCTURAL_DERIVATION_CONTENT_DIGEST_SCHEME,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_CONTENT_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME,
   computePortableStructuralDerivationContentDigest,
   computePortableStructuralDerivationWithAssumptionsContentDigest,
+  computePortableStructuralDerivationWithTheoremsContentDigest,
 } from "./portable-derivation-digest.js";
 export type {
   PortableStructuralDerivationContentDigest,
   PortableStructuralDerivationWithAssumptionsContentDigest,
+  PortableStructuralDerivationWithTheoremsContentDigest,
 } from "./portable-derivation-digest.js";
 
 export {
@@ -240,13 +250,18 @@ export {
   PORTABLE_STRUCTURAL_DERIVATION_PROVENANCE_SCHEMA,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME,
   PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_DIGEST_SCHEME,
+  PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA,
   PortableStructuralDerivationProvenanceError,
   computePortableStructuralDerivationProvenanceDigest,
   computePortableStructuralDerivationWithAssumptionsProvenanceDigest,
+  computePortableStructuralDerivationWithTheoremsProvenanceDigest,
   createPortableStructuralDerivationProvenanceClaim,
   createPortableStructuralDerivationWithAssumptionsProvenanceClaim,
+  createPortableStructuralDerivationWithTheoremsProvenanceClaim,
   verifyPortableStructuralDerivationProvenanceClaim,
   verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim,
+  verifyPortableStructuralDerivationWithTheoremsProvenanceClaim,
 } from "./portable-derivation-provenance.js";
 export type {
   PortableStructuralDerivationProducerProvenance,
@@ -256,6 +271,8 @@ export type {
   PortableStructuralDerivationSourceProvenance,
   PortableStructuralDerivationWithAssumptionsProvenanceClaim,
   PortableStructuralDerivationWithAssumptionsProvenanceDigest,
+  PortableStructuralDerivationWithTheoremsProvenanceClaim,
+  PortableStructuralDerivationWithTheoremsProvenanceDigest,
 } from "./portable-derivation-provenance.js";
 
 export {

--- a/ts/test/portable-trusted-kernel-boundary.test.ts
+++ b/ts/test/portable-trusted-kernel-boundary.test.ts
@@ -306,6 +306,7 @@ const theoremArtifact = exportPortableStructuralDerivationWithTheorems(tf.memory
 {
   const result = replayPortableStructuralProof(theoremArtifact);
   assert("theorems" in result.evidence, "theorem transport route");
+  assert("theorems" in result.replay, "theorem replay route");
   same(result.replay.derivation.occurrenceCount, 2, "reused theorem occurrence count");
   same(result.memory.linkCount, theoremArtifact.topology.links.length, "theorem replay read-only");
   const digestA = await computePortableStructuralDerivationWithTheoremsContentDigest(theoremArtifact);

--- a/ts/test/portable-trusted-kernel-boundary.test.ts
+++ b/ts/test/portable-trusted-kernel-boundary.test.ts
@@ -6,7 +6,20 @@ import {
   exportPortableStructuralDerivation,
   exportPortableStructuralDerivationWithAssumptions,
 } from "../src/portable-derivation.js";
-import { replayPortableStructuralProof } from "../src/portable-proof-replay.js";
+import { computePortableStructuralDerivationWithTheoremsContentDigest } from "../src/portable-derivation-digest.js";
+import {
+  createPortableStructuralDerivationWithTheoremsProvenanceClaim,
+  verifyPortableStructuralDerivationWithTheoremsProvenanceClaim,
+} from "../src/portable-derivation-provenance.js";
+import {
+  exportPortableStructuralDerivationWithTheorems,
+  replayPortableStructuralProof,
+} from "../src/portable-proof-replay.js";
+import { computePortableStructuralTheoryRevision } from "../src/portable-theory-digest.js";
+import {
+  exportPortableStructuralTheory,
+  verifyPortableStructuralProofTheoryRevision,
+} from "../src/portable-theory.js";
 import { defineContext } from "../src/state.js";
 import { defineActField, defineActHeader } from "../src/structural-readers.js";
 import {
@@ -23,9 +36,11 @@ import {
   defineStructuralAssumptionContext,
   defineStructuralDerivationRule,
   defineStructuralProofOccurrence,
+  defineStructuralTheorem,
   type StructuralDerivationEvidence,
   type StructuralDerivationNodeEvidence,
   type StructuralDerivationWithAssumptionsEvidence,
+  type StructuralDerivationWithTheoremsEvidence,
   type StructuralJudgmentEvidence,
 } from "../src/derivation.js";
 
@@ -70,6 +85,16 @@ function expectAssumptionReject(code: string, effect: () => unknown): void {
     return;
   }
   throw new Error("expected generic assumption rejection");
+}
+
+function expectReject(effect: () => unknown): void {
+  try { effect(); } catch { return; }
+  throw new Error("expected rejection");
+}
+
+async function expectAsyncReject(effect: () => Promise<unknown>): Promise<void> {
+  try { await effect(); } catch { return; }
+  throw new Error("expected async rejection");
 }
 
 interface Fixture {
@@ -183,10 +208,7 @@ const conditionalArtifact = exportPortableStructuralDerivationWithAssumptions(
   );
 }
 
-// R3 RED: the versioned theorem-reuse schema must select its own exact parser
-// before generic base fallback. The envelope is intentionally incomplete, so a
-// correct router reaches the new parser and reports invalid-envelope; current
-// baseline instead reports unsupported-schema from the base family.
+// R3 router reaches the exact theorem parser rather than plain fallback.
 {
   expectPortable("invalid-envelope", () => replayPortableStructuralProof({
     ...baseArtifact,
@@ -237,5 +259,91 @@ const conditionalArtifact = exportPortableStructuralDerivationWithAssumptions(
   }));
 }
 
-// Executable P7a classification:
-// SINGLE_PORTABLE_TRUSTED_REPLAY_BOUNDARY_SUPPORTED
+function theoremFixture(): {
+  memory: Memory;
+  theory: LinkHandle;
+  evidence: StructuralDerivationWithTheoremsEvidence;
+} {
+  const memory = new Memory();
+  const { R, U } = ensureRootBasis(memory);
+  let cursor = U;
+  const fresh = (): LinkHandle => (cursor = memory.ensure(cursor, R));
+  const dictionary = fresh(); const grammar = fresh(); const theory = fresh(); const role = fresh();
+  const lemmaClaim = fresh();
+  const expectedInterpreter: StructuralInterpreter = { dictionary, grammar, theory };
+  const interpreter = defineStructuralInterpreter(memory, dictionary, grammar, theory);
+  const roleDictionary = defineStructuralRoleDictionary(memory, [role]);
+  const make = (body: LinkHandle, claim: LinkHandle, templates: readonly LinkHandle[], premises: readonly LinkHandle[]) => {
+    const rule = defineStructuralRule(memory, roleDictionary, body);
+    const context = defineContext(memory, fresh(), fresh());
+    const act = defineActHeader(memory, interpreter, roleDictionary, context);
+    defineActField(memory, act, role, lemmaClaim);
+    const judgment: StructuralJudgmentEvidence = {
+      application: { act, rule, ruleAdmission: admitStructuralRule(memory, theory, rule), claimedBody: claim, expectedInterpreter, expectedAfterContext: context },
+      judgment: { theory, context, claim },
+    };
+    const occurrence = defineStructuralProofOccurrence(memory, act, claim);
+    const derivationRule = defineStructuralDerivationRule(memory, rule, templates);
+    return { occurrence, node: { occurrence, judgment, derivationRule, derivationRuleAdmission: admitStructuralDerivationRule(memory, theory, derivationRule), premiseOccurrenceSequence: materializeExactSequence(memory, premises) } };
+  };
+  const lemma = make(role, lemmaClaim, [], []);
+  const targetClaim = memory.ensure(lemmaClaim, lemmaClaim);
+  const target = make(memory.ensure(role, role), targetClaim, [role, role], [lemma.occurrence, lemma.occurrence]);
+  return {
+    memory,
+    theory,
+    evidence: {
+      derivation: { theory, targetOccurrence: target.occurrence, nodes: [target.node] },
+      theorems: [{ theorem: defineStructuralTheorem(memory, lemmaClaim, theory), proof: { theory, targetOccurrence: lemma.occurrence, nodes: [lemma.node] } }],
+    },
+  };
+}
+
+// R3 positive: one canonical topology carries the consuming derivation and full
+// theorem proof; generic theorem replay is the only proof authority.
+const tf = theoremFixture();
+const theoremArtifact = exportPortableStructuralDerivationWithTheorems(tf.memory, tf.evidence);
+{
+  const result = replayPortableStructuralProof(theoremArtifact);
+  assert("theorems" in result.evidence, "theorem transport route");
+  same(result.replay.derivation.occurrenceCount, 2, "reused theorem occurrence count");
+  same(result.memory.linkCount, theoremArtifact.topology.links.length, "theorem replay read-only");
+  const digestA = await computePortableStructuralDerivationWithTheoremsContentDigest(theoremArtifact);
+  const digestB = await computePortableStructuralDerivationWithTheoremsContentDigest(theoremArtifact);
+  same(digestA.value, digestB.value, "theorem content digest deterministic");
+  const theoryArtifact = exportPortableStructuralTheory(tf.memory, tf.theory);
+  const revision = await computePortableStructuralTheoryRevision(theoryArtifact);
+  await verifyPortableStructuralProofTheoryRevision(theoremArtifact, theoryArtifact, revision);
+}
+
+// The exact parser and generic kernel fail closed on incomplete, forged,
+// cross-Theory, dependency-tampered, ambient/noncanonical, or host-authority evidence.
+{
+  const reused = theoremArtifact.theorems[0]!;
+  const target = theoremArtifact.nodes[0]!;
+  expectPortable("invalid-envelope", () => replayPortableStructuralProof({ ...theoremArtifact, cacheKey: "trusted" }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, theorems: [{ theoremCoordinate: reused.theoremCoordinate }] }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, theorems: [{ ...reused, theoremCoordinate: theoremArtifact.theoryCoordinate }] }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, theoryCoordinate: 0 }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, theorems: [{ ...reused, proof: { ...reused.proof, theoryCoordinate: 0 } }] }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, theorems: [{ ...reused, proof: { ...reused.proof, nodes: [] } }] }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, nodes: [{ ...target, premiseOccurrenceSequence: theoremArtifact.targetOccurrenceCoordinate }] }));
+  expectReject(() => replayPortableStructuralProof({ ...theoremArtifact, topology: { ...theoremArtifact.topology, links: [...theoremArtifact.topology.links].reverse() } }));
+}
+
+// Provenance binds origin/content only: tamper is rejected, while freshly
+// re-provenancing invalid proof evidence does not make the proof true.
+{
+  const source = { locator: "github:netkeep80/anum_docs", revision: "exact", subject: "#925" };
+  const producer = { id: "@mts/core", version: "v0.11" };
+  const claim = await createPortableStructuralDerivationWithTheoremsProvenanceClaim(theoremArtifact, source, producer);
+  await verifyPortableStructuralDerivationWithTheoremsProvenanceClaim(theoremArtifact, claim);
+  await expectAsyncReject(() => verifyPortableStructuralDerivationWithTheoremsProvenanceClaim(theoremArtifact, { ...claim, contentDigest: { ...claim.contentDigest, value: "0".repeat(64) } }));
+  const invalid = { ...theoremArtifact, theoryCoordinate: 0 };
+  const freshClaim = await createPortableStructuralDerivationWithTheoremsProvenanceClaim(invalid, source, producer);
+  await verifyPortableStructuralDerivationWithTheoremsProvenanceClaim(invalid, freshClaim);
+  expectReject(() => replayPortableStructuralProof(invalid));
+}
+
+// Executable P7a/R3 classification:
+// SINGLE_PORTABLE_TRUSTED_REPLAY_BOUNDARY_WITH_THEOREMS_SUPPORTED

--- a/ts/test/portable-trusted-kernel-boundary.test.ts
+++ b/ts/test/portable-trusted-kernel-boundary.test.ts
@@ -183,6 +183,17 @@ const conditionalArtifact = exportPortableStructuralDerivationWithAssumptions(
   );
 }
 
+// R3 RED: the versioned theorem-reuse schema must select its own exact parser
+// before generic base fallback. The envelope is intentionally incomplete, so a
+// correct router reaches the new parser and reports invalid-envelope; current
+// baseline instead reports unsupported-schema from the base family.
+{
+  expectPortable("invalid-envelope", () => replayPortableStructuralProof({
+    ...baseArtifact,
+    schema: "mts-portable-structural-derivation-with-theorems/v0.1",
+  }));
+}
+
 // Host callback/opcode/rule-name vocabulary has no dispatch authority. Known
 // family parsers reject every extra field as transport pollution.
 {

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -85,6 +85,10 @@ const expectedRuntimeExports = [
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_DIGEST_SCHEME",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_PROVENANCE_SCHEMA",
   "PORTABLE_STRUCTURAL_DERIVATION_WITH_ASSUMPTIONS_SCHEMA",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_CONTENT_DIGEST_SCHEME",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_DIGEST_SCHEME",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_PROVENANCE_SCHEMA",
+  "PORTABLE_STRUCTURAL_DERIVATION_WITH_THEOREMS_SCHEMA",
   "PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME",
   "PORTABLE_STRUCTURAL_THEORY_SCHEMA",
   "PersistentStore",
@@ -110,9 +114,12 @@ const expectedRuntimeExports = [
   "computePortableStructuralDerivationProvenanceDigest",
   "computePortableStructuralDerivationWithAssumptionsContentDigest",
   "computePortableStructuralDerivationWithAssumptionsProvenanceDigest",
+  "computePortableStructuralDerivationWithTheoremsContentDigest",
+  "computePortableStructuralDerivationWithTheoremsProvenanceDigest",
   "computePortableStructuralTheoryRevision",
   "createPortableStructuralDerivationProvenanceClaim",
   "createPortableStructuralDerivationWithAssumptionsProvenanceClaim",
+  "createPortableStructuralDerivationWithTheoremsProvenanceClaim",
   "deserializeAnum",
   "deserializeStream",
   "elaborateBundleRoles",
@@ -120,6 +127,7 @@ const expectedRuntimeExports = [
   "executeAbits",
   "exportPortableStructuralDerivation",
   "exportPortableStructuralDerivationWithAssumptions",
+  "exportPortableStructuralDerivationWithTheorems",
   "exportPortableStructuralTheory",
   "materializePersistentSequence",
   "materializeSequence",
@@ -136,6 +144,7 @@ const expectedRuntimeExports = [
   "replayPersistentSequenceMaterialization",
   "replayPortableStructuralDerivation",
   "replayPortableStructuralDerivationWithAssumptions",
+  "replayPortableStructuralDerivationWithTheorems",
   "replayPortableStructuralProof",
   "replayPortableStructuralTheory",
   "replayRelationStep",
@@ -155,10 +164,11 @@ const expectedRuntimeExports = [
   "valuesEqual",
   "verifyPortableStructuralDerivationProvenanceClaim",
   "verifyPortableStructuralDerivationWithAssumptionsProvenanceClaim",
+  "verifyPortableStructuralDerivationWithTheoremsProvenanceClaim",
   "verifyPortableStructuralProofTheoryRevision",
 ].sort();
 
-assert(expectedRuntimeExports.length === 88, "R3 Theory lock runtime export budget must be exactly 88");
+assert(expectedRuntimeExports.length === 98, "R3 theorem transport runtime export budget must be exactly 98");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,


### PR DESCRIPTION
Implements #925 as a transport/package delta over accepted MTS v0.11. TDD RED was captured on head `80e475b6e1e83e3a6117042c274618a135cb1959`: CI #3708 failed exactly because the new theorem-reuse schema fell through to the base parser (`unsupported-schema !== invalid-envelope`). Production implementation follows that confirmed RED.

Closes #925

Scope refinement: exact-head CI run `32981066864` on `1d32b689a4d440e9539ea397fbf11557c5df9bfb` proved the narrowed implementation also requires the existing package-root allowlist test `ts/test/public-api.test.ts`; #925 records this refinement in its current issue thread. No semantic scope is widened.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/portable-proof-replay.ts
  - ts/src/portable-derivation-digest.ts
  - ts/src/portable-derivation-provenance.ts
  - ts/src/public.ts
  - ts/test/portable-trusted-kernel-boundary.test.ts
  - ts/test/public-api.test.ts
  - ts/consumer/package-consumer.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 800
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/portable-proof-replay.ts
  - ts/src/public.ts
  - ts/test/portable-trusted-kernel-boundary.test.ts
  - ts/test/public-api.test.ts
  - ts/consumer/package-consumer.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - repo-policy.json
  - .github/workflows/**
  - packages/visual/**
  - web/**
expected_effects:
  - "accepted P3a proof-carrying theorem reuse becomes portable and package-root consumable"
  - "portable theorem reuse delegates to existing generic replay semantics rather than adding theorem-specific authority"
  - "digest/provenance bind origin to the same artifact without becoming proof truth"
  - "no accepted MTS semantic release change is introduced"
  - "aprover R3 can re-pin an exact artifact and consume stored lemmas without local proof semantics"
```

Implementation design: one canonical support topology is built by unioning the already-defined replay-support closures of the consuming derivation and every complete theorem proof plus each theorem identity Link, then canonicalizing that union in one identity space. The envelope carries coordinates only; replay restores/checks that one topology, reconstructs all structural evidence, and delegates truth exclusively to `replayStructuralDerivationWithTheorems`. The existing #927 Theory revision verifier remains the external trusted Theory-selection boundary. Digest/provenance are origin bindings only.