### PR TITLE
[Syntax/S1.6] Close chained-triad SyntaxAset grammar

### DIFF
--- a/ts/research/syntax-aset-topology.ts
+++ b/ts/research/syntax-aset-topology.ts
@@ -1,4 +1,8 @@
 import {
+  materializeExactSequence,
+  readExactSequence,
+} from "../src/exact-sequence.js";
+import {
   MemoryError,
   type LinkHandle,
   type ReadMemory,
@@ -68,6 +72,147 @@ function isChildRole(vocabulary: SyntaxAsetToolingVocabulary, role: LinkHandle):
 }
 
 /**
+ * Historical S0 control retained only for the #970 research comparison after
+ * production SyntaxAset itself moves to the selected chained-triad topology.
+ * This is not a compatibility reader and is not exported from @mts/core.
+ */
+export class LegacyS0SyntaxAsetBuilder implements ResearchBuilder {
+  private occurrenceOrder: LinkHandle;
+  private readonly occurrences = new Set<LinkHandle>();
+  private finished = false;
+
+  constructor(
+    readonly memory: WriteMemory,
+    readonly vocabulary: SyntaxAsetToolingVocabulary,
+    readonly carrierA: LinkHandle,
+    readonly carrierB: LinkHandle,
+  ) {
+    this.occurrenceOrder = memory.root;
+  }
+
+  addOccurrence(kind: LinkHandle, fields: readonly SyntaxAsetField[]): LinkHandle {
+    if (this.finished) return fail("invalid-aset");
+
+    const fieldLinks = fields.map(({ role, value }) => {
+      if (isChildRole(this.vocabulary, role) && !this.occurrences.has(value)) {
+        return fail("invalid-child-occurrence");
+      }
+      return this.memory.ensure(role, value);
+    });
+
+    const fieldSequence = materializeExactSequence(this.memory, fieldLinks);
+    const descriptor = this.memory.ensure(kind, fieldSequence);
+    const payload = this.memory.ensure(this.occurrenceOrder, descriptor);
+    const occurrence = this.memory.ensureStartSelfClosed(payload);
+    this.occurrenceOrder = occurrence;
+    this.occurrences.add(occurrence);
+    return occurrence;
+  }
+
+  finish(root: LinkHandle): LinkHandle {
+    if (
+      this.finished ||
+      this.occurrenceOrder === this.memory.root ||
+      root !== this.occurrenceOrder
+    ) {
+      return fail("root-not-final");
+    }
+    this.finished = true;
+    const header = this.memory.ensure(this.occurrenceOrder, root);
+    return this.memory.ensure(this.vocabulary.tag, header);
+  }
+}
+
+export function readLegacyS0SyntaxAset(
+  memory: ReadMemory,
+  aset: LinkHandle,
+  vocabulary: SyntaxAsetToolingVocabulary,
+): SyntaxAsetRead {
+  let occurrenceOrder: LinkHandle;
+  let declaredRoot: LinkHandle;
+  try {
+    const wrapper = memory.poles(aset);
+    if (wrapper.start !== vocabulary.tag) return fail("invalid-aset");
+    const header = memory.poles(wrapper.end);
+    occurrenceOrder = header.start;
+    declaredRoot = header.end;
+  } catch (error) {
+    if (error instanceof MemoryError) return fail("invalid-aset");
+    throw error;
+  }
+
+  let sequence: ReturnType<typeof readExactSequence>;
+  try {
+    sequence = readExactSequence(memory, occurrenceOrder);
+  } catch {
+    return fail("invalid-occurrence-chain");
+  }
+
+  const finalOccurrence = sequence.cells.at(-1);
+  if (finalOccurrence === undefined || declaredRoot !== finalOccurrence) {
+    return fail("root-not-final");
+  }
+
+  const priorOccurrences = new Set<LinkHandle>();
+  const occurrences: SyntaxAsetOccurrence[] = [];
+  for (let index = 0; index < sequence.values.length; index += 1) {
+    const descriptor = sequence.values[index];
+    const occurrence = sequence.cells[index];
+    if (descriptor === undefined || occurrence === undefined) {
+      return fail("invalid-occurrence-chain");
+    }
+
+    let kind: LinkHandle;
+    let fieldSequence: LinkHandle;
+    try {
+      const descriptorPoles = memory.poles(descriptor);
+      kind = descriptorPoles.start;
+      fieldSequence = descriptorPoles.end;
+    } catch (error) {
+      if (error instanceof MemoryError) return fail("invalid-field-chain");
+      throw error;
+    }
+
+    let fieldLinks: readonly LinkHandle[];
+    try {
+      fieldLinks = readExactSequence(memory, fieldSequence).values;
+    } catch {
+      return fail("invalid-field-chain");
+    }
+
+    const fields: SyntaxAsetField[] = [];
+    for (const fieldLink of fieldLinks) {
+      let role: LinkHandle;
+      let value: LinkHandle;
+      try {
+        const poles = memory.poles(fieldLink);
+        role = poles.start;
+        value = poles.end;
+      } catch (error) {
+        if (error instanceof MemoryError) return fail("invalid-field-chain");
+        throw error;
+      }
+      if (isChildRole(vocabulary, role) && !priorOccurrences.has(value)) {
+        return fail("invalid-child-occurrence");
+      }
+      fields.push(Object.freeze({ role, value }));
+    }
+
+    occurrences.push(Object.freeze({
+      occurrence,
+      kind,
+      fields: Object.freeze(fields),
+    }));
+    priorOccurrences.add(occurrence);
+  }
+
+  return Object.freeze({
+    root: declaredRoot,
+    occurrences: Object.freeze(occurrences),
+  });
+}
+
+/**
  * RM-inspired nested-pair witness:
  *
  *   T(relation, subject, object) = relation ⟼ (subject ⟼ object)
@@ -115,10 +260,6 @@ function readTriad(
  *   Oi = T(kind_i, O(i-1), Fi)
  *
  *   SyntaxAset = SyntaxTag ⟼ O_last
- *
- * The previous structural entity is part of the next entity's poles, so equal
- * role/value or kind/payload facts at different positions remain occurrence-
- * distinct without UUIDs or host indexes.
  */
 export class ChainedTriadSyntaxAsetBuilder implements ResearchBuilder {
   private occurrenceHead: LinkHandle;

--- a/ts/src/syntax-aset-contract.ts
+++ b/ts/src/syntax-aset-contract.ts
@@ -143,30 +143,66 @@ function readFieldChain(
 }
 
 /**
- * Detect an occurrence-shaped carrier without confusing arbitrary Links whose
- * first pole merely happens to be a syntax kind. A real occurrence belongs to
- * the recursive O-chain selected by #970, so its triad subject is either R or
- * another occurrence-shaped Link. Cycles/self-closures fail this test.
+ * Test explicit SyntaxAset membership without treating mere pole resemblance as
+ * syntax identity. Every complete SyntaxAset is structurally rooted by
+ * `tag ⟼ O_last`; membership is recovered by walking that O-chain only.
  */
-function isOccurrenceShaped(
+function occurrenceChainContains(
+  memory: ReadMemory,
+  head: LinkHandle,
+  target: LinkHandle,
+  vocabulary: SyntaxAsetVocabulary,
+): boolean {
+  const visited = new Set<LinkHandle>();
+  let current = head;
+
+  while (current !== memory.root) {
+    if (current === target) return true;
+    if (visited.has(current)) return false;
+    visited.add(current);
+
+    try {
+      const vertical = memory.poles(current);
+      if (kindRuleOrUndefined(vocabulary, vertical.start) === undefined) return false;
+      const horizontal = memory.poles(vertical.end);
+      current = horizontal.start;
+    } catch (error) {
+      if (error instanceof MemoryError) return false;
+      throw error;
+    }
+  }
+
+  return false;
+}
+
+function isOwnedSyntaxOccurrence(
   memory: ReadMemory,
   value: LinkHandle,
   vocabulary: SyntaxAsetVocabulary,
-  visited: Set<LinkHandle> = new Set<LinkHandle>(),
 ): boolean {
-  if (visited.has(value)) return false;
-  visited.add(value);
-
+  let wrappers: readonly LinkHandle[];
   try {
-    const vertical = memory.poles(value);
-    if (kindRuleOrUndefined(vocabulary, vertical.start) === undefined) return false;
-    const horizontal = memory.poles(vertical.end);
-    return horizontal.start === memory.root ||
-      isOccurrenceShaped(memory, horizontal.start, vocabulary, visited);
+    wrappers = memory.outgoing(vocabulary.tag);
   } catch (error) {
     if (error instanceof MemoryError) return false;
     throw error;
   }
+
+  for (const wrapper of wrappers) {
+    try {
+      const poles = memory.poles(wrapper);
+      if (
+        poles.start === vocabulary.tag &&
+        occurrenceChainContains(memory, poles.end, value, vocabulary)
+      ) {
+        return true;
+      }
+    } catch (error) {
+      if (!(error instanceof MemoryError)) throw error;
+    }
+  }
+
+  return false;
 }
 
 function validateTarget(
@@ -181,7 +217,7 @@ function validateTarget(
     return;
   }
 
-  if (priorOccurrences.has(value) || isOccurrenceShaped(memory, value, vocabulary)) {
+  if (priorOccurrences.has(value) || isOwnedSyntaxOccurrence(memory, value, vocabulary)) {
     contractError("invalid-carrier-target");
   }
 }

--- a/ts/src/syntax-aset-contract.ts
+++ b/ts/src/syntax-aset-contract.ts
@@ -1,9 +1,4 @@
 import {
-  ExactSequenceError,
-  materializeExactSequence,
-  readExactSequence,
-} from "./exact-sequence.js";
-import {
   MemoryError,
   type LinkHandle,
   type ReadMemory,
@@ -46,6 +41,12 @@ export interface SyntaxAsetRead {
   readonly occurrences: readonly SyntaxAsetOccurrence[];
 }
 
+interface TriadRead {
+  readonly relation: LinkHandle;
+  readonly subject: LinkHandle;
+  readonly object: LinkHandle;
+}
+
 function contractError(code: SyntaxAsetContractErrorCode): never {
   throw new SyntaxAsetContractError(code);
 }
@@ -57,21 +58,67 @@ function isChildRole(
   return vocabulary.childRoles.some((candidate) => candidate === role);
 }
 
-function readSequenceOrReject(
+function materializeTriad(
+  memory: WriteMemory,
+  relation: LinkHandle,
+  subject: LinkHandle,
+  object: LinkHandle,
+): LinkHandle {
+  return memory.ensure(relation, memory.ensure(subject, object));
+}
+
+function readTriad(
   memory: ReadMemory,
-  final: LinkHandle,
+  entity: LinkHandle,
   code: "invalid-field-sequence" | "invalid-occurrence-sequence",
-) {
+): TriadRead {
   try {
-    return readExactSequence(memory, final);
+    const vertical = memory.poles(entity);
+    const horizontal = memory.poles(vertical.end);
+    return Object.freeze({
+      relation: vertical.start,
+      subject: horizontal.start,
+      object: horizontal.end,
+    });
   } catch (error) {
-    if (error instanceof ExactSequenceError || error instanceof MemoryError) {
-      return contractError(code);
-    }
+    if (error instanceof MemoryError) return contractError(code);
     throw error;
   }
 }
 
+function readFieldChain(
+  memory: ReadMemory,
+  final: LinkHandle,
+): readonly SyntaxAsetField[] {
+  const reversed: SyntaxAsetField[] = [];
+  const visited = new Set<LinkHandle>();
+  let current = final;
+
+  while (current !== memory.root) {
+    if (visited.has(current)) return contractError("invalid-field-sequence");
+    visited.add(current);
+    const fact = readTriad(memory, current, "invalid-field-sequence");
+    reversed.push(Object.freeze({ role: fact.relation, value: fact.object }));
+    current = fact.subject;
+  }
+
+  return Object.freeze(reversed.reverse());
+}
+
+/**
+ * Canonical syntax-only chained-triad topology selected by #970:
+ *
+ *   T(r, s, o) = r ⟼ (s ⟼ o)
+ *   F0 = R
+ *   Fi = T(role_i, F(i-1), value_i)
+ *   O0 = R
+ *   Oi = T(kind_i, O(i-1), Fi)
+ *   SyntaxAset = SyntaxTag ⟼ O_last
+ *
+ * The previous field/occurrence entity is part of the next entity's poles, so
+ * equal-looking repeated fields and occurrences stay structurally distinct
+ * without UUIDs, source offsets, host indexes or visual keys.
+ */
 export class SyntaxAsetBuilder {
   private occurrenceOrder: LinkHandle;
   private readonly occurrences = new Set<LinkHandle>();
@@ -92,18 +139,20 @@ export class SyntaxAsetBuilder {
       return contractError("invalid-aset");
     }
 
-    const fieldLinks = fields.map(({ role, value }) => {
+    let fieldOrder = this.memory.root;
+    for (const { role, value } of fields) {
       if (isChildRole(this.vocabulary, role) && !this.occurrences.has(value)) {
         return contractError("invalid-child-occurrence");
       }
-      return this.memory.ensure(role, value);
-    });
+      fieldOrder = materializeTriad(this.memory, role, fieldOrder, value);
+    }
 
-    const fieldSequence = materializeExactSequence(this.memory, fieldLinks);
-    const descriptor = this.memory.ensure(kind, fieldSequence);
-    const payload = this.memory.ensure(this.occurrenceOrder, descriptor);
-    const occurrence = this.memory.ensureStartSelfClosed(payload);
-
+    const occurrence = materializeTriad(
+      this.memory,
+      kind,
+      this.occurrenceOrder,
+      fieldOrder,
+    );
     this.occurrenceOrder = occurrence;
     this.occurrences.add(occurrence);
     return occurrence;
@@ -119,8 +168,7 @@ export class SyntaxAsetBuilder {
     }
 
     this.finished = true;
-    const header = this.memory.ensure(this.occurrenceOrder, root);
-    return this.memory.ensure(this.vocabulary.tag, header);
+    return this.memory.ensure(this.vocabulary.tag, this.occurrenceOrder);
   }
 }
 
@@ -129,7 +177,6 @@ export function readSyntaxAset(
   aset: LinkHandle,
   vocabulary: SyntaxAsetVocabulary,
 ): SyntaxAsetRead {
-  let occurrenceOrder: LinkHandle;
   let declaredRoot: LinkHandle;
 
   try {
@@ -137,9 +184,7 @@ export function readSyntaxAset(
     if (wrapper.start !== vocabulary.tag) {
       return contractError("invalid-aset");
     }
-    const header = memory.poles(wrapper.end);
-    occurrenceOrder = header.start;
-    declaredRoot = header.end;
+    declaredRoot = wrapper.end;
   } catch (error) {
     if (error instanceof MemoryError) {
       return contractError("invalid-aset");
@@ -147,73 +192,35 @@ export function readSyntaxAset(
     throw error;
   }
 
-  const sequence = readSequenceOrReject(
-    memory,
-    occurrenceOrder,
-    "invalid-occurrence-sequence",
-  );
-
-  const finalOccurrence = sequence.cells.at(-1);
-  if (finalOccurrence === undefined || declaredRoot !== finalOccurrence) {
-    return contractError("root-not-final");
+  if (declaredRoot === memory.root) {
+    return contractError("invalid-occurrence-sequence");
   }
 
+  const reversed: SyntaxAsetOccurrence[] = [];
+  const visited = new Set<LinkHandle>();
+  let current = declaredRoot;
+
+  while (current !== memory.root) {
+    if (visited.has(current)) return contractError("invalid-occurrence-sequence");
+    visited.add(current);
+    const occurrence = readTriad(memory, current, "invalid-occurrence-sequence");
+    reversed.push(Object.freeze({
+      occurrence: current,
+      kind: occurrence.relation,
+      fields: readFieldChain(memory, occurrence.object),
+    }));
+    current = occurrence.subject;
+  }
+
+  const occurrences = [...reversed].reverse();
   const priorOccurrences = new Set<LinkHandle>();
-  const occurrences: SyntaxAsetOccurrence[] = [];
-
-  for (let index = 0; index < sequence.values.length; index += 1) {
-    const descriptor = sequence.values[index];
-    const occurrence = sequence.cells[index];
-    if (descriptor === undefined || occurrence === undefined) {
-      return contractError("invalid-occurrence-sequence");
-    }
-
-    let kind: LinkHandle;
-    let fieldSequence: LinkHandle;
-    try {
-      const descriptorPoles = memory.poles(descriptor);
-      kind = descriptorPoles.start;
-      fieldSequence = descriptorPoles.end;
-    } catch (error) {
-      if (error instanceof MemoryError) {
-        return contractError("invalid-field-sequence");
-      }
-      throw error;
-    }
-
-    const fieldLinks = readSequenceOrReject(
-      memory,
-      fieldSequence,
-      "invalid-field-sequence",
-    ).values;
-
-    const fields: SyntaxAsetField[] = [];
-    for (const fieldLink of fieldLinks) {
-      let role: LinkHandle;
-      let value: LinkHandle;
-      try {
-        const poles = memory.poles(fieldLink);
-        role = poles.start;
-        value = poles.end;
-      } catch (error) {
-        if (error instanceof MemoryError) {
-          return contractError("invalid-field-sequence");
-        }
-        throw error;
-      }
-
-      if (isChildRole(vocabulary, role) && !priorOccurrences.has(value)) {
+  for (const occurrence of occurrences) {
+    for (const field of occurrence.fields) {
+      if (isChildRole(vocabulary, field.role) && !priorOccurrences.has(field.value)) {
         return contractError("invalid-child-occurrence");
       }
-      fields.push(Object.freeze({ role, value }));
     }
-
-    occurrences.push(Object.freeze({
-      occurrence,
-      kind,
-      fields: Object.freeze(fields),
-    }));
-    priorOccurrences.add(occurrence);
+    priorOccurrences.add(occurrence.occurrence);
   }
 
   return Object.freeze({

--- a/ts/src/syntax-aset-contract.ts
+++ b/ts/src/syntax-aset-contract.ts
@@ -142,16 +142,27 @@ function readFieldChain(
   return Object.freeze(reversed.reverse());
 }
 
+/**
+ * Detect an occurrence-shaped carrier without confusing arbitrary Links whose
+ * first pole merely happens to be a syntax kind. A real occurrence belongs to
+ * the recursive O-chain selected by #970, so its triad subject is either R or
+ * another occurrence-shaped Link. Cycles/self-closures fail this test.
+ */
 function isOccurrenceShaped(
   memory: ReadMemory,
   value: LinkHandle,
   vocabulary: SyntaxAsetVocabulary,
+  visited: Set<LinkHandle> = new Set<LinkHandle>(),
 ): boolean {
+  if (visited.has(value)) return false;
+  visited.add(value);
+
   try {
     const vertical = memory.poles(value);
     if (kindRuleOrUndefined(vocabulary, vertical.start) === undefined) return false;
-    memory.poles(vertical.end);
-    return true;
+    const horizontal = memory.poles(vertical.end);
+    return horizontal.start === memory.root ||
+      isOccurrenceShaped(memory, horizontal.start, vocabulary, visited);
   } catch (error) {
     if (error instanceof MemoryError) return false;
     throw error;

--- a/ts/src/syntax-aset-contract.ts
+++ b/ts/src/syntax-aset-contract.ts
@@ -10,6 +10,11 @@ export type SyntaxAsetContractErrorCode =
   | "invalid-field-sequence"
   | "invalid-occurrence-sequence"
   | "invalid-child-occurrence"
+  | "invalid-carrier-target"
+  | "unknown-kind"
+  | "unknown-role"
+  | "invalid-grammar"
+  | "unreachable-occurrence"
   | "root-not-final";
 
 export class SyntaxAsetContractError extends Error {
@@ -20,8 +25,28 @@ export class SyntaxAsetContractError extends Error {
   }
 }
 
+export type SyntaxAsetTargetClass = "child" | "carrier";
+
+export interface SyntaxAsetFieldRule {
+  readonly role: LinkHandle;
+  readonly target: SyntaxAsetTargetClass;
+  readonly min: number;
+  readonly max: number | null;
+}
+
+export interface SyntaxAsetKindRule {
+  readonly kind: LinkHandle;
+  readonly fields: readonly SyntaxAsetFieldRule[];
+}
+
 export interface SyntaxAsetVocabulary {
   readonly tag: LinkHandle;
+  readonly knownRoles: readonly LinkHandle[];
+  readonly rules: readonly SyntaxAsetKindRule[];
+  /**
+   * Derived convenience for research/inspection only. Production validation
+   * is per-kind through `rules`; this global list is not grammar authority.
+   */
   readonly childRoles: readonly LinkHandle[];
 }
 
@@ -51,11 +76,23 @@ function contractError(code: SyntaxAsetContractErrorCode): never {
   throw new SyntaxAsetContractError(code);
 }
 
-function isChildRole(
+function includesHandle(values: readonly LinkHandle[], candidate: LinkHandle): boolean {
+  return values.some((value) => value === candidate);
+}
+
+function kindRule(
   vocabulary: SyntaxAsetVocabulary,
-  role: LinkHandle,
-): boolean {
-  return vocabulary.childRoles.some((candidate) => candidate === role);
+  kind: LinkHandle,
+): SyntaxAsetKindRule {
+  const rule = vocabulary.rules.find((candidate) => candidate.kind === kind);
+  return rule ?? contractError("unknown-kind");
+}
+
+function kindRuleOrUndefined(
+  vocabulary: SyntaxAsetVocabulary,
+  kind: LinkHandle,
+): SyntaxAsetKindRule | undefined {
+  return vocabulary.rules.find((candidate) => candidate.kind === kind);
 }
 
 function materializeTriad(
@@ -105,6 +142,101 @@ function readFieldChain(
   return Object.freeze(reversed.reverse());
 }
 
+function isOccurrenceShaped(
+  memory: ReadMemory,
+  value: LinkHandle,
+  vocabulary: SyntaxAsetVocabulary,
+): boolean {
+  try {
+    const vertical = memory.poles(value);
+    if (kindRuleOrUndefined(vocabulary, vertical.start) === undefined) return false;
+    memory.poles(vertical.end);
+    return true;
+  } catch (error) {
+    if (error instanceof MemoryError) return false;
+    throw error;
+  }
+}
+
+function validateTarget(
+  memory: ReadMemory,
+  vocabulary: SyntaxAsetVocabulary,
+  targetClass: SyntaxAsetTargetClass,
+  value: LinkHandle,
+  priorOccurrences: ReadonlySet<LinkHandle>,
+): void {
+  if (targetClass === "child") {
+    if (!priorOccurrences.has(value)) contractError("invalid-child-occurrence");
+    return;
+  }
+
+  if (priorOccurrences.has(value) || isOccurrenceShaped(memory, value, vocabulary)) {
+    contractError("invalid-carrier-target");
+  }
+}
+
+function validateGrammar(
+  memory: ReadMemory,
+  vocabulary: SyntaxAsetVocabulary,
+  kind: LinkHandle,
+  fields: readonly SyntaxAsetField[],
+  priorOccurrences: ReadonlySet<LinkHandle>,
+): void {
+  const rule = kindRule(vocabulary, kind);
+
+  for (const field of fields) {
+    if (!includesHandle(vocabulary.knownRoles, field.role)) {
+      contractError("unknown-role");
+    }
+  }
+
+  let fieldIndex = 0;
+  for (const fieldRule of rule.fields) {
+    let count = 0;
+    while (
+      fieldIndex < fields.length &&
+      fields[fieldIndex]?.role === fieldRule.role &&
+      (fieldRule.max === null || count < fieldRule.max)
+    ) {
+      const field = fields[fieldIndex];
+      if (field === undefined) contractError("invalid-grammar");
+      validateTarget(memory, vocabulary, fieldRule.target, field.value, priorOccurrences);
+      count += 1;
+      fieldIndex += 1;
+    }
+    if (count < fieldRule.min) contractError("invalid-grammar");
+  }
+
+  if (fieldIndex !== fields.length) contractError("invalid-grammar");
+}
+
+function validateReachability(
+  root: LinkHandle,
+  occurrences: readonly SyntaxAsetOccurrence[],
+  vocabulary: SyntaxAsetVocabulary,
+): void {
+  const byHandle = new Map<LinkHandle, SyntaxAsetOccurrence>(
+    occurrences.map((occurrence) => [occurrence.occurrence, occurrence]),
+  );
+  const reachable = new Set<LinkHandle>();
+  const pending: LinkHandle[] = [root];
+
+  while (pending.length > 0) {
+    const handle = pending.pop();
+    if (handle === undefined || reachable.has(handle)) continue;
+    const occurrence = byHandle.get(handle);
+    if (occurrence === undefined) contractError("invalid-child-occurrence");
+    reachable.add(handle);
+    const rule = kindRule(vocabulary, occurrence.kind);
+    for (const field of occurrence.fields) {
+      const fieldRule = rule.fields.find((candidate) => candidate.role === field.role);
+      if (fieldRule?.target === "child") pending.push(field.value);
+    }
+  }
+
+  if (reachable.size !== occurrences.length) contractError("unreachable-occurrence");
+}
+
 /**
  * Canonical syntax-only chained-triad topology selected by #970:
  *
@@ -122,6 +254,7 @@ function readFieldChain(
 export class SyntaxAsetBuilder {
   private occurrenceOrder: LinkHandle;
   private readonly occurrences = new Set<LinkHandle>();
+  private readonly occurrenceReads: SyntaxAsetOccurrence[] = [];
   private finished = false;
 
   constructor(
@@ -139,11 +272,10 @@ export class SyntaxAsetBuilder {
       return contractError("invalid-aset");
     }
 
+    validateGrammar(this.memory, this.vocabulary, kind, fields, this.occurrences);
+
     let fieldOrder = this.memory.root;
     for (const { role, value } of fields) {
-      if (isChildRole(this.vocabulary, role) && !this.occurrences.has(value)) {
-        return contractError("invalid-child-occurrence");
-      }
       fieldOrder = materializeTriad(this.memory, role, fieldOrder, value);
     }
 
@@ -155,6 +287,11 @@ export class SyntaxAsetBuilder {
     );
     this.occurrenceOrder = occurrence;
     this.occurrences.add(occurrence);
+    this.occurrenceReads.push(Object.freeze({
+      occurrence,
+      kind,
+      fields: Object.freeze([...fields]),
+    }));
     return occurrence;
   }
 
@@ -167,6 +304,7 @@ export class SyntaxAsetBuilder {
       return contractError("root-not-final");
     }
 
+    validateReachability(root, this.occurrenceReads, this.vocabulary);
     this.finished = true;
     return this.memory.ensure(this.vocabulary.tag, this.occurrenceOrder);
   }
@@ -204,6 +342,7 @@ export function readSyntaxAset(
     if (visited.has(current)) return contractError("invalid-occurrence-sequence");
     visited.add(current);
     const occurrence = readTriad(memory, current, "invalid-occurrence-sequence");
+    kindRule(vocabulary, occurrence.relation);
     reversed.push(Object.freeze({
       occurrence: current,
       kind: occurrence.relation,
@@ -215,13 +354,16 @@ export function readSyntaxAset(
   const occurrences = [...reversed].reverse();
   const priorOccurrences = new Set<LinkHandle>();
   for (const occurrence of occurrences) {
-    for (const field of occurrence.fields) {
-      if (isChildRole(vocabulary, field.role) && !priorOccurrences.has(field.value)) {
-        return contractError("invalid-child-occurrence");
-      }
-    }
+    validateGrammar(
+      memory,
+      vocabulary,
+      occurrence.kind,
+      occurrence.fields,
+      priorOccurrences,
+    );
     priorOccurrences.add(occurrence.occurrence);
   }
+  validateReachability(declaredRoot, occurrences, vocabulary);
 
   return Object.freeze({
     root: declaredRoot,

--- a/ts/src/tooling/syntax-aset.ts
+++ b/ts/src/tooling/syntax-aset.ts
@@ -7,8 +7,11 @@ import {
   SyntaxAsetContractError,
   readSyntaxAset,
   type SyntaxAsetField,
+  type SyntaxAsetFieldRule,
+  type SyntaxAsetKindRule,
   type SyntaxAsetOccurrence,
   type SyntaxAsetRead,
+  type SyntaxAsetTargetClass,
   type SyntaxAsetVocabulary,
 } from "../syntax-aset-contract.js";
 
@@ -19,8 +22,11 @@ export {
 };
 export type {
   SyntaxAsetField,
+  SyntaxAsetFieldRule,
+  SyntaxAsetKindRule,
   SyntaxAsetOccurrence,
   SyntaxAsetRead,
+  SyntaxAsetTargetClass,
   SyntaxAsetVocabulary,
 };
 
@@ -55,11 +61,14 @@ const ROLE_NAMES = [
   "value",
 ] as const;
 
+// Derived inspection convenience only. Per-kind grammar rules below are the
+// authoritative target-class contract. `name` is a child in Definition.
 const CHILD_ROLE_NAMES = [
   "item",
   "expression",
   "start",
   "end",
+  "name",
   "body",
   "left",
   "right",
@@ -90,11 +99,72 @@ function materializeNamedSeries<Name extends string>(
   return Object.freeze(Object.fromEntries(entries)) as Readonly<Record<Name, LinkHandle>>;
 }
 
+function fieldRule(
+  role: LinkHandle,
+  target: SyntaxAsetTargetClass,
+  min: number,
+  max: number | null,
+): SyntaxAsetFieldRule {
+  return Object.freeze({ role, target, min, max });
+}
+
+function syntaxRule(
+  kind: LinkHandle,
+  fields: readonly SyntaxAsetFieldRule[],
+): SyntaxAsetKindRule {
+  return Object.freeze({ kind, fields: Object.freeze([...fields]) });
+}
+
+function materializeGrammar(
+  kinds: SyntaxAsetKindLinks,
+  roles: SyntaxAsetRoleLinks,
+): readonly SyntaxAsetKindRule[] {
+  const child = (role: LinkHandle, min: number, max: number | null) =>
+    fieldRule(role, "child", min, max);
+  const carrier = (role: LinkHandle, min: number, max: number | null) =>
+    fieldRule(role, "carrier", min, max);
+
+  return Object.freeze([
+    syntaxRule(kinds.File, [child(roles.item, 0, null)]),
+    syntaxRule(kinds.Statement, [child(roles.expression, 1, 1)]),
+    syntaxRule(kinds.Link, [
+      child(roles.start, 1, 1),
+      child(roles.end, 1, 1),
+    ]),
+    syntaxRule(kinds.Definition, [
+      child(roles.name, 1, 1),
+      child(roles.body, 1, 1),
+    ]),
+    syntaxRule(kinds.Equality, [
+      child(roles.left, 1, 1),
+      child(roles.right, 1, 1),
+    ]),
+    syntaxRule(kinds.Inequality, [
+      child(roles.left, 1, 1),
+      child(roles.right, 1, 1),
+    ]),
+    syntaxRule(kinds.Sequence, [child(roles.item, 2, null)]),
+    // Set retains textual/source order at the syntax layer. This does not
+    // assign ordering semantics to the lowered semantic set.
+    syntaxRule(kinds.Set, [child(roles.item, 0, null)]),
+    syntaxRule(kinds.Round, [child(roles.expression, 0, 1)]),
+    syntaxRule(kinds.Square, [child(roles.expression, 0, 1)]),
+    syntaxRule(kinds.Not, [child(roles.operand, 1, 1)]),
+    syntaxRule(kinds.Female, [child(roles.operand, 1, 1)]),
+    syntaxRule(kinds.Male, [child(roles.operand, 1, 1)]),
+    syntaxRule(kinds.ContextPronoun, [carrier(roles.value, 1, 1)]),
+    syntaxRule(kinds.Literal, [carrier(roles.value, 1, 1)]),
+  ]);
+}
+
 /**
  * Materialize the reusable syntax-only vocabulary relative to one explicit
  * caller-owned seed Link. Names in this TypeScript object are API labels only:
  * the Link identities are the structural forms derived below, never strings,
  * source positions, host object identities, allocation indexes or visual keys.
+ *
+ * The finite grammar is source-structure tooling authority only. It does not
+ * assign accepted MTS semantics to kind/role Links.
  */
 export function materializeSyntaxAsetVocabulary(
   memory: WriteMemory,
@@ -107,14 +177,16 @@ export function materializeSyntaxAsetVocabulary(
   const tag = memory.ensure(kindScope, roleScope);
   const kinds = materializeNamedSeries(memory, kindScope, KIND_NAMES);
   const roles = materializeNamedSeries(memory, roleScope, ROLE_NAMES);
-  const childRoles = Object.freeze(
-    CHILD_ROLE_NAMES.map((name) => roles[name]),
-  );
+  const knownRoles = Object.freeze(ROLE_NAMES.map((name) => roles[name]));
+  const childRoles = Object.freeze(CHILD_ROLE_NAMES.map((name) => roles[name]));
+  const rules = materializeGrammar(kinds, roles);
 
   return Object.freeze({
     tag,
     kinds,
     roles,
+    knownRoles,
+    rules,
     childRoles,
   });
 }

--- a/ts/test/research-syntax-aset-topology.test.ts
+++ b/ts/test/research-syntax-aset-topology.test.ts
@@ -1,15 +1,15 @@
 import { Memory, type LinkHandle, type LinkPoles, type ReadMemory } from "../src/memory.js";
 import {
-  SyntaxAsetBuilder,
   materializeSyntaxAsetVocabulary,
-  readSyntaxAset,
 } from "../src/tooling/syntax-aset.js";
 import {
   ChainedTriadSyntaxAsetBuilder,
+  LegacyS0SyntaxAsetBuilder,
   ResearchSyntaxAsetError,
   buildResearchCorpus,
   normalizeResearchRead,
   readChainedTriadSyntaxAset,
+  readLegacyS0SyntaxAset,
   triad,
   type ResearchBuilder,
 } from "../research/syntax-aset-topology.js";
@@ -52,7 +52,7 @@ class ReadProbe implements ReadMemory {
 function s0Fixture(): {
   readonly memory: Memory;
   readonly vocabulary: ReturnType<typeof materializeSyntaxAsetVocabulary>;
-  readonly builder: ResearchBuilder;
+  readonly builder: LegacyS0SyntaxAsetBuilder;
   readonly baseline: number;
 } {
   const memory = new Memory();
@@ -61,15 +61,7 @@ function s0Fixture(): {
   const carrierA = memory.ensure(vocabulary.tag, vocabulary.kinds.Literal);
   const carrierB = memory.ensure(vocabulary.tag, vocabulary.kinds.ContextPronoun);
   const baseline = memory.linkCount;
-  const delegate = new SyntaxAsetBuilder(memory, vocabulary);
-  const builder: ResearchBuilder = {
-    memory,
-    vocabulary,
-    carrierA,
-    carrierB,
-    addOccurrence: (kind, fields) => delegate.addOccurrence(kind, fields),
-    finish: (root) => delegate.finish(root),
-  };
+  const builder = new LegacyS0SyntaxAsetBuilder(memory, vocabulary, carrierA, carrierB);
   return Object.freeze({ memory, vocabulary, builder, baseline });
 }
 
@@ -145,8 +137,8 @@ function triadFixture(): {
   same(read.occurrences[0]?.fields.length, 0, "empty Round has an empty structural field chain");
 }
 
-// The same full corpus must round-trip through S0 and the chained-triad
-// candidate to the same syntax-level normalized structure.
+// The historical S0 control and the chained-triad candidate must normalize to
+// the same syntax-level corpus, while the selected candidate remains smaller.
 {
   const s0 = s0Fixture();
   const triads = triadFixture();
@@ -154,7 +146,7 @@ function triadFixture(): {
   const triadRoot = buildResearchCorpus(triads.builder);
   const s0Aset = s0.builder.finish(s0Root);
   const triadAset = triads.builder.finish(triadRoot);
-  const s0Read = readSyntaxAset(s0.memory, s0Aset, s0.vocabulary);
+  const s0Read = readLegacyS0SyntaxAset(s0.memory, s0Aset, s0.vocabulary);
   const triadRead = readChainedTriadSyntaxAset(triads.memory, triadAset, triads.vocabulary);
 
   const s0Normalized = normalizeResearchRead(s0Read, s0.vocabulary, s0.builder.carrierA, s0.builder.carrierB);

--- a/ts/test/syntax-aset-contract.test.ts
+++ b/ts/test/syntax-aset-contract.test.ts
@@ -8,6 +8,7 @@ import {
   SyntaxAsetBuilder,
   SyntaxAsetContractError,
   readSyntaxAset,
+  type SyntaxAsetFieldRule,
   type SyntaxAsetVocabulary,
 } from "../src/syntax-aset-contract.js";
 
@@ -67,25 +68,68 @@ function fixture(): Fixture {
   const nameRole = next();
   const bodyRole = next();
   const itemRole = next();
+  const leafKind = next();
+  const linkKind = next();
+  const definitionKind = next();
+  const sequenceKind = next();
+  const carrierX = next();
+  const carrierName = next();
+
+  const rule = (
+    role: LinkHandle,
+    target: SyntaxAsetFieldRule["target"],
+    min: number,
+    max: number | null,
+  ): SyntaxAsetFieldRule => Object.freeze({ role, target, min, max });
+
   const vocabulary: SyntaxAsetVocabulary = Object.freeze({
     tag: syntaxTag,
+    knownRoles: Object.freeze([
+      carrierRole,
+      startRole,
+      endRole,
+      nameRole,
+      bodyRole,
+      itemRole,
+    ]),
+    rules: Object.freeze([
+      Object.freeze({ kind: leafKind, fields: Object.freeze([rule(carrierRole, "carrier", 0, 1)]) }),
+      Object.freeze({
+        kind: linkKind,
+        fields: Object.freeze([
+          rule(startRole, "child", 1, 1),
+          rule(endRole, "child", 1, 1),
+        ]),
+      }),
+      Object.freeze({
+        kind: definitionKind,
+        fields: Object.freeze([
+          rule(nameRole, "carrier", 1, 1),
+          rule(bodyRole, "child", 1, 1),
+        ]),
+      }),
+      Object.freeze({
+        kind: sequenceKind,
+        fields: Object.freeze([rule(itemRole, "child", 1, null)]),
+      }),
+    ]),
     childRoles: Object.freeze([startRole, endRole, bodyRole, itemRole]),
   });
   return Object.freeze({
     memory,
     vocabulary,
-    leafKind: next(),
-    linkKind: next(),
-    definitionKind: next(),
-    sequenceKind: next(),
+    leafKind,
+    linkKind,
+    definitionKind,
+    sequenceKind,
     carrierRole,
     startRole,
     endRole,
     nameRole,
     bodyRole,
     itemRole,
-    carrierX: next(),
-    carrierName: next(),
+    carrierX,
+    carrierName,
   });
 }
 
@@ -118,7 +162,7 @@ function wrapSyntaxAset(memory: Memory, tag: LinkHandle, rootOccurrence: LinkHan
   return memory.ensure(tag, rootOccurrence);
 }
 
-// Equal syntax descriptors remain distinct occurrences because the previous
+// Equal-looking structures remain distinct occurrences because the previous
 // occurrence is structurally embedded in each chained triad.
 {
   const f = fixture();
@@ -216,7 +260,10 @@ function wrapSyntaxAset(memory: Memory, tag: LinkHandle, rootOccurrence: LinkHan
   otherBuilder.finish(foreign);
   const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
   rejectContract(
-    () => builder.addOccurrence(f.linkKind, [{ role: f.startRole, value: foreign }]),
+    () => builder.addOccurrence(f.linkKind, [
+      { role: f.startRole, value: foreign },
+      { role: f.endRole, value: foreign },
+    ]),
     "invalid-child-occurrence",
   );
 }
@@ -228,8 +275,9 @@ function wrapSyntaxAset(memory: Memory, tag: LinkHandle, rootOccurrence: LinkHan
   const foreign = foreignBuilder.addOccurrence(f.leafKind, []);
   foreignBuilder.finish(foreign);
 
-  const field = triad(f.memory, f.startRole, f.memory.root, foreign);
-  const localOccurrence = triad(f.memory, f.linkKind, f.memory.root, field);
+  const start = triad(f.memory, f.startRole, f.memory.root, foreign);
+  const end = triad(f.memory, f.endRole, start, foreign);
+  const localOccurrence = triad(f.memory, f.linkKind, f.memory.root, end);
   const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, localOccurrence);
   rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-child-occurrence");
 }
@@ -251,6 +299,8 @@ function wrapSyntaxAset(memory: Memory, tag: LinkHandle, rootOccurrence: LinkHan
   const aset = builder.finish(leaf);
   const wrongVocabulary: SyntaxAsetVocabulary = Object.freeze({
     tag: f.carrierX,
+    knownRoles: f.vocabulary.knownRoles,
+    rules: f.vocabulary.rules,
     childRoles: f.vocabulary.childRoles,
   });
   rejectContract(() => readSyntaxAset(f.memory, aset, wrongVocabulary), "invalid-aset");

--- a/ts/test/syntax-aset-contract.test.ts
+++ b/ts/test/syntax-aset-contract.test.ts
@@ -1,4 +1,3 @@
-import { materializeExactSequence } from "../src/exact-sequence.js";
 import {
   Memory,
   type LinkHandle,
@@ -106,21 +105,21 @@ class ReadProbe implements ReadMemory {
   incoming(end: LinkHandle): readonly LinkHandle[] { return this.source.incoming(end); }
 }
 
-function appendOccurrenceCell(memory: Memory, previous: LinkHandle, descriptor: LinkHandle): LinkHandle {
-  return memory.ensureStartSelfClosed(memory.ensure(previous, descriptor));
-}
-
-function wrapSyntaxAset(
+function triad(
   memory: Memory,
-  tag: LinkHandle,
-  occurrenceOrder: LinkHandle,
-  rootOccurrence: LinkHandle,
+  relation: LinkHandle,
+  subject: LinkHandle,
+  object: LinkHandle,
 ): LinkHandle {
-  return memory.ensure(tag, memory.ensure(occurrenceOrder, rootOccurrence));
+  return memory.ensure(relation, memory.ensure(subject, object));
 }
 
-// Equal syntax descriptors remain distinct occurrences because occurrence identity
-// is the structural ExactSequence Cell, never descriptor identity or host index.
+function wrapSyntaxAset(memory: Memory, tag: LinkHandle, rootOccurrence: LinkHandle): LinkHandle {
+  return memory.ensure(tag, rootOccurrence);
+}
+
+// Equal syntax descriptors remain distinct occurrences because the previous
+// occurrence is structurally embedded in each chained triad.
 {
   const f = fixture();
   const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
@@ -209,7 +208,7 @@ function wrapSyntaxAset(
 }
 
 // A child-bearing role may reference only an already-issued occurrence in this
-// builder's post-order sequence; a foreign occurrence cannot become local syntax.
+// builder's post-order chain; a foreign occurrence cannot become local syntax.
 {
   const f = fixture();
   const otherBuilder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
@@ -222,48 +221,26 @@ function wrapSyntaxAset(
   );
 }
 
-// Reader rejects a child reference that is not a prior occurrence of this Aset.
+// Reader applies the same prior-membership rule to arbitrary chained-triad input.
 {
   const f = fixture();
   const foreignBuilder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
   const foreign = foreignBuilder.addOccurrence(f.leafKind, []);
   foreignBuilder.finish(foreign);
 
-  const field = f.memory.ensure(f.startRole, foreign);
-  const fieldSequence = materializeExactSequence(f.memory, [field]);
-  const descriptor = f.memory.ensure(f.linkKind, fieldSequence);
-  const localOccurrence = appendOccurrenceCell(f.memory, f.memory.root, descriptor);
-  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, localOccurrence, localOccurrence);
+  const field = triad(f.memory, f.startRole, f.memory.root, foreign);
+  const localOccurrence = triad(f.memory, f.linkKind, f.memory.root, field);
+  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, localOccurrence);
   rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-child-occurrence");
 }
 
-// Exact-sequence shape is mandatory for descriptor fields.
+// The explicit root supplied to the builder must be the final occurrence.
 {
   const f = fixture();
-  const notAFieldSequence = f.memory.ensure(f.leafKind, f.carrierX);
-  const descriptor = f.memory.ensure(f.leafKind, notAFieldSequence);
-  const occurrence = appendOccurrenceCell(f.memory, f.memory.root, descriptor);
-  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, occurrence, occurrence);
-  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-field-sequence");
-}
-
-// Exact-sequence shape is mandatory for occurrence order.
-{
-  const f = fixture();
-  const notAnOccurrenceSequence = f.memory.ensure(f.leafKind, f.carrierX);
-  const fakeRoot = f.memory.ensureStartSelfClosed(f.carrierX);
-  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, notAnOccurrenceSequence, fakeRoot);
-  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "invalid-occurrence-sequence");
-}
-
-// The explicit root in the header must be the final structural occurrence Cell.
-{
-  const f = fixture();
-  const descriptor = f.memory.ensure(f.leafKind, materializeExactSequence(f.memory, []));
-  const first = appendOccurrenceCell(f.memory, f.memory.root, descriptor);
-  const second = appendOccurrenceCell(f.memory, first, descriptor);
-  const aset = wrapSyntaxAset(f.memory, f.vocabulary.tag, second, first);
-  rejectContract(() => readSyntaxAset(f.memory, aset, f.vocabulary), "root-not-final");
+  const builder = new SyntaxAsetBuilder(f.memory, f.vocabulary);
+  const first = builder.addOccurrence(f.leafKind, []);
+  builder.addOccurrence(f.leafKind, []);
+  rejectContract(() => builder.finish(first), "root-not-final");
 }
 
 // Syntax tag and Link ownership are checked structurally, not by scalar IDs.

--- a/ts/test/syntax-aset-grammar.test.ts
+++ b/ts/test/syntax-aset-grammar.test.ts
@@ -1,0 +1,439 @@
+import { Memory, type LinkHandle } from "../src/memory.js";
+import {
+  SyntaxAsetBuilder,
+  SyntaxAsetContractError,
+  materializeSyntaxAsetVocabulary,
+  readSyntaxAset,
+  type SyntaxAsetToolingVocabulary,
+} from "../src/tooling/syntax-aset.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function reject(
+  effect: () => unknown,
+  code: SyntaxAsetContractError["code"],
+): void {
+  try {
+    effect();
+  } catch (error) {
+    assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
+    same(error.code, code, "SyntaxAset error code");
+    return;
+  }
+  throw new Error(`expected SyntaxAset rejection: ${code}`);
+}
+
+function fixture(): {
+  readonly memory: Memory;
+  readonly vocabulary: SyntaxAsetToolingVocabulary;
+} {
+  const memory = new Memory();
+  const seed = memory.ensureEndSelfClosed(memory.root);
+  return Object.freeze({
+    memory,
+    vocabulary: materializeSyntaxAsetVocabulary(memory, seed),
+  });
+}
+
+function carrier(memory: Memory, salt: LinkHandle): LinkHandle {
+  return memory.ensureStartSelfClosed(salt);
+}
+
+function triad(
+  memory: Memory,
+  relation: LinkHandle,
+  subject: LinkHandle,
+  object: LinkHandle,
+): LinkHandle {
+  return memory.ensure(relation, memory.ensure(subject, object));
+}
+
+function addLiteral(
+  builder: SyntaxAsetBuilder,
+  vocabulary: SyntaxAsetToolingVocabulary,
+  value: LinkHandle,
+): LinkHandle {
+  return builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value },
+  ]);
+}
+
+// A carrier is not a syntax child merely because its poles accidentally look
+// like an occurrence. Membership in a SyntaxAset, not shape resemblance, is
+// what makes an occurrence a syntax occurrence.
+{
+  const { memory, vocabulary } = fixture();
+  const occurrenceShapedCarrier = memory.ensure(vocabulary.kinds.Literal, memory.root);
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const literal = addLiteral(builder, vocabulary, occurrenceShapedCarrier);
+  const aset = builder.finish(literal);
+  same(readSyntaxAset(memory, aset, vocabulary).root, literal, "shape-only carrier remains a carrier");
+}
+
+// A real occurrence owned by another SyntaxAset cannot be smuggled through a
+// carrier relation. Its foreign SyntaxAset wrapper provides structural proof
+// that it is syntax, even though it is not a local child.
+{
+  const { memory, vocabulary } = fixture();
+  const foreignBuilder = new SyntaxAsetBuilder(memory, vocabulary);
+  const foreign = addLiteral(
+    foreignBuilder,
+    vocabulary,
+    carrier(memory, vocabulary.kinds.Literal),
+  );
+  foreignBuilder.finish(foreign);
+
+  const localBuilder = new SyntaxAsetBuilder(memory, vocabulary);
+  reject(
+    () => addLiteral(localBuilder, vocabulary, foreign),
+    "invalid-carrier-target",
+  );
+}
+
+// A local occurrence is likewise forbidden where a carrier is required.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.tag));
+  reject(() => addLiteral(builder, vocabulary, child), "invalid-carrier-target");
+}
+
+// Link has the exact ordered singleton grammar start,end. Missing, duplicate,
+// reversed and wrong known roles all fail closed.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const a = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Link));
+  const b = addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.end));
+
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Link, [
+      { role: vocabulary.roles.end, value: b },
+    ]),
+    "invalid-grammar",
+  );
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Link, [
+      { role: vocabulary.roles.start, value: a },
+    ]),
+    "invalid-grammar",
+  );
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Link, [
+      { role: vocabulary.roles.start, value: a },
+      { role: vocabulary.roles.start, value: b },
+      { role: vocabulary.roles.end, value: b },
+    ]),
+    "invalid-grammar",
+  );
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Link, [
+      { role: vocabulary.roles.end, value: b },
+      { role: vocabulary.roles.start, value: a },
+    ]),
+    "invalid-grammar",
+  );
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Link, [
+      { role: vocabulary.roles.start, value: a },
+      { role: vocabulary.roles.operand, value: b },
+    ]),
+    "invalid-grammar",
+  );
+
+  const link = builder.addOccurrence(vocabulary.kinds.Link, [
+    { role: vocabulary.roles.start, value: a },
+    { role: vocabulary.roles.end, value: b },
+  ]);
+  same(readSyntaxAset(memory, builder.finish(link), vocabulary).root, link, "canonical Link accepted");
+}
+
+// Statement and unary forms are exact single-child productions.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Statement));
+  reject(() => builder.addOccurrence(vocabulary.kinds.Statement, []), "invalid-grammar");
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Statement, [
+      { role: vocabulary.roles.expression, value: child },
+      { role: vocabulary.roles.expression, value: child },
+    ]),
+    "invalid-grammar",
+  );
+  for (const kind of [vocabulary.kinds.Not, vocabulary.kinds.Female, vocabulary.kinds.Male]) {
+    reject(() => builder.addOccurrence(kind, []), "invalid-grammar");
+    reject(
+      () => builder.addOccurrence(kind, [
+        { role: vocabulary.roles.operand, value: child },
+        { role: vocabulary.roles.operand, value: child },
+      ]),
+      "invalid-grammar",
+    );
+  }
+  const statement = builder.addOccurrence(vocabulary.kinds.Statement, [
+    { role: vocabulary.roles.expression, value: child },
+  ]);
+  same(readSyntaxAset(memory, builder.finish(statement), vocabulary).root, statement, "Statement accepted");
+}
+
+// Definition name and body are both syntax children. Equality/Inequality are
+// exact ordered left/right child pairs.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const left = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Equality));
+  const right = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Inequality));
+
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Definition, [
+      { role: vocabulary.roles.name, value: left },
+    ]),
+    "invalid-grammar",
+  );
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Definition, [
+      { role: vocabulary.roles.body, value: right },
+      { role: vocabulary.roles.name, value: left },
+    ]),
+    "invalid-grammar",
+  );
+
+  for (const kind of [vocabulary.kinds.Equality, vocabulary.kinds.Inequality]) {
+    reject(
+      () => builder.addOccurrence(kind, [
+        { role: vocabulary.roles.left, value: left },
+      ]),
+      "invalid-grammar",
+    );
+    reject(
+      () => builder.addOccurrence(kind, [
+        { role: vocabulary.roles.left, value: left },
+        { role: vocabulary.roles.left, value: right },
+        { role: vocabulary.roles.right, value: right },
+      ]),
+      "invalid-grammar",
+    );
+    reject(
+      () => builder.addOccurrence(kind, [
+        { role: vocabulary.roles.left, value: left },
+        { role: vocabulary.roles.right, value: right },
+        { role: vocabulary.roles.operand, value: left },
+      ]),
+      "invalid-grammar",
+    );
+  }
+
+  const definition = builder.addOccurrence(vocabulary.kinds.Definition, [
+    { role: vocabulary.roles.name, value: left },
+    { role: vocabulary.roles.body, value: right },
+  ]);
+  same(readSyntaxAset(memory, builder.finish(definition), vocabulary).root, definition, "Definition accepted");
+}
+
+// Sequence exists only for 2+ juxtaposed source forms. Repeated equal child
+// occurrences remain explicit ordered positions.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const item = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Sequence));
+  reject(() => builder.addOccurrence(vocabulary.kinds.Sequence, []), "invalid-grammar");
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds.Sequence, [
+      { role: vocabulary.roles.item, value: item },
+    ]),
+    "invalid-grammar",
+  );
+  const sequence = builder.addOccurrence(vocabulary.kinds.Sequence, [
+    { role: vocabulary.roles.item, value: item },
+    { role: vocabulary.roles.item, value: item },
+  ]);
+  const read = readSyntaxAset(memory, builder.finish(sequence), vocabulary);
+  same(read.occurrences.at(-1)?.fields[0]?.value, item, "first Sequence position retained");
+  same(read.occurrences.at(-1)?.fields[1]?.value, item, "second Sequence position retained");
+}
+
+// File and Set accept empty syntax. Set preserves textual order at the syntax
+// layer; this is not a claim that semantic set membership is ordered.
+for (const kindName of ["File", "Set"] as const) {
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const empty = builder.addOccurrence(vocabulary.kinds[kindName], []);
+  same(readSyntaxAset(memory, builder.finish(empty), vocabulary).root, empty, `${kindName} empty accepted`);
+}
+
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const first = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Set));
+  const second = addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.item));
+  const set = builder.addOccurrence(vocabulary.kinds.Set, [
+    { role: vocabulary.roles.item, value: second },
+    { role: vocabulary.roles.item, value: first },
+  ]);
+  const fields = readSyntaxAset(memory, builder.finish(set), vocabulary).occurrences.at(-1)?.fields;
+  same(fields?.[0]?.value, second, "Set first textual item retained");
+  same(fields?.[1]?.value, first, "Set second textual item retained");
+}
+
+// Round/Square are optional-single-child wrappers: empty and singleton are
+// valid, two expressions are not.
+for (const kindName of ["Round", "Square"] as const) {
+  {
+    const { memory, vocabulary } = fixture();
+    const builder = new SyntaxAsetBuilder(memory, vocabulary);
+    const empty = builder.addOccurrence(vocabulary.kinds[kindName], []);
+    same(readSyntaxAset(memory, builder.finish(empty), vocabulary).root, empty, `${kindName} empty accepted`);
+  }
+  {
+    const { memory, vocabulary } = fixture();
+    const builder = new SyntaxAsetBuilder(memory, vocabulary);
+    const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds[kindName]));
+    reject(
+      () => builder.addOccurrence(vocabulary.kinds[kindName], [
+        { role: vocabulary.roles.expression, value: child },
+        { role: vocabulary.roles.expression, value: child },
+      ]),
+      "invalid-grammar",
+    );
+    const wrapper = builder.addOccurrence(vocabulary.kinds[kindName], [
+      { role: vocabulary.roles.expression, value: child },
+    ]);
+    same(readSyntaxAset(memory, builder.finish(wrapper), vocabulary).root, wrapper, `${kindName} singleton accepted`);
+  }
+}
+
+// ContextPronoun and Literal are exact one-carrier leaves.
+for (const kindName of ["ContextPronoun", "Literal"] as const) {
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const value = carrier(memory, vocabulary.kinds[kindName]);
+  reject(() => builder.addOccurrence(vocabulary.kinds[kindName], []), "invalid-grammar");
+  reject(
+    () => builder.addOccurrence(vocabulary.kinds[kindName], [
+      { role: vocabulary.roles.value, value },
+      { role: vocabulary.roles.value, value },
+    ]),
+    "invalid-grammar",
+  );
+  const leaf = builder.addOccurrence(vocabulary.kinds[kindName], [
+    { role: vocabulary.roles.value, value },
+  ]);
+  same(readSyntaxAset(memory, builder.finish(leaf), vocabulary).root, leaf, `${kindName} carrier accepted`);
+}
+
+// The occurrence chain is also the owned SyntaxAset closure. An otherwise valid
+// earlier occurrence that is not reachable from the declared final root fails.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.left));
+  const root = addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.right));
+  reject(() => builder.finish(root), "unreachable-occurrence");
+}
+
+// The untrusted reader independently enforces the same reachability rule.
+{
+  const { memory, vocabulary } = fixture();
+  const fieldA = triad(
+    memory,
+    vocabulary.roles.value,
+    memory.root,
+    carrier(memory, vocabulary.roles.start),
+  );
+  const unused = triad(memory, vocabulary.kinds.Literal, memory.root, fieldA);
+  const fieldB = triad(
+    memory,
+    vocabulary.roles.value,
+    memory.root,
+    carrier(memory, vocabulary.roles.end),
+  );
+  const root = triad(memory, vocabulary.kinds.Literal, unused, fieldB);
+  const aset = memory.ensure(vocabulary.tag, root);
+  reject(() => readSyntaxAset(memory, aset, vocabulary), "unreachable-occurrence");
+}
+
+// DAG-like reuse is allowed when it is explicit and every owned occurrence is
+// reachable. The same child can fill both Link roles without host identity.
+{
+  const { memory, vocabulary } = fixture();
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Link));
+  const link = builder.addOccurrence(vocabulary.kinds.Link, [
+    { role: vocabulary.roles.start, value: child },
+    { role: vocabulary.roles.end, value: child },
+  ]);
+  same(readSyntaxAset(memory, builder.finish(link), vocabulary).root, link, "explicit child sharing accepted");
+}
+
+// Arbitrary/untrusted topology cannot introduce unknown kind/role Links.
+{
+  const { memory, vocabulary } = fixture();
+  const value = carrier(memory, vocabulary.tag);
+  const field = triad(memory, vocabulary.roles.value, memory.root, value);
+  const unknownKind = memory.ensureStartSelfClosed(value);
+  const occurrence = triad(memory, unknownKind, memory.root, field);
+  reject(
+    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, occurrence), vocabulary),
+    "unknown-kind",
+  );
+}
+
+{
+  const { memory, vocabulary } = fixture();
+  const value = carrier(memory, vocabulary.tag);
+  const unknownRole = memory.ensureEndSelfClosed(value);
+  const field = triad(memory, unknownRole, memory.root, value);
+  const occurrence = triad(memory, vocabulary.kinds.Literal, memory.root, field);
+  reject(
+    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, occurrence), vocabulary),
+    "unknown-role",
+  );
+}
+
+// Kind/role Links from another explicit vocabulary seed are foreign syntax
+// vocabulary even when they carry the same TypeScript display labels.
+{
+  const { memory, vocabulary } = fixture();
+  const secondSeed = memory.ensureStartSelfClosed(vocabulary.tag);
+  const foreignVocabulary = materializeSyntaxAsetVocabulary(memory, secondSeed);
+  const value = carrier(memory, vocabulary.kinds.Literal);
+
+  const localField = triad(memory, vocabulary.roles.value, memory.root, value);
+  const foreignKindOccurrence = triad(
+    memory,
+    foreignVocabulary.kinds.Literal,
+    memory.root,
+    localField,
+  );
+  reject(
+    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, foreignKindOccurrence), vocabulary),
+    "unknown-kind",
+  );
+
+  const foreignField = triad(memory, foreignVocabulary.roles.value, memory.root, value);
+  const localKindOccurrence = triad(memory, vocabulary.kinds.Literal, memory.root, foreignField);
+  reject(
+    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, localKindOccurrence), vocabulary),
+    "unknown-role",
+  );
+}
+
+// Swapping the nested-pair orientation is not an alternate canonical encoding.
+{
+  const { memory, vocabulary } = fixture();
+  const value = carrier(memory, vocabulary.kinds.Literal);
+  const horizontal = memory.ensure(memory.root, value);
+  const dualizedField = memory.ensure(horizontal, vocabulary.roles.value);
+  const occurrence = triad(memory, vocabulary.kinds.Literal, memory.root, dualizedField);
+  reject(
+    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, occurrence), vocabulary),
+    "unknown-role",
+  );
+}

