### PR TITLE
[Corrective][Observatory/V4c] Unify browser interaction policy

### DIFF
--- a/web/contract-observatory/src/browser-controller.ts
+++ b/web/contract-observatory/src/browser-controller.ts
@@ -1,0 +1,226 @@
+import {
+  createObservatoryInteractionKernel,
+  type ObservatoryInteractionConfig,
+  type ObservatoryInteractionKernel,
+  type ObservatoryInteractionState,
+} from "./interaction.js";
+
+export interface ObservatoryBrowserEvent {
+  readonly target?: ObservatoryBrowserNode | null;
+  readonly key?: string;
+  preventDefault?: () => void;
+}
+
+export interface ObservatoryBrowserClassList {
+  toggle(name: string, force?: boolean): void;
+}
+
+export interface ObservatoryBrowserNode {
+  readonly dataset: Record<string, string | undefined>;
+  hidden?: boolean;
+  textContent?: string | null;
+  scrollLeft?: number;
+  scrollTop?: number;
+  readonly style?: Record<string, string | undefined>;
+  readonly classList?: ObservatoryBrowserClassList;
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | null;
+  querySelector(selector: string): ObservatoryBrowserNode | null;
+  querySelectorAll(selector: string): readonly ObservatoryBrowserNode[];
+  closest?(selector: string): ObservatoryBrowserNode | null;
+  focus?(): void;
+  click?(): void;
+  addEventListener?(type: string, listener: (event: ObservatoryBrowserEvent) => void): void;
+}
+
+export interface ObservatoryBrowserDocument {
+  activeElement?: ObservatoryBrowserNode | null;
+  querySelector(selector: string): ObservatoryBrowserNode | null;
+  querySelectorAll(selector: string): readonly ObservatoryBrowserNode[];
+}
+
+export interface ObservatoryBrowserLocation {
+  hash: string;
+  readonly pathname: string;
+  readonly search: string;
+}
+
+export interface ObservatoryBrowserHistory {
+  replaceState(data: null, title: string, url: string): void;
+}
+
+export interface ObservatoryBrowserWindow {
+  addEventListener(type: string, listener: (event: ObservatoryBrowserEvent) => void): void;
+}
+
+export interface ObservatoryBrowserEnvironment {
+  readonly document: ObservatoryBrowserDocument;
+  readonly location: ObservatoryBrowserLocation;
+  readonly history: ObservatoryBrowserHistory;
+  readonly window: ObservatoryBrowserWindow;
+}
+
+export interface ObservatoryBrowserController {
+  readonly getState: () => ObservatoryInteractionState;
+  readonly apply: () => void;
+}
+
+/**
+ * Thin DOM adapter. State parsing, validation, filters and viewport policy are
+ * delegated to the supplied canonical interaction kernel.
+ */
+export function installObservatoryBrowserController(
+  environment: ObservatoryBrowserEnvironment,
+  kernel: ObservatoryInteractionKernel,
+): ObservatoryBrowserController {
+  const map = environment.document.querySelector(".methodology-map");
+  if (map === null) {
+    let absentState = kernel.initialState();
+    return Object.freeze({
+      getState: () => absentState,
+      apply: () => { absentState = kernel.decode(environment.location.hash); },
+    });
+  }
+  const grid = map.querySelector(".methodology-grid");
+  let state = kernel.decode(environment.location.hash);
+
+  const visibleButtons = (): readonly ObservatoryBrowserNode[] => map
+    .querySelectorAll("button")
+    .filter((button) => button.hidden !== true && button.closest?.("[hidden]") == null);
+
+  const apply = (): void => {
+    map.querySelectorAll("[data-methodology-stage]").forEach((button) => {
+      button.setAttribute("aria-pressed", String(button.dataset.methodologyStage === state.selectedStage));
+    });
+    map.querySelectorAll("[data-methodology-filter]").forEach((button) => {
+      button.setAttribute("aria-pressed", String(state.filters.includes(button.dataset.methodologyFilter ?? "")));
+    });
+    map.querySelectorAll("[data-item-id]").forEach((button) => {
+      button.setAttribute("aria-pressed", String(button.dataset.itemId === state.selectedItemId));
+    });
+    map.querySelectorAll("[data-version-lane]").forEach((lane) => {
+      const versionId = lane.dataset.versionLane ?? "";
+      const selected = versionId === state.selectedVersionId;
+      lane.hidden = !kernel.isVersionVisible(versionId, state);
+      lane.classList?.toggle("selected", selected);
+      lane.querySelector("[data-version-id]")?.setAttribute("aria-pressed", String(selected));
+      lane.querySelectorAll("[data-lane-stage]").forEach((cell) => {
+        cell.classList?.toggle("stage-selected", cell.dataset.laneStage === state.selectedStage);
+      });
+    });
+    environment.document.querySelectorAll("[data-overview-version-id]").forEach((node) => {
+      node.classList?.toggle("selection-synced", node.dataset.overviewVersionId === state.selectedVersionId);
+    });
+    if (grid !== null) {
+      if (grid.style !== undefined) grid.style.zoom = String(state.viewport.scale);
+      grid.scrollLeft = state.viewport.x;
+      grid.scrollTop = state.viewport.y;
+    }
+    const status = map.querySelector(".methodology-status");
+    if (status !== null) {
+      status.textContent = `Selected: ${state.selectedVersionId ?? "none"}; stage: ${state.selectedStage ?? "all"}; item: ${state.selectedItemId ?? "none"}; filters: ${state.filters.join(", ") || "none"}; zoom: ${state.viewport.scale}.`;
+    }
+    const active = environment.document.activeElement;
+    if (active?.closest?.("[hidden]") != null) visibleButtons()[0]?.focus?.();
+  };
+
+  const commit = (next: ObservatoryInteractionState, replace = false): void => {
+    state = next;
+    const hash = kernel.encode(state);
+    if (replace) {
+      environment.history.replaceState(
+        null,
+        "",
+        environment.location.pathname + environment.location.search + hash,
+      );
+    } else if (environment.location.hash !== hash) {
+      environment.location.hash = hash;
+    }
+    apply();
+  };
+
+  const eventButton = (event: ObservatoryBrowserEvent): ObservatoryBrowserNode | null => {
+    const target = event.target;
+    return target?.closest?.("button") ?? null;
+  };
+
+  map.addEventListener?.("click", (event) => {
+    const target = eventButton(event);
+    if (target === null) return;
+    const stage = target.dataset.methodologyStage;
+    const versionId = target.dataset.versionId;
+    const itemId = target.dataset.itemId;
+    const filter = target.dataset.methodologyFilter;
+    const viewportAction = target.dataset.viewportAction;
+    if (stage !== undefined) {
+      const nextStage = target.getAttribute("aria-pressed") === "true" ? null : stage;
+      commit(kernel.reduce(state, { type: "select-stage", stage: nextStage as ObservatoryInteractionState["selectedStage"] }));
+    } else if (versionId !== undefined) {
+      commit(kernel.reduce(state, { type: "select-version", versionId }));
+    } else if (itemId !== undefined) {
+      commit(kernel.reduce(state, { type: "select-item", itemId }));
+    } else if (filter !== undefined) {
+      commit(kernel.reduce(state, { type: "toggle-filter", filter }));
+    } else if (viewportAction === "reset") {
+      commit(kernel.reduce(state, { type: "reset-viewport" }));
+    } else if (viewportAction === "zoom-in") {
+      commit(kernel.reduce(state, { type: "zoom", delta: 0.1 }));
+    } else if (viewportAction === "zoom-out") {
+      commit(kernel.reduce(state, { type: "zoom", delta: -0.1 }));
+    }
+  });
+
+  map.addEventListener?.("keydown", (event) => {
+    const key = event.key ?? "";
+    const target = eventButton(event);
+    if (target === null) return;
+    if (key === "Enter" || key === " ") {
+      event.preventDefault?.();
+      target.click?.();
+      return;
+    }
+    if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(key)) return;
+    const buttons = visibleButtons();
+    const current = buttons.indexOf(target);
+    if (current < 0 || buttons.length === 0) return;
+    event.preventDefault?.();
+    let next = current;
+    if (key === "Home") next = 0;
+    else if (key === "End") next = buttons.length - 1;
+    else if (key === "ArrowLeft" || key === "ArrowUp") next = (current - 1 + buttons.length) % buttons.length;
+    else next = (current + 1) % buttons.length;
+    buttons[next]?.focus?.();
+  });
+
+  grid?.addEventListener?.("scroll", () => {
+    commit(kernel.reduce(state, {
+      type: "set-viewport",
+      viewport: {
+        x: Math.round(grid.scrollLeft ?? 0),
+        y: Math.round(grid.scrollTop ?? 0),
+        scale: state.viewport.scale,
+      },
+    }), true);
+  });
+
+  environment.window.addEventListener("hashchange", () => {
+    state = kernel.decode(environment.location.hash);
+    apply();
+  });
+
+  apply();
+  return Object.freeze({ getState: () => state, apply });
+}
+
+export function renderObservatoryBrowserControllerScript(
+  config: ObservatoryInteractionConfig,
+): string {
+  const serialized = escapeJsonForScript(JSON.stringify(config));
+  const kernelSource = createObservatoryInteractionKernel.toString();
+  const controllerSource = installObservatoryBrowserController.toString();
+  return `    <script data-observatory-controller="shared-kernel">\n(() => {\n  "use strict";\n  const createKernel = (${kernelSource});\n  const installController = (${controllerSource});\n  const config = ${serialized};\n  installController({ document, location, history, window }, createKernel(config));\n})();\n    </script>`;
+}
+
+function escapeJsonForScript(value: string): string {
+  return value.replaceAll("<", "\\u003c").replaceAll(">", "\\u003e").replaceAll("&", "\\u0026");
+}

