### PR TITLE
research(mathlib-m0): proof-preserving importer micro-corpus

### DIFF
--- a/research/mathlib-m0/corpus-reproduction.json
+++ b/research/mathlib-m0/corpus-reproduction.json
@@ -1,0 +1,60 @@
+{
+  "schema": "mts-mathlib-m0-corpus-reproduction/v0.1",
+  "upstream": {
+    "repository": "leanprover-community/mathlib4",
+    "mathlibSha": "d6893048e0d784c43f3cf098b61299b3a4b4aed0",
+    "leanToolchain": "leanprover/lean4:v4.34.0-rc2"
+  },
+  "source": {
+    "module": "Mathlib.Logic.Pairwise",
+    "path": "Mathlib/Logic/Pairwise.lean",
+    "blobSha": "7a2f0dc7819c5656049e1d99f6ba0be56f1e04ca"
+  },
+  "seed": "research/mathlib-m0/corpus-seed.json",
+  "selection": {
+    "minimumDeclarations": 10,
+    "maximumDeclarations": 100,
+    "roots": [
+      "Pairwise",
+      "Pairwise.mono",
+      "Pairwise.eq",
+      "Subsingleton.pairwise",
+      "Function.injective_iff_pairwise_ne",
+      "Function.Injective.pairwise_ne",
+      "Pairwise.comp_of_injective",
+      "Pairwise.of_comp_of_surjective",
+      "Function.Bijective.pairwise_comp_iff",
+      "pairwise_fin_succ_iff",
+      "pairwise_fin_succ_iff_of_isSymm",
+      "Set.Pairwise",
+      "Set.pairwise_of_forall",
+      "Set.Pairwise.imp_on",
+      "Set.Pairwise.imp",
+      "Set.Pairwise.eq",
+      "Set.pairwise_iff_of_refl",
+      "Set.Pairwise.forall₂",
+      "Set.Pairwise.of_forall₂",
+      "Set.Pairwise.on_injective",
+      "Pairwise.set_pairwise"
+    ]
+  },
+  "export": {
+    "stage": "post-elaboration-kernel-environment",
+    "dependencyClosure": "recursive-constant-references",
+    "dependencyPolicy": "every non-primitive referenced declaration must either appear earlier in the emitted corpus or be classified explicitly as external-kernel/runtime support",
+    "ordering": "dependency-topological-then-qualified-name",
+    "identity": "qualified-name-plus-kernel-type-and-value-under-exact-upstream-pin",
+    "outputSchema": "mts-mathlib-m0-transport/v0.1",
+    "outputPath": "research/mathlib-m0/corpus-export.json"
+  },
+  "failClosed": {
+    "rejectFloatingRevision": true,
+    "rejectSourceOnlyApproximation": true,
+    "rejectMissingDependency": true,
+    "rejectDuplicateDeclaration": true,
+    "rejectDependencyCycle": true,
+    "rejectUnsupportedKernelForm": true,
+    "translatorOutputTrusted": false
+  },
+  "acceptanceBoundary": "This manifest makes the corpus selection and export contract reproducible but is not itself corpus evidence. Acceptance still requires the generated 10-100 declaration post-elaboration corpus, MTS evidence encoding, and trusted approval/replay for every admitted declaration."
+}