--- a/ts/test/syntax-aset-grammar.test.ts
+++ b/ts/test/syntax-aset-grammar.test.ts
@@ -1,67 +1,47 @@
 import { Memory, type LinkHandle } from "../src/memory.js";
 import {
-  SyntaxAsetBuilder,
-  SyntaxAsetContractError,
-  materializeSyntaxAsetVocabulary,
-  readSyntaxAset,
-  type SyntaxAsetToolingVocabulary,
+  SyntaxAsetBuilder, SyntaxAsetContractError, materializeSyntaxAsetVocabulary,
+  readSyntaxAset, type SyntaxAsetToolingVocabulary,
 } from "../src/tooling/syntax-aset.js";
-
-function assert(value: unknown, message: string): asserts value {
-  if (!value) throw new Error(message);
-}
+function assert(value: unknown, message: string): asserts value { if (!value) throw new Error(message); }
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
 }
 function reject(effect: () => unknown, code: SyntaxAsetContractError["code"]): void {
   try { effect(); } catch (error) {
     assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
-    same(error.code, code, "SyntaxAset error code");
-    return;
+    same(error.code, code, "SyntaxAset error code"); return;
   }
   throw new Error(`expected SyntaxAset rejection: ${code}`);
 }
 function fixture() {
   const memory = new Memory();
-  const vocabulary = materializeSyntaxAsetVocabulary(
-    memory,
-    memory.ensureEndSelfClosed(memory.root),
-  );
-  return { memory, vocabulary };
+  return { memory, vocabulary: materializeSyntaxAsetVocabulary(memory, memory.ensureEndSelfClosed(memory.root)) };
 }
