### PR TITLE
[Syntax/S1] Export reusable SyntaxAset tooling boundary

### DIFF
--- a/ts/consumer/package-consumer.ts
+++ b/ts/consumer/package-consumer.ts
@@ -34,6 +34,12 @@ import {
   type StructuralDerivationEvidence,
 } from "@mts/core";
 import { textToAnum } from "@mts/core/tooling/payload";
+import {
+  SyntaxAsetBuilder,
+  materializeSyntaxAsetVocabulary,
+  readSyntaxAset,
+  type SyntaxAsetToolingVocabulary,
+} from "@mts/core/tooling/syntax-aset";
 
 // Package-boundary smoke: this file must resolve through package exports and
 // generated declarations, not through source-relative imports.
@@ -42,6 +48,20 @@ const basis = ensureRootBasis(memory);
 const read: ReadMemory = memory;
 const link: LinkHandle = basis.L;
 const encoded: string = textToAnum("A");
+
+// Syntax tooling is reusable only through its non-root package subpath. The
+// vocabulary is structurally derived in caller-owned Memory and interoperates
+// with the exact S0 builder/reader contract without downstream AST types.
+const syntaxSeed = memory.ensureEndSelfClosed(basis.U);
+const syntaxVocabulary: SyntaxAsetToolingVocabulary =
+  materializeSyntaxAsetVocabulary(memory, syntaxSeed);
+const syntaxBuilder = new SyntaxAsetBuilder(memory, syntaxVocabulary);
+const syntaxCarrier = memory.ensureStartSelfClosed(syntaxVocabulary.tag);
+const syntaxLiteral = syntaxBuilder.addOccurrence(syntaxVocabulary.kinds.Literal, [
+  { role: syntaxVocabulary.roles.value, value: syntaxCarrier },
+]);
+const syntaxAset = syntaxBuilder.finish(syntaxLiteral);
+const syntaxRead = readSyntaxAset(memory, syntaxAset, syntaxVocabulary);
 
 const semanticBase: "mts-contract/v0.11" = PORTABLE_MTS_SEMANTIC_BASE;
 const portableReplay: (input: unknown) => PortableStructuralDerivationReplayResult =