--- a/research/mathlib-m0/corpus-seed.json
+++ b/research/mathlib-m0/corpus-seed.json
@@ -1,0 +1,37 @@
+{
+  "schema": "mts-mathlib-m0-corpus-seed/v0.1",
+  "upstream": {
+    "repository": "leanprover-community/mathlib4",
+    "mathlibSha": "d6893048e0d784c43f3cf098b61299b3a4b4aed0",
+    "leanToolchain": "leanprover/lean4:v4.34.0-rc2"
+  },
+  "source": {
+    "module": "Mathlib.Logic.Pairwise",
+    "path": "Mathlib/Logic/Pairwise.lean",
+    "blobSha": "7a2f0dc7819c5656049e1d99f6ba0be56f1e04ca"
+  },
+  "roots": [
+    "Pairwise",
+    "Pairwise.mono",
+    "Pairwise.eq",
+    "Subsingleton.pairwise",
+    "Function.injective_iff_pairwise_ne",
+    "Function.Injective.pairwise_ne",
+    "Pairwise.comp_of_injective",
+    "Pairwise.of_comp_of_surjective",
+    "Function.Bijective.pairwise_comp_iff",
+    "pairwise_fin_succ_iff",
+    "pairwise_fin_succ_iff_of_isSymm",
+    "Set.Pairwise",
+    "Set.pairwise_of_forall",
+    "Set.Pairwise.imp_on",
+    "Set.Pairwise.imp",
+    "Set.Pairwise.eq",
+    "Set.pairwise_iff_of_refl",
+    "Set.Pairwise.forall₂",
+    "Set.Pairwise.of_forall₂",
+    "Set.Pairwise.on_injective",
+    "Pairwise.set_pairwise"
+  ],
+  "semantics": "Source-level seed only. These roots are not dependency-closure evidence and are not trusted MTS evidence. The post-elaboration exporter must resolve exact kernel identities and recursively compute closure from the pinned upstream environment before any declaration can be admitted."
+}

--- a/research/mathlib-m0/upstream-pin.json
+++ b/research/mathlib-m0/upstream-pin.json
@@ -1,0 +1,11 @@
+{
+  "schema": "mts-mathlib-m0-upstream-pin/v0.1",
+  "repository": "leanprover-community/mathlib4",
+  "mathlibSha": "d6893048e0d784c43f3cf098b61299b3a4b4aed0",
+  "leanToolchain": "leanprover/lean4:v4.34.0-rc2",
+  "verifiedFrom": {
+    "commitApi": "repos/leanprover-community/mathlib4/commits/d6893048e0d784c43f3cf098b61299b3a4b4aed0",
+    "toolchainPath": "lean-toolchain"
+  },
+  "purpose": "Pinned upstream identity for anum_docs#969 Mathlib/M0 research corpus. This file is provenance only and grants no trust to exporter or translator output."
+}