-function carrier(memory: Memory, salt: LinkHandle): LinkHandle {
-  return memory.ensureStartSelfClosed(salt);
-}
+function carrier(memory: Memory, salt: LinkHandle): LinkHandle { return memory.ensureStartSelfClosed(salt); }
 function triad(memory: Memory, r: LinkHandle, s: LinkHandle, o: LinkHandle): LinkHandle {
   return memory.ensure(r, memory.ensure(s, o));
 }
-function literal(
-  builder: SyntaxAsetBuilder,
-  vocabulary: SyntaxAsetToolingVocabulary,
-  value: LinkHandle,
-): LinkHandle {
-  return builder.addOccurrence(vocabulary.kinds.Literal, [
-    { role: vocabulary.roles.value, value },
-  ]);
+function literal(builder: SyntaxAsetBuilder, v: SyntaxAsetToolingVocabulary, value: LinkHandle): LinkHandle {
+  return builder.addOccurrence(v.kinds.Literal, [{ role: v.roles.value, value }]);
 }
 
-// Carrier classification is by explicit SyntaxAset membership, never pole shape.
+// Carrier classification uses explicit SyntaxAset membership, never pole shape.
 {
-  const { memory, vocabulary } = fixture();
-  const shapeOnly = memory.ensure(vocabulary.kinds.Literal, memory.root);
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const root = literal(builder, vocabulary, shapeOnly);
-  same(readSyntaxAset(memory, builder.finish(root), vocabulary).root, root, "shape-only carrier accepted");
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const root = literal(b, v, memory.ensure(v.kinds.Literal, memory.root));
+  same(readSyntaxAset(memory, b.finish(root), v).root, root, "shape-only carrier accepted");
 }
 {
-  const { memory, vocabulary } = fixture();
-  const foreignBuilder = new SyntaxAsetBuilder(memory, vocabulary);
-  const foreign = literal(foreignBuilder, vocabulary, carrier(memory, vocabulary.tag));
+  const { memory, vocabulary: v } = fixture();
+  const foreignBuilder = new SyntaxAsetBuilder(memory, v);
+  const foreign = literal(foreignBuilder, v, carrier(memory, v.tag));
   foreignBuilder.finish(foreign);
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  reject(() => literal(builder, vocabulary, foreign), "invalid-carrier-target");
-  const local = literal(builder, vocabulary, carrier(memory, vocabulary.kinds.Literal));
-  reject(() => literal(builder, vocabulary, local), "invalid-carrier-target");
+  const b = new SyntaxAsetBuilder(memory, v);
+  reject(() => literal(b, v, foreign), "invalid-carrier-target");
+  const local = literal(b, v, carrier(memory, v.kinds.Literal));
+  reject(() => literal(b, v, local), "invalid-carrier-target");
 }
 
 // Fixed productions reject missing, duplicate, reversed and extra known roles.
@@ -72,107 +52,70 @@ function literal(
   const c = literal(b, v, carrier(memory, v.roles.right));
   const bad = (kind: LinkHandle, fields: readonly { role: LinkHandle; value: LinkHandle }[]) =>
     reject(() => b.addOccurrence(kind, fields), "invalid-grammar");
-
   bad(v.kinds.Link, [{ role: v.roles.end, value: c }]);
   bad(v.kinds.Link, [{ role: v.roles.start, value: a }]);
   bad(v.kinds.Link, [
-    { role: v.roles.start, value: a },
-    { role: v.roles.start, value: c },
-    { role: v.roles.end, value: c },
+    { role: v.roles.start, value: a }, { role: v.roles.start, value: c }, { role: v.roles.end, value: c },
   ]);
-  bad(v.kinds.Link, [
-    { role: v.roles.end, value: c },
-    { role: v.roles.start, value: a },
-  ]);
-  bad(v.kinds.Link, [
-    { role: v.roles.start, value: a },
-    { role: v.roles.operand, value: c },
-  ]);
-
+  bad(v.kinds.Link, [{ role: v.roles.end, value: c }, { role: v.roles.start, value: a }]);
+  bad(v.kinds.Link, [{ role: v.roles.start, value: a }, { role: v.roles.operand, value: c }]);
   for (const kind of [v.kinds.Equality, v.kinds.Inequality]) {
     bad(kind, [{ role: v.roles.left, value: a }]);
     bad(kind, [
-      { role: v.roles.left, value: a },
-      { role: v.roles.left, value: c },
-      { role: v.roles.right, value: c },
+      { role: v.roles.left, value: a }, { role: v.roles.left, value: c }, { role: v.roles.right, value: c },
     ]);
     bad(kind, [
-      { role: v.roles.left, value: a },
-      { role: v.roles.right, value: c },
-      { role: v.roles.operand, value: a },
+      { role: v.roles.left, value: a }, { role: v.roles.right, value: c }, { role: v.roles.operand, value: a },
     ]);
   }
   bad(v.kinds.Definition, [{ role: v.roles.name, value: a }]);
-  bad(v.kinds.Definition, [
-    { role: v.roles.body, value: c },
-    { role: v.roles.name, value: a },
-  ]);
+  bad(v.kinds.Definition, [{ role: v.roles.body, value: c }, { role: v.roles.name, value: a }]);
   bad(v.kinds.Statement, []);
   bad(v.kinds.Statement, [
-    { role: v.roles.expression, value: a },
-    { role: v.roles.expression, value: c },
+    { role: v.roles.expression, value: a }, { role: v.roles.expression, value: c },
   ]);
   for (const kind of [v.kinds.Not, v.kinds.Female, v.kinds.Male]) {
     bad(kind, []);
-    bad(kind, [
-      { role: v.roles.operand, value: a },
-      { role: v.roles.operand, value: c },
-    ]);
+    bad(kind, [{ role: v.roles.operand, value: a }, { role: v.roles.operand, value: c }]);
   }
 }
 
-// Container/wrapper cardinality follows the actual source parser grammar.
+// Cardinality follows the actual source parser grammar.
 {
   const { memory, vocabulary: v } = fixture();
   const b = new SyntaxAsetBuilder(memory, v);
   const item = literal(b, v, carrier(memory, v.kinds.Sequence));
   reject(() => b.addOccurrence(v.kinds.Sequence, []), "invalid-grammar");
-  reject(
-    () => b.addOccurrence(v.kinds.Sequence, [{ role: v.roles.item, value: item }]),
-    "invalid-grammar",
-  );
+  reject(() => b.addOccurrence(v.kinds.Sequence, [{ role: v.roles.item, value: item }]), "invalid-grammar");
 }
 for (const kindName of ["File", "Set", "Round", "Square"] as const) {
   const { memory, vocabulary: v } = fixture();
-  const b = new SyntaxAsetBuilder(memory, v);
-  const root = b.addOccurrence(v.kinds[kindName], []);
+  const b = new SyntaxAsetBuilder(memory, v); const root = b.addOccurrence(v.kinds[kindName], []);
   same(readSyntaxAset(memory, b.finish(root), v).root, root, `${kindName} empty accepted`);
 }
 for (const kindName of ["Round", "Square"] as const) {
-  const { memory, vocabulary: v } = fixture();
-  const b = new SyntaxAsetBuilder(memory, v);
+  const { memory, vocabulary: v } = fixture(); const b = new SyntaxAsetBuilder(memory, v);
   const child = literal(b, v, carrier(memory, v.kinds[kindName]));
-  reject(
-    () => b.addOccurrence(v.kinds[kindName], [
-      { role: v.roles.expression, value: child },
-      { role: v.roles.expression, value: child },
-    ]),
-    "invalid-grammar",
-  );
+  reject(() => b.addOccurrence(v.kinds[kindName], [
+    { role: v.roles.expression, value: child }, { role: v.roles.expression, value: child },
+  ]), "invalid-grammar");
 }
 for (const kindName of ["ContextPronoun", "Literal"] as const) {
-  const { memory, vocabulary: v } = fixture();
-  const b = new SyntaxAsetBuilder(memory, v);
+  const { memory, vocabulary: v } = fixture(); const b = new SyntaxAsetBuilder(memory, v);
   const value = carrier(memory, v.kinds[kindName]);
   reject(() => b.addOccurrence(v.kinds[kindName], []), "invalid-grammar");
-  reject(
-    () => b.addOccurrence(v.kinds[kindName], [
-      { role: v.roles.value, value },
-      { role: v.roles.value, value },
-    ]),
-    "invalid-grammar",
-  );
+  reject(() => b.addOccurrence(v.kinds[kindName], [
+    { role: v.roles.value, value }, { role: v.roles.value, value },
+  ]), "invalid-grammar");
 }
 
-// Set source order is syntax structure, not semantic-set ordering.
+// Set preserves textual order at syntax layer; this does not order semantic membership.
 {
-  const { memory, vocabulary: v } = fixture();
-  const b = new SyntaxAsetBuilder(memory, v);
+  const { memory, vocabulary: v } = fixture(); const b = new SyntaxAsetBuilder(memory, v);
   const first = literal(b, v, carrier(memory, v.roles.start));
   const second = literal(b, v, carrier(memory, v.roles.end));
   const set = b.addOccurrence(v.kinds.Set, [
-    { role: v.roles.item, value: second },
-    { role: v.roles.item, value: first },
+    { role: v.roles.item, value: second }, { role: v.roles.item, value: first },
   ]);
   const fields = readSyntaxAset(memory, b.finish(set), v).occurrences.at(-1)?.fields;
   same(fields?.[0]?.value, second, "Set first textual item");
@@ -181,8 +124,7 @@ for (const kindName of ["ContextPronoun", "Literal"] as const) {
 
 // Occurrence chain is owned closure; unused earlier members fail closed.
 {
-  const { memory, vocabulary: v } = fixture();
-  const b = new SyntaxAsetBuilder(memory, v);
+  const { memory, vocabulary: v } = fixture(); const b = new SyntaxAsetBuilder(memory, v);
   literal(b, v, carrier(memory, v.roles.left));
   const root = literal(b, v, carrier(memory, v.roles.right));
   reject(() => b.finish(root), "unreachable-occurrence");
@@ -193,71 +135,42 @@ for (const kindName of ["ContextPronoun", "Literal"] as const) {
   const unused = triad(memory, v.kinds.Literal, memory.root, fa);
   const fb = triad(memory, v.roles.value, memory.root, carrier(memory, v.roles.end));
   const root = triad(memory, v.kinds.Literal, unused, fb);
-  reject(
-    () => readSyntaxAset(memory, memory.ensure(v.tag, root), v),
-    "unreachable-occurrence",
-  );
+  reject(() => readSyntaxAset(memory, memory.ensure(v.tag, root), v), "unreachable-occurrence");
 }
 
-// Explicit DAG reuse is valid when all owned occurrences stay reachable.
+// Explicit DAG reuse remains valid when all owned occurrences are reachable.
 {
-  const { memory, vocabulary: v } = fixture();
-  const b = new SyntaxAsetBuilder(memory, v);
+  const { memory, vocabulary: v } = fixture(); const b = new SyntaxAsetBuilder(memory, v);
   const child = literal(b, v, carrier(memory, v.kinds.Link));
   const root = b.addOccurrence(v.kinds.Link, [
-    { role: v.roles.start, value: child },
-    { role: v.roles.end, value: child },
+    { role: v.roles.start, value: child }, { role: v.roles.end, value: child },
   ]);
   same(readSyntaxAset(memory, b.finish(root), v).root, root, "shared child accepted");
 }
 
 // Untrusted topology rejects unknown/foreign vocabulary and dualized encoding.
 {
-  const { memory, vocabulary: v } = fixture();
-  const value = carrier(memory, v.tag);
+  const { memory, vocabulary: v } = fixture(); const value = carrier(memory, v.tag);
   const field = triad(memory, v.roles.value, memory.root, value);
   const unknownKind = memory.ensureStartSelfClosed(value);
-  reject(
-    () => readSyntaxAset(memory, memory.ensure(v.tag, triad(memory, unknownKind, memory.root, field)), v),
-    "unknown-kind",
-  );
+  reject(() => readSyntaxAset(
+    memory, memory.ensure(v.tag, triad(memory, unknownKind, memory.root, field)), v,
+  ), "unknown-kind");
   const unknownRole = memory.ensureEndSelfClosed(value);
-  reject(
-    () => readSyntaxAset(
-      memory,
-      memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, triad(memory, unknownRole, memory.root, value))),
-      v,
-    ),
-    "unknown-role",
-  );
-
+  reject(() => readSyntaxAset(
+    memory, memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root,
+      triad(memory, unknownRole, memory.root, value))), v,
+  ), "unknown-role");
   const foreign = materializeSyntaxAsetVocabulary(memory, memory.ensureStartSelfClosed(v.tag));
-  reject(
-    () => readSyntaxAset(
-      memory,
-      memory.ensure(v.tag, triad(memory, foreign.kinds.Literal, memory.root, field)),
-      v,
-    ),
-    "unknown-kind",
-  );
+  reject(() => readSyntaxAset(
+    memory, memory.ensure(v.tag, triad(memory, foreign.kinds.Literal, memory.root, field)), v,
+  ), "unknown-kind");
   const foreignField = triad(memory, foreign.roles.value, memory.root, value);
-  reject(
-    () => readSyntaxAset(
-      memory,
-      memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, foreignField)),
-      v,
-    ),
-    "unknown-role",
-  );
-
-  const horizontal = memory.ensure(memory.root, value);
-  const dualized = memory.ensure(horizontal, v.roles.value);
-  reject(
-    () => readSyntaxAset(
-      memory,
-      memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, dualized)),
-      v,
-    ),
-    "unknown-role",
-  );
+  reject(() => readSyntaxAset(
+    memory, memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, foreignField)), v,
+  ), "unknown-role");
+  const dualized = memory.ensure(memory.ensure(memory.root, value), v.roles.value);
+  reject(() => readSyntaxAset(
+    memory, memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, dualized)), v,
+  ), "unknown-role");
 }