@@ -143,6 +163,8 @@ void [
   read,
   link,
   encoded,
+  syntaxVocabulary,
+  syntaxRead,
   semanticBase,
   portableReplay,
   portableAssumptionReplay,
@@ -170,3 +192,8 @@ void [
 // @ts-expect-error @mts/core/memory is not exported by package.json.
 import type { AppendOnlyReadMemory } from "@mts/core/memory";
 void (undefined as unknown as AppendOnlyReadMemory);
+
+// Syntax tooling must not enlarge the trusted package-root semantic surface.
+// @ts-expect-error SyntaxAsetToolingVocabulary is tooling-only, not @mts/core root.
+import type { SyntaxAsetToolingVocabulary as RootSyntaxAsetToolingVocabulary } from "@mts/core";
+void (undefined as unknown as RootSyntaxAsetToolingVocabulary);

--- a/ts/package.json
+++ b/ts/package.json
@@ -34,7 +34,7 @@
     "package:check": "tsc -p tsconfig.consumer.json --noEmit",
     "package:artifact": "npm run build --silent && npm pack",
     "browser:typecheck": "tsc -p tsconfig.browser.json",
-    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
+    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node24 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
     "test": "npm run build && npm run package:check && node dist/src/tooling/test-runner.js",
     "docs:sync": "npm run build --silent && node dist/src/tooling/docs-sync.js --write",
     "docs:check": "npm run build --silent && node dist/src/tooling/docs-sync.js --check",

--- a/ts/package.json
+++ b/ts/package.json
@@ -19,6 +19,10 @@
     "./tooling/notation": {
       "types": "./dist/src/tooling/notation.d.ts",
       "default": "./dist/src/tooling/notation.js"
+    },
+    "./tooling/syntax-aset": {
+      "types": "./dist/src/tooling/syntax-aset.d.ts",
+      "default": "./dist/src/tooling/syntax-aset.js"
     }
   },
   "bin": {
@@ -30,7 +34,7 @@
     "package:check": "tsc -p tsconfig.consumer.json --noEmit",
     "package:artifact": "npm run build --silent && npm pack",
     "browser:typecheck": "tsc -p tsconfig.browser.json",
-    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && esbuild browser/indexeddb-dataset-repository.test.ts --bundle --platform=node --format=esm --target=node24 --outfile=dist/browser/indexeddb-dataset-repository.test.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
+    "browser:check": "npm run browser:typecheck && esbuild browser/core-smoke.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/core-smoke.js && esbuild browser/indexeddb-dataset-repository.ts --bundle --platform=browser --format=esm --target=es2022 --outfile=dist/browser/indexeddb-dataset-repository.js && node dist/browser/core-smoke.js && node dist/browser/indexeddb-dataset-repository.test.js",
     "test": "npm run build && npm run package:check && node dist/src/tooling/test-runner.js",
     "docs:sync": "npm run build --silent && node dist/src/tooling/docs-sync.js --write",
     "docs:check": "npm run build --silent && node dist/src/tooling/docs-sync.js --check",

--- a/ts/src/tooling/syntax-aset.ts
+++ b/ts/src/tooling/syntax-aset.ts
@@ -1,0 +1,120 @@
+import {
+  type LinkHandle,
+  type WriteMemory,
+} from "../memory.js";
+import {
+  SyntaxAsetBuilder,
+  SyntaxAsetContractError,
+  readSyntaxAset,
+  type SyntaxAsetField,
+  type SyntaxAsetOccurrence,
+  type SyntaxAsetRead,
+  type SyntaxAsetVocabulary,
+} from "../syntax-aset-contract.js";
+
+export {
+  SyntaxAsetBuilder,
+  SyntaxAsetContractError,
+  readSyntaxAset,
+};
+export type {
+  SyntaxAsetField,
+  SyntaxAsetOccurrence,
+  SyntaxAsetRead,
+  SyntaxAsetVocabulary,
+};
+
+const KIND_NAMES = [
+  "File",
+  "Statement",
+  "Link",
+  "Definition",
+  "Equality",
+  "Inequality",
+  "Sequence",
+  "Set",
+  "Round",
+  "Square",
+  "Not",
+  "Female",
+  "Male",
+  "ContextPronoun",
+  "Literal",
+] as const;
+
+const ROLE_NAMES = [
+  "item",
+  "expression",
+  "start",
+  "end",
+  "name",
+  "body",
+  "left",
+  "right",
+  "operand",
+  "value",
+] as const;
+
+const CHILD_ROLE_NAMES = [
+  "item",
+  "expression",
+  "start",
+  "end",
+  "body",
+  "left",
+  "right",
+  "operand",
+] as const;
+
+export type SyntaxAsetKindName = typeof KIND_NAMES[number];
+export type SyntaxAsetRoleName = typeof ROLE_NAMES[number];
+export type SyntaxAsetKindLinks = Readonly<Record<SyntaxAsetKindName, LinkHandle>>;
+export type SyntaxAsetRoleLinks = Readonly<Record<SyntaxAsetRoleName, LinkHandle>>;
+
+export interface SyntaxAsetToolingVocabulary extends SyntaxAsetVocabulary {
+  readonly kinds: SyntaxAsetKindLinks;
+  readonly roles: SyntaxAsetRoleLinks;
+}
+
+function materializeNamedSeries<Name extends string>(
+  memory: WriteMemory,
+  scope: LinkHandle,
+  names: readonly Name[],
+): Readonly<Record<Name, LinkHandle>> {
+  let cursor = scope;
+  const entries: Array<readonly [Name, LinkHandle]> = [];
+  for (const name of names) {
+    cursor = memory.ensure(cursor, scope);
+    entries.push(Object.freeze([name, cursor]));
+  }
+  return Object.freeze(Object.fromEntries(entries)) as Readonly<Record<Name, LinkHandle>>;
+}
+
+/**
+ * Materialize the reusable syntax-only vocabulary relative to one explicit
+ * caller-owned seed Link. Names in this TypeScript object are API labels only:
+ * the Link identities are the structural forms derived below, never strings,
+ * source positions, host object identities, allocation indexes or visual keys.
+ */
+export function materializeSyntaxAsetVocabulary(
+  memory: WriteMemory,
+  seed: LinkHandle,
+): SyntaxAsetToolingVocabulary {
+  const seedClosure = memory.ensureStartSelfClosed(seed);
+  const namespace = memory.ensure(seed, seedClosure);
+  const kindScope = memory.ensureStartSelfClosed(namespace);
+  const roleScope = memory.ensureEndSelfClosed(namespace);
+  const tag = memory.ensure(kindScope, roleScope);
+  const kinds = materializeNamedSeries(memory, kindScope, KIND_NAMES);
+  const roles = materializeNamedSeries(memory, roleScope, ROLE_NAMES);
+  const childRoles = Object.freeze(
+    CHILD_ROLE_NAMES.map((name) => roles[name]),
+  );
+
+  return Object.freeze({
+    tag,
+    kinds,
+    roles,
+    childRoles,
+  });
+}

--- a/ts/test/syntax-aset-tooling.test.ts
+++ b/ts/test/syntax-aset-tooling.test.ts
@@ -1,0 +1,207 @@
+import {
+  Memory,
+  type LinkHandle,
+  type LinkPoles,
+  type ReadMemory,
+} from "../src/memory.js";
+import {
+  SyntaxAsetBuilder,
+  SyntaxAsetContractError,
+  materializeSyntaxAsetVocabulary,
+  readSyntaxAset,
+  type SyntaxAsetToolingVocabulary,
+} from "../src/tooling/syntax-aset.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function rejectContract(
+  effect: () => unknown,
+  code: SyntaxAsetContractError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
+    same(error.code, code, "SyntaxAset error code");
+    return;
+  }
+  throw new Error(`expected SyntaxAset rejection: ${code}`);
+}
+
+function vocabularySeed(memory: Memory): LinkHandle {
+  return memory.ensureEndSelfClosed(memory.root);
+}
+
+function topology(memory: ReadMemory, root: LinkHandle): string {
+  const ids = new Map<LinkHandle, number>([[root, 0]]);
+  const queue: LinkHandle[] = [root];
+  const records: Array<readonly [number, number]> = [];
+  const id = (link: LinkHandle): number => {
+    const existing = ids.get(link);
+    if (existing !== undefined) return existing;
+    const created = ids.size;
+    ids.set(link, created);
+    queue.push(link);
+    return created;
+  };
+  for (let cursor = 0; cursor < queue.length; cursor += 1) {
+    const link = queue[cursor];
+    assert(link !== undefined, "topology queue entry exists");
+    const poles = memory.poles(link);
+    records.push(Object.freeze([id(poles.start), id(poles.end)]));
+  }
+  return JSON.stringify(records);
+}
+
+function vocabularyFingerprint(
+  memory: ReadMemory,
+  vocabulary: SyntaxAsetToolingVocabulary,
+): string {
+  return JSON.stringify({
+    tag: topology(memory, vocabulary.tag),
+    kinds: Object.fromEntries(
+      Object.entries(vocabulary.kinds).map(([name, link]) => [name, topology(memory, link)]),
+    ),
+    roles: Object.fromEntries(
+      Object.entries(vocabulary.roles).map(([name, link]) => [name, topology(memory, link)]),
+    ),
+  });
+}
+
+class ReadProbe implements ReadMemory {
+  polesCalls = 0;
+
+  constructor(private readonly source: ReadMemory) {}
+
+  get root(): LinkHandle { return this.source.root; }
+  get linkCount(): number { return this.source.linkCount; }
+  poles(link: LinkHandle): LinkPoles {
+    this.polesCalls += 1;
+    return this.source.poles(link);
+  }
+  find(start: LinkHandle, end: LinkHandle): LinkHandle | undefined {
+    return this.source.find(start, end);
+  }
+  outgoing(start: LinkHandle): readonly LinkHandle[] { return this.source.outgoing(start); }
+  incoming(end: LinkHandle): readonly LinkHandle[] { return this.source.incoming(end); }
+}
+
+// The explicit caller-owned seed determines vocabulary topology. Equivalent
+// memories yield the same structure without comparing allocation indexes.
+{
+  const firstMemory = new Memory();
+  const secondMemory = new Memory();
+  const first = materializeSyntaxAsetVocabulary(firstMemory, vocabularySeed(firstMemory));
+  const second = materializeSyntaxAsetVocabulary(secondMemory, vocabularySeed(secondMemory));
+  same(
+    vocabularyFingerprint(firstMemory, first),
+    vocabularyFingerprint(secondMemory, second),
+    "equivalent vocabulary seeds must yield equivalent topology",
+  );
+
+  const before = firstMemory.linkCount;
+  const repeated = materializeSyntaxAsetVocabulary(firstMemory, vocabularySeed(firstMemory));
+  same(repeated.tag, first.tag, "same seed rematerializes the exact syntax tag");
+  same(repeated.kinds.Link, first.kinds.Link, "same seed rematerializes exact kind Links");
+  same(repeated.roles.start, first.roles.start, "same seed rematerializes exact role Links");
+  same(firstMemory.linkCount, before, "vocabulary rematerialization is idempotent");
+}
+
+// Public tooling reuses S0 occurrence identity and explicit child roles.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const carrier = memory.ensureStartSelfClosed(vocabulary.tag);
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const first = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: carrier },
+  ]);
+  const second = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: carrier },
+  ]);
+  assert(first !== second, "equal-looking literals remain distinct occurrences");
+  const link = builder.addOccurrence(vocabulary.kinds.Link, [
+    { role: vocabulary.roles.start, value: first },
+    { role: vocabulary.roles.end, value: second },
+  ]);
+  const aset = builder.finish(link);
+  const read = readSyntaxAset(memory, aset, vocabulary);
+  same(read.occurrences[2]?.fields[0]?.value, first, "start role targets first occurrence");
+  same(read.occurrences[2]?.fields[1]?.value, second, "end role targets second occurrence");
+}
+
+// Ordered containers, definitions, statements and unary forms retain explicit
+// structural roles rather than host object properties or array indexes.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const nameCarrier = memory.ensureStartSelfClosed(vocabulary.kinds.Definition);
+  const valueCarrier = memory.ensureEndSelfClosed(vocabulary.kinds.Literal);
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const value = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: valueCarrier },
+  ]);
+  const sequence = builder.addOccurrence(vocabulary.kinds.Sequence, [
+    { role: vocabulary.roles.item, value },
+    { role: vocabulary.roles.item, value },
+  ]);
+  const unary = builder.addOccurrence(vocabulary.kinds.Not, [
+    { role: vocabulary.roles.operand, value: sequence },
+  ]);
+  const definition = builder.addOccurrence(vocabulary.kinds.Definition, [
+    { role: vocabulary.roles.name, value: nameCarrier },
+    { role: vocabulary.roles.body, value: unary },
+  ]);
+  const statement = builder.addOccurrence(vocabulary.kinds.Statement, [
+    { role: vocabulary.roles.expression, value: definition },
+  ]);
+  const read = readSyntaxAset(memory, builder.finish(statement), vocabulary);
+  same(read.occurrences[1]?.fields.length, 2, "repeated ordered items remain two structural fields");
+  same(read.occurrences[1]?.fields[0]?.value, value, "first ordered item retained");
+  same(read.occurrences[1]?.fields[1]?.value, value, "second ordered item retained");
+  same(read.occurrences[2]?.fields[0]?.role, vocabulary.roles.operand, "unary operand role retained");
+  same(read.occurrences[3]?.fields[0]?.role, vocabulary.roles.name, "definition name role retained");
+  same(read.occurrences[3]?.fields[1]?.role, vocabulary.roles.body, "definition body role retained");
+  same(read.occurrences[4]?.fields[0]?.role, vocabulary.roles.expression, "statement expression role retained");
+}
+
+// Child-bearing roles remain fail-closed and cannot point at arbitrary carrier
+// Links or future/foreign occurrences.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const carrier = memory.ensureStartSelfClosed(vocabulary.roles.start);
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  rejectContract(
+    () => builder.addOccurrence(vocabulary.kinds.Link, [
+      { role: vocabulary.roles.start, value: carrier },
+    ]),
+    "invalid-child-occurrence",
+  );
+}
+
+// Reading remains deterministic/read-only, and source provenance stays an
+// external map that cannot affect vocabulary or SyntaxAset identity.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const leaf = builder.addOccurrence(vocabulary.kinds.Literal, []);
+  const aset = builder.finish(leaf);
+  const provenanceA = new Map([[leaf, { source: "a.mts", start: 0, end: 1 }]]);
+  const provenanceB = new Map([[leaf, { source: "b.mts", start: 30, end: 50 }]]);
+  assert(provenanceA.get(leaf)?.source !== provenanceB.get(leaf)?.source, "provenance fixtures differ");
+  const before = memory.linkCount;
+  const probe = new ReadProbe(memory);
+  const first = readSyntaxAset(probe, aset, vocabulary);
+  const second = readSyntaxAset(probe, aset, vocabulary);
+  same(first.root, second.root, "repeat read is deterministic");
+  same(memory.linkCount, before, "read and provenance lookup do not materialize Links");
+  assert(probe.polesCalls > 0, "reader inspects structural topology");
+}