--- a/ts/src/mathlib-m0-result-accounting.ts
+++ b/ts/src/mathlib-m0-result-accounting.ts
@@ -1,0 +1,161 @@
+import {
+  MATHLIB_M0_TRANSPORT_DIGEST_SCHEME,
+  type MathlibM0TransportBundle,
+  parseMathlibM0TransportBundle,
+} from "./mathlib-m0-transport.js";
+
+export const MATHLIB_M0_RESULT_SCHEMA = "mts-mathlib-m0-result/v0.1" as const;
+export const MATHLIB_M0_DECLARATION_DIGEST_SCHEME =
+  "mts-mathlib-m0-declaration/sha-256/v0.1" as const;
+
+export type MathlibM0DeclarationDisposition =
+  | "approved"
+  | "rejected"
+  | "unsupported"
+  | "blocked-by-dependency";
+
+export interface MathlibM0DeclarationOutcome {
+  readonly qualifiedName: string;
+  readonly dependencies: readonly string[];
+  readonly translated: boolean;
+  readonly disposition: MathlibM0DeclarationDisposition;
+  readonly mtsEvidenceDigest: string | null;
+  readonly trustedApproverDigest: string | null;
+}
+
+export interface MathlibM0DeclarationResult extends MathlibM0DeclarationOutcome {
+  readonly transportDigest: string;
+}
+
+export interface MathlibM0ResultCounts {
+  readonly translated: number;
+  readonly approved: number;
+  readonly rejected: number;
+  readonly unsupported: number;
+  readonly blockedByDependency: number;
+}
+
+export interface MathlibM0ResultReport {
+  readonly schema: typeof MATHLIB_M0_RESULT_SCHEMA;
+  readonly upstream: MathlibM0TransportBundle["upstream"];
+  readonly transportScheme: typeof MATHLIB_M0_TRANSPORT_DIGEST_SCHEME;
+  readonly declarationDigestScheme: typeof MATHLIB_M0_DECLARATION_DIGEST_SCHEME;
+  readonly declarations: readonly MathlibM0DeclarationResult[];
+  readonly counts: MathlibM0ResultCounts;
+}
+
+export type MathlibM0ResultErrorCode =
+  | "result-set-mismatch"
+  | "dependency-identity-mismatch"
+  | "invalid-result-state"
+  | "invalid-evidence-digest"
+  | "invalid-dependency-result";
+
+export class MathlibM0ResultError extends Error {
+  override readonly name = "MathlibM0ResultError";
+
+  constructor(readonly code: MathlibM0ResultErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: MathlibM0ResultErrorCode): never {
+  throw new MathlibM0ResultError(code);
+}
+
+function lowercaseHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256(domain: string, value: unknown): Promise<string> {
+  const raw = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${domain}\n${JSON.stringify(value)}`),
+  );
+  return lowercaseHex(new Uint8Array(raw));
+}
+
+function validDigest(value: string | null): boolean {
+  return value !== null && /^[0-9a-f]{64}$/.test(value);
+}
+
+export async function computeMathlibM0DeclarationTransportDigest(
+  input: unknown,
+  qualifiedName: string,
+): Promise<string> {
+  const bundle = parseMathlibM0TransportBundle(input);
+  const declaration = bundle.declarations.find((candidate) => candidate.qualifiedName === qualifiedName);
+  if (declaration === undefined) fail("result-set-mismatch");
+  return sha256(MATHLIB_M0_DECLARATION_DIGEST_SCHEME, {
+    upstream: bundle.upstream,
+    declaration,
+  });
+}
+
+export async function buildMathlibM0ResultReport(
+  input: unknown,
+  outcomes: readonly MathlibM0DeclarationOutcome[],
+): Promise<MathlibM0ResultReport> {
+  const bundle = parseMathlibM0TransportBundle(input);
+  if (outcomes.length !== bundle.declarations.length) fail("result-set-mismatch");
+
+  const approved = new Set<string>();
+  const declarations: MathlibM0DeclarationResult[] = [];
+
+  for (let index = 0; index < bundle.declarations.length; index += 1) {
+    const declaration = bundle.declarations[index]!;
+    const outcome = outcomes[index]!;
+    if (outcome.qualifiedName !== declaration.qualifiedName) fail("result-set-mismatch");
+    if (
+      outcome.dependencies.length !== declaration.dependencies.length ||
+      outcome.dependencies.some((dependency, dependencyIndex) => dependency !== declaration.dependencies[dependencyIndex])
+    ) {
+      fail("dependency-identity-mismatch");
+    }
+
+    const hasBlockedDependency = declaration.dependencies.some((dependency) => !approved.has(dependency));
+    if (outcome.disposition === "blocked-by-dependency") {
+      if (!hasBlockedDependency || outcome.translated) fail("invalid-dependency-result");
+    } else if (hasBlockedDependency) {
+      fail("invalid-dependency-result");
+    }
+
+    if (outcome.disposition === "approved" || outcome.disposition === "rejected") {
+      if (!outcome.translated) fail("invalid-result-state");
+      if (!validDigest(outcome.mtsEvidenceDigest) || !validDigest(outcome.trustedApproverDigest)) {
+        fail("invalid-evidence-digest");
+      }
+    } else if (outcome.mtsEvidenceDigest !== null || outcome.trustedApproverDigest !== null) {
+      fail("invalid-result-state");
+    }
+
+    if (outcome.disposition === "unsupported" && outcome.translated) fail("invalid-result-state");
+    if (outcome.disposition === "approved") approved.add(outcome.qualifiedName);
+
+    declarations.push(
+      Object.freeze({
+        ...outcome,
+        dependencies: Object.freeze([...outcome.dependencies]),
+        transportDigest: await computeMathlibM0DeclarationTransportDigest(bundle, declaration.qualifiedName),
+      }),
+    );
+  }
+
+  const count = (disposition: MathlibM0DeclarationDisposition): number =>
+    declarations.filter((result) => result.disposition === disposition).length;
+
+  return Object.freeze({
+    schema: MATHLIB_M0_RESULT_SCHEMA,
+    upstream: bundle.upstream,
+    transportScheme: MATHLIB_M0_TRANSPORT_DIGEST_SCHEME,
+    declarationDigestScheme: MATHLIB_M0_DECLARATION_DIGEST_SCHEME,
+    declarations: Object.freeze(declarations),
+    counts: Object.freeze({
+      translated: declarations.filter((result) => result.translated).length,
+      approved: count("approved"),
+      rejected: count("rejected"),
+      unsupported: count("unsupported"),
+      blockedByDependency: count("blocked-by-dependency"),
+    }),
+  });
+}

--- a/ts/src/mathlib-m0-transport.ts
+++ b/ts/src/mathlib-m0-transport.ts
@@ -1,0 +1,172 @@
+export const MATHLIB_M0_TRANSPORT_SCHEMA = "mts-mathlib-m0-transport/v0.1" as const;
+export const MATHLIB_M0_TRANSPORT_DIGEST_SCHEME =
+  "mts-mathlib-m0-transport/sha-256/v0.1" as const;
+
+export interface MathlibM0UpstreamPin {
+  readonly mathlibSha: string;
+  readonly leanToolchain: string;
+}
+
+export type MathlibM0KernelForm =
+  | Readonly<{ kind: "axiom"; type: string }>
+  | Readonly<{ kind: "theorem"; type: string; value: string }>
+  | Readonly<{ kind: "definition"; type: string; value: string }>;
+
+export interface MathlibM0TransportDeclaration {
+  readonly qualifiedName: string;
+  readonly dependencies: readonly string[];
+  readonly kernel: MathlibM0KernelForm;
+}
+
+export interface MathlibM0TransportBundle {
+  readonly schema: typeof MATHLIB_M0_TRANSPORT_SCHEMA;
+  readonly upstream: MathlibM0UpstreamPin;
+  readonly declarations: readonly MathlibM0TransportDeclaration[];
+}
+
+export interface MathlibM0TransportBundleDigest {
+  readonly scheme: typeof MATHLIB_M0_TRANSPORT_DIGEST_SCHEME;
+  readonly value: string;
+}
+
+export type MathlibM0TransportErrorCode =
+  | "invalid-envelope"
+  | "unsupported-schema"
+  | "invalid-upstream"
+  | "invalid-declaration"
+  | "duplicate-declaration"
+  | "missing-dependency"
+  | "forward-dependency"
+  | "unsupported-kernel-form";
+
+export class MathlibM0TransportError extends Error {
+  override readonly name = "MathlibM0TransportError";
+
+  constructor(readonly code: MathlibM0TransportErrorCode) {
+    super(code);
+  }
+}
+
+function fail(code: MathlibM0TransportErrorCode): never {
+  throw new MathlibM0TransportError(code);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) fail("invalid-envelope");
+  return value as Record<string, unknown>;
+}
+
+function exactRecord(value: unknown, keys: readonly string[]): Record<string, unknown> {
+  const candidate = record(value);
+  const actual = Object.keys(candidate).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    fail("invalid-envelope");
+  }
+  return candidate;
+}
+
+function declarationText(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) fail("invalid-declaration");
+  return value;
+}
+
+function parseUpstream(value: unknown): MathlibM0UpstreamPin {
+  const upstream = exactRecord(value, ["mathlibSha", "leanToolchain"]);
+  if (
+    typeof upstream.mathlibSha !== "string" ||
+    !/^[0-9a-f]{40}$/.test(upstream.mathlibSha) ||
+    typeof upstream.leanToolchain !== "string" ||
+    upstream.leanToolchain.trim().length === 0
+  ) {
+    fail("invalid-upstream");
+  }
+  return Object.freeze({
+    mathlibSha: upstream.mathlibSha,
+    leanToolchain: upstream.leanToolchain,
+  });
+}
+
+function parseKernel(value: unknown): MathlibM0KernelForm {
+  const candidate = record(value);
+  if (candidate.kind === "axiom") {
+    const kernel = exactRecord(candidate, ["kind", "type"]);
+    return Object.freeze({ kind: "axiom", type: declarationText(kernel.type) });
+  }
+  if (candidate.kind === "theorem" || candidate.kind === "definition") {
+    const kernel = exactRecord(candidate, ["kind", "type", "value"]);
+    return Object.freeze({
+      kind: candidate.kind,
+      type: declarationText(kernel.type),
+      value: declarationText(kernel.value),
+    });
+  }
+  fail("unsupported-kernel-form");
+}
+
+export function parseMathlibM0TransportBundle(input: unknown): MathlibM0TransportBundle {
+  const bundle = exactRecord(input, ["schema", "upstream", "declarations"]);
+  if (bundle.schema !== MATHLIB_M0_TRANSPORT_SCHEMA) fail("unsupported-schema");
+  if (!Array.isArray(bundle.declarations) || bundle.declarations.length === 0) fail("invalid-declaration");
+
+  const seen = new Set<string>();
+  const declarations: MathlibM0TransportDeclaration[] = [];
+
+  for (const rawDeclaration of bundle.declarations) {
+    const candidate = exactRecord(rawDeclaration, ["qualifiedName", "dependencies", "kernel"]);
+    const qualifiedName = declarationText(candidate.qualifiedName);
+    if (seen.has(qualifiedName)) fail("duplicate-declaration");
+    if (!Array.isArray(candidate.dependencies)) fail("invalid-declaration");
+
+    const dependencies = candidate.dependencies.map(declarationText);
+    if (new Set(dependencies).size !== dependencies.length || dependencies.includes(qualifiedName)) {
+      fail("invalid-declaration");
+    }
+    for (const dependency of dependencies) {
+      if (!seen.has(dependency)) {
+        const appearsLater = bundle.declarations.some((value) => {
+          if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+          return (value as Record<string, unknown>).qualifiedName === dependency;
+        });
+        fail(appearsLater ? "forward-dependency" : "missing-dependency");
+      }
+    }
+
+    declarations.push(
+      Object.freeze({
+        qualifiedName,
+        dependencies: Object.freeze([...dependencies]),
+        kernel: parseKernel(candidate.kernel),
+      }),
+    );
+    seen.add(qualifiedName);
+  }
+
+  return Object.freeze({
+    schema: MATHLIB_M0_TRANSPORT_SCHEMA,
+    upstream: parseUpstream(bundle.upstream),
+    declarations: Object.freeze(declarations),
+  });
+}
+
+export function canonicalMathlibM0TransportBundleJson(input: unknown): string {
+  return JSON.stringify(parseMathlibM0TransportBundle(input));
+}
+
+function lowercaseHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function computeMathlibM0TransportBundleDigest(
+  input: unknown,
+): Promise<MathlibM0TransportBundleDigest> {
+  const canonicalJson = canonicalMathlibM0TransportBundleJson(input);
+  const raw = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${MATHLIB_M0_TRANSPORT_DIGEST_SCHEME}\n${canonicalJson}`),
+  );
+  return Object.freeze({
+    scheme: MATHLIB_M0_TRANSPORT_DIGEST_SCHEME,
+    value: lowercaseHex(new Uint8Array(raw)),
+  });
+}