--- a/web/contract-observatory/src/interaction.ts
+++ b/web/contract-observatory/src/interaction.ts
@@ -14,6 +14,18 @@ export const METHODOLOGY_STAGE_ORDER: readonly MethodologyStage[] = Object.freez
   "released",
 ]);
 
+export const OBSERVATORY_FILTERS = Object.freeze([
+  "accepted",
+  "candidate",
+  "current",
+  "evidence",
+  "negative",
+  "positive",
+  "previous",
+] as const);
+
+export type ObservatoryFilter = typeof OBSERVATORY_FILTERS[number];
+
 export interface ObservatoryViewport {
   readonly x: number;
   readonly y: number;
@@ -33,7 +45,10 @@ export type ObservatoryInteractionAction =
   | { readonly type: "select-stage"; readonly stage: MethodologyStage | null }
   | { readonly type: "select-item"; readonly itemId: string | null }
   | { readonly type: "set-filters"; readonly filters: readonly string[] }
-  | { readonly type: "set-viewport"; readonly viewport: ObservatoryViewport };
+  | { readonly type: "toggle-filter"; readonly filter: string }
+  | { readonly type: "set-viewport"; readonly viewport: ObservatoryViewport }
+  | { readonly type: "zoom"; readonly delta: number }
+  | { readonly type: "reset-viewport" };
 
 export interface InteractiveMethodologyStageState {
   readonly stage: MethodologyStage;
@@ -61,24 +76,187 @@ export interface InteractiveMethodologyModel {
   readonly versions: readonly InteractiveMethodologyVersion[];
 }
 
-const DEFAULT_VIEWPORT: ObservatoryViewport = Object.freeze({ x: 0, y: 0, scale: 1 });
+export interface ObservatoryInteractionVersionConfig {
+  readonly id: string;
+  readonly categories: readonly string[];
+  readonly itemIds: readonly string[];
+}
+
+export interface ObservatoryInteractionConfig {
+  readonly versions: readonly ObservatoryInteractionVersionConfig[];
+  readonly defaultVersionId: string | null;
+  readonly stages: readonly MethodologyStage[];
+  readonly filters: readonly string[];
+  readonly minScale: number;
+  readonly maxScale: number;
+  readonly zoomStep: number;
+}
+
+export interface ObservatoryInteractionKernel {
+  readonly initialState: () => ObservatoryInteractionState;
+  readonly decode: (hash: string) => ObservatoryInteractionState;
+  readonly encode: (state: ObservatoryInteractionState) => string;
+  readonly reduce: (
+    state: ObservatoryInteractionState,
+    action: ObservatoryInteractionAction,
+  ) => ObservatoryInteractionState;
+  readonly isVersionVisible: (
+    versionId: string,
+    state: ObservatoryInteractionState,
+  ) => boolean;
+}
+
+export function buildObservatoryInteractionConfig(
+  projection: MethodologyProjection,
+): ObservatoryInteractionConfig {
+  const versions = projection.versions.map((version) => Object.freeze({
+    id: version.contractId,
+    categories: Object.freeze(methodologyCategories(version)),
+    itemIds: Object.freeze(methodologyItemIds(version)),
+  }));
+  return Object.freeze({
+    versions: Object.freeze(versions),
+    defaultVersionId: defaultVersionId(projection),
+    stages: METHODOLOGY_STAGE_ORDER,
+    filters: OBSERVATORY_FILTERS,
+    minScale: 0.7,
+    maxScale: 1.8,
+    zoomStep: 0.1,
+  });
+}
+
+/**
+ * Browser-safe interaction policy. Keep every helper inside this function:
+ * the same compiled function body is embedded into the generated static page.
+ */
+export function createObservatoryInteractionKernel(
+  config: ObservatoryInteractionConfig,
+): ObservatoryInteractionKernel {
+  const versionIds = new Set(config.versions.map((entry) => entry.id));
+  const itemIds = new Set(config.versions.flatMap((entry) => entry.itemIds));
+  const stages = new Set<string>(config.stages);
+  const filters = new Set(config.filters);
+  const categoriesByVersion = new Map(
+    config.versions.map((entry) => [entry.id, new Set(entry.categories)] as const),
+  );
+
+  const uniqueSortedAllowed = (values: readonly string[], allowed: Set<string>): readonly string[] =>
+    Object.freeze([...new Set(values.filter((value) => allowed.has(value)))].sort((a, b) => a.localeCompare(b)));
+
+  const finite = (value: number, fallback: number): number => Number.isFinite(value) ? value : fallback;
+  const clampScale = (value: number): number => {
+    const finiteScale = finite(value, 1);
+    return Math.min(config.maxScale, Math.max(config.minScale, finiteScale));
+  };
+  const normalizeViewport = (viewport: ObservatoryViewport): ObservatoryViewport => Object.freeze({
+    x: finite(viewport.x, 0),
+    y: finite(viewport.y, 0),
+    scale: clampScale(viewport.scale),
+  });
+  const finiteParam = (value: string | null, fallback: number): number => {
+    if (value === null || value.trim() === "") return fallback;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+  const validVersion = (value: string | null): string | null =>
+    value !== null && versionIds.has(value) ? value : config.defaultVersionId;
+  const validStage = (value: string | null): MethodologyStage | null =>
+    value !== null && stages.has(value) ? value as MethodologyStage : null;
+  const validItem = (value: string | null): string | null =>
+    value !== null && itemIds.has(value) ? value : null;
+  const normalizeState = (state: ObservatoryInteractionState): ObservatoryInteractionState => Object.freeze({
+    selectedVersionId: validVersion(state.selectedVersionId),
+    selectedStage: validStage(state.selectedStage),
+    selectedItemId: validItem(state.selectedItemId),
+    filters: uniqueSortedAllowed(state.filters, filters),
+    viewport: normalizeViewport(state.viewport),
+  });
+
+  const decode = (hash: string): ObservatoryInteractionState => {
+    const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash);
+    return normalizeState({
+      selectedVersionId: params.get("v"),
+      selectedStage: validStage(params.get("s")),
+      selectedItemId: params.get("item"),
+      filters: params.getAll("f"),
+      viewport: {
+        x: finiteParam(params.get("x"), 0),
+        y: finiteParam(params.get("y"), 0),
+        scale: finiteParam(params.get("z"), 1),
+      },
+    });
+  };
+
+  const encode = (state: ObservatoryInteractionState): string => {
+    const normalized = normalizeState(state);
+    const params = new URLSearchParams();
+    if (normalized.selectedVersionId !== null) params.set("v", normalized.selectedVersionId);
+    if (normalized.selectedStage !== null) params.set("s", normalized.selectedStage);
+    if (normalized.selectedItemId !== null) params.set("item", normalized.selectedItemId);
+    for (const filter of normalized.filters) params.append("f", filter);
+    if (normalized.viewport.x !== 0 || normalized.viewport.y !== 0 || normalized.viewport.scale !== 1) {
+      params.set("x", String(normalized.viewport.x));
+      params.set("y", String(normalized.viewport.y));
+      params.set("z", String(normalized.viewport.scale));
+    }
+    return `#${params.toString()}`;
+  };
+
+  const reduce = (
+    state: ObservatoryInteractionState,
+    action: ObservatoryInteractionAction,
+  ): ObservatoryInteractionState => {
+    const current = normalizeState(state);
+    switch (action.type) {
+      case "select-version":
+        return normalizeState({ ...current, selectedVersionId: action.versionId });
+      case "select-stage":
+        return normalizeState({ ...current, selectedStage: action.stage });
+      case "select-item":
+        return normalizeState({ ...current, selectedItemId: action.itemId });
+      case "set-filters":
+        return normalizeState({ ...current, filters: action.filters });
+      case "toggle-filter": {
+        if (!filters.has(action.filter)) return current;
+        const next = new Set(current.filters);
+        next.has(action.filter) ? next.delete(action.filter) : next.add(action.filter);
+        return normalizeState({ ...current, filters: [...next] });
+      }
+      case "set-viewport":
+        return normalizeState({ ...current, viewport: action.viewport });
+      case "zoom": {
+        const scale = Math.round((current.viewport.scale + action.delta) * 1000) / 1000;
+        return normalizeState({ ...current, viewport: { ...current.viewport, scale } });
+      }
+      case "reset-viewport":
+        return normalizeState({ ...current, viewport: { x: 0, y: 0, scale: 1 } });
+    }
+  };
+
+  const isVersionVisible = (
+    versionId: string,
+    state: ObservatoryInteractionState,
+  ): boolean => {
+    const categories = categoriesByVersion.get(versionId);
+    if (categories === undefined) return false;
+    return normalizeState(state).filters.every((filter) => categories.has(filter));
+  };
+
+  return Object.freeze({
+    initialState: () => decode("#"),
+    decode,
+    encode,
+    reduce,
+    isVersionVisible,
+  });
+}
 
 export function reduceInteractionState(
   state: ObservatoryInteractionState,
   action: ObservatoryInteractionAction,
+  projection: MethodologyProjection,
 ): ObservatoryInteractionState {
-  switch (action.type) {
-    case "select-version":
-      return freezeState({ ...state, selectedVersionId: action.versionId });
-    case "select-stage":
-      return freezeState({ ...state, selectedStage: action.stage });
-    case "select-item":
-      return freezeState({ ...state, selectedItemId: action.itemId });
-    case "set-filters":
-      return freezeState({ ...state, filters: uniqueSorted(action.filters) });
-    case "set-viewport":
-      return freezeState({ ...state, viewport: normalizeViewport(action.viewport) });
-  }
+  return createObservatoryInteractionKernel(buildObservatoryInteractionConfig(projection)).reduce(state, action);
 }
 
 export function buildInteractiveMethodologyModel(
@@ -96,39 +274,18 @@ export function buildInteractiveMethodologyModel(
   });
 }
 
-export function encodeObservatoryHash(state: ObservatoryInteractionState): string {
-  const params = new URLSearchParams();
-  if (state.selectedVersionId !== null) params.set("v", state.selectedVersionId);
-  if (state.selectedStage !== null) params.set("s", state.selectedStage);
-  if (state.selectedItemId !== null) params.set("item", state.selectedItemId);
-  for (const filter of uniqueSorted(state.filters)) params.append("f", filter);
-  if (!isDefaultViewport(state.viewport)) {
-    params.set("x", String(state.viewport.x));
-    params.set("y", String(state.viewport.y));
-    params.set("z", String(state.viewport.scale));
-  }
-  return `#${params.toString()}`;
+export function encodeObservatoryHash(
+  state: ObservatoryInteractionState,
+  projection: MethodologyProjection,
+): string {
+  return createObservatoryInteractionKernel(buildObservatoryInteractionConfig(projection)).encode(state);
 }
 
 export function decodeObservatoryHash(
   hash: string,
   projection: MethodologyProjection,
 ): ObservatoryInteractionState {
-  const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash);
-  const requestedVersion = params.get("v");
-  const selectedVersionId = hasVersion(projection, requestedVersion)
-    ? requestedVersion
-    : defaultVersionId(projection);
-  const requestedStage = params.get("s");
-  const selectedStage = isMethodologyStage(requestedStage) ? requestedStage : null;
-  const selectedItemId = params.get("item");
-  const filters = uniqueSorted(params.getAll("f"));
-  const viewport = normalizeViewport({
-    x: finiteNumber(params.get("x"), 0),
-    y: finiteNumber(params.get("y"), 0),
-    scale: finiteNumber(params.get("z"), 1),
-  });
-  return freezeState({ selectedVersionId, selectedStage, selectedItemId, filters, viewport });
+  return createObservatoryInteractionKernel(buildObservatoryInteractionConfig(projection)).decode(hash);
 }
 
 function projectVersion(
@@ -166,41 +323,22 @@ function defaultVersionId(projection: MethodologyProjection): string | null {
     ?? null;
 }
 
-function hasVersion(projection: MethodologyProjection, value: string | null): value is string {
-  return value !== null && projection.versions.some((entry) => entry.contractId === value);
+function methodologyItemIds(version: MethodologyVersionProjection): string[] {
+  return [...new Set([
+    ...version.theoryReferences.map((entry) => entry.id),
+    ...version.contractReferences.map((entry) => entry.id),
+    ...version.positiveVectors.map((entry) => entry.id),
+    ...version.negativeVectors.map((entry) => entry.id),
+    ...version.evidenceReferences.map((entry) => entry.id),
+    ...version.acceptanceReferences.map((entry) => entry.id),
+  ])].sort((a, b) => a.localeCompare(b));
 }
 
-function isMethodologyStage(value: string | null): value is MethodologyStage {
-  return value !== null && (METHODOLOGY_STAGE_ORDER as readonly string[]).includes(value);
-}
-
-function normalizeViewport(viewport: ObservatoryViewport): ObservatoryViewport {
-  const scale = Number.isFinite(viewport.scale) && viewport.scale > 0 ? viewport.scale : 1;
-  const x = Number.isFinite(viewport.x) ? viewport.x : 0;
-  const y = Number.isFinite(viewport.y) ? viewport.y : 0;
-  return Object.freeze({ x, y, scale });
-}
-
-function finiteNumber(value: string | null, fallback: number): number {
-  if (value === null || value.trim() === "") return fallback;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-function isDefaultViewport(viewport: ObservatoryViewport): boolean {
-  return viewport.x === 0 && viewport.y === 0 && viewport.scale === 1;
-}
-
-function uniqueSorted(values: readonly string[]): readonly string[] {
-  return Object.freeze([...new Set(values)].sort((left, right) => left.localeCompare(right)));
-}
-
-function freezeState(state: ObservatoryInteractionState): ObservatoryInteractionState {
-  return Object.freeze({
-    selectedVersionId: state.selectedVersionId,
-    selectedStage: state.selectedStage,
-    selectedItemId: state.selectedItemId,
-    filters: Object.freeze([...state.filters]),
-    viewport: normalizeViewport(state.viewport),
-  });
+function methodologyCategories(version: MethodologyVersionProjection): string[] {
+  const values = [classify(version).toLowerCase()];
+  if (version.accepted) values.push("accepted");
+  if (version.positiveVectors.length > 0) values.push("positive");
+  if (version.negativeVectors.length > 0) values.push("negative");
+  if (version.evidenceReferences.length > 0) values.push("evidence");
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
 }

--- a/web/contract-observatory/src/site.ts
+++ b/web/contract-observatory/src/site.ts
@@ -1,8 +1,11 @@
+import { renderObservatoryBrowserControllerScript } from "./browser-controller.js";
 import type { ContractObservatoryIndex, ContractVersionSummary } from "./contract-index.js";
 import {
-  METHODOLOGY_STAGE_ORDER,
+  OBSERVATORY_FILTERS,
   buildInteractiveMethodologyModel,
-  type ObservatoryInteractionState,
+  buildObservatoryInteractionConfig,
+  createObservatoryInteractionKernel,
+  type ObservatoryInteractionVersionConfig,
 } from "./interaction.js";
 import type { MethodologyProjection, MethodologyVersionProjection } from "./methodology-projection.js";
 
@@ -105,12 +108,16 @@ ${methodologyMap}
 }
 
 function renderMethodologyMap(projection: MethodologyProjection): string {
-  const selectedVersionId = projection.versions.find((entry) => entry.isCurrent)?.contractId ?? projection.versions[0]?.contractId ?? null;
-  const state: ObservatoryInteractionState = Object.freeze({ selectedVersionId, selectedStage: null, selectedItemId: null, filters: Object.freeze([]), viewport: Object.freeze({ x: 0, y: 0, scale: 1 }) });
+  const config = buildObservatoryInteractionConfig(projection);
+  const state = createObservatoryInteractionKernel(config).initialState();
   const model = buildInteractiveMethodologyModel(projection, state);
   const stageControls = model.stages.map((entry) => `<button type="button" data-methodology-stage="${entry.stage}" aria-pressed="false" title="Lifecycle stage: ${entry.stage}; derived presentation state">${escapeHtml(entry.stage)}</button>`).join("\n");
-  const lanes = model.versions.map((entry, ordinal) => renderMethodologyLane(projection.versions[ordinal]!, entry)).join("\n");
-  const controllerData = projection.versions.map((version, ordinal) => ({ id: version.contractId, classification: model.versions[ordinal]!.classification.toLowerCase(), itemIds: methodologyItemIds(version) }));
+  const filterControls = OBSERVATORY_FILTERS.map((filter) => renderFilterButton(filter, filter.toUpperCase())).join("");
+  const lanes = model.versions.map((entry, ordinal) => renderMethodologyLane(
+    projection.versions[ordinal]!,
+    entry,
+    config.versions[ordinal]!,
+  )).join("\n");
 
   return `    <section class="methodology-map" aria-labelledby="methodology-title">
       <div class="methodology-heading"><p class="eyebrow">Primary explanatory view · derived methodology</p><h2 id="methodology-title">Methodology map + version lifecycle lanes</h2><p>Две координированные, но не тождественные структуры: метод разработки и состояние жизненного цикла версии.</p></div>
@@ -118,90 +125,27 @@ function renderMethodologyMap(projection: MethodologyProjection): string {
       <div class="methodology-authority" aria-label="Relation authority"><span>Method/lifecycle relation: derived presentation relation</span><span>Traceability/evidence relation: source-derived reference</span><span>Semantic topology Link: not rendered in this view</span></div>
       <div class="methodology-controls">
         <div class="stage-controls" role="group" aria-label="Methodology stages">${stageControls}</div>
-        <div class="filter-controls" role="group" aria-label="Version and evidence filters">${renderFilterButton("current", "CURRENT")}${renderFilterButton("previous", "PREVIOUS")}${renderFilterButton("candidate", "CANDIDATE")}${renderFilterButton("accepted", "ACCEPTED")}${renderFilterButton("positive", "POSITIVE")}${renderFilterButton("negative", "NEGATIVE")}${renderFilterButton("evidence", "EVIDENCE")}</div>
+        <div class="filter-controls" role="group" aria-label="Version and evidence filters">${filterControls}</div>
         <div class="viewport-controls" role="group" aria-label="Map viewport"><button type="button" data-viewport-action="zoom-out" aria-label="Zoom out">−</button><button type="button" data-viewport-action="reset">Reset viewport</button><button type="button" data-viewport-action="zoom-in" aria-label="Zoom in">+</button></div>
       </div>
       <div class="methodology-grid" tabindex="0" aria-label="Version lifecycle lanes">${lanes}</div>
       <p class="methodology-status" aria-live="polite"></p>
     </section>
-${renderMethodologyController(controllerData, selectedVersionId)}`;
+${renderObservatoryBrowserControllerScript(config)}`;
 }
 
-function renderMethodologyLane(projection: MethodologyVersionProjection, model: ReturnType<typeof buildInteractiveMethodologyModel>["versions"][number]): string {
+function renderMethodologyLane(
+  projection: MethodologyVersionProjection,
+  model: ReturnType<typeof buildInteractiveMethodologyModel>["versions"][number],
+  config: ObservatoryInteractionVersionConfig,
+): string {
   const evidenceByStage = new Map(projection.lifecycle.map((entry) => [entry.stage, entry.evidence.length] as const));
   const stages = model.stageStates.map((entry) => `<div class="stage-cell${entry.present ? " present" : ""}" data-lane-stage="${entry.stage}" title="${entry.stage}: ${entry.present ? "source evidence present" : "no linked source evidence"}"><span>${escapeHtml(entry.stage)}</span><span class="stage-evidence">${entry.present ? `${evidenceByStage.get(entry.stage) ?? 0} evidence` : "—"}</span></div>`).join("\n");
-  const categories = methodologyCategories(projection, model.classification.toLowerCase()).join(" ");
-  const evidenceItems = methodologyItemIds(projection).slice(0, 6).map((id) => `<button type="button" data-item-id="${escapeAttribute(id)}" aria-pressed="false" title="Traceability/evidence reference; presentation-only">${escapeHtml(id)}</button>`).join("");
-  return `<div class="methodology-lane${model.selected ? " selected" : ""}" data-version-lane="${escapeAttribute(model.contractId)}" data-categories="${categories}"><div class="lane-version"><button type="button" class="version-select" data-version-id="${escapeAttribute(model.contractId)}" aria-pressed="${model.selected ? "true" : "false"}" title="Select version and synchronize Observatory views">${escapeHtml(model.contractId)}</button><span class="lane-classification">${model.classification}</span></div>${stages}<div class="evidence-items" aria-label="Evidence references for ${escapeAttribute(model.contractId)}">${evidenceItems || "<span>No linked evidence references</span>"}</div></div>`;
-}
-
-function methodologyItemIds(version: MethodologyVersionProjection): string[] {
-  return [...new Set([...version.theoryReferences.map((entry) => entry.id), ...version.contractReferences.map((entry) => entry.id), ...version.positiveVectors.map((entry) => entry.id), ...version.negativeVectors.map((entry) => entry.id), ...version.evidenceReferences.map((entry) => entry.id), ...version.acceptanceReferences.map((entry) => entry.id)])].sort((a, b) => a.localeCompare(b));
-}
-
-function methodologyCategories(version: MethodologyVersionProjection, classification: string): string[] {
-  const values = [classification];
-  if (version.accepted) values.push("accepted");
-  if (version.positiveVectors.length > 0) values.push("positive");
-  if (version.negativeVectors.length > 0) values.push("negative");
-  if (version.evidenceReferences.length > 0) values.push("evidence");
-  return [...new Set(values)].sort();
+  const evidenceItems = config.itemIds.slice(0, 6).map((id) => `<button type="button" data-item-id="${escapeAttribute(id)}" aria-pressed="false" title="Traceability/evidence reference; presentation-only">${escapeHtml(id)}</button>`).join("");
+  return `<div class="methodology-lane${model.selected ? " selected" : ""}" data-version-lane="${escapeAttribute(model.contractId)}"><div class="lane-version"><button type="button" class="version-select" data-version-id="${escapeAttribute(model.contractId)}" aria-pressed="${model.selected ? "true" : "false"}" title="Select version and synchronize Observatory views">${escapeHtml(model.contractId)}</button><span class="lane-classification">${model.classification}</span></div>${stages}<div class="evidence-items" aria-label="Evidence references for ${escapeAttribute(model.contractId)}">${evidenceItems || "<span>No linked evidence references</span>"}</div></div>`;
 }
 
 function renderFilterButton(filter: string, label: string): string { return `<button type="button" data-methodology-filter="${filter}" aria-pressed="false">${label}</button>`; }
-
-function renderMethodologyController(versions: readonly { readonly id: string; readonly classification: string; readonly itemIds: readonly string[] }[], defaultVersionId: string | null): string {
-  const data = escapeJsonForScript(JSON.stringify({ versions, stages: METHODOLOGY_STAGE_ORDER, defaultVersionId, filters: ["accepted", "candidate", "current", "evidence", "negative", "positive", "previous"] }));
-  return `    <script>
-(() => {
-  "use strict";
-  const map = document.querySelector(".methodology-map");
-  if (!map) return;
-  const grid = map.querySelector(".methodology-grid");
-  const config = ${data};
-  const versionIds = new Set(config.versions.map((entry) => entry.id));
-  const itemIds = new Set(config.versions.flatMap((entry) => entry.itemIds));
-  const stages = new Set(config.stages);
-  const filters = new Set(config.filters);
-  const number = (value, fallback) => { const parsed = Number(value); return Number.isFinite(parsed) ? parsed : fallback; };
-
-  const readState = () => {
-    const params = new URLSearchParams(location.hash.startsWith("#") ? location.hash.slice(1) : location.hash);
-    const requestedVersion = params.get("v");
-    const requestedStage = params.get("s");
-    const requestedItem = params.get("item");
-    return { versionId: versionIds.has(requestedVersion) ? requestedVersion : config.defaultVersionId, stage: stages.has(requestedStage) ? requestedStage : null, item: itemIds.has(requestedItem) ? requestedItem : null, filters: [...new Set(params.getAll("f").filter((value) => filters.has(value)))].sort(), x: number(params.get("x"), 0), y: number(params.get("y"), 0), z: Math.min(1.8, Math.max(.7, number(params.get("z"), 1))) };
-  };
-  const writeState = (mutate, replace = false) => { const params = new URLSearchParams(location.hash.startsWith("#") ? location.hash.slice(1) : location.hash); mutate(params); const next = params.toString(); if (replace) history.replaceState(null, "", location.pathname + location.search + (next ? "#" + next : "#")); else location.hash = next ? "#" + next : "#"; };
-
-  const apply = () => {
-    const state = readState();
-    map.querySelectorAll("[data-methodology-stage]").forEach((button) => button.setAttribute("aria-pressed", String(button.dataset.methodologyStage === state.stage)));
-    map.querySelectorAll("[data-methodology-filter]").forEach((button) => button.setAttribute("aria-pressed", String(state.filters.includes(button.dataset.methodologyFilter))));
-    map.querySelectorAll("[data-item-id]").forEach((button) => button.setAttribute("aria-pressed", String(button.dataset.itemId === state.item)));
-    map.querySelectorAll("[data-version-lane]").forEach((lane) => { const selected = lane.dataset.versionLane === state.versionId; const categories = (lane.dataset.categories || "").split(" "); const visible = state.filters.length === 0 || state.filters.every((value) => categories.includes(value)); lane.hidden = !visible; lane.classList.toggle("selected", selected); lane.querySelector("[data-version-id]")?.setAttribute("aria-pressed", String(selected)); lane.querySelectorAll("[data-lane-stage]").forEach((cell) => cell.classList.toggle("stage-selected", cell.dataset.laneStage === state.stage)); });
-    document.querySelectorAll("[data-overview-version-id]").forEach((node) => node.classList.toggle("selection-synced", node.dataset.overviewVersionId === state.versionId));
-    if (grid) { grid.style.zoom = String(state.z); grid.scrollLeft = state.x; grid.scrollTop = state.y; }
-    const status = map.querySelector(".methodology-status");
-    if (status) status.textContent = "Selected: " + (state.versionId ?? "none") + "; stage: " + (state.stage ?? "all") + "; item: " + (state.item ?? "none") + "; filters: " + (state.filters.join(", ") || "none") + "; zoom: " + state.z + ".";
-  };
-
-  map.addEventListener("click", (event) => {
-    const target = event.target instanceof Element ? event.target.closest("button") : null;
-    if (!(target instanceof HTMLButtonElement)) return;
-    if (target.dataset.methodologyStage) { const stage = target.dataset.methodologyStage; const active = target.getAttribute("aria-pressed") === "true"; writeState((params) => active ? params.delete("s") : params.set("s", stage)); }
-    else if (target.dataset.versionId) writeState((params) => params.set("v", target.dataset.versionId));
-    else if (target.dataset.itemId) writeState((params) => params.set("item", target.dataset.itemId));
-    else if (target.dataset.methodologyFilter) { const filter = target.dataset.methodologyFilter; writeState((params) => { const values = new Set(params.getAll("f").filter((value) => filters.has(value))); values.has(filter) ? values.delete(filter) : values.add(filter); params.delete("f"); [...values].sort().forEach((value) => params.append("f", value)); }); }
-    else if (target.dataset.viewportAction) writeState((params) => { const state = readState(); if (target.dataset.viewportAction === "reset") { params.delete("x"); params.delete("y"); params.delete("z"); } else params.set("z", String(Math.min(1.8, Math.max(.7, state.z + (target.dataset.viewportAction === "zoom-in" ? .1 : -.1))))); });
-  });
-  map.addEventListener("keydown", (event) => { if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "Enter"].includes(event.key)) return; const target = event.target; if (!(target instanceof HTMLButtonElement)) return; if (event.key === "Enter") { target.click(); return; } const buttons = [...map.querySelectorAll("button:not([hidden])")].filter((button) => !button.closest("[hidden]")); const current = buttons.indexOf(target); if (current < 0 || buttons.length === 0) return; event.preventDefault(); let next = current; if (event.key === "Home") next = 0; else if (event.key === "End") next = buttons.length - 1; else if (event.key === "ArrowLeft" || event.key === "ArrowUp") next = (current - 1 + buttons.length) % buttons.length; else next = (current + 1) % buttons.length; buttons[next]?.focus(); });
-  grid?.addEventListener("scroll", () => writeState((params) => { if (grid.scrollLeft) params.set("x", String(Math.round(grid.scrollLeft))); else params.delete("x"); if (grid.scrollTop) params.set("y", String(Math.round(grid.scrollTop))); else params.delete("y"); }, true));
-  window.addEventListener("hashchange", apply);
-  apply();
-})();
-    </script>`;
-}
 
 function renderTimelineItem(version: ContractVersionSummary, ordinal: number, interactive: boolean): string {
   const anchor = anchorId(ordinal); const classification = classify(version); const semanticDelta = version.observableSemanticDelta ? "SEMANTIC DELTA" : "NO SEMANTIC DELTA"; const href = interactive ? `#v=${encodeURIComponent(version.contractId)}` : `#${anchor}`;
@@ -221,5 +165,4 @@ function classify(version: ContractVersionSummary): string { if (version.isCurre
 function yesNo(value: boolean): string { return value ? "YES" : "NO"; }
 function anchorId(ordinal: number): string { return `version-${ordinal + 1}`; }
 function escapeAttribute(value: string): string { return escapeHtml(value); }
-function escapeJsonForScript(value: string): string { return value.replaceAll("<", "\\u003c").replaceAll(">", "\\u003e").replaceAll("&", "\\u0026"); }
 function escapeHtml(value: string): string { return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll("\"", "&quot;").replaceAll("'", "&#39;"); }

--- a/web/contract-observatory/test/browser-controller.test.ts
+++ b/web/contract-observatory/test/browser-controller.test.ts
@@ -1,0 +1,280 @@
+import {
+  installObservatoryBrowserController,
+  renderObservatoryBrowserControllerScript,
+  type ObservatoryBrowserDocument,
+  type ObservatoryBrowserEnvironment,
+  type ObservatoryBrowserEvent,
+  type ObservatoryBrowserNode,
+} from "../src/browser-controller.js";
+import {
+  METHODOLOGY_STAGE_ORDER,
+  OBSERVATORY_FILTERS,
+  createObservatoryInteractionKernel,
+  type ObservatoryInteractionConfig,
+} from "../src/interaction.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Contract Observatory V4c browser controller: ${message}`);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+class FakeNode implements ObservatoryBrowserNode {
+  readonly dataset: Record<string, string | undefined>;
+  readonly style: Record<string, string | undefined> = {};
+  readonly children: FakeNode[] = [];
+  readonly classes = new Set<string>();
+  readonly attributes = new Map<string, string>();
+  readonly listeners = new Map<string, ((event: ObservatoryBrowserEvent) => void)[]>();
+  readonly classList = {
+    toggle: (name: string, force?: boolean): void => {
+      const enabled = force ?? !this.classes.has(name);
+      enabled ? this.classes.add(name) : this.classes.delete(name);
+    },
+  };
+  parent: FakeNode | null = null;
+  ownerDocument: FakeDocument | null = null;
+  hidden = false;
+  textContent: string | null = null;
+  scrollLeft = 0;
+  scrollTop = 0;
+
+  constructor(
+    readonly tagName = "div",
+    classes: readonly string[] = [],
+    dataset: Record<string, string | undefined> = {},
+  ) {
+    classes.forEach((value) => this.classes.add(value));
+    this.dataset = { ...dataset };
+  }
+
+  append(...nodes: FakeNode[]): this {
+    for (const node of nodes) {
+      node.parent = this;
+      node.setOwnerDocument(this.ownerDocument);
+      this.children.push(node);
+    }
+    return this;
+  }
+
+  setOwnerDocument(document: FakeDocument | null): void {
+    this.ownerDocument = document;
+    this.children.forEach((child) => child.setOwnerDocument(document));
+  }
+
+  setAttribute(name: string, value: string): void { this.attributes.set(name, value); }
+  getAttribute(name: string): string | null { return this.attributes.get(name) ?? null; }
+
+  querySelector(selector: string): FakeNode | null { return this.querySelectorAll(selector)[0] ?? null; }
+
+  querySelectorAll(selector: string): FakeNode[] {
+    const result: FakeNode[] = [];
+    const visit = (node: FakeNode): void => {
+      for (const child of node.children) {
+        if (child.matches(selector)) result.push(child);
+        visit(child);
+      }
+    };
+    visit(this);
+    return result;
+  }
+
+  closest(selector: string): FakeNode | null {
+    let current: FakeNode | null = this;
+    while (current !== null) {
+      if (current.matches(selector)) return current;
+      current = current.parent;
+    }
+    return null;
+  }
+
+  matches(selector: string): boolean {
+    if (selector === "button") return this.tagName === "button";
+    if (selector === "[hidden]") return this.hidden;
+    if (selector.startsWith(".")) return this.classes.has(selector.slice(1));
+    const data = selector.match(/^\[data-([a-z0-9-]+)\]$/);
+    if (data !== null) {
+      const key = data[1]!.replace(/-([a-z])/g, (_all, letter: string) => letter.toUpperCase());
+      return this.dataset[key] !== undefined;
+    }
+    return false;
+  }
+
+  focus(): void { if (this.ownerDocument !== null) this.ownerDocument.activeElement = this; }
+
+  click(): void {
+    let current: FakeNode | null = this;
+    const event: ObservatoryBrowserEvent = { target: this };
+    while (current !== null) {
+      current.emit("click", event);
+      current = current.parent;
+    }
+  }
+
+  addEventListener(type: string, listener: (event: ObservatoryBrowserEvent) => void): void {
+    const entries = this.listeners.get(type) ?? [];
+    entries.push(listener);
+    this.listeners.set(type, entries);
+  }
+
+  emit(type: string, event: ObservatoryBrowserEvent = { target: this }): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+class FakeDocument implements ObservatoryBrowserDocument {
+  activeElement: FakeNode | null = null;
+  constructor(readonly root: FakeNode) {
+    root.setOwnerDocument(this);
+  }
+  querySelector(selector: string): FakeNode | null {
+    if (this.root.matches(selector)) return this.root;
+    return this.root.querySelector(selector);
+  }
+  querySelectorAll(selector: string): FakeNode[] {
+    const descendants = this.root.querySelectorAll(selector);
+    return this.root.matches(selector) ? [this.root, ...descendants] : descendants;
+  }
+}
+
+class FakeWindow {
+  readonly listeners = new Map<string, ((event: ObservatoryBrowserEvent) => void)[]>();
+  addEventListener(type: string, listener: (event: ObservatoryBrowserEvent) => void): void {
+    const entries = this.listeners.get(type) ?? [];
+    entries.push(listener);
+    this.listeners.set(type, entries);
+  }
+  emit(type: string): void { for (const listener of this.listeners.get(type) ?? []) listener({}); }
+}
+
+const config: ObservatoryInteractionConfig = Object.freeze({
+  versions: Object.freeze([
+    Object.freeze({
+      id: "current",
+      categories: Object.freeze(["accepted", "current", "evidence", "negative"]),
+      itemIds: Object.freeze(["item:current"]),
+    }),
+    Object.freeze({
+      id: "previous",
+      categories: Object.freeze(["accepted", "positive", "previous"]),
+      itemIds: Object.freeze(["item:previous"]),
+    }),
+  ]),
+  defaultVersionId: "current",
+  stages: METHODOLOGY_STAGE_ORDER,
+  filters: OBSERVATORY_FILTERS,
+  minScale: 0.7,
+  maxScale: 1.8,
+  zoomStep: 0.1,
+});
+
+const body = new FakeNode("body");
+const map = new FakeNode("section", ["methodology-map"]);
+const stageCandidate = new FakeNode("button", [], { methodologyStage: "candidate" });
+const stageAccepted = new FakeNode("button", [], { methodologyStage: "accepted" });
+const filterCurrent = new FakeNode("button", [], { methodologyFilter: "current" });
+const filterNegative = new FakeNode("button", [], { methodologyFilter: "negative" });
+const filterPositive = new FakeNode("button", [], { methodologyFilter: "positive" });
+const zoomIn = new FakeNode("button", [], { viewportAction: "zoom-in" });
+const reset = new FakeNode("button", [], { viewportAction: "reset" });
+const grid = new FakeNode("div", ["methodology-grid"]);
+const currentLane = new FakeNode("div", [], { versionLane: "current" });
+const currentVersion = new FakeNode("button", [], { versionId: "current" });
+const currentCandidateCell = new FakeNode("div", [], { laneStage: "candidate" });
+const currentItem = new FakeNode("button", [], { itemId: "item:current" });
+currentLane.append(currentVersion, currentCandidateCell, currentItem);
+const previousLane = new FakeNode("div", [], { versionLane: "previous" });
+const previousVersion = new FakeNode("button", [], { versionId: "previous" });
+const previousCandidateCell = new FakeNode("div", [], { laneStage: "candidate" });
+const previousItem = new FakeNode("button", [], { itemId: "item:previous" });
+previousLane.append(previousVersion, previousCandidateCell, previousItem);
+grid.append(currentLane, previousLane);
+const status = new FakeNode("p", ["methodology-status"]);
+map.append(stageCandidate, stageAccepted, filterCurrent, filterNegative, filterPositive, zoomIn, reset, grid, status);
+const currentOverview = new FakeNode("a", [], { overviewVersionId: "current" });
+const previousOverview = new FakeNode("a", [], { overviewVersionId: "previous" });
+body.append(map, currentOverview, previousOverview);
+const document = new FakeDocument(body);
+const location = {
+  hash: "#v=missing&s=unknown&item=%3Cscript%3E&f=unknown&z=99",
+  pathname: "/observatory/",
+  search: "",
+};
+const window = new FakeWindow();
+let replaceCount = 0;
+const history = {
+  replaceState: (_data: null, _title: string, url: string): void => {
+    replaceCount += 1;
+    const marker = url.indexOf("#");
+    location.hash = marker >= 0 ? url.slice(marker) : "";
+  },
+};
+const environment: ObservatoryBrowserEnvironment = { document, location, history, window };
+const controller = installObservatoryBrowserController(environment, createObservatoryInteractionKernel(config));
+
+same(controller.getState().selectedVersionId, "current", "unknown version fails closed in the actual browser controller");
+same(controller.getState().selectedStage, null, "unknown stage fails closed in the actual browser controller");
+same(controller.getState().selectedItemId, null, "script-like unknown item fails closed in the actual browser controller");
+same(controller.getState().filters.length, 0, "unknown filters fail closed in the actual browser controller");
+same(controller.getState().viewport.scale, 1.8, "browser controller uses canonical zoom clamp");
+same(currentVersion.getAttribute("aria-pressed"), "true", "default current version is selected in DOM");
+assert(currentOverview.classes.has("selection-synced"), "overview selection derives from canonical state");
+assert(!(status.textContent ?? "").includes("<script>"), "malicious hash data remains inert and absent from rendered status");
+
+stageCandidate.click();
+same(controller.getState().selectedStage, "candidate", "stage click reduces through canonical state");
+same(stageCandidate.getAttribute("aria-pressed"), "true", "stage DOM state follows canonical state");
+currentItem.click();
+same(controller.getState().selectedItemId, "item:current", "known evidence item selection is canonical");
+
+previousVersion.focus();
+filterCurrent.click();
+filterNegative.click();
+same(controller.getState().filters.join(","), "current,negative", "filter toggles use canonical normalized order");
+same(currentLane.hidden, false, "conjunctive CURRENT + NEGATIVE retains matching lane");
+same(previousLane.hidden, true, "conjunctive CURRENT + NEGATIVE hides partial match");
+assert(document.activeElement !== previousVersion, "focus is repaired when filtering hides the focused lane");
+filterCurrent.click();
+filterNegative.click();
+same(controller.getState().filters.length, 0, "filter toggles are reversible");
+
+let prevented = false;
+stageCandidate.focus();
+map.emit("keydown", { target: stageCandidate, key: "ArrowRight", preventDefault: () => { prevented = true; } });
+assert(prevented, "arrow keyboard navigation prevents scroll side effects");
+same(document.activeElement, stageAccepted, "arrow keyboard navigation follows visible control order");
+map.emit("keydown", { target: stageCandidate, key: " ", preventDefault: () => undefined });
+same(controller.getState().selectedStage, null, "Space activates button and toggles selected stage off");
+map.emit("keydown", { target: stageCandidate, key: "Enter", preventDefault: () => undefined });
+same(controller.getState().selectedStage, "candidate", "Enter activates button through the same click path");
+
+for (let index = 0; index < 20; index += 1) zoomIn.click();
+same(controller.getState().viewport.scale, 1.8, "repeated browser zoom remains canonically bounded");
+reset.click();
+same(controller.getState().viewport.scale, 1, "viewport reset uses canonical reducer");
+
+location.hash = "#v=previous&item=item%3Aprevious&f=positive&x=12&y=5&z=.5";
+window.emit("hashchange");
+same(controller.getState().selectedVersionId, "previous", "hashchange/back-forward restores canonical version");
+same(controller.getState().selectedItemId, "item:previous", "hashchange restores canonical known item");
+same(controller.getState().filters.join(","), "positive", "hashchange restores canonical filters");
+same(controller.getState().viewport.scale, 0.7, "hashchange uses the same viewport clamp");
+same(grid.scrollLeft, 12, "canonical viewport x is rendered");
+same(grid.scrollTop, 5, "canonical viewport y is rendered");
+
+grid.scrollLeft = 21;
+grid.scrollTop = 9;
+grid.emit("scroll", { target: grid });
+same(controller.getState().viewport.x, 21, "scroll updates canonical viewport x");
+same(controller.getState().viewport.y, 9, "scroll updates canonical viewport y");
+assert(replaceCount > 0, "scroll uses replaceState rather than history-spamming navigation");
+assert(location.hash.includes("x=21") && location.hash.includes("y=9"), "replaceState receives canonical hash bytes");
+
+const generated = renderObservatoryBrowserControllerScript(config);
+assert(generated.includes("data-observatory-controller=\"shared-kernel\""), "generated page marks the shared-kernel controller");
+assert(generated.includes("createKernel"), "generated page embeds the exact canonical kernel factory");
+assert(!generated.includes("const readState ="), "generated controller does not retain the old handwritten hash parser");
+
+console.log("Contract Observatory V4c executable browser-controller specification passed.");

--- a/web/contract-observatory/test/interaction.test.ts
+++ b/web/contract-observatory/test/interaction.test.ts
@@ -1,6 +1,8 @@
 import {
   METHODOLOGY_STAGE_ORDER,
   buildInteractiveMethodologyModel,
+  buildObservatoryInteractionConfig,
+  createObservatoryInteractionKernel,
   decodeObservatoryHash,
   encodeObservatoryHash,
   reduceInteractionState,
@@ -57,6 +59,12 @@ const projection: MethodologyProjection = Object.freeze({
       contractId: "mts-contract/v0.11",
       conformanceId: "mts-conformance/v0.11",
       isCurrent: true,
+      contractReferences: Object.freeze([
+        Object.freeze({ authority: "contract", id: "mts-contract/v0.11", path: "contracts/mts-contract-v0.11.json" }),
+      ]),
+      negativeVectors: Object.freeze([
+        Object.freeze({ authority: "conformance-vector", id: "negative:edge", polarity: "negative", evidence: Object.freeze([]) }),
+      ]),
       lifecycle: Object.freeze([
         Object.freeze({ stage: "research", evidence: Object.freeze(["issue:758"]) }),
         Object.freeze({ stage: "problem", evidence: Object.freeze(["issue:759"]) }),
@@ -101,21 +109,21 @@ same(initialModel.versions.find((entry) => entry.isCurrent)?.contractId, "mts-co
 same(initialModel.versions.find((entry) => entry.contractId.includes("candidate"))?.classification, "CANDIDATE", "candidate is textually distinct from accepted");
 same(initialModel.versions.find((entry) => entry.contractId === "mts-contract/v0.11")?.classification, "CURRENT", "current classification is explicit");
 
-const stageSelected = reduceInteractionState(initial, { type: "select-stage", stage: "challenged" });
+const stageSelected = reduceInteractionState(initial, { type: "select-stage", stage: "challenged" }, projection);
 same(stageSelected.selectedStage, "challenged", "stage selection is observable state");
 const stageModel = buildInteractiveMethodologyModel(projection, stageSelected);
 assert(stageModel.stages.find((entry) => entry.stage === "challenged")?.selected === true, "selected stage is emphasized");
 assert(stageModel.versions.every((entry) => entry.stageStates.some((stage) => stage.stage === "challenged")), "stage state is synchronized across version lanes");
 
-const versionSelected = reduceInteractionState(stageSelected, { type: "select-version", versionId: "mts-contract/v0.10" });
+const versionSelected = reduceInteractionState(stageSelected, { type: "select-version", versionId: "mts-contract/v0.10" }, projection);
 same(versionSelected.selectedVersionId, "mts-contract/v0.10", "version selection is synchronized state");
 
-const encoded = encodeObservatoryHash(versionSelected);
+const encoded = encodeObservatoryHash(versionSelected, projection);
 assert(encoded.startsWith("#v="), "deep link is a stable hash");
 const decoded = decodeObservatoryHash(encoded, projection);
 same(decoded.selectedVersionId, versionSelected.selectedVersionId, "hash restores selected version");
 same(decoded.selectedStage, versionSelected.selectedStage, "hash restores selected stage");
-same(encodeObservatoryHash(decoded), encoded, "hash round-trip is deterministic");
+same(encodeObservatoryHash(decoded, projection), encoded, "hash round-trip is deterministic");
 
 const unknown = decodeObservatoryHash(
   "#v=missing&s=unknown&item=%3Cscript%3E&f=negative&f=unknown&f=negative&x=NaN&y=Infinity&z=99",
@@ -129,12 +137,22 @@ same(unknown.viewport.x, 0, "invalid x fails closed");
 same(unknown.viewport.y, 0, "invalid y fails closed");
 same(unknown.viewport.scale, 1.8, "zoom is clamped to the canonical maximum");
 
+const knownItem = decodeObservatoryHash("#item=mts-contract%2Fv0.11", projection);
+same(knownItem.selectedItemId, "mts-contract/v0.11", "known projected item survives canonical decoding");
+
 const lowZoom = decodeObservatoryHash("#z=-5", projection);
 same(lowZoom.viewport.scale, 0.7, "zoom is clamped to the canonical minimum");
 
 const unorderedFilters = decodeObservatoryHash("#f=previous&f=accepted", projection);
 same(unorderedFilters.filters.join(","), "accepted,previous", "known filters normalize to canonical order");
-same(encodeObservatoryHash(unorderedFilters), "#v=mts-contract%2Fv0.11&f=accepted&f=previous", "canonical hash re-encodes normalized filters deterministically");
+same(encodeObservatoryHash(unorderedFilters, projection), "#v=mts-contract%2Fv0.11&f=accepted&f=previous", "canonical hash re-encodes normalized filters deterministically");
+
+const kernel = createObservatoryInteractionKernel(buildObservatoryInteractionConfig(projection));
+const conjunctive = kernel.reduce(initial, { type: "set-filters", filters: ["current", "accepted", "negative"] });
+assert(kernel.isVersionVisible("mts-contract/v0.11", conjunctive), "CURRENT + ACCEPTED + NEGATIVE uses explicit conjunctive filter semantics");
+assert(!kernel.isVersionVisible("mts-contract/v0.10", conjunctive), "version missing any active category is hidden");
+const unknownFilter = kernel.reduce(conjunctive, { type: "toggle-filter", filter: "invented" });
+same(unknownFilter.filters.join(","), conjunctive.filters.join(","), "unknown UI filter action is inert");
 
 same(
   JSON.stringify(buildInteractiveMethodologyModel(projection, versionSelected)),

--- a/web/contract-observatory/test/interaction.test.ts
+++ b/web/contract-observatory/test/interaction.test.ts
@@ -117,10 +117,24 @@ same(decoded.selectedVersionId, versionSelected.selectedVersionId, "hash restore
 same(decoded.selectedStage, versionSelected.selectedStage, "hash restores selected stage");
 same(encodeObservatoryHash(decoded), encoded, "hash round-trip is deterministic");
 
-const unknown = decodeObservatoryHash("#v=missing&s=unknown&item=%3Cscript%3E", projection);
+const unknown = decodeObservatoryHash(
+  "#v=missing&s=unknown&item=%3Cscript%3E&f=negative&f=unknown&f=negative&x=NaN&y=Infinity&z=99",
+  projection,
+);
 same(unknown.selectedVersionId, "mts-contract/v0.11", "unknown version fails closed to projected current version");
 same(unknown.selectedStage, null, "unknown methodology stage is not fabricated");
-same(unknown.selectedItemId, "<script>", "item identity remains data and is not interpreted as markup");
+same(unknown.selectedItemId, null, "unknown item fails closed rather than surviving as opaque browser-only state");
+same(unknown.filters.join(","), "negative", "unknown filters are dropped and known duplicates normalize");
+same(unknown.viewport.x, 0, "invalid x fails closed");
+same(unknown.viewport.y, 0, "invalid y fails closed");
+same(unknown.viewport.scale, 1.8, "zoom is clamped to the canonical maximum");
+
+const lowZoom = decodeObservatoryHash("#z=-5", projection);
+same(lowZoom.viewport.scale, 0.7, "zoom is clamped to the canonical minimum");
+
+const unorderedFilters = decodeObservatoryHash("#f=previous&f=accepted", projection);
+same(unorderedFilters.filters.join(","), "accepted,previous", "known filters normalize to canonical order");
+same(encodeObservatoryHash(unorderedFilters), "#v=mts-contract%2Fv0.11&f=accepted&f=previous", "canonical hash re-encodes normalized filters deterministically");
 
 same(
   JSON.stringify(buildInteractiveMethodologyModel(projection, versionSelected)),

--- a/web/contract-observatory/test/site.test.ts
+++ b/web/contract-observatory/test/site.test.ts
@@ -11,7 +11,6 @@ import {
 } from "../src/contract-index.js";
 import { buildMethodologyProjection } from "../src/methodology-projection.js";
 import { renderContractObservatoryHtml } from "../src/site.js";
-import "./interaction.test.js";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(`Contract Observatory V3b/V3c/V4c: ${message}`);
@@ -99,8 +98,8 @@ assert(realHtml.includes("CURRENT"), "current classification remains explicit in
 assert(realHtml.includes("PREVIOUS"), "previous classification remains explicit in V4c");
 assert(realHtml.includes("Method/lifecycle relation"), "methodology relation authority is textually distinguished");
 assert(realHtml.includes("Semantic topology Link: not rendered in this view"), "methodology view cannot be mistaken for MTS semantic Links");
-assert(realHtml.includes("addEventListener(\"hashchange\""), "deep-link back/forward restoration is wired in the client controller");
-assert(realHtml.includes("addEventListener(\"keydown\""), "keyboard stage/version activation is wired in the client controller");
+assert(realHtml.includes("data-observatory-controller=\"shared-kernel\""), "static page embeds the shared canonical interaction kernel controller");
+assert(!realHtml.includes("const readState ="), "static page no longer owns the old handwritten hash parser");
 
 const v010Position = realHtml.indexOf("mts-contract/v0.10");
 const v011Position = realHtml.indexOf("mts-contract/v0.11");


### PR DESCRIPTION
Closes #972.

This removes the duplicated V4c browser state machine and makes one executable interaction policy authoritative for both TypeScript model tests and the generated static browser controller.

Exact base at branch creation / pre-PR revalidation:
`8eb5df94c5a1bee844731179210ea34617162810`

Exact head:
`8ce6c6502c55a0e44ae55bcd710a0442efac67d6`

## One canonical interaction kernel

`interaction.ts` now owns the finite policy for:

- version validation and default-current fallback;
- methodology-stage validation;
- projected item validation;
- allowed filter vocabulary and canonical ordering;
- conjunctive filter semantics;
- finite viewport coordinates;
- zoom clamping to `[0.7, 1.8]`;
- deterministic hash decode/encode;
- state reduction.

The browser receives a projection-derived immutable config and the exact compiled `createObservatoryInteractionKernel` function body. `site.ts` no longer emits a second handwritten `readState/writeState/apply` policy.

Unknown or malformed hash state fails closed:

```text
unknown version -> projected current/default
unknown stage   -> null
unknown item    -> null
unknown filter  -> dropped
invalid x/y     -> 0
z < .7          -> .7
z > 1.8         -> 1.8
```

Filter semantics are explicit AND semantics: a version lane is visible only when it satisfies every active filter category.

## Thin browser adapter

New `browser-controller.ts` is a DOM adapter over the shared kernel. It maps browser events into canonical actions and renders canonical state back to the DOM. It does not parse/validate hashes or implement its own filter/viewport policy.

It handles:

- click selection for stages, versions, evidence items and filters;
- bounded zoom and viewport reset;
- scroll persistence with `history.replaceState`;
- `hashchange` / back-forward restoration;
- Arrow/Home/End focus navigation;
- Enter and Space activation through the same click path;
- focus repair if filtering hides the currently focused lane;
- status output through `textContent` only.

The generated static page carries `data-observatory-controller="shared-kernel"`; the previous handwritten `const readState = ...` controller no longer exists.

## Executable browser/controller evidence

New `browser-controller.test.ts` uses a small browser-neutral fake DOM and executes the real adapter + real canonical kernel. It verifies malformed/malicious hashes, item validation, filter conjunction, focus repair, keyboard behavior, zoom bounds, reset, hashchange restoration, viewport scroll persistence, and generated-controller provenance.

`interaction.test.ts` separately exercises the same kernel for deterministic hash normalization, finite vocabulary, conjunctive filters and state transitions.

The old `site.test.ts` assertions that only searched emitted JavaScript for literal `addEventListener(...)` strings were removed. Site tests now verify the architectural boundary, while actual interaction behavior is executed.

## TDD evidence

- RED `b04543659657c1a87a142201c8b421733688986b`, push CI #3843: failed exactly on the known divergence because `<script>` survived as `selectedItemId` in the TypeScript path.
- First implementation `252c1117f61bcde554bd754f1b8b206cb40dab5f`, CI #3844: the new executable browser-controller and interaction suites passed; only the obsolete `site.test.ts` handler-string assertion failed.
- Current head `8ce6c6502c55a0e44ae55bcd710a0442efac67d6`, push CI #3845: SUCCESS across core, visual and Contract Observatory checks.

## Scope / authority boundary

No accepted MTS semantic contract or conformance state changes. No theory, proof, SyntaxAset, visual package, or cutover authority is modified. No frontend framework or runtime dependency is introduced.

Compared with exact base: 3 commits, 6 files changed, 2 new files, +782/-164 = net +618 lines, within repository defaults.

```repo-guard-yaml
change_type: corrective
scope:
  - web/contract-observatory/src/interaction.ts
  - web/contract-observatory/src/browser-controller.ts
  - web/contract-observatory/src/site.ts
  - web/contract-observatory/test/interaction.test.ts
  - web/contract-observatory/test/browser-controller.test.ts
  - web/contract-observatory/test/site.test.ts
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 700
anchors:
  affects: []
  implements:
    - "#972"
  verifies: []
must_touch:
  - web/contract-observatory/src/interaction.ts
  - web/contract-observatory/src/browser-controller.ts
  - web/contract-observatory/test/browser-controller.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - packages/visual/**
  - docs/**
  - .github/**
  - repo-policy.json
expected_effects:
  - browser and model interaction state use one executable validation/hash/filter/viewport policy
  - unknown or malformed deep-link state fails closed and normalizes deterministically
  - browser interaction semantics are executed in CI rather than inferred from emitted JavaScript strings
  - accepted MTS v0.11 semantic authority remains unchanged
```