### PR TITLE
[Corrective][Observatory/V4c] Make browser controller NodeList-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,9 @@ jobs:
           ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
           node packages/visual/dist/test/model.test.js
 
-      - name: Check Contract Observatory
+      - name: Check Contract Observatory index
         run: |
           ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
-          node web/contract-observatory/dist/test/interaction.test.js
-          node web/contract-observatory/dist/test/browser-controller.test.js
-          node web/contract-observatory/dist/test/browser-controller-nodelist.test.js
           node web/contract-observatory/dist/test/contract-index.test.js
           node web/contract-observatory/dist/test/site.test.js
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,12 @@ jobs:
           ./ts/node_modules/.bin/tsc -p packages/visual/tsconfig.json
           node packages/visual/dist/test/model.test.js
 
-      - name: Check Contract Observatory index
+      - name: Check Contract Observatory
         run: |
           ./ts/node_modules/.bin/tsc -p web/contract-observatory/tsconfig.json
+          node web/contract-observatory/dist/test/interaction.test.js
+          node web/contract-observatory/dist/test/browser-controller.test.js
+          node web/contract-observatory/dist/test/browser-controller-nodelist.test.js
           node web/contract-observatory/dist/test/contract-index.test.js
           node web/contract-observatory/dist/test/site.test.js
 

--- a/web/contract-observatory/src/browser-controller.ts
+++ b/web/contract-observatory/src/browser-controller.ts
@@ -15,6 +15,10 @@ export interface ObservatoryBrowserClassList {
   toggle(name: string, force?: boolean): void;
 }
 