--- a/ts/test/syntax-aset-grammar.test.ts
+++ b/ts/test/syntax-aset-grammar.test.ts
@@ -7,54 +7,35 @@ import {
   type SyntaxAsetToolingVocabulary,
 } from "../src/tooling/syntax-aset.js";
 
-function assert(condition: unknown, message: string): asserts condition {
-  if (!condition) throw new Error(message);
+function assert(value: unknown, message: string): asserts value {
+  if (!value) throw new Error(message);
 }
-
 function same<T>(actual: T, expected: T, message: string): void {
   assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
 }
-
-function reject(
-  effect: () => unknown,
-  code: SyntaxAsetContractError["code"],
-): void {
-  try {
-    effect();
-  } catch (error) {
+function reject(effect: () => unknown, code: SyntaxAsetContractError["code"]): void {
+  try { effect(); } catch (error) {
     assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
     same(error.code, code, "SyntaxAset error code");
     return;
   }
   throw new Error(`expected SyntaxAset rejection: ${code}`);
 }
-
-function fixture(): {
-  readonly memory: Memory;
-  readonly vocabulary: SyntaxAsetToolingVocabulary;
-} {
+function fixture() {
   const memory = new Memory();
-  const seed = memory.ensureEndSelfClosed(memory.root);
-  return Object.freeze({
+  const vocabulary = materializeSyntaxAsetVocabulary(
     memory,
-    vocabulary: materializeSyntaxAsetVocabulary(memory, seed),
-  });
+    memory.ensureEndSelfClosed(memory.root),
+  );
+  return { memory, vocabulary };
 }
-
 function carrier(memory: Memory, salt: LinkHandle): LinkHandle {
   return memory.ensureStartSelfClosed(salt);
 }
-
-function triad(
-  memory: Memory,
-  relation: LinkHandle,
-  subject: LinkHandle,
-  object: LinkHandle,
-): LinkHandle {
-  return memory.ensure(relation, memory.ensure(subject, object));
+function triad(memory: Memory, r: LinkHandle, s: LinkHandle, o: LinkHandle): LinkHandle {
+  return memory.ensure(r, memory.ensure(s, o));
 }
-
-function addLiteral(
+function literal(
   builder: SyntaxAsetBuilder,
   vocabulary: SyntaxAsetToolingVocabulary,
   value: LinkHandle,
@@ -64,376 +45,219 @@ function addLiteral(
   ]);
 }
 
-// A carrier is not a syntax child merely because its poles accidentally look
-// like an occurrence. Membership in a SyntaxAset, not shape resemblance, is
-// what makes an occurrence a syntax occurrence.
+// Carrier classification is by explicit SyntaxAset membership, never pole shape.
 {
   const { memory, vocabulary } = fixture();
-  const occurrenceShapedCarrier = memory.ensure(vocabulary.kinds.Literal, memory.root);
+  const shapeOnly = memory.ensure(vocabulary.kinds.Literal, memory.root);
   const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const literal = addLiteral(builder, vocabulary, occurrenceShapedCarrier);
-  const aset = builder.finish(literal);
-  same(readSyntaxAset(memory, aset, vocabulary).root, literal, "shape-only carrier remains a carrier");
+  const root = literal(builder, vocabulary, shapeOnly);
+  same(readSyntaxAset(memory, builder.finish(root), vocabulary).root, root, "shape-only carrier accepted");
 }
-
-// A real occurrence owned by another SyntaxAset cannot be smuggled through a
-// carrier relation. Its foreign SyntaxAset wrapper provides structural proof
-// that it is syntax, even though it is not a local child.
 {
   const { memory, vocabulary } = fixture();
   const foreignBuilder = new SyntaxAsetBuilder(memory, vocabulary);
-  const foreign = addLiteral(
-    foreignBuilder,
-    vocabulary,
-    carrier(memory, vocabulary.kinds.Literal),
-  );
+  const foreign = literal(foreignBuilder, vocabulary, carrier(memory, vocabulary.tag));
   foreignBuilder.finish(foreign);
-
-  const localBuilder = new SyntaxAsetBuilder(memory, vocabulary);
-  reject(
-    () => addLiteral(localBuilder, vocabulary, foreign),
-    "invalid-carrier-target",
-  );
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  reject(() => literal(builder, vocabulary, foreign), "invalid-carrier-target");
+  const local = literal(builder, vocabulary, carrier(memory, vocabulary.kinds.Literal));
+  reject(() => literal(builder, vocabulary, local), "invalid-carrier-target");
 }
 
-// A local occurrence is likewise forbidden where a carrier is required.
+// Fixed productions reject missing, duplicate, reversed and extra known roles.
 {
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.tag));
-  reject(() => addLiteral(builder, vocabulary, child), "invalid-carrier-target");
-}
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const a = literal(b, v, carrier(memory, v.roles.left));
+  const c = literal(b, v, carrier(memory, v.roles.right));
+  const bad = (kind: LinkHandle, fields: readonly { role: LinkHandle; value: LinkHandle }[]) =>
+    reject(() => b.addOccurrence(kind, fields), "invalid-grammar");
 
-// Link has the exact ordered singleton grammar start,end. Missing, duplicate,
-// reversed and wrong known roles all fail closed.
-{
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const a = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Link));
-  const b = addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.end));
-
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Link, [
-      { role: vocabulary.roles.end, value: b },
-    ]),
-    "invalid-grammar",
-  );
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Link, [
-      { role: vocabulary.roles.start, value: a },
-    ]),
-    "invalid-grammar",
-  );
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Link, [
-      { role: vocabulary.roles.start, value: a },
-      { role: vocabulary.roles.start, value: b },
-      { role: vocabulary.roles.end, value: b },
-    ]),
-    "invalid-grammar",
-  );
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Link, [
-      { role: vocabulary.roles.end, value: b },
-      { role: vocabulary.roles.start, value: a },
-    ]),
-    "invalid-grammar",
-  );
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Link, [
-      { role: vocabulary.roles.start, value: a },
-      { role: vocabulary.roles.operand, value: b },
-    ]),
-    "invalid-grammar",
-  );
-
-  const link = builder.addOccurrence(vocabulary.kinds.Link, [
-    { role: vocabulary.roles.start, value: a },
-    { role: vocabulary.roles.end, value: b },
+  bad(v.kinds.Link, [{ role: v.roles.end, value: c }]);
+  bad(v.kinds.Link, [{ role: v.roles.start, value: a }]);
+  bad(v.kinds.Link, [
+    { role: v.roles.start, value: a },
+    { role: v.roles.start, value: c },
+    { role: v.roles.end, value: c },
   ]);
-  same(readSyntaxAset(memory, builder.finish(link), vocabulary).root, link, "canonical Link accepted");
-}
-
-// Statement and unary forms are exact single-child productions.
-{
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Statement));
-  reject(() => builder.addOccurrence(vocabulary.kinds.Statement, []), "invalid-grammar");
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Statement, [
-      { role: vocabulary.roles.expression, value: child },
-      { role: vocabulary.roles.expression, value: child },
-    ]),
-    "invalid-grammar",
-  );
-  for (const kind of [vocabulary.kinds.Not, vocabulary.kinds.Female, vocabulary.kinds.Male]) {
-    reject(() => builder.addOccurrence(kind, []), "invalid-grammar");
-    reject(
-      () => builder.addOccurrence(kind, [
-        { role: vocabulary.roles.operand, value: child },
-        { role: vocabulary.roles.operand, value: child },
-      ]),
-      "invalid-grammar",
-    );
-  }
-  const statement = builder.addOccurrence(vocabulary.kinds.Statement, [
-    { role: vocabulary.roles.expression, value: child },
+  bad(v.kinds.Link, [
+    { role: v.roles.end, value: c },
+    { role: v.roles.start, value: a },
   ]);
-  same(readSyntaxAset(memory, builder.finish(statement), vocabulary).root, statement, "Statement accepted");
-}
-
-// Definition name and body are both syntax children. Equality/Inequality are
-// exact ordered left/right child pairs.
-{
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const left = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Equality));
-  const right = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Inequality));
-
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Definition, [
-      { role: vocabulary.roles.name, value: left },
-    ]),
-    "invalid-grammar",
-  );
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Definition, [
-      { role: vocabulary.roles.body, value: right },
-      { role: vocabulary.roles.name, value: left },
-    ]),
-    "invalid-grammar",
-  );
-
-  for (const kind of [vocabulary.kinds.Equality, vocabulary.kinds.Inequality]) {
-    reject(
-      () => builder.addOccurrence(kind, [
-        { role: vocabulary.roles.left, value: left },
-      ]),
-      "invalid-grammar",
-    );
-    reject(
-      () => builder.addOccurrence(kind, [
-        { role: vocabulary.roles.left, value: left },
-        { role: vocabulary.roles.left, value: right },
-        { role: vocabulary.roles.right, value: right },
-      ]),
-      "invalid-grammar",
-    );
-    reject(
-      () => builder.addOccurrence(kind, [
-        { role: vocabulary.roles.left, value: left },
-        { role: vocabulary.roles.right, value: right },
-        { role: vocabulary.roles.operand, value: left },
-      ]),
-      "invalid-grammar",
-    );
-  }
-
-  const definition = builder.addOccurrence(vocabulary.kinds.Definition, [
-    { role: vocabulary.roles.name, value: left },
-    { role: vocabulary.roles.body, value: right },
+  bad(v.kinds.Link, [
+    { role: v.roles.start, value: a },
+    { role: v.roles.operand, value: c },
   ]);
-  same(readSyntaxAset(memory, builder.finish(definition), vocabulary).root, definition, "Definition accepted");
-}
 
-// Sequence exists only for 2+ juxtaposed source forms. Repeated equal child
-// occurrences remain explicit ordered positions.
-{
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const item = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Sequence));
-  reject(() => builder.addOccurrence(vocabulary.kinds.Sequence, []), "invalid-grammar");
-  reject(
-    () => builder.addOccurrence(vocabulary.kinds.Sequence, [
-      { role: vocabulary.roles.item, value: item },
-    ]),
-    "invalid-grammar",
-  );
-  const sequence = builder.addOccurrence(vocabulary.kinds.Sequence, [
-    { role: vocabulary.roles.item, value: item },
-    { role: vocabulary.roles.item, value: item },
-  ]);
-  const read = readSyntaxAset(memory, builder.finish(sequence), vocabulary);
-  same(read.occurrences.at(-1)?.fields[0]?.value, item, "first Sequence position retained");
-  same(read.occurrences.at(-1)?.fields[1]?.value, item, "second Sequence position retained");
-}
-
-// File and Set accept empty syntax. Set preserves textual order at the syntax
-// layer; this is not a claim that semantic set membership is ordered.
-for (const kindName of ["File", "Set"] as const) {
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const empty = builder.addOccurrence(vocabulary.kinds[kindName], []);
-  same(readSyntaxAset(memory, builder.finish(empty), vocabulary).root, empty, `${kindName} empty accepted`);
-}
-
-{
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const first = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Set));
-  const second = addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.item));
-  const set = builder.addOccurrence(vocabulary.kinds.Set, [
-    { role: vocabulary.roles.item, value: second },
-    { role: vocabulary.roles.item, value: first },
-  ]);
-  const fields = readSyntaxAset(memory, builder.finish(set), vocabulary).occurrences.at(-1)?.fields;
-  same(fields?.[0]?.value, second, "Set first textual item retained");
-  same(fields?.[1]?.value, first, "Set second textual item retained");
-}
-
-// Round/Square are optional-single-child wrappers: empty and singleton are
-// valid, two expressions are not.
-for (const kindName of ["Round", "Square"] as const) {
-  {
-    const { memory, vocabulary } = fixture();
-    const builder = new SyntaxAsetBuilder(memory, vocabulary);
-    const empty = builder.addOccurrence(vocabulary.kinds[kindName], []);
-    same(readSyntaxAset(memory, builder.finish(empty), vocabulary).root, empty, `${kindName} empty accepted`);
-  }
-  {
-    const { memory, vocabulary } = fixture();
-    const builder = new SyntaxAsetBuilder(memory, vocabulary);
-    const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds[kindName]));
-    reject(
-      () => builder.addOccurrence(vocabulary.kinds[kindName], [
-        { role: vocabulary.roles.expression, value: child },
-        { role: vocabulary.roles.expression, value: child },
-      ]),
-      "invalid-grammar",
-    );
-    const wrapper = builder.addOccurrence(vocabulary.kinds[kindName], [
-      { role: vocabulary.roles.expression, value: child },
+  for (const kind of [v.kinds.Equality, v.kinds.Inequality]) {
+    bad(kind, [{ role: v.roles.left, value: a }]);
+    bad(kind, [
+      { role: v.roles.left, value: a },
+      { role: v.roles.left, value: c },
+      { role: v.roles.right, value: c },
     ]);
-    same(readSyntaxAset(memory, builder.finish(wrapper), vocabulary).root, wrapper, `${kindName} singleton accepted`);
+    bad(kind, [
+      { role: v.roles.left, value: a },
+      { role: v.roles.right, value: c },
+      { role: v.roles.operand, value: a },
+    ]);
+  }
+  bad(v.kinds.Definition, [{ role: v.roles.name, value: a }]);
+  bad(v.kinds.Definition, [
+    { role: v.roles.body, value: c },
+    { role: v.roles.name, value: a },
+  ]);
+  bad(v.kinds.Statement, []);
+  bad(v.kinds.Statement, [
+    { role: v.roles.expression, value: a },
+    { role: v.roles.expression, value: c },
+  ]);
+  for (const kind of [v.kinds.Not, v.kinds.Female, v.kinds.Male]) {
+    bad(kind, []);
+    bad(kind, [
+      { role: v.roles.operand, value: a },
+      { role: v.roles.operand, value: c },
+    ]);
   }
 }
 
-// ContextPronoun and Literal are exact one-carrier leaves.
-for (const kindName of ["ContextPronoun", "Literal"] as const) {
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const value = carrier(memory, vocabulary.kinds[kindName]);
-  reject(() => builder.addOccurrence(vocabulary.kinds[kindName], []), "invalid-grammar");
+// Container/wrapper cardinality follows the actual source parser grammar.
+{
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const item = literal(b, v, carrier(memory, v.kinds.Sequence));
+  reject(() => b.addOccurrence(v.kinds.Sequence, []), "invalid-grammar");
   reject(
-    () => builder.addOccurrence(vocabulary.kinds[kindName], [
-      { role: vocabulary.roles.value, value },
-      { role: vocabulary.roles.value, value },
+    () => b.addOccurrence(v.kinds.Sequence, [{ role: v.roles.item, value: item }]),
+    "invalid-grammar",
+  );
+}
+for (const kindName of ["File", "Set", "Round", "Square"] as const) {
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const root = b.addOccurrence(v.kinds[kindName], []);
+  same(readSyntaxAset(memory, b.finish(root), v).root, root, `${kindName} empty accepted`);
+}
+for (const kindName of ["Round", "Square"] as const) {
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const child = literal(b, v, carrier(memory, v.kinds[kindName]));
+  reject(
+    () => b.addOccurrence(v.kinds[kindName], [
+      { role: v.roles.expression, value: child },
+      { role: v.roles.expression, value: child },
     ]),
     "invalid-grammar",
   );
-  const leaf = builder.addOccurrence(vocabulary.kinds[kindName], [
-    { role: vocabulary.roles.value, value },
-  ]);
-  same(readSyntaxAset(memory, builder.finish(leaf), vocabulary).root, leaf, `${kindName} carrier accepted`);
 }
-
-// The occurrence chain is also the owned SyntaxAset closure. An otherwise valid
-// earlier occurrence that is not reachable from the declared final root fails.
-{
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.left));
-  const root = addLiteral(builder, vocabulary, carrier(memory, vocabulary.roles.right));
-  reject(() => builder.finish(root), "unreachable-occurrence");
-}
-
-// The untrusted reader independently enforces the same reachability rule.
-{
-  const { memory, vocabulary } = fixture();
-  const fieldA = triad(
-    memory,
-    vocabulary.roles.value,
-    memory.root,
-    carrier(memory, vocabulary.roles.start),
+for (const kindName of ["ContextPronoun", "Literal"] as const) {
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const value = carrier(memory, v.kinds[kindName]);
+  reject(() => b.addOccurrence(v.kinds[kindName], []), "invalid-grammar");
+  reject(
+    () => b.addOccurrence(v.kinds[kindName], [
+      { role: v.roles.value, value },
+      { role: v.roles.value, value },
+    ]),
+    "invalid-grammar",
   );
-  const unused = triad(memory, vocabulary.kinds.Literal, memory.root, fieldA);
-  const fieldB = triad(
-    memory,
-    vocabulary.roles.value,
-    memory.root,
-    carrier(memory, vocabulary.roles.end),
-  );
-  const root = triad(memory, vocabulary.kinds.Literal, unused, fieldB);
-  const aset = memory.ensure(vocabulary.tag, root);
-  reject(() => readSyntaxAset(memory, aset, vocabulary), "unreachable-occurrence");
 }
 
-// DAG-like reuse is allowed when it is explicit and every owned occurrence is
-// reachable. The same child can fill both Link roles without host identity.
+// Set source order is syntax structure, not semantic-set ordering.
 {
-  const { memory, vocabulary } = fixture();
-  const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const child = addLiteral(builder, vocabulary, carrier(memory, vocabulary.kinds.Link));
-  const link = builder.addOccurrence(vocabulary.kinds.Link, [
-    { role: vocabulary.roles.start, value: child },
-    { role: vocabulary.roles.end, value: child },
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const first = literal(b, v, carrier(memory, v.roles.start));
+  const second = literal(b, v, carrier(memory, v.roles.end));
+  const set = b.addOccurrence(v.kinds.Set, [
+    { role: v.roles.item, value: second },
+    { role: v.roles.item, value: first },
   ]);
-  same(readSyntaxAset(memory, builder.finish(link), vocabulary).root, link, "explicit child sharing accepted");
+  const fields = readSyntaxAset(memory, b.finish(set), v).occurrences.at(-1)?.fields;
+  same(fields?.[0]?.value, second, "Set first textual item");
+  same(fields?.[1]?.value, first, "Set second textual item");
 }
 
-// Arbitrary/untrusted topology cannot introduce unknown kind/role Links.
+// Occurrence chain is owned closure; unused earlier members fail closed.
 {
-  const { memory, vocabulary } = fixture();
-  const value = carrier(memory, vocabulary.tag);
-  const field = triad(memory, vocabulary.roles.value, memory.root, value);
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  literal(b, v, carrier(memory, v.roles.left));
+  const root = literal(b, v, carrier(memory, v.roles.right));
+  reject(() => b.finish(root), "unreachable-occurrence");
+}
+{
+  const { memory, vocabulary: v } = fixture();
+  const fa = triad(memory, v.roles.value, memory.root, carrier(memory, v.roles.start));
+  const unused = triad(memory, v.kinds.Literal, memory.root, fa);
+  const fb = triad(memory, v.roles.value, memory.root, carrier(memory, v.roles.end));
+  const root = triad(memory, v.kinds.Literal, unused, fb);
+  reject(
+    () => readSyntaxAset(memory, memory.ensure(v.tag, root), v),
+    "unreachable-occurrence",
+  );
+}
+
+// Explicit DAG reuse is valid when all owned occurrences stay reachable.
+{
+  const { memory, vocabulary: v } = fixture();
+  const b = new SyntaxAsetBuilder(memory, v);
+  const child = literal(b, v, carrier(memory, v.kinds.Link));
+  const root = b.addOccurrence(v.kinds.Link, [
+    { role: v.roles.start, value: child },
+    { role: v.roles.end, value: child },
+  ]);
+  same(readSyntaxAset(memory, b.finish(root), v).root, root, "shared child accepted");
+}
+
+// Untrusted topology rejects unknown/foreign vocabulary and dualized encoding.
+{
+  const { memory, vocabulary: v } = fixture();
+  const value = carrier(memory, v.tag);
+  const field = triad(memory, v.roles.value, memory.root, value);
   const unknownKind = memory.ensureStartSelfClosed(value);
-  const occurrence = triad(memory, unknownKind, memory.root, field);
   reject(
-    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, occurrence), vocabulary),
+    () => readSyntaxAset(memory, memory.ensure(v.tag, triad(memory, unknownKind, memory.root, field)), v),
     "unknown-kind",
   );
-}
-
-{
-  const { memory, vocabulary } = fixture();
-  const value = carrier(memory, vocabulary.tag);
   const unknownRole = memory.ensureEndSelfClosed(value);
-  const field = triad(memory, unknownRole, memory.root, value);
-  const occurrence = triad(memory, vocabulary.kinds.Literal, memory.root, field);
   reject(
-    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, occurrence), vocabulary),
+    () => readSyntaxAset(
+      memory,
+      memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, triad(memory, unknownRole, memory.root, value))),
+      v,
+    ),
     "unknown-role",
   );
-}
 