### PR DESCRIPTION
Closes #967.
Implements the S1 slice of #944 only.

This adds the smallest reusable syntax-only consumer surface as `@mts/core/tooling/syntax-aset` without enlarging the `@mts/core` package-root semantic API and without creating a separate package.

The tooling subpath reuses the accepted S0 `SyntaxAsetBuilder` / `readSyntaxAset` topology and adds an explicit caller-memory-scoped vocabulary for the currently inventoried syntax kinds and roles. Vocabulary identity is structural Link topology derived from an explicit seed; TypeScript names are API labels only. Provenance, AST identity, visual identity and accepted MTS semantic authority remain outside this boundary.

TDD evidence:
- RED `0da823b871840daa0dcc1445439980e2a337ecd3`: new tooling contract tests failed before the tooling module existed.
- GREEN `28404293162989a50212368bab7fd210bdb1f1c3`: internal tooling tests and full TypeScript gate passed.
- RED `0980e3741d88f754411ab826a44874ff42d8e461`: package consumer required `@mts/core/tooling/syntax-aset` before it was exported.
- GREEN head `88a35f8134fbd16e9bb2a1305a333642ea4c98f5`: package subpath exported; push CI #3799 passed the core TypeScript/test/browser gate, visual check and Contract Observatory check. During the package edit an existing browser-test bundling command was accidentally dropped; `88a35f...` restores that exact baseline command, so the final diff contains only the intended export addition in `package.json`.