--- a/ts/test/mathlib-m0-result-accounting.test.ts
+++ b/ts/test/mathlib-m0-result-accounting.test.ts
@@ -1,0 +1,138 @@
+import { MATHLIB_M0_TRANSPORT_SCHEMA } from "../src/mathlib-m0-transport.js";
+import {
+  MathlibM0ResultError,
+  buildMathlibM0ResultReport,
+  computeMathlibM0DeclarationTransportDigest,
+} from "../src/mathlib-m0-result-accounting.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+async function expectReject(code: MathlibM0ResultError["code"], work: () => Promise<unknown>): Promise<void> {
+  try {
+    await work();
+  } catch (error) {
+    assert(error instanceof MathlibM0ResultError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected result rejection`);
+}
+
+const bundle = {
+  schema: MATHLIB_M0_TRANSPORT_SCHEMA,
+  upstream: {
+    mathlibSha: "d6893048e0d784c43f3cf098b61299b3a4b4aed0",
+    leanToolchain: "leanprover/lean4:v4.34.0-rc2",
+  },
+  declarations: [
+    {
+      qualifiedName: "M0.Base",
+      dependencies: [],
+      kernel: { kind: "axiom", type: "Sort 0" },
+    },
+    {
+      qualifiedName: "M0.Rejected",
+      dependencies: ["M0.Base"],
+      kernel: { kind: "theorem", type: "M0.Base", value: "proof" },
+    },
+    {
+      qualifiedName: "M0.Blocked",
+      dependencies: ["M0.Rejected"],
+      kernel: { kind: "definition", type: "M0.Base", value: "value" },
+    },
+  ],
+} as const;
+
+const digest = "a".repeat(64);
+const outcomes = [
+  {
+    qualifiedName: "M0.Base",
+    dependencies: [],
+    translated: true,
+    disposition: "approved",
+    mtsEvidenceDigest: digest,
+    trustedApproverDigest: digest,
+  },
+  {
+    qualifiedName: "M0.Rejected",
+    dependencies: ["M0.Base"],
+    translated: true,
+    disposition: "rejected",
+    mtsEvidenceDigest: digest,
+    trustedApproverDigest: digest,
+  },
+  {
+    qualifiedName: "M0.Blocked",
+    dependencies: ["M0.Rejected"],
+    translated: false,
+    disposition: "blocked-by-dependency",
+    mtsEvidenceDigest: null,
+    trustedApproverDigest: null,
+  },
+] as const;
+
+const report = await buildMathlibM0ResultReport(bundle, outcomes);
+same(report.declarations.length, 3, "all dependency-closed declarations must be accounted");
+same(report.counts.translated, 2, "translated count");
+same(report.counts.approved, 1, "approved count");
+same(report.counts.rejected, 1, "rejected count");
+same(report.counts.unsupported, 0, "unsupported count");
+same(report.counts.blockedByDependency, 1, "blocked count");
+assert(/^[0-9a-f]{64}$/.test(report.declarations[0]!.transportDigest), "per-declaration transport digest");
+
+const replayDigest = await computeMathlibM0DeclarationTransportDigest(bundle, "M0.Rejected");
+same(replayDigest, report.declarations[1]!.transportDigest, "declaration transport identity must replay");
+
+const changedDigest = await computeMathlibM0DeclarationTransportDigest(
+  {
+    ...bundle,
+    declarations: [
+      bundle.declarations[0],
+      {
+        ...bundle.declarations[1],
+        kernel: { ...bundle.declarations[1].kernel, type: "Sort 0" },
+      },
+      bundle.declarations[2],
+    ],
+  },
+  "M0.Rejected",
+);
+assert(changedDigest !== replayDigest, "changed declaration target must change per-declaration transport identity");
+
+await expectReject("dependency-identity-mismatch", () =>
+  buildMathlibM0ResultReport(bundle, [
+    outcomes[0],
+    { ...outcomes[1], dependencies: [] },
+    outcomes[2],
+  ]),
+);
+
+await expectReject("invalid-evidence-digest", () =>
+  buildMathlibM0ResultReport(bundle, [
+    outcomes[0],
+    { ...outcomes[1], trustedApproverDigest: "forged" },
+    outcomes[2],
+  ]),
+);
+
+await expectReject("invalid-dependency-result", () =>
+  buildMathlibM0ResultReport(bundle, [
+    outcomes[0],
+    outcomes[1],
+    {
+      ...outcomes[2],
+      translated: true,
+      disposition: "approved",
+      mtsEvidenceDigest: digest,
+      trustedApproverDigest: digest,
+    },
+  ]),
+);
+
+console.log("mathlib-m0-result-accounting.test.ts: ok");

--- a/ts/test/mathlib-m0-transport.test.ts
+++ b/ts/test/mathlib-m0-transport.test.ts
@@ -1,0 +1,111 @@
+import {
+  MATHLIB_M0_TRANSPORT_SCHEMA,
+  MathlibM0TransportError,
+  canonicalMathlibM0TransportBundleJson,
+  computeMathlibM0TransportBundleDigest,
+  parseMathlibM0TransportBundle,
+} from "../src/mathlib-m0-transport.js";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function same<T>(actual: T, expected: T, message: string): void {
+  assert(Object.is(actual, expected), `${message}: ${String(actual)} !== ${String(expected)}`);
+}
+
+function expectReject(code: MathlibM0TransportError["code"], input: unknown): void {
+  try {
+    parseMathlibM0TransportBundle(input);
+  } catch (error) {
+    assert(error instanceof MathlibM0TransportError, `${code}: wrong error type`);
+    same(error.code, code, `${code}: wrong error code`);
+    return;
+  }
+  throw new Error(`${code}: expected transport rejection`);
+}
+
+const PIN = Object.freeze({
+  mathlibSha: "d6893048e0d784c43f3cf098b61299b3a4b4aed0",
+  leanToolchain: "leanprover/lean4:v4.34.0-rc2",
+});
+
+const bundle = Object.freeze({
+  schema: MATHLIB_M0_TRANSPORT_SCHEMA,
+  upstream: PIN,
+  declarations: [
+    {
+      qualifiedName: "M0.Base",
+      dependencies: [],
+      kernel: { kind: "axiom", type: "Sort 0" },
+    },
+    {
+      qualifiedName: "M0.Identity",
+      dependencies: ["M0.Base"],
+      kernel: { kind: "theorem", type: "M0.Base -> M0.Base", value: "fun x => x" },
+    },
+  ],
+});
+
+const parsed = parseMathlibM0TransportBundle(bundle);
+same(parsed.schema, MATHLIB_M0_TRANSPORT_SCHEMA, "schema must be canonical");
+same(parsed.upstream.mathlibSha, PIN.mathlibSha, "mathlib pin must survive parsing");
+same(parsed.upstream.leanToolchain, PIN.leanToolchain, "Lean pin must survive parsing");
+same(parsed.declarations.length, 2, "dependency-closed corpus size");
+same(parsed.declarations[1]?.dependencies[0], "M0.Base", "dependency identity must remain explicit");
+
+const canonicalA = canonicalMathlibM0TransportBundleJson(bundle);
+const canonicalB = canonicalMathlibM0TransportBundleJson({
+  declarations: [...bundle.declarations],
+  upstream: { ...PIN },
+  schema: MATHLIB_M0_TRANSPORT_SCHEMA,
+});
+same(canonicalA, canonicalB, "transport identity must ignore input object key order");
+
+const digestA = await computeMathlibM0TransportBundleDigest(bundle);
+const digestB = await computeMathlibM0TransportBundleDigest(JSON.parse(canonicalA));
+same(digestA.scheme, "mts-mathlib-m0-transport/sha-256/v0.1", "digest scheme");
+same(digestA.value, digestB.value, "canonical transport digest must replay");
+assert(/^[0-9a-f]{64}$/.test(digestA.value), "digest must be lowercase SHA-256");
+
+expectReject("invalid-upstream", {
+  ...bundle,
+  upstream: { ...PIN, mathlibSha: "main" },
+});
+
+expectReject("duplicate-declaration", {
+  ...bundle,
+  declarations: [bundle.declarations[0], bundle.declarations[0]],
+});
+
+expectReject("missing-dependency", {
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    { ...bundle.declarations[1], dependencies: ["M0.Missing"] },
+  ],
+});
+
+expectReject("forward-dependency", {
+  ...bundle,
+  declarations: [bundle.declarations[1], bundle.declarations[0]],
+});
+
+expectReject("unsupported-kernel-form", {
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    {
+      qualifiedName: "M0.Unsafe",
+      dependencies: ["M0.Base"],
+      kernel: { kind: "opaque-bytecode", type: "M0.Base" },
+    },
+  ],
+});
+
+expectReject("invalid-envelope", {
+  ...bundle,
+  translatorTrusted: true,
+});
+
+console.log("mathlib-m0-transport.test.ts: ok");

--- a/ts/test/mathlib-m0-transport.test.ts
+++ b/ts/test/mathlib-m0-transport.test.ts
@@ -75,7 +75,7 @@ const changedTargetDigest = await computeMathlibM0TransportBundleDigest({
     {
       ...bundle.declarations[1],
       kernel: {
-        ...bundle.declarations[1].kernel,
+        ...bundle.declarations[1]!.kernel,
         type: "M0.Base -> Sort 0",
       },
     },
@@ -90,7 +90,7 @@ const changedProofDigest = await computeMathlibM0TransportBundleDigest({
     {
       ...bundle.declarations[1],
       kernel: {
-        ...bundle.declarations[1].kernel,
+        ...bundle.declarations[1]!.kernel,
         value: "fun _ => M0.Base",
       },
     },
@@ -187,7 +187,7 @@ expectReject("invalid-envelope", {
     {
       ...bundle.declarations[1],
       kernel: {
-        ...bundle.declarations[1].kernel,
+        ...bundle.declarations[1]!.kernel,
         trusted: true,
       },
     },

--- a/ts/test/mathlib-m0-transport.test.ts
+++ b/ts/test/mathlib-m0-transport.test.ts
@@ -68,14 +68,75 @@ same(digestA.scheme, "mts-mathlib-m0-transport/sha-256/v0.1", "digest scheme");
 same(digestA.value, digestB.value, "canonical transport digest must replay");
 assert(/^[0-9a-f]{64}$/.test(digestA.value), "digest must be lowercase SHA-256");
 
+const changedTargetDigest = await computeMathlibM0TransportBundleDigest({
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    {
+      ...bundle.declarations[1],
+      kernel: {
+        ...bundle.declarations[1].kernel,
+        type: "M0.Base -> Sort 0",
+      },
+    },
+  ],
+});
+assert(changedTargetDigest.value !== digestA.value, "changed theorem target must change transport identity");
+
+const changedProofDigest = await computeMathlibM0TransportBundleDigest({
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    {
+      ...bundle.declarations[1],
+      kernel: {
+        ...bundle.declarations[1].kernel,
+        value: "fun _ => M0.Base",
+      },
+    },
+  ],
+});
+assert(changedProofDigest.value !== digestA.value, "changed theorem value must change transport identity");
+
+expectReject("unsupported-schema", {
+  ...bundle,
+  schema: "mts-mathlib-m0-transport/v9.9",
+});
+
 expectReject("invalid-upstream", {
   ...bundle,
   upstream: { ...PIN, mathlibSha: "main" },
 });
 
+expectReject("invalid-upstream", {
+  ...bundle,
+  upstream: { ...PIN, leanToolchain: "" },
+});
+
+expectReject("invalid-declaration", {
+  ...bundle,
+  declarations: [],
+});
+
 expectReject("duplicate-declaration", {
   ...bundle,
   declarations: [bundle.declarations[0], bundle.declarations[0]],
+});
+
+expectReject("invalid-declaration", {
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    { ...bundle.declarations[1], dependencies: ["M0.Base", "M0.Base"] },
+  ],
+});
+
+expectReject("invalid-declaration", {
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    { ...bundle.declarations[1], dependencies: ["M0.Identity"] },
+  ],
 });
 
 expectReject("missing-dependency", {
@@ -106,6 +167,31 @@ expectReject("unsupported-kernel-form", {
 expectReject("invalid-envelope", {
   ...bundle,
   translatorTrusted: true,
+});
+
+expectReject("invalid-envelope", {
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    {
+      ...bundle.declarations[1],
+      approved: true,
+    },
+  ],
+});
+
+expectReject("invalid-envelope", {
+  ...bundle,
+  declarations: [
+    bundle.declarations[0],
+    {
+      ...bundle.declarations[1],
+      kernel: {
+        ...bundle.declarations[1].kernel,
+        trusted: true,
+      },
+    },
+  ],
 });
 
 console.log("mathlib-m0-transport.test.ts: ok");


### PR DESCRIPTION
Closes #969

Research-only Mathlib/M0 spike. Keeps the exporter/translator untrusted and preserves the existing trusted MTS approval/replay boundary.

Current evidence:
- exact mathlib4 revision pinned to `d6893048e0d784c43f3cf098b61299b3a4b4aed0`;
- exact Lean toolchain pinned to `leanprover/lean4:v4.34.0-rc2`;
- deterministic explicit transport boundary with fail-closed dependency and unsupported-form validation;
- upstream pin recorded as durable provenance.

Still in progress: actual dependency-closed 10–100 declaration export corpus, MTS evidence encoding/replay, per-declaration results and mutation corpus.

No foundational MTS semantic delta is authorized by this PR.