### PR TITLE
[Observatory/V4d] Contract anatomy and evidence traceability

### DIFF
--- a/web/contract-observatory/src/interaction.ts
+++ b/web/contract-observatory/src/interaction.ts
@@ -2,6 +2,7 @@ import type {
   MethodologyProjection,
   MethodologyStage,
   MethodologyVersionProjection,
+  TraceabilityRelation,
 } from "./methodology-projection.js";
 
 export const METHODOLOGY_STAGE_ORDER: readonly MethodologyStage[] = Object.freeze([
@@ -61,6 +62,20 @@ export interface InteractiveMethodologyModel {
   readonly versions: readonly InteractiveMethodologyVersion[];
 }
 
+export interface EvidenceAnatomyModel {
+  readonly versionId: string | null;
+  readonly selectedItemId: string | null;
+  readonly positiveVectorIds: readonly string[];
+  readonly negativeVectorIds: readonly string[];
+  readonly executableGateIds: readonly string[];
+  readonly evidenceIds: readonly string[];
+  readonly acceptanceIds: readonly string[];
+  readonly highlightedItemIds: readonly string[];
+  readonly sourcePaths: readonly string[];
+  readonly relations: readonly TraceabilityRelation[];
+  readonly unresolvedRelations: readonly string[];
+}
+
 const DEFAULT_VIEWPORT: ObservatoryViewport = Object.freeze({ x: 0, y: 0, scale: 1 });
 
 export function reduceInteractionState(
@@ -93,6 +108,73 @@ export function buildInteractiveMethodologyModel(
   return Object.freeze({
     stages: Object.freeze(stages),
     versions: Object.freeze(versions),
+  });
+}
+
+export function buildEvidenceAnatomyModel(
+  projection: MethodologyProjection,
+  state: ObservatoryInteractionState,
+): EvidenceAnatomyModel {
+  const version = projection.versions.find((entry) => entry.contractId === state.selectedVersionId)
+    ?? projection.versions.find((entry) => entry.isCurrent)
+    ?? projection.versions[0];
+  if (version === undefined) {
+    return Object.freeze({
+      versionId: null,
+      selectedItemId: null,
+      positiveVectorIds: Object.freeze([]),
+      negativeVectorIds: Object.freeze([]),
+      executableGateIds: Object.freeze([]),
+      evidenceIds: Object.freeze([]),
+      acceptanceIds: Object.freeze([]),
+      highlightedItemIds: Object.freeze([]),
+      sourcePaths: Object.freeze([]),
+      relations: Object.freeze([]),
+      unresolvedRelations: Object.freeze([]),
+    });
+  }
+
+  const knownItemIds = new Set<string>([
+    ...version.theoryReferences.map((entry) => `theory:${entry.id}`),
+    ...version.contractReferences.map((entry) => `contract:${entry.id}`),
+    ...version.positiveVectors.map((entry) => `vector:${entry.id}`),
+    ...version.negativeVectors.map((entry) => `vector:${entry.id}`),
+    ...version.executableGates.map((entry) => entry.id),
+    ...version.evidenceReferences.map((entry) => entry.id),
+    ...version.acceptanceReferences.map((entry) => entry.id),
+  ]);
+  const selectedItemId = state.selectedItemId !== null && knownItemIds.has(state.selectedItemId)
+    ? state.selectedItemId
+    : null;
+  const highlighted = new Set<string>();
+  if (selectedItemId !== null) {
+    highlighted.add(selectedItemId);
+    for (const relation of version.traceability) {
+      if (relation.from === selectedItemId) highlighted.add(relation.to);
+      if (relation.to === selectedItemId) highlighted.add(relation.from);
+    }
+  }
+  const sourcePaths = uniqueSorted([
+    version.contractPath,
+    version.conformancePath,
+    ...version.contractReferences.map((entry) => entry.path),
+    ...version.executableGates.map((entry) => entry.path),
+    ...version.evidenceReferences.map((entry) => entry.sourcePath),
+    ...version.acceptanceReferences.map((entry) => entry.sourcePath),
+  ]);
+
+  return Object.freeze({
+    versionId: version.contractId,
+    selectedItemId,
+    positiveVectorIds: Object.freeze(version.positiveVectors.map((entry) => entry.id)),
+    negativeVectorIds: Object.freeze(version.negativeVectors.map((entry) => entry.id)),
+    executableGateIds: Object.freeze(version.executableGates.map((entry) => entry.id)),
+    evidenceIds: Object.freeze(version.evidenceReferences.map((entry) => entry.id)),
+    acceptanceIds: Object.freeze(version.acceptanceReferences.map((entry) => entry.id)),
+    highlightedItemIds: Object.freeze([...highlighted].sort((left, right) => left.localeCompare(right))),
+    sourcePaths,
+    relations: Object.freeze([...version.traceability]),
+    unresolvedRelations: Object.freeze([...version.unresolvedRelations]),
   });
 }
 

--- a/web/contract-observatory/src/site.ts
+++ b/web/contract-observatory/src/site.ts
@@ -1,7 +1,9 @@
 import type { ContractObservatoryIndex, ContractVersionSummary } from "./contract-index.js";
 import {
   METHODOLOGY_STAGE_ORDER,
+  buildEvidenceAnatomyModel,
   buildInteractiveMethodologyModel,
+  type EvidenceAnatomyModel,
   type ObservatoryInteractionState,
 } from "./interaction.js";
 import type { MethodologyProjection, MethodologyVersionProjection } from "./methodology-projection.js";
@@ -47,9 +49,9 @@ export function renderContractObservatoryHtml(
     .methodology-authority { display: flex; flex-wrap: wrap; gap: .5rem; margin: .8rem 0 1rem; font-size: .82rem; }
     .methodology-authority span { padding: .35rem .55rem; border: 1px solid color-mix(in srgb, CanvasText 22%, transparent); border-radius: .6rem; }
     .methodology-controls { display: grid; gap: .8rem; margin-bottom: 1rem; }
-    .stage-controls, .filter-controls, .viewport-controls, .evidence-items { display: flex; flex-wrap: wrap; gap: .45rem; }
-    .stage-controls button, .filter-controls button, .viewport-controls button, .version-select, .evidence-items button { cursor: pointer; border: 1px solid color-mix(in srgb, CanvasText 24%, transparent); border-radius: .65rem; background: Canvas; padding: .5rem .7rem; }
-    button[aria-pressed="true"] { border-width: 2px; font-weight: 800; }
+    .stage-controls, .filter-controls, .viewport-controls, .evidence-items, .anatomy-items { display: flex; flex-wrap: wrap; gap: .45rem; }
+    .stage-controls button, .filter-controls button, .viewport-controls button, .version-select, .evidence-items button, .anatomy-items button { cursor: pointer; border: 1px solid color-mix(in srgb, CanvasText 24%, transparent); border-radius: .65rem; background: Canvas; padding: .5rem .7rem; }
+    button[aria-pressed="true"], button.trace-highlighted { border-width: 2px; font-weight: 800; }
     .methodology-grid { display: grid; gap: .65rem; overflow: auto; padding-bottom: .25rem; }
     .methodology-lane { min-width: 780px; display: grid; grid-template-columns: minmax(190px, 1.4fr) repeat(7, minmax(72px, 1fr)); gap: .35rem; align-items: stretch; padding: .5rem; border: 1px solid color-mix(in srgb, CanvasText 15%, transparent); border-radius: .8rem; }
     .methodology-lane.selected, .methodology-lane.selection-synced { border-width: 2px; }
@@ -61,7 +63,12 @@ export function renderContractObservatoryHtml(
     .stage-cell.stage-selected { border-width: 2px; font-weight: 800; }
     .stage-evidence { display: block; margin-top: .2rem; font-size: .65rem; opacity: .7; }
     .evidence-items { grid-column: 1 / -1; padding-top: .25rem; }
-    .evidence-items button { padding: .3rem .5rem; font-size: .7rem; overflow-wrap: anywhere; }
+    .evidence-items button, .anatomy-items button { padding: .3rem .5rem; font-size: .7rem; overflow-wrap: anywhere; }
+    .evidence-anatomy { display: grid; gap: .7rem; margin-top: 1rem; padding: .8rem; border: 1px solid color-mix(in srgb, CanvasText 15%, transparent); border-radius: .8rem; }
+    .evidence-anatomy h3 { margin: 0; font-size: 1rem; }
+    .anatomy-group { display: grid; gap: .35rem; }
+    .anatomy-group strong { font-size: .72rem; letter-spacing: .05em; text-transform: uppercase; }
+    .anatomy-provenance, .anatomy-unresolved { margin: 0; padding-left: 1.2rem; font-size: .75rem; overflow-wrap: anywhere; }
     .methodology-status { margin: .8rem 0 0; min-height: 1.3em; font-size: .82rem; opacity: .75; }
     .timeline { margin: 0 0 2.5rem; }
     .timeline h2, .versions h2 { margin: 0 0 1rem; font-size: 1.5rem; }
@@ -110,7 +117,13 @@ function renderMethodologyMap(projection: MethodologyProjection): string {
   const model = buildInteractiveMethodologyModel(projection, state);
   const stageControls = model.stages.map((entry) => `<button type="button" data-methodology-stage="${entry.stage}" aria-pressed="false" title="Lifecycle stage: ${entry.stage}; derived presentation state">${escapeHtml(entry.stage)}</button>`).join("\n");
   const lanes = model.versions.map((entry, ordinal) => renderMethodologyLane(projection.versions[ordinal]!, entry)).join("\n");
-  const controllerData = projection.versions.map((version, ordinal) => ({ id: version.contractId, classification: model.versions[ordinal]!.classification.toLowerCase(), itemIds: methodologyItemIds(version) }));
+  const anatomies = projection.versions.map((version) => buildEvidenceAnatomyModel(projection, Object.freeze({ ...state, selectedVersionId: version.contractId }))).map(renderEvidenceAnatomy).join("\n");
+  const controllerData = projection.versions.map((version, ordinal) => ({
+    id: version.contractId,
+    classification: model.versions[ordinal]!.classification.toLowerCase(),
+    itemIds: methodologyItemIds(version),
+    relations: version.traceability.map((relation) => ({ from: relation.from, to: relation.to })),
+  }));
 
   return `    <section class="methodology-map" aria-labelledby="methodology-title">
       <div class="methodology-heading"><p class="eyebrow">Primary explanatory view · derived methodology</p><h2 id="methodology-title">Methodology map + version lifecycle lanes</h2><p>Две координированные, но не тождественные структуры: метод разработки и состояние жизненного цикла версии.</p></div>
@@ -122,6 +135,7 @@ function renderMethodologyMap(projection: MethodologyProjection): string {
         <div class="viewport-controls" role="group" aria-label="Map viewport"><button type="button" data-viewport-action="zoom-out" aria-label="Zoom out">−</button><button type="button" data-viewport-action="reset">Reset viewport</button><button type="button" data-viewport-action="zoom-in" aria-label="Zoom in">+</button></div>
       </div>
       <div class="methodology-grid" tabindex="0" aria-label="Version lifecycle lanes">${lanes}</div>
+      <div class="evidence-anatomies" aria-label="Contract anatomy and evidence traceability">${anatomies}</div>
       <p class="methodology-status" aria-live="polite"></p>
     </section>
 ${renderMethodologyController(controllerData, selectedVersionId)}`;
@@ -135,8 +149,25 @@ function renderMethodologyLane(projection: MethodologyVersionProjection, model: 
   return `<div class="methodology-lane${model.selected ? " selected" : ""}" data-version-lane="${escapeAttribute(model.contractId)}" data-categories="${categories}"><div class="lane-version"><button type="button" class="version-select" data-version-id="${escapeAttribute(model.contractId)}" aria-pressed="${model.selected ? "true" : "false"}" title="Select version and synchronize Observatory views">${escapeHtml(model.contractId)}</button><span class="lane-classification">${model.classification}</span></div>${stages}<div class="evidence-items" aria-label="Evidence references for ${escapeAttribute(model.contractId)}">${evidenceItems || "<span>No linked evidence references</span>"}</div></div>`;
 }
 
+function renderEvidenceAnatomy(anatomy: EvidenceAnatomyModel): string {
+  const versionId = anatomy.versionId ?? "none";
+  return `<section class="evidence-anatomy" data-anatomy-version="${escapeAttribute(versionId)}"${anatomy.versionId === null ? " hidden" : ""}><h3>Contract anatomy · ${escapeHtml(versionId)}</h3>${renderAnatomyGroup("Positive obligations", anatomy.positiveVectorIds.map((id) => `vector:${id}`))}${renderAnatomyGroup("Negative / veto obligations", anatomy.negativeVectorIds.map((id) => `vector:${id}`))}${renderAnatomyGroup("Executable gates", anatomy.executableGateIds)}${renderAnatomyGroup("Evidence", anatomy.evidenceIds)}${renderAnatomyGroup("Acceptance", anatomy.acceptanceIds)}<div class="anatomy-group"><strong>Raw provenance</strong><ul class="anatomy-provenance">${anatomy.sourcePaths.map((path) => `<li data-source-path="${escapeAttribute(path)}"><code>${escapeHtml(path)}</code></li>`).join("")}</ul></div><div class="anatomy-group"><strong>Unresolved traceability</strong><ul class="anatomy-unresolved">${anatomy.unresolvedRelations.length > 0 ? anatomy.unresolvedRelations.map((item) => `<li>${escapeHtml(item)}</li>`).join("") : "<li>none</li>"}</ul></div></section>`;
+}
+
+function renderAnatomyGroup(label: string, ids: readonly string[]): string {
+  return `<div class="anatomy-group"><strong>${escapeHtml(label)}</strong><div class="anatomy-items">${ids.length > 0 ? ids.map((id) => `<button type="button" data-item-id="${escapeAttribute(id)}" aria-pressed="false">${escapeHtml(id)}</button>`).join("") : "<span>none</span>"}</div></div>`;
+}
+
 function methodologyItemIds(version: MethodologyVersionProjection): string[] {
-  return [...new Set([...version.theoryReferences.map((entry) => entry.id), ...version.contractReferences.map((entry) => entry.id), ...version.positiveVectors.map((entry) => entry.id), ...version.negativeVectors.map((entry) => entry.id), ...version.evidenceReferences.map((entry) => entry.id), ...version.acceptanceReferences.map((entry) => entry.id)])].sort((a, b) => a.localeCompare(b));
+  return [...new Set([
+    ...version.theoryReferences.map((entry) => `theory:${entry.id}`),
+    ...version.contractReferences.map((entry) => `contract:${entry.id}`),
+    ...version.positiveVectors.map((entry) => `vector:${entry.id}`),
+    ...version.negativeVectors.map((entry) => `vector:${entry.id}`),
+    ...version.executableGates.map((entry) => entry.id),
+    ...version.evidenceReferences.map((entry) => entry.id),
+    ...version.acceptanceReferences.map((entry) => entry.id),
+  ])].sort((a, b) => a.localeCompare(b));
 }
 
 function methodologyCategories(version: MethodologyVersionProjection, classification: string): string[] {
@@ -150,7 +181,7 @@ function methodologyCategories(version: MethodologyVersionProjection, classifica
 
 function renderFilterButton(filter: string, label: string): string { return `<button type="button" data-methodology-filter="${filter}" aria-pressed="false">${label}</button>`; }
 
-function renderMethodologyController(versions: readonly { readonly id: string; readonly classification: string; readonly itemIds: readonly string[] }[], defaultVersionId: string | null): string {
+function renderMethodologyController(versions: readonly { readonly id: string; readonly classification: string; readonly itemIds: readonly string[]; readonly relations: readonly { readonly from: string; readonly to: string }[] }[], defaultVersionId: string | null): string {
   const data = escapeJsonForScript(JSON.stringify({ versions, stages: METHODOLOGY_STAGE_ORDER, defaultVersionId, filters: ["accepted", "candidate", "current", "evidence", "negative", "positive", "previous"] }));
   return `    <script>
 (() => {
@@ -176,14 +207,18 @@ function renderMethodologyController(versions: readonly { readonly id: string; r
 
   const apply = () => {
     const state = readState();
+    const activeVersion = config.versions.find((entry) => entry.id === state.versionId);
+    const highlighted = new Set(state.item ? [state.item] : []);
+    if (state.item && activeVersion) for (const relation of activeVersion.relations) { if (relation.from === state.item) highlighted.add(relation.to); if (relation.to === state.item) highlighted.add(relation.from); }
     map.querySelectorAll("[data-methodology-stage]").forEach((button) => button.setAttribute("aria-pressed", String(button.dataset.methodologyStage === state.stage)));
     map.querySelectorAll("[data-methodology-filter]").forEach((button) => button.setAttribute("aria-pressed", String(state.filters.includes(button.dataset.methodologyFilter))));
-    map.querySelectorAll("[data-item-id]").forEach((button) => button.setAttribute("aria-pressed", String(button.dataset.itemId === state.item)));
+    map.querySelectorAll("[data-item-id]").forEach((button) => { button.setAttribute("aria-pressed", String(button.dataset.itemId === state.item)); button.classList.toggle("trace-highlighted", highlighted.has(button.dataset.itemId)); });
     map.querySelectorAll("[data-version-lane]").forEach((lane) => { const selected = lane.dataset.versionLane === state.versionId; const categories = (lane.dataset.categories || "").split(" "); const visible = state.filters.length === 0 || state.filters.every((value) => categories.includes(value)); lane.hidden = !visible; lane.classList.toggle("selected", selected); lane.querySelector("[data-version-id]")?.setAttribute("aria-pressed", String(selected)); lane.querySelectorAll("[data-lane-stage]").forEach((cell) => cell.classList.toggle("stage-selected", cell.dataset.laneStage === state.stage)); });
+    map.querySelectorAll("[data-anatomy-version]").forEach((panel) => { panel.hidden = panel.dataset.anatomyVersion !== state.versionId; });
     document.querySelectorAll("[data-overview-version-id]").forEach((node) => node.classList.toggle("selection-synced", node.dataset.overviewVersionId === state.versionId));
     if (grid) { grid.style.zoom = String(state.z); grid.scrollLeft = state.x; grid.scrollTop = state.y; }
     const status = map.querySelector(".methodology-status");
-    if (status) status.textContent = "Selected: " + (state.versionId ?? "none") + "; stage: " + (state.stage ?? "all") + "; item: " + (state.item ?? "none") + "; filters: " + (state.filters.join(", ") || "none") + "; zoom: " + state.z + ".";
+    if (status) status.textContent = "Selected: " + (state.versionId ?? "none") + "; stage: " + (state.stage ?? "all") + "; item: " + (state.item ?? "none") + "; linked: " + ([...highlighted].join(", ") || "none") + "; filters: " + (state.filters.join(", ") || "none") + "; zoom: " + state.z + ".";
   };
 
   map.addEventListener("click", (event) => {

--- a/web/contract-observatory/test/evidence-anatomy.test.ts
+++ b/web/contract-observatory/test/evidence-anatomy.test.ts
@@ -1,0 +1,93 @@
+import {
+  buildEvidenceAnatomyModel,
+  type ObservatoryInteractionState,
+} from "../src/interaction.js";
+import type {
+  MethodologyProjection,
+  MethodologyVersionProjection,
+} from "../src/methodology-projection.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Contract Observatory V4d: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+const version: MethodologyVersionProjection = Object.freeze({
+  contractId: "mts-contract/v0.11",
+  conformanceId: "mts-conformance/v0.11",
+  contractPath: "contracts/mts-contract-v0.11.json",
+  conformancePath: "contracts/mts-conformance-v0.11.json",
+  status: "accepted",
+  accepted: true,
+  acceptanceReady: true,
+  isCurrent: true,
+  isPrevious: false,
+  theoryReferences: Object.freeze([
+    Object.freeze({ authority: "theory-reference", id: "mts-contract/v0.10" }),
+  ]),
+  contractReferences: Object.freeze([
+    Object.freeze({ authority: "contract", id: "mts-contract/v0.11", path: "contracts/mts-contract-v0.11.json" }),
+  ]),
+  positiveVectors: Object.freeze([
+    Object.freeze({ authority: "conformance-vector", id: "POS-A", polarity: "positive", evidence: Object.freeze(["ts/test/positive.test.ts"]) }),
+  ]),
+  negativeVectors: Object.freeze([
+    Object.freeze({ authority: "conformance-vector", id: "NEG-A", polarity: "negative", evidence: Object.freeze(["ts/test/negative.test.ts"]) }),
+    Object.freeze({ authority: "conformance-vector", id: "NEG-UNLINKED", polarity: "negative", evidence: Object.freeze([]) }),
+  ]),
+  executableGates: Object.freeze([
+    Object.freeze({ authority: "executable-gate", id: "gate:ts/test/release-cutover.test.ts", path: "ts/test/release-cutover.test.ts" }),
+  ]),
+  evidenceReferences: Object.freeze([
+    Object.freeze({ authority: "evidence", id: "evidence:ts/test/negative.test.ts", sourcePath: "ts/test/negative.test.ts" }),
+    Object.freeze({ authority: "evidence", id: "evidence:ts/test/positive.test.ts", sourcePath: "ts/test/positive.test.ts" }),
+  ]),
+  acceptanceReferences: Object.freeze([
+    Object.freeze({ authority: "acceptance", id: "acceptance:mts-contract/v0.11:current", sourcePath: "cutover/typescript-c1-acceptance-v0.4.json" }),
+  ]),
+  lifecycle: Object.freeze([]),
+  traceability: Object.freeze([
+    Object.freeze({ authority: "traceability", from: "vector:NEG-A", to: "evidence:ts/test/negative.test.ts", relation: "supported-by" }),
+    Object.freeze({ authority: "traceability", from: "vector:POS-A", to: "evidence:ts/test/positive.test.ts", relation: "supported-by" }),
+    Object.freeze({ authority: "traceability", from: "contract:mts-contract/v0.11", to: "acceptance:mts-contract/v0.11:current", relation: "accepted-by" }),
+  ]),
+  unresolvedRelations: Object.freeze(["vector-evidence:NEG-UNLINKED"]),
+});
+
+const projection: MethodologyProjection = Object.freeze({
+  schema: "mts-contract-methodology-projection/v0.1",
+  versions: Object.freeze([version]),
+});
+
+const state: ObservatoryInteractionState = Object.freeze({
+  selectedVersionId: "mts-contract/v0.11",
+  selectedStage: null,
+  selectedItemId: "evidence:ts/test/negative.test.ts",
+  filters: Object.freeze([]),
+  viewport: Object.freeze({ x: 0, y: 0, scale: 1 }),
+});
+
+const anatomy = buildEvidenceAnatomyModel(projection, state);
+same(anatomy.versionId, "mts-contract/v0.11", "selected version drives anatomy");
+same(anatomy.selectedItemId, "evidence:ts/test/negative.test.ts", "selected evidence remains explicit");
+same(anatomy.positiveVectorIds.join(","), "POS-A", "positive vectors remain a separate first-class group");
+same(anatomy.negativeVectorIds.join(","), "NEG-A,NEG-UNLINKED", "negative vectors remain a separate first-class group");
+assert(anatomy.highlightedItemIds.includes("evidence:ts/test/negative.test.ts"), "selected evidence is highlighted");
+assert(anatomy.highlightedItemIds.includes("vector:NEG-A"), "evidence selection back-highlights only an explicitly linked obligation");
+assert(!anatomy.highlightedItemIds.includes("vector:POS-A"), "unrelated positive obligation is not guessed as linked");
+assert(anatomy.sourcePaths.includes("contracts/mts-contract-v0.11.json"), "contract raw provenance is reachable");
+assert(anatomy.sourcePaths.includes("contracts/mts-conformance-v0.11.json"), "conformance raw provenance is reachable");
+assert(anatomy.sourcePaths.includes("cutover/typescript-c1-acceptance-v0.4.json"), "acceptance raw provenance is reachable");
+assert(anatomy.unresolvedRelations.includes("vector-evidence:NEG-UNLINKED"), "missing traceability stays explicit");
+
+const unknownSelection = buildEvidenceAnatomyModel(
+  projection,
+  Object.freeze({ ...state, selectedItemId: "evidence:missing" }),
+);
+same(unknownSelection.selectedItemId, null, "unknown selected item fails closed instead of fabricating traceability");
+same(unknownSelection.highlightedItemIds.length, 0, "unknown item highlights nothing");
+
+console.log("Contract Observatory V4d evidence anatomy specification passed.");

--- a/web/contract-observatory/test/site.test.ts
+++ b/web/contract-observatory/test/site.test.ts
@@ -12,9 +12,10 @@ import {
 import { buildMethodologyProjection } from "../src/methodology-projection.js";
 import { renderContractObservatoryHtml } from "../src/site.js";
 import "./interaction.test.js";
+import "./evidence-anatomy.test.js";
 
 function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(`Contract Observatory V3b/V3c/V4c: ${message}`);
+  if (!condition) throw new Error(`Contract Observatory V3b/V3c/V4c/V4d: ${message}`);
 }
 
 function same<T>(actual: T, expected: T, message: string): void {
@@ -101,6 +102,15 @@ assert(realHtml.includes("Method/lifecycle relation"), "methodology relation aut
 assert(realHtml.includes("Semantic topology Link: not rendered in this view"), "methodology view cannot be mistaken for MTS semantic Links");
 assert(realHtml.includes("addEventListener(\"hashchange\""), "deep-link back/forward restoration is wired in the client controller");
 assert(realHtml.includes("addEventListener(\"keydown\""), "keyboard stage/version activation is wired in the client controller");
+
+assert(realHtml.includes("aria-label=\"Contract anatomy and evidence traceability\""), "V4d anatomy has an explicit landmark");
+assert(realHtml.includes("Contract anatomy · mts-contract/v0.11"), "current contract anatomy is rendered");
+assert(realHtml.includes("Positive obligations"), "positive obligations are separately visible");
+assert(realHtml.includes("Negative / veto obligations"), "negative/veto obligations are separately visible");
+assert(realHtml.includes("Raw provenance"), "raw provenance is visible from the anatomy view");
+assert(realHtml.includes("Unresolved traceability"), "missing traceability remains explicit");
+assert(realHtml.includes("trace-highlighted"), "client controller carries explicit cross-highlighting state");
+assert(realHtml.includes("data-source-path="), "raw provenance keeps source path identity in rendered output");
 
 const v010Position = realHtml.indexOf("mts-contract/v0.10");
 const v011Position = realHtml.indexOf("mts-contract/v0.11");
@@ -206,4 +216,4 @@ execFileSync(
   { cwd: repositoryRoot, stdio: "inherit" },
 );
 
-console.log("Contract Observatory V3b/V3c static UI, materialization and V4a/V4c interaction checks passed.");
+console.log("Contract Observatory V3b/V3c static UI, materialization and V4a/V4c/V4d interaction checks passed.");


### PR DESCRIPTION
Partial implementation for #959.

This draft implements the source-derived V4d anatomy/cross-highlighting that is justified by the current accepted V4b projection:

- positive and negative conformance vectors remain separate first-class groups;
- raw contract/conformance/gate/evidence/acceptance provenance stays visible;
- missing traceability remains explicit;
- selecting an evidence/reference item cross-highlights only exact existing V4b traceability endpoints, bidirectionally;
- methodology/evidence presentation remains explicitly distinct from semantic MTS Link identity.

TDD evidence:

- RED head `9eada5d74b8e44aa669c67f4b74e794f68b551b4`: Contract Observatory Pages run #26 failed exactly because `buildEvidenceAnatomyModel` did not exist (`TS2305`);
- current partial GREEN head `860226297860fc8d014fac05d08e8be8aead4629`: full CI #3794 SUCCESS, Contract Observatory Pages #29 SUCCESS, blocking repo-guard #873 SUCCESS.

## Explicit unresolved authority boundary

The full Done criterion of #959 is invariant-centric: a selected contract invariant must link to its exact positive/negative vectors, gates/evidence and acceptance chain. Current authoritative repository data does not expose that relation machine-addressably:

- `contracts/mts-contract-v0.11.json` contains contract fields including `requiredSemanticLaws`, but no stable invariant identifier or explicit invariant -> vector/gate cross-reference;
- `contracts/mts-conformance-v0.11.json` contains required vector IDs, negative vectors, executable gates, `vectorEvidence` and production evidence, but no exact pointer back to a particular contract invariant/field;
- the accepted V4b projection currently serializes vector -> evidence and contract -> acceptance traceability, but no `SemanticInvariant` / invariant -> vector/gate relation.

#959 explicitly forbids guessing missing links. Therefore this PR remains **draft** and does not close #959. Do not infer invariant traceability from similar names, prose, test paths, CI success, or visual adjacency, and do not mutate accepted contracts merely to satisfy the UI.

No #960 compare work, #961 semantic topology work, or accepted MTS semantic delta is included.

```repo-guard-yaml
change_type: feature
scope:
  - web/contract-observatory/src/interaction.ts
  - web/contract-observatory/src/site.ts
  - web/contract-observatory/test/evidence-anatomy.test.ts
  - web/contract-observatory/test/site.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 500
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - web/contract-observatory/test/evidence-anatomy.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/src/**
  - packages/visual/**
  - repo-policy.json
expected_effects:
  - "Positive and negative conformance vectors remain separately visible in V4d anatomy."
  - "Selecting an evidence item cross-highlights only explicitly traceability-linked items."
  - "Raw contract/conformance/evidence/acceptance provenance remains reachable and unresolved relations stay explicit."
  - "Methodology/evidence presentation does not claim semantic MTS Link identity."
```