-// Kind/role Links from another explicit vocabulary seed are foreign syntax
-// vocabulary even when they carry the same TypeScript display labels.
-{
-  const { memory, vocabulary } = fixture();
-  const secondSeed = memory.ensureStartSelfClosed(vocabulary.tag);
-  const foreignVocabulary = materializeSyntaxAsetVocabulary(memory, secondSeed);
-  const value = carrier(memory, vocabulary.kinds.Literal);
-
-  const localField = triad(memory, vocabulary.roles.value, memory.root, value);
-  const foreignKindOccurrence = triad(
-    memory,
-    foreignVocabulary.kinds.Literal,
-    memory.root,
-    localField,
-  );
+  const foreign = materializeSyntaxAsetVocabulary(memory, memory.ensureStartSelfClosed(v.tag));
   reject(
-    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, foreignKindOccurrence), vocabulary),
+    () => readSyntaxAset(
+      memory,
+      memory.ensure(v.tag, triad(memory, foreign.kinds.Literal, memory.root, field)),
+      v,
+    ),
     "unknown-kind",
   );
-
-  const foreignField = triad(memory, foreignVocabulary.roles.value, memory.root, value);
-  const localKindOccurrence = triad(memory, vocabulary.kinds.Literal, memory.root, foreignField);
+  const foreignField = triad(memory, foreign.roles.value, memory.root, value);
   reject(
-    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, localKindOccurrence), vocabulary),
+    () => readSyntaxAset(
+      memory,
+      memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, foreignField)),
+      v,
+    ),
     "unknown-role",
   );