Exact pre-PR audit against `main@ac080818f6477e2f0782a2aa5a57c2b3f90a9505`:
- `behind_by=0`, `ahead_by=5`;
- 4 changed files, 2 new files;
- +358 / -0 lines;
- no `ts/src/public.ts`, contracts, cutover, visual, web, policy, workflow or docs changes.

The package-boundary smoke uses the existing `ts/consumer/package-consumer.ts`; this is the concrete repository path corresponding to the package-consumer test named abstractly in #967.

No parser cutover, AST-to-SyntaxAset oracle, semantic lowering, accepted MTS semantic delta, v0.12 candidate, `@mts/syntax` package, root syntax export, source-coordinate identity, visual/proof dependency, or compatibility facade is included.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/tooling/syntax-aset.ts
  - ts/test/syntax-aset-tooling.test.ts
  - ts/consumer/package-consumer.ts
  - ts/package.json
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 520
anchors:
  affects: []
  implements:
    - "#944"
  verifies: []
must_touch:
  - ts/src/tooling/syntax-aset.ts
  - ts/test/syntax-aset-tooling.test.ts
  - ts/consumer/package-consumer.ts
  - ts/package.json
must_not_touch:
  - ts/src/public.ts
  - contracts/**
  - cutover/**
  - packages/visual/**
  - web/**
  - repo-policy.json
  - .github/**
  - README.md
  - docs/**
expected_effects:
  - expose one reusable SyntaxAset tooling subpath without enlarging the @mts/core root semantic surface
  - reuse the accepted S0 topology and fail-closed reader/builder invariants
  - provide only the explicit syntax vocabulary required for the current downstream migration corpus
  - preserve structural occurrence identity and ExactSequence ordering
  - keep provenance visual identity AST identity and semantic proof authority outside the syntax tooling boundary
  - make no accepted MTS semantic change and no parser cutover
```