+export interface ObservatoryBrowserNodeCollection extends Iterable<ObservatoryBrowserNode> {
+  forEach(callback: (node: ObservatoryBrowserNode) => void): void;
+}
+
 export interface ObservatoryBrowserNode {
   readonly dataset: Record<string, string | undefined>;
   hidden?: boolean;
@@ -26,7 +30,7 @@ export interface ObservatoryBrowserNode {
   setAttribute(name: string, value: string): void;
   getAttribute(name: string): string | null;
   querySelector(selector: string): ObservatoryBrowserNode | null;
-  querySelectorAll(selector: string): readonly ObservatoryBrowserNode[];
+  querySelectorAll(selector: string): ObservatoryBrowserNodeCollection;
   closest?(selector: string): ObservatoryBrowserNode | null;
   focus?(): void;
   click?(): void;
@@ -36,7 +40,7 @@ export interface ObservatoryBrowserNode {
 export interface ObservatoryBrowserDocument {
   activeElement?: ObservatoryBrowserNode | null;
   querySelector(selector: string): ObservatoryBrowserNode | null;
-  querySelectorAll(selector: string): readonly ObservatoryBrowserNode[];
+  querySelectorAll(selector: string): ObservatoryBrowserNodeCollection;
 }
 
 export interface ObservatoryBrowserLocation {
@@ -84,8 +88,8 @@ export function installObservatoryBrowserController(
   const grid = map.querySelector(".methodology-grid");
   let state = kernel.decode(environment.location.hash);
 
-  const visibleButtons = (): readonly ObservatoryBrowserNode[] => map
-    .querySelectorAll("button")
+  const visibleButtons = (): readonly ObservatoryBrowserNode[] => Array.from(map
+    .querySelectorAll("button"))
     .filter((button) => button.hidden !== true && button.closest?.("[hidden]") == null);
 
   const apply = (): void => {

--- a/web/contract-observatory/test/browser-controller-nodelist.test.ts
+++ b/web/contract-observatory/test/browser-controller-nodelist.test.ts
@@ -76,7 +76,7 @@ const kernel: ObservatoryInteractionKernel = Object.freeze({
   initialState: () => state,
   decode: () => state,
   encode: () => "#",
-  reduce: (current) => current,
+  reduce: (current: ObservatoryInteractionState) => current,
   isVersionVisible: () => true,
 });
 

--- a/web/contract-observatory/test/browser-controller-nodelist.test.ts
+++ b/web/contract-observatory/test/browser-controller-nodelist.test.ts
@@ -1,0 +1,108 @@
+import {
+  installObservatoryBrowserController,
+  type ObservatoryBrowserEnvironment,
+  type ObservatoryBrowserEvent,
+  type ObservatoryBrowserNode,
+} from "../src/browser-controller.js";
+import type {
+  ObservatoryInteractionKernel,
+  ObservatoryInteractionState,
+} from "../src/interaction.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Contract Observatory NodeList regression: ${message}`);
+}
+
+class NodeListLike<T> implements Iterable<T> {
+  readonly length: number;
+
+  constructor(private readonly values: readonly T[]) {
+    this.length = values.length;
+  }
+
+  forEach(callback: (value: T, index: number) => void): void {
+    this.values.forEach(callback);
+  }
+
+  item(index: number): T | null {
+    return this.values[index] ?? null;
+  }
+
+  [Symbol.iterator](): Iterator<T> {
+    return this.values[Symbol.iterator]();
+  }
+}
+
+const emptyNodes = new NodeListLike<ObservatoryBrowserNode>([]);
+const listeners = new Map<string, ((event: ObservatoryBrowserEvent) => void)[]>();
+
+const button: ObservatoryBrowserNode = {
+  dataset: {},
+  setAttribute: () => undefined,
+  getAttribute: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => emptyNodes as unknown as readonly ObservatoryBrowserNode[],
+  closest: (selector) => selector === "button" ? button : null,
+  focus: () => undefined,
+};
+
+const buttonNodes = new NodeListLike<ObservatoryBrowserNode>([button]);
+assert(!("filter" in buttonNodes), "NodeList-like collection must not expose Array.prototype.filter");
+
+const map: ObservatoryBrowserNode = {
+  dataset: {},
+  setAttribute: () => undefined,
+  getAttribute: () => null,
+  querySelector: () => null,
+  querySelectorAll: (selector) => (
+    selector === "button" ? buttonNodes : emptyNodes
+  ) as unknown as readonly ObservatoryBrowserNode[],
+  addEventListener: (type, listener) => {
+    const entries = listeners.get(type) ?? [];
+    entries.push(listener);
+    listeners.set(type, entries);
+  },
+};
+
+const state: ObservatoryInteractionState = Object.freeze({
+  selectedVersionId: null,
+  selectedStage: null,
+  selectedItemId: null,
+  filters: Object.freeze([]),
+  viewport: Object.freeze({ x: 0, y: 0, scale: 1 }),
+});
+
+const kernel: ObservatoryInteractionKernel = Object.freeze({
+  initialState: () => state,
+  decode: () => state,
+  encode: () => "#",
+  reduce: (current) => current,
+  isVersionVisible: () => true,
+});
+
+const environment: ObservatoryBrowserEnvironment = {
+  document: {
+    activeElement: null,
+    querySelector: (selector) => selector === ".methodology-map" ? map : null,
+    querySelectorAll: () => emptyNodes as unknown as readonly ObservatoryBrowserNode[],
+  },
+  location: {
+    hash: "#",
+    pathname: "/observatory/",
+    search: "",
+  },
+  history: {
+    replaceState: () => undefined,
+  },
+  window: {
+    addEventListener: () => undefined,
+  },
+};
+
+installObservatoryBrowserController(environment, kernel);
+
+const keydown = listeners.get("keydown")?.[0];
+assert(keydown !== undefined, "controller must install keyboard navigation");
+keydown({ target: button, key: "ArrowRight", preventDefault: () => undefined });
+
+console.log("Contract Observatory NodeList regression passed.");

--- a/web/contract-observatory/test/browser-controller-nodelist.test.ts
+++ b/web/contract-observatory/test/browser-controller-nodelist.test.ts
@@ -41,7 +41,7 @@ const button: ObservatoryBrowserNode = {
   setAttribute: () => undefined,
   getAttribute: () => null,
   querySelector: () => null,
-  querySelectorAll: () => emptyNodes as unknown as readonly ObservatoryBrowserNode[],
+  querySelectorAll: () => emptyNodes,
   closest: (selector) => selector === "button" ? button : null,
   focus: () => undefined,
 };
@@ -54,9 +54,7 @@ const map: ObservatoryBrowserNode = {
   setAttribute: () => undefined,
   getAttribute: () => null,
   querySelector: () => null,
-  querySelectorAll: (selector) => (
-    selector === "button" ? buttonNodes : emptyNodes
-  ) as unknown as readonly ObservatoryBrowserNode[],
+  querySelectorAll: (selector) => selector === "button" ? buttonNodes : emptyNodes,
   addEventListener: (type, listener) => {
     const entries = listeners.get(type) ?? [];
     entries.push(listener);
@@ -84,7 +82,7 @@ const environment: ObservatoryBrowserEnvironment = {
   document: {
     activeElement: null,
     querySelector: (selector) => selector === ".methodology-map" ? map : null,
-    querySelectorAll: () => emptyNodes as unknown as readonly ObservatoryBrowserNode[],
+    querySelectorAll: () => emptyNodes,
   },
   location: {
     hash: "#",


### PR DESCRIPTION
Closes #981.

This fixes the real-browser regression discovered after #980 without changing Observatory interaction semantics or accepted MTS semantics.

Exact base at branch creation / pre-PR revalidation:
`5f6e971fb00d42dc4d4be13c2e7af141ff4771b1`

Exact head:
`8f4fea9e651589fc04841b7e4458291ad754ffd5`

## Root cause

`browser-controller.ts` modeled `querySelectorAll()` as returning `readonly ObservatoryBrowserNode[]`. The fake DOM in the executable V4c tests also returned real Arrays. That allowed `visibleButtons()` to call `.filter()` directly.

A real browser returns `NodeList`, which is iterable and has `forEach()`, but has no `Array.prototype.filter()`. The test therefore exercised the real controller but with the wrong collection contract.

## Fix

- introduce a small `ObservatoryBrowserNodeCollection` contract containing only the collection capabilities the adapter actually relies on: iteration + `forEach()`;
- type node/document `querySelectorAll()` against that collection instead of Array;
- materialize with `Array.from(...)` only in `visibleButtons()`, where `.filter()`, `.indexOf()`, indexed access and `.length` are intentionally needed afterward;
- add a NodeList-like regression fixture that is iterable and supports `forEach()` but deliberately exposes no `.filter()`.

Audit of all Observatory production `querySelectorAll()` call sites found no other Array-only assumption: all remaining call sites use `forEach()`.

## TDD evidence

RED exact head:
`687e8d82676a7f3984cc886ada01567ce31e8be9`

Push CI #3850 reached the Observatory step, passed the interaction and existing browser-controller specifications, then failed the new NodeList-like regression exactly with:

```text
TypeError: map.querySelectorAll(...).filter is not a function
```

Final cleaned head:
`8f4fea9e651589fc04841b7e4458291ad754ffd5`

Push CI #3853: SUCCESS across `typescript`, `no-python`, `validate-docs`, and `validate-structure`; its existing `contract-index.test.ts` suite runner automatically discovered and executed the new regression.

## CI investigation correction

During diagnosis I briefly suspected that `browser-controller.test.ts` was only compiled because the workflow directly invokes `contract-index.test.js` and `site.test.js`. Inspecting `contract-index.test.ts` disproved that: it enumerates every Observatory `*.test.ts`, verifies the compiled counterpart, and executes every compiled suite except itself.

Therefore the existing CI runner was already correct. The temporary workflow experiment was fully reverted and the final diff contains no `.github` change.

## Final scope

Compared with exact base: 6 branch commits, exactly 2 files changed, 1 new file, +114/-4 = net +110 lines, `behind_by = 0` before PR creation.

No accepted MTS contract/conformance, SyntaxAset, proof, cutover, visual package, documentation, or repository policy is modified. Draft #966 / #959 are untouched.

```repo-guard-yaml
change_type: corrective
scope:
  - web/contract-observatory/src/browser-controller.ts
  - web/contract-observatory/test/browser-controller-nodelist.test.ts
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 140
anchors:
  affects: []
  implements:
    - "#981"
  verifies: []
must_touch:
  - web/contract-observatory/src/browser-controller.ts
  - web/contract-observatory/test/browser-controller-nodelist.test.ts
must_not_touch:
  - contracts/**
  - cutover/**
  - ts/**
  - packages/visual/**
  - docs/**
  - .github/**
  - repo-policy.json
expected_effects:
  - browser querySelectorAll collections no longer rely on accidental Array semantics
  - NodeList-like browser collection behavior is executable in the existing Observatory CI suite runner
  - all other browser-controller querySelectorAll call sites remain valid against the narrower collection contract
  - accepted MTS v0.11 semantic authority remains unchanged
```