### PR TITLE
[Corrective][Observatory/V4b] Make authority projection fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,33 +39,11 @@ jobs:
           ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
           node packages/visual/dist/test/model.test.js
 
-      - name: Check Contract Observatory
-        shell: bash
+      - name: Check Contract Observatory index
         run: |
-          set -euo pipefail
           ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
-
-          mapfile -t source_tests < <(
-            find web/contract-observatory/test -maxdepth 1 -type f -name '*.test.ts' -printf '%f\n' \
-              | sed 's/\.ts$/.js/' \
-              | sort
-          )
-          mapfile -t built_tests < <(
-            find web/contract-observatory/dist/test -maxdepth 1 -type f -name '*.test.js' -printf '%f\n' \
-              | sort
-          )
-
-          if ! diff -u \
-            <(printf '%s\n' "${source_tests[@]}") \
-            <(printf '%s\n' "${built_tests[@]}"); then
-            echo "::error::Contract Observatory source test set differs from compiled executable test set"
-            exit 1
-          fi
-
-          for test_file in "${built_tests[@]}"; do
-            echo "Running Contract Observatory test: ${test_file}"
-            node "web/contract-observatory/dist/test/${test_file}"
-          done
+          node web/contract-observatory/dist/test/contract-index.test.js
+          node web/contract-observatory/dist/test/site.test.js
 
   no-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,33 @@ jobs:
           ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
           node packages/visual/dist/test/model.test.js
 
-      - name: Check Contract Observatory index
+      - name: Check Contract Observatory
+        shell: bash
         run: |
+          set -euo pipefail
           ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
-          node web/contract-observatory/dist/test/contract-index.test.js
-          node web/contract-observatory/dist/test/site.test.js
+
+          mapfile -t source_tests < <(
+            find web/contract-observatory/test -maxdepth 1 -type f -name '*.test.ts' -printf '%f\n' \
+              | sed 's/\.ts$/.js/' \
+              | sort
+          )
+          mapfile -t built_tests < <(
+            find web/contract-observatory/dist/test -maxdepth 1 -type f -name '*.test.js' -printf '%f\n' \
+              | sort
+          )
+
+          if ! diff -u \
+            <(printf '%s\n' "${source_tests[@]}") \
+            <(printf '%s\n' "${built_tests[@]}"); then
+            echo "::error::Contract Observatory source test set differs from compiled executable test set"
+            exit 1
+          fi
+
+          for test_file in "${built_tests[@]}"; do
+            echo "Running Contract Observatory test: ${test_file}"
+            node "web/contract-observatory/dist/test/${test_file}"
+          done
 
   no-python:
     runs-on: ubuntu-latest

--- a/web/contract-observatory/src/methodology-projection.ts
+++ b/web/contract-observatory/src/methodology-projection.ts
@@ -112,9 +112,14 @@ function projectVersion(
 ): MethodologyVersionProjection {
   const contract = readJson(join(repoRoot, summary.contractPath));
   const conformance = readJson(join(repoRoot, summary.conformancePath));
-  const vectorEvidence = readVectorEvidence(conformance);
   const positiveIds = collectPositiveVectorIds(conformance);
-  const negativeIds = stringArray(conformance.requiredNegativeVectors);
+  const negativeIds = [...stringArray(conformance.requiredNegativeVectors)];
+  validateVectorIds([...positiveIds, ...negativeIds]);
+  positiveIds.sort((a, b) => a.localeCompare(b));
+  negativeIds.sort((a, b) => a.localeCompare(b));
+
+  const knownVectorIds = new Set([...positiveIds, ...negativeIds]);
+  const vectorEvidence = readVectorEvidence(conformance, knownVectorIds);
   const positiveVectors = positiveIds.map((id) => vector(id, "positive", vectorEvidence));
   const negativeVectors = negativeIds.map((id) => vector(id, "negative", vectorEvidence));
   const gatePaths = uniqueSorted(stringArray(conformance.requiredExecutableGates));
@@ -123,6 +128,7 @@ function projectVersion(
     id: `gate:${path}`,
     path,
   }));