-}
 
-// Swapping the nested-pair orientation is not an alternate canonical encoding.
-{
-  const { memory, vocabulary } = fixture();
-  const value = carrier(memory, vocabulary.kinds.Literal);
   const horizontal = memory.ensure(memory.root, value);
-  const dualizedField = memory.ensure(horizontal, vocabulary.roles.value);
-  const occurrence = triad(memory, vocabulary.kinds.Literal, memory.root, dualizedField);
+  const dualized = memory.ensure(horizontal, v.roles.value);
   reject(
-    () => readSyntaxAset(memory, memory.ensure(vocabulary.tag, occurrence), vocabulary),
+    () => readSyntaxAset(
+      memory,
+      memory.ensure(v.tag, triad(memory, v.kinds.Literal, memory.root, dualized)),
+      v,
+    ),
     "unknown-role",
   );
 }

--- a/ts/test/syntax-aset-tooling.test.ts
+++ b/ts/test/syntax-aset-tooling.test.ts
@@ -22,13 +22,13 @@ function same<T>(actual: T, expected: T, message: string): void {
 
 function rejectContract(
   effect: () => unknown,
-  code: SyntaxAsetContractError["code"],
+  code: string,
 ): void {
   try {
     effect();
   } catch (error) {
     assert(error instanceof SyntaxAsetContractError, `expected SyntaxAsetContractError, got ${String(error)}`);
-    same(error.code, code, "SyntaxAset error code");
+    same(String(error.code), code, "SyntaxAset error code");
     return;
   }
   throw new Error(`expected SyntaxAset rejection: ${code}`);
@@ -113,7 +113,7 @@ class ReadProbe implements ReadMemory {
   same(firstMemory.linkCount, before, "vocabulary rematerialization is idempotent");
 }
 
-// Public tooling reuses S0 occurrence identity and explicit child roles.
+// Public tooling preserves occurrence identity and explicit structural roles.
 {
   const memory = new Memory();
   const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
@@ -141,9 +141,11 @@ class ReadProbe implements ReadMemory {
 {
   const memory = new Memory();
   const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
-  const nameCarrier = memory.ensureStartSelfClosed(vocabulary.kinds.Definition);
   const valueCarrier = memory.ensureEndSelfClosed(vocabulary.kinds.Literal);
   const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const name = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: memory.ensureStartSelfClosed(vocabulary.kinds.Definition) },
+  ]);
   const value = builder.addOccurrence(vocabulary.kinds.Literal, [
     { role: vocabulary.roles.value, value: valueCarrier },
   ]);
@@ -155,20 +157,20 @@ class ReadProbe implements ReadMemory {
     { role: vocabulary.roles.operand, value: sequence },
   ]);
   const definition = builder.addOccurrence(vocabulary.kinds.Definition, [
-    { role: vocabulary.roles.name, value: nameCarrier },
+    { role: vocabulary.roles.name, value: name },
     { role: vocabulary.roles.body, value: unary },
   ]);
   const statement = builder.addOccurrence(vocabulary.kinds.Statement, [
     { role: vocabulary.roles.expression, value: definition },
   ]);
   const read = readSyntaxAset(memory, builder.finish(statement), vocabulary);
-  same(read.occurrences[1]?.fields.length, 2, "repeated ordered items remain two structural fields");
-  same(read.occurrences[1]?.fields[0]?.value, value, "first ordered item retained");
-  same(read.occurrences[1]?.fields[1]?.value, value, "second ordered item retained");
-  same(read.occurrences[2]?.fields[0]?.role, vocabulary.roles.operand, "unary operand role retained");
-  same(read.occurrences[3]?.fields[0]?.role, vocabulary.roles.name, "definition name role retained");
-  same(read.occurrences[3]?.fields[1]?.role, vocabulary.roles.body, "definition body role retained");
-  same(read.occurrences[4]?.fields[0]?.role, vocabulary.roles.expression, "statement expression role retained");
+  same(read.occurrences[2]?.fields.length, 2, "repeated ordered items remain two structural fields");
+  same(read.occurrences[2]?.fields[0]?.value, value, "first ordered item retained");
+  same(read.occurrences[2]?.fields[1]?.value, value, "second ordered item retained");
+  same(read.occurrences[3]?.fields[0]?.role, vocabulary.roles.operand, "unary operand role retained");
+  same(read.occurrences[4]?.fields[0]?.role, vocabulary.roles.name, "definition name role retained");
+  same(read.occurrences[4]?.fields[1]?.role, vocabulary.roles.body, "definition body role retained");
+  same(read.occurrences[5]?.fields[0]?.role, vocabulary.roles.expression, "statement expression role retained");
 }
 
 // Child-bearing roles remain fail-closed and cannot point at arbitrary carrier
