### PR TITLE
[Proof producer/R3] Public untrusted candidate-construction facade

### DIFF
--- a/ts/consumer/package-consumer.ts
+++ b/ts/consumer/package-consumer.ts
@@ -4,10 +4,13 @@ import {
   PORTABLE_STRUCTURAL_THEORY_REVISION_SCHEME,
   PORTABLE_STRUCTURAL_THEORY_SCHEMA,
   computePortableStructuralTheoryRevision,
+  createStructuralProofProducer,
   ensureRootBasis,
+  exportPortableStructuralDerivation,
   exportPortableStructuralTheory,
   replayPortableStructuralDerivation,
   replayPortableStructuralDerivationWithAssumptions,
+  replayPortableStructuralProof,
   replayPortableStructuralTheory,
   replayStructuralDerivation,
   replayStructuralDerivationWithAssumptions,
@@ -16,10 +19,12 @@ import {
   type LinkHandle,
   type PortableStructuralDerivationReplayResult,
   type PortableStructuralDerivationWithAssumptionsReplayResult,
+  type PortableStructuralProofReplayResult,
   type PortableStructuralTheoryArtifact,
   type PortableStructuralTheoryReplayResult,
   type PortableStructuralTheoryRevision,
   type ReadMemory,
+  type StructuralDerivationEvidence,
 } from "@mts/core";
 import { textToAnum } from "@mts/core/tooling/payload";
 
@@ -31,9 +36,6 @@ const read: ReadMemory = memory;
 const link: LinkHandle = basis.L;
 const encoded: string = textToAnum("A");
 
-// Downstream approvers only need the public verification boundary to accept
-// untrusted portable evidence; producer/search construction may remain outside
-// the trusted package facade.
 const semanticBase: "mts-contract/v0.11" = PORTABLE_MTS_SEMANTIC_BASE;
 const portableReplay: (input: unknown) => PortableStructuralDerivationReplayResult =
   replayPortableStructuralDerivation;
@@ -41,6 +43,72 @@ const portableAssumptionReplay: (
   input: unknown,
 ) => PortableStructuralDerivationWithAssumptionsReplayResult =
   replayPortableStructuralDerivationWithAssumptions;
+
+// Untrusted search/importers construct existing structural candidate evidence
+// through one package-root facade. Construction itself has no proof authority:
+// the resulting portable artifact still crosses the ordinary trusted replay API.
+const producer = createStructuralProofProducer(memory);
+let producerCursor = basis.U;
+const freshProducerLink = (): LinkHandle =>
+  (producerCursor = memory.ensure(producerCursor, basis.R));
+const producerDictionary = freshProducerLink();
+const producerGrammar = freshProducerLink();
+const producerTheory = freshProducerLink();
+const producerContext = producer.defineContext(freshProducerLink(), freshProducerLink());
+const producerRole = freshProducerLink();
+const producerValue = freshProducerLink();
+const producerInterpreter = producer.defineInterpreter(
+  producerDictionary,
+  producerGrammar,
+  producerTheory,
+);
+const producerRoleDictionary = producer.defineRoleDictionary([producerRole]);
+const producerRule = producer.defineRule(producerRoleDictionary, producerRole);
+const producerRuleAdmission = producer.admitRule(producerTheory, producerRule);
+const producerAct = producer.defineAct(
+  producerInterpreter,
+  producerRoleDictionary,
+  producerContext,
+);
+producer.defineActField(producerAct, producerRole, producerValue);
+const producerOccurrence = producer.defineProofOccurrence(producerAct, producerValue);
+const producerDerivationRule = producer.defineDerivationRule(producerRule, []);
+const producerDerivationRuleAdmission = producer.admitDerivationRule(
+  producerTheory,
+  producerDerivationRule,
+);
+const producerEvidence: StructuralDerivationEvidence = {
+  theory: producerTheory,
+  targetOccurrence: producerOccurrence,
+  nodes: [{
+    occurrence: producerOccurrence,
+    judgment: {
+      application: {
+        act: producerAct,
+        rule: producerRule,
+        ruleAdmission: producerRuleAdmission,
+        claimedBody: producerValue,
+        expectedInterpreter: {
+          dictionary: producerDictionary,
+          grammar: producerGrammar,
+          theory: producerTheory,
+        },
+        expectedAfterContext: producerContext,
+      },
+      judgment: {
+        theory: producerTheory,
+        context: producerContext,
+        claim: producerValue,
+      },
+    },
+    derivationRule: producerDerivationRule,
+    derivationRuleAdmission: producerDerivationRuleAdmission,
+    premiseOccurrenceSequence: producer.definePremiseOccurrenceSequence([]),
+  }],
+};
+const producerArtifact = exportPortableStructuralDerivation(memory, producerEvidence);
+const producerTrustedReplay: PortableStructuralProofReplayResult =
+  replayPortableStructuralProof(producerArtifact);
 
 // Exact Theory selection is separately package-root consumable and remains
 // identity/provenance evidence rather than a substitute for proof replay.
@@ -60,6 +128,8 @@ void [
   semanticBase,
   portableReplay,
   portableAssumptionReplay,
+  producerArtifact,
+  producerTrustedReplay,
   theoryArtifact,
   theoryReplay,
   theoryRevision,

--- a/ts/src/proof-producer.ts
+++ b/ts/src/proof-producer.ts
@@ -1,16 +1,74 @@
-import type { WriteMemory } from "./memory.js";
+import {
+  admitStructuralDerivationRule,
+  defineStructuralAssumptionContext,
+  defineStructuralDerivationRule,
+  defineStructuralProofOccurrence,
+  defineStructuralTheorem,
+} from "./derivation.js";
+import { materializeExactSequence } from "./exact-sequence.js";
+import type { LinkHandle, WriteMemory } from "./memory.js";
+import { defineContext } from "./state.js";
+import { defineActField, defineActHeader } from "./structural-readers.js";
+import {
+  admitStructuralRule,
+  defineStructuralInterpreter,
+  defineStructuralRoleDictionary,
+  defineStructuralRule,
+} from "./structural-rule.js";
 
 /**
  * Construction-only facade for untrusted proof producers.
  *
- * This object deliberately carries no replay/acceptance operation. Successful
- * construction is transport preparation only; existing replay APIs remain the
- * sole proof-authority boundary.
+ * Every method only materializes the existing structural evidence vocabulary.
+ * The facade deliberately exposes no replay/acceptance operation: successful
+ * construction is candidate preparation only, while existing replay APIs remain
+ * the sole proof-authority boundary.
  */
-export interface StructuralProofProducer {}
+export interface StructuralProofProducer {
+  defineContext(parent: LinkHandle, current: LinkHandle): LinkHandle;
+  defineInterpreter(dictionary: LinkHandle, grammar: LinkHandle, theory: LinkHandle): LinkHandle;
+  defineRoleDictionary(roles: readonly LinkHandle[]): LinkHandle;
+  defineRule(roleDictionary: LinkHandle, body: LinkHandle): LinkHandle;
+  admitRule(theory: LinkHandle, rule: LinkHandle): LinkHandle;
+  defineAct(interpreter: LinkHandle, roleDictionary: LinkHandle, afterContext: LinkHandle): LinkHandle;
+  defineActField(act: LinkHandle, role: LinkHandle, value: LinkHandle): LinkHandle;
+  defineProofOccurrence(act: LinkHandle, claim: LinkHandle): LinkHandle;
+  defineDerivationRule(rule: LinkHandle, premiseTemplates: readonly LinkHandle[]): LinkHandle;
+  admitDerivationRule(theory: LinkHandle, derivationRule: LinkHandle): LinkHandle;
+  definePremiseOccurrenceSequence(occurrences: readonly LinkHandle[]): LinkHandle;
+  defineAssumptionContext(theory: LinkHandle, claims: readonly LinkHandle[]): LinkHandle;
+  defineTheorem(claim: LinkHandle, theory: LinkHandle): LinkHandle;
+}
 
 export function createStructuralProofProducer(
-  _memory: WriteMemory,
+  memory: WriteMemory,
 ): StructuralProofProducer {
-  return Object.freeze({});
+  return Object.freeze({
+    defineContext: (parent: LinkHandle, current: LinkHandle) =>
+      defineContext(memory, parent, current),
+    defineInterpreter: (dictionary: LinkHandle, grammar: LinkHandle, theory: LinkHandle) =>
+      defineStructuralInterpreter(memory, dictionary, grammar, theory),
+    defineRoleDictionary: (roles: readonly LinkHandle[]) =>
+      defineStructuralRoleDictionary(memory, roles),
+    defineRule: (roleDictionary: LinkHandle, body: LinkHandle) =>
+      defineStructuralRule(memory, roleDictionary, body),
+    admitRule: (theory: LinkHandle, rule: LinkHandle) =>
+      admitStructuralRule(memory, theory, rule),
+    defineAct: (interpreter: LinkHandle, roleDictionary: LinkHandle, afterContext: LinkHandle) =>
+      defineActHeader(memory, interpreter, roleDictionary, afterContext),
+    defineActField: (act: LinkHandle, role: LinkHandle, value: LinkHandle) =>
+      defineActField(memory, act, role, value),
+    defineProofOccurrence: (act: LinkHandle, claim: LinkHandle) =>
+      defineStructuralProofOccurrence(memory, act, claim),
+    defineDerivationRule: (rule: LinkHandle, premiseTemplates: readonly LinkHandle[]) =>
+      defineStructuralDerivationRule(memory, rule, premiseTemplates),
+    admitDerivationRule: (theory: LinkHandle, derivationRule: LinkHandle) =>
+      admitStructuralDerivationRule(memory, theory, derivationRule),
+    definePremiseOccurrenceSequence: (occurrences: readonly LinkHandle[]) =>
+      materializeExactSequence(memory, occurrences),
+    defineAssumptionContext: (theory: LinkHandle, claims: readonly LinkHandle[]) =>
+      defineStructuralAssumptionContext(memory, theory, claims),
+    defineTheorem: (claim: LinkHandle, theory: LinkHandle) =>
+      defineStructuralTheorem(memory, claim, theory),
+  });
 }

--- a/ts/src/proof-producer.ts
+++ b/ts/src/proof-producer.ts
@@ -1,0 +1,16 @@
+import type { WriteMemory } from "./memory.js";
+
+/**
+ * Construction-only facade for untrusted proof producers.
+ *
+ * This object deliberately carries no replay/acceptance operation. Successful
+ * construction is transport preparation only; existing replay APIs remain the
+ * sole proof-authority boundary.
+ */
+export interface StructuralProofProducer {}
+
+export function createStructuralProofProducer(
+  _memory: WriteMemory,
+): StructuralProofProducer {
+  return Object.freeze({});
+}

--- a/ts/src/public.ts
+++ b/ts/src/public.ts
@@ -170,6 +170,13 @@ export type {
 } from "./derivation.js";
 
 export {
+  createStructuralProofProducer,
+} from "./proof-producer.js";
+export type {
+  StructuralProofProducer,
+} from "./proof-producer.js";
+
+export {
   StructuralScopedDerivationReplayError,
   replayStructuralScopedDerivation,
 } from "./scoped-derivation.js";

--- a/ts/test/proof-producer.test.ts
+++ b/ts/test/proof-producer.test.ts
@@ -89,8 +89,7 @@ const evidence: core.StructuralDerivationEvidence = Object.freeze({
 const beforeExport = memory.linkCount;
 const artifact = core.exportPortableStructuralDerivation(memory, evidence);
 same(memory.linkCount, beforeExport, "portable export must stay source read-only");
-const imported = core.replayPortableStructuralProof(artifact);
-assert("replay" in imported, "plain producer artifact must select plain trusted replay");
+const imported = core.replayPortableStructuralProof(artifact) as core.PortableStructuralDerivationReplayResult;
 same(imported.replay.occurrenceCount, 1, "trusted replay must verify one candidate node");
 same(
   imported.replay.target.judgment.claim,

--- a/ts/test/proof-producer.test.ts
+++ b/ts/test/proof-producer.test.ts
@@ -14,3 +14,28 @@ assert(
   typeof createStructuralProofProducer === "function",
   "package root must expose createStructuralProofProducer",
 );
+
+const memory = new core.Memory();
+const producer = (createStructuralProofProducer as (memory: core.WriteMemory) => object)(memory);
+const methods = producer as Readonly<Record<string, unknown>>;
+for (const name of [
+  "defineContext",
+  "defineInterpreter",
+  "defineRoleDictionary",
+  "defineRule",
+  "admitRule",
+  "defineAct",
+  "defineActField",
+  "defineProofOccurrence",
+  "defineDerivationRule",
+  "admitDerivationRule",
+  "definePremiseOccurrenceSequence",
+  "defineAssumptionContext",
+  "defineTheorem",
+] as const) {
+  assert(typeof methods[name] === "function", `producer must expose ${name}`);
+}
+
+for (const forbidden of ["accept", "approve", "prove", "replay"] as const) {
+  assert(!(forbidden in methods), `producer must not expose privileged ${forbidden} authority`);
+}

--- a/ts/test/proof-producer.test.ts
+++ b/ts/test/proof-producer.test.ts
@@ -4,6 +4,10 @@ function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
 
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
 const createStructuralProofProducer = (
   core as unknown as {
     readonly createStructuralProofProducer?: unknown;
@@ -16,8 +20,8 @@ assert(
 );
 
 const memory = new core.Memory();
-const producer = (createStructuralProofProducer as (memory: core.WriteMemory) => object)(memory);
-const methods = producer as Readonly<Record<string, unknown>>;
+const producer = core.createStructuralProofProducer(memory);
+const methods = producer as unknown as Readonly<Record<string, unknown>>;
 for (const name of [
   "defineContext",
   "defineInterpreter",
@@ -39,3 +43,83 @@ for (const name of [
 for (const forbidden of ["accept", "approve", "prove", "replay"] as const) {
   assert(!(forbidden in methods), `producer must not expose privileged ${forbidden} authority`);
 }
+
+const { R, U } = core.ensureRootBasis(memory);
+let cursor = U;
+const fresh = (): core.LinkHandle => (cursor = memory.ensure(cursor, R));
+const dictionary = fresh();
+const grammar = fresh();
+const theory = fresh();
+const context = producer.defineContext(fresh(), fresh());
+const role = fresh();
+const value = fresh();
+const expectedInterpreter = Object.freeze({ dictionary, grammar, theory });
+const interpreter = producer.defineInterpreter(dictionary, grammar, theory);
+const roleDictionary = producer.defineRoleDictionary([role]);
+const rule = producer.defineRule(roleDictionary, role);
+const ruleAdmission = producer.admitRule(theory, rule);
+const act = producer.defineAct(interpreter, roleDictionary, context);
+producer.defineActField(act, role, value);
+const occurrence = producer.defineProofOccurrence(act, value);
+const derivationRule = producer.defineDerivationRule(rule, []);
+const derivationRuleAdmission = producer.admitDerivationRule(theory, derivationRule);
+const premiseOccurrenceSequence = producer.definePremiseOccurrenceSequence([]);
+const evidence: core.StructuralDerivationEvidence = Object.freeze({
+  theory,
+  targetOccurrence: occurrence,
+  nodes: Object.freeze([Object.freeze({
+    occurrence,
+    judgment: Object.freeze({
+      application: Object.freeze({
+        act,
+        rule,
+        ruleAdmission,
+        claimedBody: value,
+        expectedInterpreter,
+        expectedAfterContext: context,
+      }),
+      judgment: Object.freeze({ theory, context, claim: value }),
+    }),
+    derivationRule,
+    derivationRuleAdmission,
+    premiseOccurrenceSequence,
+  })]),
+});
+
+const beforeExport = memory.linkCount;
+const artifact = core.exportPortableStructuralDerivation(memory, evidence);
+same(memory.linkCount, beforeExport, "portable export must stay source read-only");
+const imported = core.replayPortableStructuralProof(artifact);
+assert("replay" in imported, "plain producer artifact must select plain trusted replay");
+same(imported.replay.occurrenceCount, 1, "trusted replay must verify one candidate node");
+same(
+  imported.replay.target.judgment.claim,
+  imported.evidence.nodes[0]?.judgment.judgment.claim,
+  "trusted replay must preserve the exact target claim in reconstructed memory",
+);
+
+// Construction alone carries no proof authority: the same facade can materialize
+// a candidate whose Rule admission is merely some unrelated Link. Trusted replay
+// must reject it rather than treating producer success as acceptance.
+const badRuleAdmission = fresh();
+const badEvidence: core.StructuralDerivationEvidence = Object.freeze({
+  ...evidence,
+  nodes: Object.freeze([Object.freeze({
+    ...evidence.nodes[0]!,
+    judgment: Object.freeze({
+      ...evidence.nodes[0]!.judgment,
+      application: Object.freeze({
+        ...evidence.nodes[0]!.judgment.application,
+        ruleAdmission: badRuleAdmission,
+      }),
+    }),
+  })]),
+});
+let rejected = false;
+try {
+  core.replayStructuralDerivation(memory, badEvidence);
+} catch (error) {
+  assert(error instanceof core.StructuralDerivationReplayError, "unadmitted candidate must fail generic replay");
+  rejected = true;
+}
+assert(rejected, "producer construction must not imply proof acceptance");

--- a/ts/test/proof-producer.test.ts
+++ b/ts/test/proof-producer.test.ts
@@ -1,0 +1,16 @@
+import * as core from "../src/public.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const createStructuralProofProducer = (
+  core as unknown as {
+    readonly createStructuralProofProducer?: unknown;
+  }
+).createStructuralProofProducer;
+
+assert(
+  typeof createStructuralProofProducer === "function",
+  "package root must expose createStructuralProofProducer",
+);

--- a/ts/test/public-api.test.ts
+++ b/ts/test/public-api.test.ts
@@ -113,6 +113,7 @@ const expectedRuntimeExports = [
   "computePortableStructuralTheoryRevision",
   "createPortableStructuralDerivationProvenanceClaim",
   "createPortableStructuralDerivationWithAssumptionsProvenanceClaim",
+  "createStructuralProofProducer",
   "deserializeAnum",
   "deserializeStream",
   "elaborateBundleRoles",
@@ -158,7 +159,7 @@ const expectedRuntimeExports = [
   "verifyPortableStructuralProofTheoryRevision",
 ].sort();
 
-assert(expectedRuntimeExports.length === 88, "R3 Theory lock runtime export budget must be exactly 88");
+assert(expectedRuntimeExports.length === 89, "R3 Theory lock runtime export budget must be exactly 89");
 assert(
   JSON.stringify(Object.keys(publicApi).sort()) === JSON.stringify(expectedRuntimeExports),
   `unexpected runtime exports: ${Object.keys(publicApi).sort().join(",")}`,


### PR DESCRIPTION
Implements #926 as a package-root construction-only proof producer facade over the existing structural evidence vocabulary.

TDD evidence:
- RED head `0cfe5d7ddb72a15b307d7e99e994557edc5c543b`: CI #3712 failed exactly because `createStructuralProofProducer` was absent from the package root.
- First GREEN exposed the repository's existing public API allowlist; CI #3719 passed the producer boundary test and failed only on the stale 88-export count. The allowlist was updated explicitly within scope.
- Method-contract RED head `a984797ac01eb9df4b3d54c71451478dc2c11e4a`: CI #3730 failed exactly at `producer must expose defineContext`.
- Construction facade GREEN head `bab4200da7e34d2042cee629bdaab634964ecd24`: CI #3732 SUCCESS.
- Final head `ecee7996ad84f877180afdbc823613de77f587b1`: CI #3738 SUCCESS, including runtime build -> export -> trusted replay, package-root consumer smoke, visual companion and Contract Observatory.

Authority invariant: producer methods only materialize existing structural candidates. The facade exposes no `accept`, `approve`, `prove`, or `replay` method. An explicitly unadmitted candidate is constructed successfully and then rejected by the existing generic trusted replay path. Accepted MTS v0.11 semantics and trusted replay behavior are unchanged.

Closes #926

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/proof-producer.ts
  - ts/src/public.ts
  - ts/consumer/package-consumer.ts
  - ts/test/proof-producer.test.ts
  - ts/test/public-api.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 650
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - ts/src/public.ts
  - ts/consumer/package-consumer.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - repo-policy.json
  - .github/workflows/**
  - packages/visual/**
  - web/**
expected_effects:
  - "untrusted search/importers can construct generic candidate evidence through package root without deep imports"
  - "producer construction reuses existing structural representations instead of duplicating them downstream"
  - "producer success has zero proof authority until ordinary trusted replay accepts the complete artifact"
  - "trusted replay semantics and accepted MTS v0.11 remain unchanged"
```

`ts/consumer/package-consumer.ts` now exercises only `@mts/core` root imports for producer -> candidate -> portable export -> unified trusted replay. Existing generic negative replay coverage remains authoritative for wrong bindings, missing premises, wrong dependencies and cycles; #926 adds the producer-specific no-privileged-authority and unadmitted-candidate negative.