+  const theoryReferences: TheoryReference[] = [];
   const evidenceReferences = collectEvidenceReferences(conformance, vectorEvidence);
   const acceptanceReferences = collectAcceptanceReferences(index, acceptance, summary);
   const traceability = collectTraceability(
@@ -132,11 +138,17 @@ function projectVersion(
     summary,
   );
   const unresolvedRelations = collectUnresolved(
+    theoryReferences,
     positiveVectors,
     negativeVectors,
     executableGates,
     acceptanceReferences,
   );
+
+  // semanticBase is intentionally not promoted to TheoryReference. It is a
+  // contract-version dependency and no current authoritative document exposes
+  // a machine-addressable normative theory reference for this projection.
+  requireString(contract.semanticBase, `${summary.contractPath}#/semanticBase`);
 
   return Object.freeze({
     contractId: summary.contractId,
@@ -148,10 +160,7 @@ function projectVersion(
     acceptanceReady: summary.acceptanceReady,
     isCurrent: summary.isCurrent,
     isPrevious: summary.isPrevious,
-    theoryReferences: Object.freeze([Object.freeze({
-      authority: "theory-reference" as const,
-      id: requireString(contract.semanticBase, `${summary.contractPath}#/semanticBase`),
-    })]),
+    theoryReferences: Object.freeze(theoryReferences),
     contractReferences: Object.freeze([Object.freeze({
       authority: "contract" as const,
       id: summary.contractId,
@@ -162,22 +171,34 @@ function projectVersion(
     executableGates: Object.freeze(executableGates),
     evidenceReferences: Object.freeze(evidenceReferences),
     acceptanceReferences: Object.freeze(acceptanceReferences),
-    lifecycle: Object.freeze(buildLifecycle(summary, contract, positiveVectors, negativeVectors, executableGates)),
+    lifecycle: Object.freeze(buildLifecycle(summary, acceptanceReferences)),
     traceability: Object.freeze(traceability),
     unresolvedRelations: Object.freeze(unresolvedRelations),
   });
 }
 
-function collectPositiveVectorIds(conformance: JsonRecord): readonly string[] {
+function collectPositiveVectorIds(conformance: JsonRecord): string[] {
   const ids: string[] = [];
   for (const key of Object.keys(conformance).sort()) {
     if (!key.startsWith("required") || !key.endsWith("Vectors") || key === "requiredNegativeVectors") continue;
     ids.push(...stringArray(conformance[key]));
   }
-  return uniqueSorted(ids);
+  return ids;
 }
 
-function readVectorEvidence(conformance: JsonRecord): ReadonlyMap<string, readonly string[]> {
+function validateVectorIds(ids: readonly string[]): void {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (id.length === 0) throw new Error("Contract Observatory V4b: empty vector id");
+    if (seen.has(id)) throw new Error(`Contract Observatory V4b: duplicate vector id: ${id}`);
+    seen.add(id);
+  }
+}
+
+function readVectorEvidence(
+  conformance: JsonRecord,
+  knownVectorIds: ReadonlySet<string>,
+): ReadonlyMap<string, readonly string[]> {
   const result = new Map<string, string[]>();
   const root = optionalRecord(conformance.vectorEvidence);
   if (root === undefined) return result;
@@ -186,6 +207,9 @@ function readVectorEvidence(conformance: JsonRecord): ReadonlyMap<string, readon
     if (bindings === undefined) continue;
     for (const sourcePath of Object.keys(bindings).sort()) {
       for (const vectorId of stringArray(bindings[sourcePath])) {
+        if (!knownVectorIds.has(vectorId)) {
+          throw new Error(`Contract Observatory V4b: evidence references unknown vector: ${vectorId}`);
+        }
         const paths = result.get(vectorId) ?? [];
         paths.push(sourcePath);
         result.set(vectorId, paths);
@@ -249,26 +273,21 @@ function collectAcceptanceReferences(
 
 function buildLifecycle(
   summary: ContractVersionSummary,
-  contract: JsonRecord,
-  positive: readonly ConformanceVector[],
-  negative: readonly ConformanceVector[],
-  gates: readonly ExecutableGate[],
+  acceptance: readonly AcceptanceReference[],
 ): MethodologyStageReference[] {
   const stages: MethodologyStageReference[] = [];
-  const candidateIssue = optionalInteger(contract.candidateLifecycleIssue);
-  if (candidateIssue !== undefined) stages.push(stage("research", [`issue:${candidateIssue}`]));
-  const issue = optionalInteger(contract.issue);
-  if (issue !== undefined) stages.push(stage("problem", [`issue:${issue}`]));
-  if (summary.status === "candidate" || summary.acceptanceReady || summary.accepted) {
+
+  // Lifecycle stages are source-derived, not reconstructed from nearby evidence.
+  // A generic issue number, vector/gate presence or coverageState cannot prove a
+  // historical research/problem/challenge/model stage.
+  if (summary.status === "candidate") {
     stages.push(stage("candidate", [summary.contractPath]));
   }
-  if (positive.length > 0 || negative.length > 0 || gates.length > 0) {
-    stages.push(stage("challenged", [summary.conformancePath]));
+  if (summary.accepted) {
+    stages.push(stage("accepted", [summary.contractPath, summary.conformancePath]));
   }
-  if (summary.coverageState === "complete") stages.push(stage("modeled", [summary.conformancePath]));
-  if (summary.accepted) stages.push(stage("accepted", [summary.contractPath, summary.conformancePath]));
-  if (summary.accepted && (summary.isCurrent || summary.isPrevious)) {
-    stages.push(stage("released", [summary.isCurrent ? "pointer:current" : "pointer:previous"]));
+  if (summary.accepted && acceptance.length > 0) {
+    stages.push(stage("released", acceptance.map((reference) => reference.id)));
   }
   return stages;
 }
@@ -306,6 +325,7 @@ function collectTraceability(
 }
 
 function collectUnresolved(
+  theory: readonly TheoryReference[],
   positive: readonly ConformanceVector[],
   negative: readonly ConformanceVector[],
   gates: readonly ExecutableGate[],
@@ -314,6 +334,7 @@ function collectUnresolved(
   const unresolved = [...positive, ...negative]
     .filter((item) => item.evidence.length === 0)
     .map((item) => `vector-evidence:${item.id}`);
+  if (theory.length === 0) unresolved.push("theory-reference");
   if (gates.length === 0) unresolved.push("executable-gates");
   if (acceptance.length === 0) unresolved.push("acceptance-reference");
   return uniqueSorted(unresolved);
@@ -345,10 +366,6 @@ function requireString(value: unknown, source: string): string {
     throw new Error(`Contract Observatory V4b: expected string: ${source}`);
   }
   return value;
-}
-
-function optionalInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isSafeInteger(value) ? value : undefined;
 }
 
 function uniqueSorted(values: readonly string[]): string[] {

--- a/web/contract-observatory/test/contract-index.test.ts
+++ b/web/contract-observatory/test/contract-index.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -230,3 +231,30 @@ fixtureCase(({ root }) => {
   });
   expectCode(() => buildContractObservatoryIndex(root), "invalid-schema-version", "ambiguous schema version");
 });
+
+const sourceTestDirectory = join(repositoryRoot, "web", "contract-observatory", "test");
+const compiledTestDirectory = join(repositoryRoot, "web", "contract-observatory", "dist", "test");
+const sourceTests = readdirSync(sourceTestDirectory)
+  .filter((name) => name.endsWith(".test.ts"))
+  .map((name) => name.replace(/\.ts$/, ".js"))
+  .sort();
+const compiledTests = readdirSync(compiledTestDirectory)
+  .filter((name) => name.endsWith(".test.js"))
+  .sort();
+
+same(
+  sourceTests.join("\n"),
+  compiledTests.join("\n"),
+  "every TypeScript test source has exactly one compiled executable",
+);
+
+for (const testName of compiledTests) {
+  if (testName === "contract-index.test.js") continue;
+  console.log(`Contract Observatory V3a suite runner: ${testName}`);
+  execFileSync(process.execPath, [join(compiledTestDirectory, testName)], {
+    cwd: repositoryRoot,
+    stdio: "inherit",
+  });
+}
+
+console.log(`Contract Observatory V3a suite runner covered ${compiledTests.length} compiled TypeScript tests.`);

--- a/web/contract-observatory/test/methodology-projection.test.ts
+++ b/web/contract-observatory/test/methodology-projection.test.ts
@@ -1,9 +1,16 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildMethodologyProjection,
   serializeMethodologyProjection,
   type MethodologyProjection,
 } from "../src/methodology-projection.js";
-import { buildContractObservatoryIndex } from "../src/contract-index.js";
+import {
+  buildContractObservatoryIndex,
+  type ContractObservatoryIndex,
+  type ContractVersionSummary,
+} from "../src/contract-index.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`Contract Observatory V4b: ${message}`);
@@ -11,6 +18,17 @@ function assert(condition: unknown, message: string): asserts condition {
 
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function throws(action: () => unknown, expected: RegExp, message: string): void {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  assert(thrown instanceof Error, `${message}: expected Error`);
+  assert(expected.test(thrown.message), `${message}: ${thrown.message}`);
 }
 
 const repositoryRoot = process.cwd();
@@ -38,6 +56,18 @@ assert(
   "negative vectors cannot collapse into positive evidence",
 );
 
+same(current.theoryReferences.length, 0, "semanticBase is not projected as normative TheoryReference");
+assert(
+  current.unresolvedRelations.includes("theory-reference"),
+  "missing machine-addressable theory authority remains explicit",
+);
+assert(
+  !current.lifecycle.some((entry) => ["research", "problem", "candidate", "challenged", "modeled"].includes(entry.stage)),
+  "accepted contract does not reconstruct unsupported historical lifecycle stages from nearby fields",
+);
+assert(current.lifecycle.some((entry) => entry.stage === "accepted"), "explicit accepted flag supports accepted stage");
+assert(current.lifecycle.some((entry) => entry.stage === "released"), "exact acceptance pointer supports released stage");
+
 const serialized = serializeMethodologyProjection(projection);
 same(
   serialized,
@@ -45,3 +75,196 @@ same(
   "same repository evidence serializes byte-identically",
 );
 assert(!serialized.includes("semanticLink"), "methodology projection does not claim MTS semantic Link identity");
+
+withSyntheticRepository(({ repoRoot, syntheticIndex }) => {
+  const candidate = buildMethodologyProjection(repoRoot, syntheticIndex({
+    status: "candidate",
+    accepted: false,
+    acceptanceReady: false,
+    isCurrent: false,
+    isPrevious: false,
+  }));
+  const version = candidate.versions[0]!;
+  same(version.acceptanceReferences.length, 0, "candidate without acceptance pointer has no acceptance authority");
+  assert(version.lifecycle.some((entry) => entry.stage === "candidate"), "explicit candidate status supports candidate stage");
+  assert(!version.lifecycle.some((entry) => entry.stage === "accepted"), "candidate is not inferred accepted");
+  assert(!version.lifecycle.some((entry) => entry.stage === "released"), "candidate is not inferred released");
+  assert(version.unresolvedRelations.includes("acceptance-reference"), "candidate missing acceptance remains unresolved");
+});
+
+withSyntheticRepository(({ repoRoot, syntheticIndex, writeAcceptance }) => {
+  writeAcceptance({});
+  const acceptedWithoutPointer = buildMethodologyProjection(repoRoot, syntheticIndex({
+    status: "accepted",
+    accepted: true,
+    acceptanceReady: true,
+    isCurrent: true,
+    isPrevious: false,
+  }));
+  const version = acceptedWithoutPointer.versions[0]!;
+  assert(version.lifecycle.some((entry) => entry.stage === "accepted"), "accepted flag is represented");
+  assert(!version.lifecycle.some((entry) => entry.stage === "released"), "current classification alone cannot invent release evidence");
+  assert(version.unresolvedRelations.includes("acceptance-reference"), "missing acceptance pointer stays explicit");
+});
+
+withSyntheticRepository(({ repoRoot, syntheticIndex, writeConformance }) => {
+  writeConformance({
+    requiredAlphaVectors: ["duplicate", "duplicate"],
+  });
+  throws(
+    () => buildMethodologyProjection(repoRoot, syntheticIndex()),
+    /duplicate vector id: duplicate/,
+    "duplicate vector IDs fail closed",
+  );
+});
+
+withSyntheticRepository(({ repoRoot, syntheticIndex, writeConformance }) => {
+  writeConformance({
+    requiredAlphaVectors: ["same-id"],
+    requiredNegativeVectors: ["same-id"],
+  });
+  throws(
+    () => buildMethodologyProjection(repoRoot, syntheticIndex()),
+    /duplicate vector id: same-id/,
+    "positive/negative identity ambiguity fails closed",
+  );
+});
+
+withSyntheticRepository(({ repoRoot, syntheticIndex, writeConformance }) => {
+  writeConformance({
+    requiredAlphaVectors: ["known"],
+    vectorEvidence: {
+      c1: {
+        "ts/test/evidence.test.ts": ["unknown"],
+      },
+    },
+  });
+  throws(
+    () => buildMethodologyProjection(repoRoot, syntheticIndex()),
+    /evidence references unknown vector: unknown/,
+    "dangling vector-evidence binding fails closed",
+  );
+});
+
+withSyntheticRepository(({ repoRoot, syntheticIndex, writeConformance }) => {
+  writeConformance({
+    requiredAlphaVectors: ["v2", "v1"],
+    requiredNegativeVectors: ["n2", "n1"],
+    requiredExecutableGates: ["z.test.ts", "a.test.ts"],
+    vectorEvidence: {
+      c2: { "z.test.ts": ["v2", "n2"] },
+      c1: { "a.test.ts": ["n1", "v1"] },
+    },
+  });
+  const first = serializeMethodologyProjection(buildMethodologyProjection(repoRoot, syntheticIndex()));
+  writeConformance({
+    vectorEvidence: {
+      c1: { "a.test.ts": ["v1", "n1"] },
+      c2: { "z.test.ts": ["n2", "v2"] },
+    },
+    requiredExecutableGates: ["a.test.ts", "z.test.ts"],
+    requiredNegativeVectors: ["n1", "n2"],
+    requiredAlphaVectors: ["v1", "v2"],
+  });
+  const second = serializeMethodologyProjection(buildMethodologyProjection(repoRoot, syntheticIndex()));
+  same(second, first, "non-semantic source ordering does not change normalized projection bytes");
+});
+
+withSyntheticRepository(({ repoRoot, syntheticIndex, writeConformance }) => {
+  writeConformance({
+    requiredAlphaVectors: ["v1", "v2"],
+    vectorEvidence: {
+      c1: {
+        "ts/test/shared-evidence.test.ts": ["v1", "v2"],
+      },
+    },
+  });
+  const version = buildMethodologyProjection(repoRoot, syntheticIndex()).versions[0]!;
+  same(version.traceability.length, 2, "one explicit evidence reference may support multiple vectors");
+  assert(
+    version.traceability.every((relation) => relation.to === "evidence:ts/test/shared-evidence.test.ts"),
+    "shared evidence identity is preserved exactly",
+  );
+});
+
+interface SyntheticRepository {
+  readonly repoRoot: string;
+  readonly syntheticIndex: (overrides?: Partial<ContractVersionSummary>) => ContractObservatoryIndex;
+  readonly writeContract: (overrides?: Record<string, unknown>) => void;
+  readonly writeConformance: (overrides?: Record<string, unknown>) => void;
+  readonly writeAcceptance: (value: Record<string, unknown>) => void;
+}
+
+function withSyntheticRepository(action: (repository: SyntheticRepository) => void): void {
+  const repoRoot = mkdtempSync(join(tmpdir(), "mts-observatory-v4b-"));
+  const contractPath = "contracts/mts-contract-v9.1.json";
+  const conformancePath = "contracts/mts-conformance-v9.1.json";
+  const acceptancePath = "cutover/acceptance.json";
+  mkdirSync(join(repoRoot, "contracts"), { recursive: true });
+  mkdirSync(join(repoRoot, "cutover"), { recursive: true });
+
+  const baseContract: Record<string, unknown> = {
+    schema: "mts-contract/v9.1",
+    status: "candidate",
+    accepted: false,
+    acceptanceReady: false,
+    semanticBase: "mts-contract/v9.0",
+    conformanceCorpus: conformancePath,
+  };
+  const baseConformance: Record<string, unknown> = {
+    schema: "mts-conformance/v9.1",
+    contract: "mts-contract/v9.1",
+    status: "candidate",
+    accepted: false,
+    coverageState: "partial",
+    requiredExecutableGates: [],
+    requiredNegativeVectors: [],
+  };
+
+  const writeContract = (overrides: Record<string, unknown> = {}): void => {
+    writeFileSync(join(repoRoot, contractPath), `${JSON.stringify({ ...baseContract, ...overrides }, null, 2)}\n`, "utf8");
+  };
+  const writeConformance = (overrides: Record<string, unknown> = {}): void => {
+    writeFileSync(join(repoRoot, conformancePath), `${JSON.stringify({ ...baseConformance, ...overrides }, null, 2)}\n`, "utf8");
+  };
+  const writeAcceptance = (value: Record<string, unknown>): void => {
+    writeFileSync(join(repoRoot, acceptancePath), `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  };
+
+  writeContract();
+  writeConformance();
+  writeAcceptance({});
+
+  const summary: ContractVersionSummary = Object.freeze({
+    contractId: "mts-contract/v9.1",
+    conformanceId: "mts-conformance/v9.1",
+    contractPath,
+    conformancePath,
+    status: "candidate",
+    accepted: false,
+    acceptanceReady: false,
+    semanticBase: "mts-contract/v9.0",
+    observableSemanticDelta: true,
+    coverageState: "partial",
+    requiredExecutableGateCount: 0,
+    requiredNegativeVectorCount: 0,
+    isCurrent: false,
+    isPrevious: false,
+  });
+
+  const syntheticIndex = (overrides: Partial<ContractVersionSummary> = {}): ContractObservatoryIndex => Object.freeze({
+    schema: "mts-contract-observatory-index/v0.1",
+    acceptancePath,
+    currentContractPath: "contracts/none-current.json",
+    currentConformancePath: "contracts/none-current-conformance.json",
+    previousContractPath: "contracts/none-previous.json",
+    previousConformancePath: "contracts/none-previous-conformance.json",
+    versions: Object.freeze([Object.freeze({ ...summary, ...overrides })]),
+  });
+
+  try {
+    action({ repoRoot, syntheticIndex, writeContract, writeConformance, writeAcceptance });
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
Closes #971.

This corrective slice repairs the V4b methodology projection without changing accepted MTS semantics or contract/conformance source documents.

The audit found two concrete integrity defects:

1. `contract.semanticBase` (for v0.11: `mts-contract/v0.10`) was promoted to `TheoryReference`, even though it is a previous-contract dependency rather than a machine-addressable normative theory reference.
2. `methodology-projection.test.ts` was compiled but not executed by CI, so green CI did not prove the V4b executable specification.

The implementation now fails closed:

- `semanticBase` remains validated as contract source data but is never promoted to `TheoryReference`;
- absent machine-addressable theory authority is represented explicitly as unresolved `theory-reference`;
- lifecycle no longer reconstructs `research/problem/challenged/modeled` from nearby issue/vector/gate/coverage fields;
- `candidate` requires explicit candidate status;
- `accepted` requires the explicit accepted flag;
- `released` requires accepted state plus an exact current/previous acceptance reference;
- duplicate vector IDs (including positive/negative collisions) reject;
- `vectorEvidence` references to unknown vectors reject;
- non-semantic source ordering is normalized deterministically;
- explicit many-vectors-to-one-evidence traceability remains supported.

The existing CI entrypoint `contract-index.test.js` now discovers every Observatory TypeScript test source and every compiled `*.test.js`, proves those sets are identical, and executes every other compiled test. This keeps test discovery inside the Observatory test boundary and avoids a governance/workflow change merely to enumerate tests. A future `.test.ts` can therefore no longer become compile-only silently.

TDD evidence:

- RED head `ab241623bb1fa92457c34756c9664e32facfed89`: CI #3803 failed exactly when the newly executed V4b test observed `semanticBase is not projected as normative TheoryReference: 1 !== 0`.
- Initial GREEN head `8a52e5719b069337d221640ca422e1d8ff740fa8`: push CI #3804 SUCCESS after the authority correction.
- Current head `6b01fa4fcbf17c4ed02570167608ce21a85763f1` moves suite discovery out of `.github/workflows/ci.yml` and into the already-invoked Observatory test entrypoint; final merge is gated on CI + repo-guard for this exact head.

Current diff against `main@1bc6de1f5c06f46858100807b5fe9191d057c6a2`:

- 3 changed files, 0 new files;
- no workflow/governance files in the final diff;
- no contracts, cutover, core TypeScript runtime, visual package, repo policy, README or docs changes.

PR #966 remains draft and still must be revalidated after this correction; this PR does not invent invariant-to-vector/gate mappings for #959.

```repo-guard-yaml
change_type: feature
scope:
  - web/contract-observatory/src/methodology-projection.ts
  - web/contract-observatory/test/methodology-projection.test.ts
  - web/contract-observatory/test/contract-index.test.ts
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 400
anchors:
  affects: []
  implements:
    - "#971"
  verifies: []
must_touch:
  - web/contract-observatory/src/methodology-projection.ts
  - web/contract-observatory/test/methodology-projection.test.ts
  - web/contract-observatory/test/contract-index.test.ts
must_not_touch:
  - .github/workflows/**
  - contracts/**
  - cutover/**
  - ts/src/**
  - packages/visual/**
  - repo-policy.json
  - README.md
  - docs/**
expected_effects:
  - semanticBase is not represented as normative TheoryReference
  - missing theory authority and acceptance traceability remain explicit and fail closed
  - duplicate or dangling vector identities reject deterministically
  - lifecycle presentation uses only explicitly supported authority facts
  - every compiled Contract Observatory TypeScript test is executed by the existing CI entrypoint
  - accepted MTS v0.11 semantics remain unchanged
```