@@ -191,8 +193,11 @@ class ReadProbe implements ReadMemory {
 {
   const memory = new Memory();
   const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const carrier = memory.ensureStartSelfClosed(vocabulary.kinds.Literal);
   const builder = new SyntaxAsetBuilder(memory, vocabulary);
-  const leaf = builder.addOccurrence(vocabulary.kinds.Literal, []);
+  const leaf = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: carrier },
+  ]);
   const aset = builder.finish(leaf);
   const provenanceA = new Map([[leaf, { source: "a.mts", start: 0, end: 1 }]]);
   const provenanceB = new Map([[leaf, { source: "b.mts", start: 30, end: 50 }]]);
@@ -212,9 +217,6 @@ class ReadProbe implements ReadMemory {
 //   F1 = valueRole ⟼ (R ⟼ carrier)
 //   O1 = LiteralKind ⟼ (R ⟼ F1)
 //   A  = SyntaxTag ⟼ O1
-//
-// This test intentionally names only the public structural equation; no
-// research helper is imported into production tooling.
 {
   const memory = new Memory();
   const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
@@ -235,4 +237,99 @@ class ReadProbe implements ReadMemory {
   assert(expectedOccurrence !== undefined, "occurrence triad exists");
   same(occurrence, expectedOccurrence, "production occurrence uses chained-triad topology");
   same(memory.find(vocabulary.tag, occurrence), aset, "SyntaxAset wrapper points directly at final occurrence");
+}
+
+// #973 closes the syntax language: a Literal is exactly one value carrier.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  rejectContract(
+    () => builder.addOccurrence(vocabulary.kinds.Literal, []),
+    "invalid-grammar",
+  );
+  const carrier = memory.ensureStartSelfClosed(vocabulary.tag);
+  rejectContract(
+    () => builder.addOccurrence(vocabulary.kinds.Literal, [
+      { role: vocabulary.roles.value, value: carrier },
+      { role: vocabulary.roles.value, value: carrier },
+    ]),
+    "invalid-grammar",
+  );
+}
+
+// The finite grammar rejects unknown kinds/roles instead of accepting any
+// structurally readable Link as syntax vocabulary.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const carrier = memory.ensureStartSelfClosed(vocabulary.tag);
+  const unknownKind = memory.ensureStartSelfClosed(carrier);
+  const unknownRole = memory.ensureEndSelfClosed(carrier);
+  rejectContract(
+    () => builder.addOccurrence(unknownKind, [
+      { role: vocabulary.roles.value, value: carrier },
+    ]),
+    "unknown-kind",
+  );
+  rejectContract(
+    () => builder.addOccurrence(vocabulary.kinds.Literal, [
+      { role: unknownRole, value: carrier },
+    ]),
+    "unknown-role",
+  );
+}
+
+// Definition.name is a syntax child in the actual parser grammar, not a free
+// carrier. This is the old global-childRoles gap that #973 must close.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const carrier = memory.ensureStartSelfClosed(vocabulary.kinds.Definition);
+  const body = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: memory.ensureEndSelfClosed(carrier) },
+  ]);
+  rejectContract(
+    () => builder.addOccurrence(vocabulary.kinds.Definition, [
+      { role: vocabulary.roles.name, value: carrier },
+      { role: vocabulary.roles.body, value: body },
+    ]),
+    "invalid-child-occurrence",
+  );
+}
+
+// Cardinality is per kind: Sequence exists only for 2+ adjacent forms, while
+// empty File/Set and empty Round/Square are valid source syntax.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const carrier = memory.ensureStartSelfClosed(vocabulary.kinds.Literal);
+  const child = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: carrier },
+  ]);
+  rejectContract(
+    () => builder.addOccurrence(vocabulary.kinds.Sequence, [
+      { role: vocabulary.roles.item, value: child },
+    ]),
+    "invalid-grammar",
+  );
+}
+
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const fileBuilder = new SyntaxAsetBuilder(memory, vocabulary);
+  const file = fileBuilder.addOccurrence(vocabulary.kinds.File, []);
+  same(readSyntaxAset(memory, fileBuilder.finish(file), vocabulary).root, file, "empty File accepted");
+}
+
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const roundBuilder = new SyntaxAsetBuilder(memory, vocabulary);
+  const round = roundBuilder.addOccurrence(vocabulary.kinds.Round, []);
+  same(readSyntaxAset(memory, roundBuilder.finish(round), vocabulary).root, round, "empty Round accepted");
 }

--- a/ts/test/syntax-aset-tooling.test.ts
+++ b/ts/test/syntax-aset-tooling.test.ts
@@ -205,3 +205,34 @@ class ReadProbe implements ReadMemory {
   same(memory.linkCount, before, "read and provenance lookup do not materialize Links");
   assert(probe.polesCalls > 0, "reader inspects structural topology");
 }
+
+// #970 selected the chained-triad form as the production target. A single
+// Literal occurrence must therefore be encoded directly as:
+//
+//   F1 = valueRole ⟼ (R ⟼ carrier)
+//   O1 = LiteralKind ⟼ (R ⟼ F1)
+//   A  = SyntaxTag ⟼ O1
+//
+// This test intentionally names only the public structural equation; no
+// research helper is imported into production tooling.
+{
+  const memory = new Memory();
+  const vocabulary = materializeSyntaxAsetVocabulary(memory, vocabularySeed(memory));
+  const carrier = memory.ensureStartSelfClosed(vocabulary.tag);
+  const builder = new SyntaxAsetBuilder(memory, vocabulary);
+  const occurrence = builder.addOccurrence(vocabulary.kinds.Literal, [
+    { role: vocabulary.roles.value, value: carrier },
+  ]);
+  const aset = builder.finish(occurrence);
+
+  const fieldHorizontal = memory.find(memory.root, carrier);
+  assert(fieldHorizontal !== undefined, "field horizontal Link exists");
+  const field = memory.find(vocabulary.roles.value, fieldHorizontal);
+  assert(field !== undefined, "field triad exists");
+  const occurrenceHorizontal = memory.find(memory.root, field);
+  assert(occurrenceHorizontal !== undefined, "occurrence horizontal Link exists");
+  const expectedOccurrence = memory.find(vocabulary.kinds.Literal, occurrenceHorizontal);
+  assert(expectedOccurrence !== undefined, "occurrence triad exists");
+  same(occurrence, expectedOccurrence, "production occurrence uses chained-triad topology");
+  same(memory.find(vocabulary.tag, occurrence), aset, "SyntaxAset wrapper points directly at final occurrence");
+}


### PR DESCRIPTION
Closes #973.

Prerequisite topology decision: #970 / PR #978 (`REPLACE_S0`).

This closes the production SyntaxAset grammar around the relation-native chained-triad topology selected by #970. No accepted MTS semantic contract, conformance corpus, cutover state, visual package, or parser consumer is changed here.

## Canonical topology

```text
T(r, s, o) = r ⟼ (s ⟼ o)

F0 = R
Fi = T(role_i, F(i-1), value_i)

O0 = R
Oi = T(kind_i, O(i-1), Fi)

SyntaxAset = SyntaxTag ⟼ O_last
```

Production `SyntaxAsetBuilder` and `readSyntaxAset` now use this topology directly. The historical S0 `Descriptor + ExactSequence + occurrence Cell` model survives only as a research control under `ts/research/`; there is no production compatibility reader for the rejected topology.

## Closed finite syntax grammar

The executable grammar is derived from the actual downstream parser at pinned source:

```text
netkeep80/aprover@437a1ee662aa3bcf0b917707d4b0322cf92b0845
src/core/parser.ts
src/core/syntaxAsetDirectEmitter.ts
```

Exact production rules:

```text
File           item(child)        0..∞
Statement      expression(child)  1
Link           start(child)       1, end(child) 1
Definition     name(child)        1, body(child) 1
Equality       left(child)        1, right(child) 1
Inequality     left(child)        1, right(child) 1
Sequence       item(child)        2..∞
Set            item(child)        0..∞
Round          expression(child)  0..1
Square         expression(child)  0..1
Not            operand(child)     1
Female         operand(child)     1
Male           operand(child)     1
ContextPronoun value(carrier)     1
Literal        value(carrier)     1
```

This corrects the provisional S1 gap where `Definition.name` was not classified as a child occurrence.

Field order above is canonical syntax structure. In particular `Set` preserves textual/source order at the syntax layer only; this makes no claim that semantic set membership is ordered.

## Fail-closed trust boundary

The grammar is now explicit in the tooling vocabulary and independently enforced by the untrusted reader:

- unknown kind -> `unknown-kind`;
- unknown role -> `unknown-role`;
- known role on the wrong kind, wrong role order, missing/duplicate/extra role or bad cardinality -> `invalid-grammar`;
- child target not a prior member of this SyntaxAset -> `invalid-child-occurrence`;
- local or structurally owned foreign SyntaxAset occurrence passed through a carrier relation -> `invalid-carrier-target`;
- owned occurrence-chain member not reachable from the declared final root -> `unreachable-occurrence`.

Carrier classification is deliberately **membership-based, not shape-based**. A Link that merely resembles an occurrence by its poles is still a legal carrier unless it is structurally owned by a SyntaxAset. This fell out of an explicit RED adversarial test; no host-side type tag or UUID was introduced.

The occurrence chain is both deterministic occurrence order and the owned SyntaxAset closure. Child edges may explicitly share an earlier occurrence (DAG-like reuse) when every owned occurrence remains reachable from the root.

## API boundary

The generic construction surface remains intentionally small:

```text
SyntaxAsetBuilder.addOccurrence(kind, fields)
```

The finite grammar descriptor validates that call; this PR does not recreate the old AST class hierarchy in tooling. TypeScript names are API/display labels only; canonical identity remains Link topology.

## Adversarial evidence

The test corpus covers:

- equal-looking occurrence distinction;
- repeated ordered child positions;
- empty File/Set/Round/Square;
- Sequence minimum cardinality;
- singleton/duplicate violations for fixed forms;
- Definition name/body child classification;
- unknown and foreign kind/role Links;
- wrong-role and dualized/swapped two-Link encodings;
- local/foreign occurrence smuggling through carrier relations;
- a shape-looking nonmember carrier remaining legal;
- foreign/future child rejection;
- unreachable owned occurrences;
- explicit reachable child sharing;
- deterministic/read-only reader behavior;
- historical S0 vs chained-triad normalized research equivalence and the existing 151 vs 101 Link witness.

## TDD evidence

- topology RED head `fb7914454b6d55ba3882b3310e73e15825381e8b`: CI #3827 failed because production still emitted old S0 topology;
- grammar RED head `016a831a76c29ed4d0d4aac466a2ae207cc2e9ac`: CI #3832 failed on the newly required `invalid-grammar` rejection;
- carrier-classification RED head `31a61162dc3df27579f6f1bb592a0d9ea263d0e7`: CI #3837 failed because a merely occurrence-shaped carrier was incorrectly rejected;
- GREEN head `54f760a0e854741e21645cfe0b8dd0ff260fb4fd`: CI #3838 SUCCESS after switching carrier classification to structural SyntaxAset membership;
- current branch head `15f1e2623c2ec84571fe049731b1c5abb4294e3e`: push CI #3840 SUCCESS with the bounded adversarial corpus.

## Boundary / next step

This issue is the final SyntaxAset contract prerequisite for the S2 parser migration oracle. It does **not** perform parser cutover, semantic lowering, or direct text-to-SyntaxAset replacement in `anum_docs`.

Accepted MTS v0.11 semantics remain unchanged. No v0.12 candidate is implied.

```repo-guard-yaml
change_type: feature
scope:
  - ts/src/syntax-aset-contract.ts
  - ts/src/tooling/syntax-aset.ts
  - ts/research/syntax-aset-topology.ts
  - ts/test/syntax-aset-contract.test.ts
  - ts/test/syntax-aset-tooling.test.ts
  - ts/test/syntax-aset-grammar.test.ts
  - ts/test/research-syntax-aset-topology.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 760
anchors:
  affects: []
  implements:
    - "#973"
  verifies: []
must_touch:
  - ts/src/syntax-aset-contract.ts
  - ts/src/tooling/syntax-aset.ts
  - ts/test/syntax-aset-grammar.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/src/public.ts
  - packages/visual/**
  - web/**
  - .github/**
  - repo-policy.json
  - README.md
  - docs/**
expected_effects:
  - production SyntaxAset uses the #970 chained-triad topology rather than the provisional S0 descriptor topology
  - one finite per-kind grammar validates kind role order cardinality and child/carrier target classes fail closed
  - SyntaxAset ownership and root reachability are structural and reader-enforced without host AST identity or UUIDs
  - the S2 parser migration oracle can consume a closed canonical SyntaxAset contract without an accepted MTS semantic delta
```